### PR TITLE
Remove cgo

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -2,9 +2,6 @@ name: Lint & Test
 on:
   workflow_call:
 
-env:
-  CGO_ENABLED: 1
-
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,12 +91,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 1.23
-      - name: Setup Linux
-        if: ${{ matrix.GOARCH == 'arm64' && matrix.OS == 'ubuntu-latest' }}
-        run: |
-          sudo apt update
-          sudo apt install -y gcc-aarch64-linux-gnu
-          echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
       - name: Setup macOS
         if: ${{ matrix.OS == 'macos-latest' }}
         env:
@@ -140,7 +134,6 @@ jobs:
       - name: Build
         env:
           GOARCH: ${{ matrix.GOARCH }}
-          CGO_ENABLED: 1
         run: go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '${{ matrix.BUILD_LD_FLAGS }}' ./...
       - name: Sign macOS
         if: ${{ matrix.OS == 'macos-latest' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,23 +65,18 @@ jobs:
         include:
           - OS: ubuntu-latest
             GOARCH: amd64
-            BUILD_LD_FLAGS: -s -w -linkmode external -extldflags "-static"
             RELEASE_PLATFORM: linux
           - OS: ubuntu-latest
             GOARCH: arm64
-            BUILD_LD_FLAGS: -s -w -linkmode external -extldflags "-static"
             RELEASE_PLATFORM: linux
           - OS: macos-latest
             GOARCH: amd64
-            BUILD_LD_FLAGS: -s -w
             RELEASE_PLATFORM: macos
           - OS: macos-latest
             GOARCH: arm64
-            BUILD_LD_FLAGS: -s -w
             RELEASE_PLATFORM: macos
           - OS: windows-latest
             GOARCH: amd64
-            BUILD_LD_FLAGS: -s -w -linkmode external -extldflags "-static"
             RELEASE_PLATFORM: windows
     runs-on: ${{ matrix.OS }}
     env:
@@ -134,7 +129,7 @@ jobs:
       - name: Build
         env:
           GOARCH: ${{ matrix.GOARCH }}
-        run: go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '${{ matrix.BUILD_LD_FLAGS }}' ./...
+        run: go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w' ./...
       - name: Sign macOS
         if: ${{ matrix.OS == 'macos-latest' }}
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 # codegen
 RUN go generate ./...
 # build
-RUN CGO_ENABLED=1 go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'  ./cmd/indexd
+RUN go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'  ./cmd/indexd
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 # codegen
 RUN go generate ./...
 # build
-RUN go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w -linkmode external -extldflags "-static"'  ./cmd/indexd
+RUN go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w'  ./cmd/indexd
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Unlike the SQLite driver, the Postgres driver is pure Go, we should be able to remove CGO_ENABLED from all our binaries and the special ldflags.