### PR TITLE
Shutdown http server gracefully

### DIFF
--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -123,7 +123,8 @@ func runRootCmd(ctx context.Context, cfg config.Config, log *zap.Logger) error {
 		Handler: webRouter{
 			api: jape.BasicAuth(cfg.HTTP.Password)(api.NewServer(cm, s, store, apiOpts...)),
 		},
-		ReadTimeout: 30 * time.Second,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
 	}
 	defer web.Close()
 

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 
 	"go.sia.tech/core/consensus"
@@ -133,8 +136,28 @@ func runRootCmd(ctx context.Context, cfg config.Config, log *zap.Logger) error {
 
 	log.Info("node started", zap.String("http", httpListener.Addr().String()), zap.String("p2p", string(s.Addr())))
 	<-ctx.Done()
-	log.Info("shutting down...")
+	log.Info("shutdown signal received...attempting graceful shutdown...")
 
+	// attempt to gracefully shut down the http server but allow another signal
+	// to interrupt shutdown. That way, indexd behaves in a more Linux-like way
+	// as expected by tools like Docker and Kubernetes which first try to
+	// trigger a graceful shutdown with SIGTERM followed by a user-configurable
+	// timeout after which they send a SIGKILL which causes the OS to kill the
+	// process without the process being able to catch the signal itself. For
+	// convenience, we allow the user to send a second SIGTERM to force similar
+	// behavior as if SIGKILL was sent.
+	shutdownCtx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	if err := web.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Error("graceful shutdown failed", zap.Error(err))
+	}
+	select {
+	case <-shutdownCtx.Done():
+		log.Info("graceful shutdown was interrupted")
+	default:
+	}
+
+	log.Info("...shutdown complete")
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	go.sia.tech/core v0.10.0
 	go.sia.tech/coreutils v0.11.0
 	go.sia.tech/jape v0.12.1
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
 	lukechampine.com/flagg v1.1.1

--- a/internal/testutils/host_test.go
+++ b/internal/testutils/host_test.go
@@ -11,6 +11,10 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestMain(m *testing.M) {
+	VerifyTestMain(m)
+}
+
 func TestHost(t *testing.T) {
 	tt := NewTT(t)
 	n, genesis := testutil.V2Network()

--- a/internal/testutils/tt.go
+++ b/internal/testutils/tt.go
@@ -1,5 +1,11 @@
 package testutils
 
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
 type (
 	// TT is a wrapper around testing.T that provides additional helper methods.
 	TT interface {
@@ -53,4 +59,10 @@ func (t impl) OKAll(vs ...interface{}) {
 			t.Fatal(err)
 		}
 	}
+}
+
+// VerifyTestMain contains any setup and teardown code that should be run
+// before/after running all tests that belong to a package.
+func VerifyTestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
 }

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -6,8 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"go.sia.tech/indexd/internal/testutils"
 	"go.uber.org/zap"
 )
+
+func TestMain(m *testing.M) {
+	testutils.VerifyTestMain(m)
+}
 
 func initPostgres(t *testing.T, log *zap.Logger) *Store {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
Was going over the code while catching up and noticed that we are just killing the http servers underlying connection. This PR updates that to a more graceful shutdown that handles all ongoing connections while preventing new ones before exiting.  
Giving users the chance to handle shutdowns gracefully on production setups.

Without it, commands like `docker stop` will just drop any incoming connections even though they intend to nicely handle graceful shutdowns via a `SIGTERM` followed by a `SIGKILL` after a user-configurable timeout.

For convenience sending `SIGTERM` twice will still interrupt the shutdown immediately. 