### PR TITLE
Add RHP4 client

### DIFF
--- a/internal/rhp/v4/client.go
+++ b/internal/rhp/v4/client.go
@@ -10,16 +10,20 @@ import (
 	rhp "go.sia.tech/coreutils/rhp/v4"
 )
 
+// Client is a client for RHP4. It is a wrapper around the coreutils client that
+// adds pooling of transports to reuse TCP connections.
 type Client struct {
 	tpool *transportPool
 }
 
+// New creates a new RHP4 client.
 func New() *Client {
 	return &Client{
 		tpool: newTransportPool(),
 	}
 }
 
+// Settings executes the RPCSettings RPC on the host.
 func (c *Client) Settings(ctx context.Context, hk types.PublicKey, addr string) (hs rhp4.HostSettings, _ error) {
 	err := c.tpool.withTransport(ctx, hk, addr, func(c rhp.TransportClient) (err error) {
 		hs, err = rhp.RPCSettings(ctx, c)

--- a/internal/rhp/v4/client.go
+++ b/internal/rhp/v4/client.go
@@ -3,18 +3,11 @@ package rhp
 import (
 	"context"
 	"io"
-	"net"
 
 	"go.sia.tech/core/consensus"
 	rhp4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	rhp "go.sia.tech/coreutils/rhp/v4"
-)
-
-type (
-	Dialer interface {
-		Dial(ctx context.Context, hk types.PublicKey, address string) (net.Conn, error)
-	}
 )
 
 type Client struct {

--- a/internal/rhp/v4/client.go
+++ b/internal/rhp/v4/client.go
@@ -1,0 +1,160 @@
+package rhp
+
+import (
+	"context"
+	"io"
+	"net"
+
+	"go.sia.tech/core/consensus"
+	rhp4 "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	rhp "go.sia.tech/coreutils/rhp/v4"
+)
+
+type (
+	Dialer interface {
+		Dial(ctx context.Context, hk types.PublicKey, address string) (net.Conn, error)
+	}
+)
+
+type Client struct {
+	tpool *transportPool
+}
+
+func New() *Client {
+	return &Client{
+		tpool: newTransportPool(),
+	}
+}
+
+func (c *Client) Settings(ctx context.Context, hk types.PublicKey, addr string) (hs rhp4.HostSettings, _ error) {
+	err := c.tpool.withTransport(ctx, hk, addr, func(c rhp.TransportClient) (err error) {
+		hs, err = rhp.RPCSettings(ctx, c)
+		return err
+	})
+	return hs, err
+}
+
+// ReadSector reads a sector from the host.
+func (c *Client) ReadSector(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, token rhp4.AccountToken, w io.Writer, root types.Hash256, offset, length uint64) (res rhp.RPCReadSectorResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
+		res, err = rhp.RPCReadSector(ctx, t, prices, token, w, root, offset, length)
+		return
+	})
+	return res, err
+}
+
+// WriteSector writes a sector to the host.
+func (c *Client) WriteSector(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, token rhp4.AccountToken, rl rhp.ReaderLen, length uint64) (res rhp.RPCWriteSectorResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
+		res, err = rhp.RPCWriteSector(ctx, t, prices, token, rl, length)
+		return
+	})
+	return res, err
+}
+
+// VerifySector verifies that the host is properly storing a sector
+func (c *Client) VerifySector(ctx context.Context, prices rhp4.HostPrices, token rhp4.AccountToken, root types.Hash256) (rhp.RPCVerifySectorResult, error) {
+	panic("not implemented")
+}
+
+// FreeSectors removes sectors from a contract.
+func (c *Client) FreeSectors(ctx context.Context, hk types.PublicKey, hostIP string, cs consensus.State, prices rhp4.HostPrices, sk types.PrivateKey, contract rhp.ContractRevision, indices []uint64) (res rhp.RPCFreeSectorsResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
+		res, err = rhp.RPCFreeSectors(ctx, t, cs, prices, sk, contract, indices)
+		return
+	})
+	return res, err
+}
+
+// AppendSectors appends sectors a host is storing to a contract.
+func (c *Client) AppendSectors(ctx context.Context, hk types.PublicKey, hostIP string, prices rhp4.HostPrices, sk types.PrivateKey, contract rhp.ContractRevision, roots []types.Hash256) (res rhp.RPCAppendSectorsResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(t rhp.TransportClient) (err error) {
+		// NOTE: construct an empty state object here to pass to
+		// RPCAppendSectors since it only uses it for hashing
+		cs := consensus.State{}
+
+		// NOTE: immediately append the sector for the time being, eventually
+		// this will be a 2-step process where uploads are unblocked as soon as
+		// the sector is on the host, but not yet added to the contract
+		res, err = rhp.RPCAppendSectors(ctx, t, cs, prices, sk, contract, roots)
+		return
+	})
+	return res, err
+}
+
+// FundAccounts funds accounts on the host.
+func (c *Client) FundAccounts(ctx context.Context, hk types.PublicKey, hostIP string, cs consensus.State, signer rhp.ContractSigner, contract rhp.ContractRevision, deposits []rhp4.AccountDeposit) (res rhp.RPCFundAccountResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(c rhp.TransportClient) (err error) {
+		res, err = rhp.RPCFundAccounts(ctx, c, cs, signer, contract, deposits)
+		return
+	})
+	return res, err
+}
+
+// LatestRevision returns the latest revision of a contract.
+func (c *Client) LatestRevision(ctx context.Context, hk types.PublicKey, addr string, contractID types.FileContractID) (revision types.V2FileContract, _ error) {
+	err := c.tpool.withTransport(ctx, hk, addr, func(c rhp.TransportClient) error {
+		res, err := rhp.RPCLatestRevision(ctx, c, contractID)
+		revision = res.Contract
+		return err
+	})
+	return revision, err
+}
+
+// SectorRoots returns the sector roots for a contract.
+func (c *Client) SectorRoots(ctx context.Context, hk types.PublicKey, addr string, cs consensus.State, prices rhp4.HostPrices, signer rhp.ContractSigner, contract rhp.ContractRevision, offset, length uint64) (res rhp.RPCSectorRootsResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, addr, func(c rhp.TransportClient) (err error) {
+		res, err = rhp.RPCSectorRoots(ctx, c, cs, prices, signer, contract, offset, length)
+		return err
+	})
+	return res, err
+}
+
+// AccountBalance returns the balance of an account.
+func (c *Client) AccountBalance(ctx context.Context, hk types.PublicKey, hostIP string, account rhp4.Account) (balance types.Currency, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(c rhp.TransportClient) (err error) {
+		balance, err = rhp.RPCAccountBalance(ctx, c, account)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	return balance, err
+}
+
+// FormContract forms a contract with a host
+func (c *Client) FormContract(ctx context.Context, hk types.PublicKey, hostIP string, tp rhp.TxPool, signer rhp.FormContractSigner, cs consensus.State, p rhp4.HostPrices, hostAddress types.Address, params rhp4.RPCFormContractParams) (res rhp.RPCFormContractResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(c rhp.TransportClient) (err error) {
+		res, err = rhp.RPCFormContract(ctx, c, tp, signer, cs, p, hk, hostAddress, params)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	return res, err
+}
+
+// RenewContract renews a contract with a host.
+func (c *Client) RenewContract(ctx context.Context, hk types.PublicKey, hostIP string, tp rhp.TxPool, signer rhp.FormContractSigner, cs consensus.State, p rhp4.HostPrices, existing types.V2FileContract, params rhp4.RPCRenewContractParams) (res rhp.RPCRenewContractResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(c rhp.TransportClient) (err error) {
+		res, err = rhp.RPCRenewContract(ctx, c, tp, signer, cs, p, existing, params)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	return res, err
+}
+
+// RefreshContract refreshes a contract with a host.
+func (c *Client) RefreshContract(ctx context.Context, hk types.PublicKey, hostIP string, tp rhp.TxPool, signer rhp.FormContractSigner, cs consensus.State, p rhp4.HostPrices, existing types.V2FileContract, params rhp4.RPCRefreshContractParams) (res rhp.RPCRefreshContractResult, _ error) {
+	err := c.tpool.withTransport(ctx, hk, hostIP, func(c rhp.TransportClient) (err error) {
+		res, err = rhp.RPCRefreshContract(ctx, c, tp, signer, cs, p, existing, params)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	return res, err
+}

--- a/internal/rhp/v4/transport.go
+++ b/internal/rhp/v4/transport.go
@@ -3,7 +3,6 @@ package rhp
 import (
 	"context"
 	"fmt"
-	"net"
 	"sync"
 
 	"go.sia.tech/core/types"
@@ -73,15 +72,7 @@ func (t *transport) Dial(ctx context.Context, hk types.PublicKey, addr string) (
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.t == nil {
-		// dial host
-		var d net.Dialer
-		conn, err := d.DialContext(ctx, "tcp", addr)
-		if err != nil {
-			return nil, err
-		}
-
-		// upgrade conn
-		newTransport, err := rhp.UpgradeConnSiamux(ctx, conn, hk)
+		newTransport, err := rhp.DialSiaMux(ctx, addr, hk)
 		if err != nil {
 			return nil, fmt.Errorf("failed to upgrade connection: %w", err)
 		}

--- a/internal/rhp/v4/transport.go
+++ b/internal/rhp/v4/transport.go
@@ -1,0 +1,91 @@
+package rhp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"go.sia.tech/core/types"
+	rhp "go.sia.tech/coreutils/rhp/v4"
+)
+
+type transportPool struct {
+	mu   sync.Mutex
+	pool map[string]*transport
+}
+
+func newTransportPool() *transportPool {
+	return &transportPool{
+		pool: make(map[string]*transport),
+	}
+}
+
+func (p *transportPool) withTransport(ctx context.Context, hk types.PublicKey, addr string, fn func(rhp.TransportClient) error) (err error) {
+	// fetch or create transport
+	p.mu.Lock()
+	t, found := p.pool[addr]
+	if !found {
+		t = &transport{}
+		p.pool[addr] = t
+	}
+	t.refCount++
+	p.mu.Unlock()
+
+	// execute function
+	err = func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic (withTransport): %v", r)
+			}
+		}()
+		client, err := t.Dial(ctx, hk, addr)
+		if err != nil {
+			return err
+		}
+		return fn(client)
+	}()
+
+	// Decrement refcounter again and clean up pool.
+	p.mu.Lock()
+	t.refCount--
+	if t.refCount == 0 {
+		// Cleanup
+		if t.t != nil {
+			_ = t.t.Close()
+			t.t = nil
+		}
+		delete(p.pool, addr)
+	}
+	p.mu.Unlock()
+	return err
+}
+
+type transport struct {
+	refCount uint64 // locked by pool
+
+	mu sync.Mutex
+	t  rhp.TransportClient
+}
+
+// DialStream dials a new stream on the transport.
+func (t *transport) Dial(ctx context.Context, hk types.PublicKey, addr string) (rhp.TransportClient, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.t == nil {
+		// dial host
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+
+		// upgrade conn
+		newTransport, err := rhp.UpgradeConnSiamux(ctx, conn, hk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to upgrade connection: %w", err)
+		}
+		t.t = newTransport
+	}
+	return t.t, nil
+}

--- a/internal/rhp/v4/transport.go
+++ b/internal/rhp/v4/transport.go
@@ -11,22 +11,22 @@ import (
 
 type transportPool struct {
 	mu   sync.Mutex
-	pool map[string]*transport
+	pool map[types.PublicKey]*transport
 }
 
 func newTransportPool() *transportPool {
 	return &transportPool{
-		pool: make(map[string]*transport),
+		pool: make(map[types.PublicKey]*transport),
 	}
 }
 
 func (p *transportPool) withTransport(ctx context.Context, hk types.PublicKey, addr string, fn func(rhp.TransportClient) error) (err error) {
 	// fetch or create transport
 	p.mu.Lock()
-	t, found := p.pool[addr]
+	t, found := p.pool[hk]
 	if !found {
 		t = &transport{}
-		p.pool[addr] = t
+		p.pool[hk] = t
 	}
 	t.refCount++
 	p.mu.Unlock()
@@ -54,7 +54,7 @@ func (p *transportPool) withTransport(ctx context.Context, hk types.PublicKey, a
 			_ = t.t.Close()
 			t.t = nil
 		}
-		delete(p.pool, addr)
+		delete(p.pool, hk)
 	}
 	p.mu.Unlock()
 	return err

--- a/internal/testutils/host_test.go
+++ b/internal/testutils/host_test.go
@@ -3,11 +3,10 @@ package testutils
 import (
 	"context"
 	"testing"
-	"time"
 
 	"go.sia.tech/core/types"
-	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/testutil"
+	"go.sia.tech/indexd/internal/rhp/v4"
 	"go.uber.org/zap"
 )
 
@@ -19,16 +18,7 @@ func TestHost(t *testing.T) {
 	n, genesis := testutil.V2Network()
 	h := NewHost(t, types.GeneratePrivateKey(), n, genesis, zap.NewNop())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	transport, err := rhp4.DialSiaMux(ctx, h.Addr(), h.PublicKey())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer transport.Close()
-
-	settings, err := rhp4.RPCSettings(ctx, transport)
+	settings, err := rhp.New().Settings(context.Background(), h.PublicKey(), h.Addr())
 	if err != nil {
 		t.Fatal(err)
 	} else if settings.WalletAddress != h.w.Address() {


### PR DESCRIPTION
This adds renterd's RHP4 client implementation without any of the extras we added such as decorating errors with custom errors from the utils package, the custom dialer or any of that. 

