### PR TITLE
RFC: Add database schema for hosts

### DIFF
--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -103,7 +103,7 @@ CREATE TABLE hosts {
     failed_scans INTEGER NOT NULL DEFAULT 0,
     consecutive_failed_scans INTEGER NOT NULL DEFAULT 0,
     last_scan_success BOOLEAN NOT NULL DEFAULT FALSE,
-    next_announcement TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
+    last_announcement TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     next_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     uptime INTERVAL NOT NULL DEFAULT '0 seconds',
     downtime INTERVAL NOT NULL DEFAULT '0 seconds',
@@ -111,9 +111,7 @@ CREATE TABLE hosts {
 
 CREATE TABLE host_addresses {
     id SERIAL PRIMARY KEY,
-    host_id INTEGER PRIMARY KEY
-        REFERENCES hosts(id)
-        ON DELETE CASCADE,
+    host_id INTEGER PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
 
     net_address TEXT NOT NULL,
     protocol SMALLINT NOT NULL,
@@ -121,17 +119,13 @@ CREATE TABLE host_addresses {
 
 CREATE TABLE host_resolved_cidrs {
     id SERIAL PRIMARY KEY,
-    host_id INTEGER
-        REFERENCES hosts(id)
-        ON DELETE CASCADE,
+    host_id INTEGER REFERENCES hosts(id) ON DELETE CASCADE,
 
     cidr CIDR NOT NULL,
 }
 
 CREATE TABLE host_settings {
-    host_id INTEGER PRIMARY KEY
-        REFERENCES hosts(id)
-        ON DELETE CASCADE,
+    host_id INTEGER PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
 
     protocol_version BYTEA NOT NULL,
     release TEXT NOT NULL,

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -115,8 +115,16 @@ CREATE TABLE host_addresses {
         ON DELETE CASCADE,
 
     net_address TEXT NOT NULL,
-    cidrs CIDR[] NOT NULL,
     protocol SMALLINT NOT NULL,
+}
+
+CREATE TABLE host_resolved_cidrs {
+    id SERIAL PRIMARY KEY,
+    host_id INTEGER
+        REFERENCES hosts(id)
+        ON DELETE CASCADE,
+
+    cidr CIDR NOT NULL,
 }
 
 CREATE TABLE host_settings {

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -29,7 +29,7 @@ CREATE TABLE global_settings (
 );
 ```
 
-### 2.1 Wallet
+### 2.2 Wallet
 
 The wallet stores events as well as the state of the wallet in the form of its
 outputs. There's several types of events, the raw event data is stored in the
@@ -61,7 +61,7 @@ CREATE TABLE wallet_siacoin_elements (
 CREATE INDEX wallet_siacoin_elements_output_id_idx ON wallet_siacoin_elements(output_id);
 ```
 
-### 2.2 Syncer
+### 2.3 Syncer
 
 The syncer connects to other peers and syncs the Sia blockchain. It keeps a list
 of peers alongside some information per peer, as well as a list of peers it
@@ -90,3 +90,56 @@ CREATE TABLE syncer_bans (
 CREATE INDEX syncer_bans_expiration_idx ON syncer_bans (expiration);
 CREATE INDEX syncer_bans_net_cidr_idx ON syncer_bans USING gist (net_cidr inet_ops); -- fast subnet matches
 ```
+
+### 2.4 Hosts
+
+```postgresql
+CREATE TABLE hosts {
+    id SERIAL PRIMARY KEY,
+    public_key BYTEA NOT NULL,
+
+    total_scans INTEGER NOT NULL DEFAULT 0,
+    successful_scans INTEGER NOT NULL DEFAULT 0,
+    failed_scans INTEGER NOT NULL DEFAULT 0,
+    consecutive_failed_scans INTEGER NOT NULL DEFAULT 0,
+    last_scan_success BOOLEAN NOT NULL,
+    next_scan TIMESTAMP WITH TIME ZONE NOT NULL,
+    uptime INTERVAL NOT NULL DEFAULT '0 seconds',
+    downtime INTERVAL NOT NULL DEFAULT '0 seconds',
+}
+
+CREATE TABLE host_addresses {
+    id SERIAL PRIMARY KEY,
+    host_id INTEGER PRIMARY KEY
+        REFERENCES hosts(id)
+        ON DELETE CASCADE,
+
+    net_address TEXT NOT NULL,
+    cidrs CIDR[] NOT NULL,
+    protocol SMALLINT NOT NULL,
+}
+
+CREATE TABLE host_settings {
+    host_id INTEGER PRIMARY KEY
+        REFERENCES hosts(id)
+        ON DELETE CASCADE,
+
+    protocol_version BYTEA NOT NULL,
+    release TEXT NOT NULL,
+    wallet_address BYTEA NOT NULL,
+    accepting_contracts BOOLEAN NOT NULL,
+    max_collateral NUMERIC(50,0) NOT NULL,
+    max_contract_duration NUMERIC(50,0) NOT NULL,
+    remaining_storage BIGINT NOT NULL,
+    total_storage BIGINT NOT NULL,
+
+    contract_price NUMERIC(50,0) NOT NULL,
+    collateral NUMERIC(50,0) NOT NULL,
+    storage_price NUMERIC(50,0) NOT NULL,
+    ingress_price NUMERIC(50,0) NOT NULL,
+    egress_price NUMERIC(50,0) NOT NULL,
+    free_sector_price NUMERIC(50,0) NOT NULL,
+    tip_height BIGINT NOT NULL,
+    valid_until TIMESTAMP WITH TIME ZONE NOT NULL,
+}
+´´´

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -96,14 +96,15 @@ CREATE INDEX syncer_bans_net_cidr_idx ON syncer_bans USING gist (net_cidr inet_o
 ```postgresql
 CREATE TABLE hosts {
     id SERIAL PRIMARY KEY,
-    public_key BYTEA NOT NULL,
+    public_key BYTEA UNIQUE NOT NULL,
 
     total_scans INTEGER NOT NULL DEFAULT 0,
     successful_scans INTEGER NOT NULL DEFAULT 0,
     failed_scans INTEGER NOT NULL DEFAULT 0,
     consecutive_failed_scans INTEGER NOT NULL DEFAULT 0,
-    last_scan_success BOOLEAN NOT NULL,
-    next_scan TIMESTAMP WITH TIME ZONE NOT NULL,
+    last_scan_success BOOLEAN NOT NULL DEFAULT FALSE,
+    next_announcement TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
+    next_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     uptime INTERVAL NOT NULL DEFAULT '0 seconds',
     downtime INTERVAL NOT NULL DEFAULT '0 seconds',
 }

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -94,7 +94,7 @@ CREATE INDEX syncer_bans_net_cidr_idx ON syncer_bans USING gist (net_cidr inet_o
 ### 2.4 Hosts
 
 ```postgresql
-CREATE TABLE hosts {
+CREATE TABLE hosts (
     id SERIAL PRIMARY KEY,
     public_key BYTEA UNIQUE NOT NULL,
 
@@ -106,25 +106,25 @@ CREATE TABLE hosts {
     last_announcement TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     next_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     uptime INTERVAL NOT NULL DEFAULT '0 seconds',
-    downtime INTERVAL NOT NULL DEFAULT '0 seconds',
-}
+    downtime INTERVAL NOT NULL DEFAULT '0 seconds'
+)
 
-CREATE TABLE host_addresses {
+CREATE TABLE host_addresses (
     id SERIAL PRIMARY KEY,
     host_id INTEGER PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
 
     net_address TEXT NOT NULL,
-    protocol SMALLINT NOT NULL,
-}
+    protocol SMALLINT NOT NULL
+)
 
-CREATE TABLE host_resolved_cidrs {
+CREATE TABLE host_resolved_cidrs (
     id SERIAL PRIMARY KEY,
     host_id INTEGER REFERENCES hosts(id) ON DELETE CASCADE,
 
-    cidr CIDR NOT NULL,
-}
+    cidr CIDR NOT NULL
+)
 
-CREATE TABLE host_settings {
+CREATE TABLE host_settings (
     host_id INTEGER PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
 
     protocol_version BYTEA NOT NULL,
@@ -143,6 +143,6 @@ CREATE TABLE host_settings {
     egress_price NUMERIC(50,0) NOT NULL,
     free_sector_price NUMERIC(50,0) NOT NULL,
     tip_height BIGINT NOT NULL,
-    valid_until TIMESTAMP WITH TIME ZONE NOT NULL,
-}
-´´´
+    valid_until TIMESTAMP WITH TIME ZONE NOT NULL
+)
+```


### PR DESCRIPTION
This adds the relevant tables necessary for storing hosts in the database and the results of scanning them.


- [x] Consensus relevant columns
- [x] Scanning relevant columns (settings, consecutive failed scans etc.)
- [x] Fields relevant for host checks (uptime, downtime, etc.)