### PR TITLE
Add ConsensusNode type and remove Retry

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.uber.org/zap"
@@ -18,11 +17,8 @@ func TestWalletAPI(t *testing.T) {
 	defer cancel()
 
 	// create indexer
-	network, genesis := testutil.V2Network()
-	indexer := testutils.NewIndexer(t, network, genesis, zap.NewNop())
-
-	// mine until v2 and fund the indexer
-	indexer.MineBlocksBlocking(ctx, t, indexer.WalletAddr(), network.HardforkV2.AllowHeight)
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := c.NewIndexer(t, zap.NewNop())
 
 	// assert events are being persisted
 	events, err := indexer.WalletEvents(ctx)
@@ -43,7 +39,7 @@ func TestWalletAPI(t *testing.T) {
 	}
 
 	// mine until funds mature
-	indexer.MineBlocksBlocking(ctx, t, types.Address{}, network.MaturityDelay)
+	c.MineBlocks(types.Address{}, c.Network().MaturityDelay)
 
 	// assert wallet is funded
 	res, err = indexer.Wallet(ctx)
@@ -60,11 +56,7 @@ func TestWalletAPI(t *testing.T) {
 	}
 
 	// create a wallet
-	w := testutils.NewWallet(t, network, genesis)
-	err = w.Connect(ctx, indexer.SyncerAddr())
-	if err != nil {
-		t.Fatal(err)
-	}
+	w := c.NewWallet()
 
 	// assert host wallet is empty
 	bal, err := w.Balance()
@@ -93,8 +85,7 @@ func TestWalletAPI(t *testing.T) {
 	}
 
 	// mine a block
-	indexer.MineBlocks(t, types.Address{}, 1)
-	indexer.BlockUntilSynced(ctx, t, w)
+	c.MineBlocks(types.Address{}, 1)
 
 	// assert siacons arrived successfully
 	bal, err = w.Balance()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,8 +18,8 @@ func TestWalletAPI(t *testing.T) {
 
 	// create indexer
 	c := testutils.NewConsensusNode(t, zap.NewNop())
-	indexer := c.NewIndexer(t, zap.NewNop())
-	c.MineBlocks(indexer.WalletAddr(), 1)
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+	c.MineBlocks(t, indexer.WalletAddr(), 1)
 
 	// assert events are being persisted
 	events, err := indexer.WalletEvents(ctx)
@@ -40,7 +40,7 @@ func TestWalletAPI(t *testing.T) {
 	}
 
 	// mine until funds mature
-	c.MineBlocks(types.Address{}, c.Network().MaturityDelay)
+	c.MineBlocks(t, types.Address{}, c.Network().MaturityDelay)
 
 	// assert wallet is funded
 	res, err = indexer.Wallet(ctx)
@@ -57,7 +57,7 @@ func TestWalletAPI(t *testing.T) {
 	}
 
 	// create a wallet
-	w := c.NewWallet()
+	w := testutils.NewWallet(t, c)
 
 	// assert host wallet is empty
 	bal, err := w.Balance()
@@ -86,7 +86,7 @@ func TestWalletAPI(t *testing.T) {
 	}
 
 	// mine a block
-	c.MineBlocks(types.Address{}, 1)
+	c.MineBlocks(t, types.Address{}, 1)
 
 	// assert siacons arrived successfully
 	bal, err = w.Balance()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -19,6 +19,7 @@ func TestWalletAPI(t *testing.T) {
 	// create indexer
 	c := testutils.NewConsensusNode(t, zap.NewNop())
 	indexer := c.NewIndexer(t, zap.NewNop())
+	c.MineBlocks(indexer.WalletAddr(), 1)
 
 	// assert events are being persisted
 	events, err := indexer.WalletEvents(ctx)

--- a/internal/testutils/cluster.go
+++ b/internal/testutils/cluster.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -102,7 +101,6 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	// - add volumes to hosts
 	// - wait for contracts
 
-	cluster.Sync(t)
 	return cluster
 }
 
@@ -181,44 +179,4 @@ func (c *Cluster) NewHosts(t testing.TB, n int) []*Host {
 		hosts = append(hosts, cn.NewHost(t, pk, c.log.Named("host-"+pk.PublicKey().String())))
 	}
 	return hosts
-}
-
-// Sync waits for the cluster to be in sync.
-func (c *Cluster) Sync(t testing.TB) {
-	t.Helper()
-
-	Retry(t, 100, 100*time.Millisecond, func() error {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		tip := c.Indexer.cm.Tip()
-		for _, h := range c.Hosts {
-			if h.c.Tip() != tip {
-				return fmt.Errorf("host's tip doesn't match indexer's: %v %v", tip, h.c.Tip())
-			}
-		}
-
-		if state, err := c.Indexer.State(ctx); err != nil {
-			return err
-		} else if state.ScanHeight < tip.Height {
-			return fmt.Errorf("indexer's scan height doesn't match tip: %v < %v", state.ScanHeight, tip.Height)
-		}
-
-		return nil
-	})
-}
-
-// Retry retries a function until it returns nil or the number of tries is
-// reached.
-func Retry(t testing.TB, tries int, durationBetweenAttempts time.Duration, fn func() error) {
-	t.Helper()
-	var err error
-	for i := 0; i < tries; i++ {
-		err = fn()
-		if err == nil {
-			return
-		}
-		time.Sleep(durationBetweenAttempts)
-	}
-	t.Fatal(err)
 }

--- a/internal/testutils/cluster.go
+++ b/internal/testutils/cluster.go
@@ -30,10 +30,9 @@ type (
 // Cluster is a test cluster that contains an indexer, hosts and other helper
 // types as needed for integration testing.
 type Cluster struct {
-	Network *consensus.Network
-	Genesis types.Block
-	Hosts   []*Host
-	Indexer *Indexer
+	ConsensusNode *ConsensusNode
+	Hosts         []*Host
+	Indexer       *Indexer
 
 	log *zap.Logger
 }
@@ -77,13 +76,17 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	}
 
 	// create indexer and mine until after V2 allowheight
-	indexer := NewIndexer(t, cfg.network, cfg.genesis, cfg.logger.Named("indexer"))
-	indexer.MineBlocks(t, indexer.wallet.Address(), cfg.network.HardforkV2.AllowHeight)
+	cn := NewConsensusNode(t, cfg.logger)
+	indexer := cn.NewIndexer(t, cfg.logger.Named("indexer"))
+	w, err := indexer.Wallet(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cn.MineBlocks(w.Address, 1)
 
 	// create cluster
 	cluster := &Cluster{
-		Network: cfg.network,
-		Genesis: cfg.genesis,
+		ConsensusNode: cn,
 
 		Indexer: indexer,
 		log:     cfg.logger,
@@ -132,26 +135,21 @@ func (c *Cluster) AnnounceHosts(ctx context.Context, t testing.TB, hosts ...*Hos
 		announced[h.PublicKey()] = struct{}{}
 	}
 
-	Retry(t, 100, 100*time.Millisecond, func() error {
-		hosts, err := c.Indexer.db.Hosts(ctx, 0, math.MaxInt)
-		if err != nil {
-			t.Fatal(err)
+	c.ConsensusNode.MineBlocks(types.VoidAddress, 1) // mine attestations
+	knownHosts, err := c.Indexer.db.Hosts(ctx, 0, math.MaxInt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	for _, h := range knownHosts {
+		if _, ok := announced[h.PublicKey]; !ok || h.LastAnnouncement.Before(start) {
+			continue
 		}
-
-		var n int
-		for _, h := range hosts {
-			if _, ok := announced[h.PublicKey]; !ok || h.LastAnnouncement.Before(start) {
-				continue
-			}
-			n++
-		}
-
-		if n != len(announced) {
-			c.Indexer.MineBlocks(t, types.Address{}, 1)
-			return fmt.Errorf("expected %d hosts to be announced, got %d", len(announced), n)
-		}
-		return nil
-	})
+		n++
+	}
+	if n != len(announced) {
+		t.Fatalf("expected %d hosts to be announced, got %d", len(announced), n)
+	}
 }
 
 // FundHosts funds the hosts with one block, then waits for the funds to mature.
@@ -159,9 +157,9 @@ func (c *Cluster) FundHosts(ctx context.Context, t testing.TB, hosts ...*Host) {
 	t.Helper()
 
 	for _, h := range hosts {
-		c.Indexer.MineBlocks(t, h.w.Address(), 1)
+		c.ConsensusNode.MineBlocks(h.w.Address(), 1)
 	}
-	c.Indexer.MineBlocksBlocking(ctx, t, types.Address{}, c.Network.MaturityDelay)
+	c.ConsensusNode.MineBlocks(types.Address{}, c.ConsensusNode.network.MaturityDelay)
 
 	for _, h := range hosts {
 		if res, err := h.w.Balance(); err != nil {
@@ -175,11 +173,12 @@ func (c *Cluster) FundHosts(ctx context.Context, t testing.TB, hosts ...*Host) {
 // NewHosts creates n new hosts using the cluster's network and genesis block.
 func (c *Cluster) NewHosts(t testing.TB, n int) []*Host {
 	t.Helper()
+	cn := c.ConsensusNode
 
 	var hosts []*Host
 	for i := 0; i < n; i++ {
 		pk := types.GeneratePrivateKey()
-		hosts = append(hosts, NewHost(t, pk, c.Network, c.Genesis, c.log.Named("host-"+pk.PublicKey().String())))
+		hosts = append(hosts, cn.NewHost(t, pk, c.log.Named("host-"+pk.PublicKey().String())))
 	}
 	return hosts
 }

--- a/internal/testutils/cluster.go
+++ b/internal/testutils/cluster.go
@@ -77,11 +77,7 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	// create indexer and mine until after V2 allowheight
 	cn := NewConsensusNode(t, cfg.logger)
 	indexer := cn.NewIndexer(t, cfg.logger.Named("indexer"))
-	w, err := indexer.Wallet(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	cn.MineBlocks(w.Address, 1)
+	cn.MineBlocks(indexer.WalletAddr(), 1)
 
 	// create cluster
 	cluster := &Cluster{

--- a/internal/testutils/cluster.go
+++ b/internal/testutils/cluster.go
@@ -75,13 +75,13 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	}
 
 	// create indexer and mine until after V2 allowheight
-	cn := NewConsensusNode(t, cfg.logger)
-	indexer := cn.NewIndexer(t, cfg.logger.Named("indexer"))
-	cn.MineBlocks(indexer.WalletAddr(), 1)
+	c := NewConsensusNode(t, cfg.logger)
+	indexer := NewIndexer(t, c, cfg.logger.Named("indexer"))
+	c.MineBlocks(t, indexer.WalletAddr(), 1)
 
 	// create cluster
 	cluster := &Cluster{
-		ConsensusNode: cn,
+		ConsensusNode: c,
 
 		Indexer: indexer,
 		log:     cfg.logger,
@@ -129,7 +129,7 @@ func (c *Cluster) AnnounceHosts(ctx context.Context, t testing.TB, hosts ...*Hos
 		announced[h.PublicKey()] = struct{}{}
 	}
 
-	c.ConsensusNode.MineBlocks(types.VoidAddress, 1) // mine attestations
+	c.ConsensusNode.MineBlocks(t, types.VoidAddress, 1) // mine attestations
 	knownHosts, err := c.Indexer.db.Hosts(ctx, 0, math.MaxInt)
 	if err != nil {
 		t.Fatal(err)
@@ -151,9 +151,9 @@ func (c *Cluster) FundHosts(ctx context.Context, t testing.TB, hosts ...*Host) {
 	t.Helper()
 
 	for _, h := range hosts {
-		c.ConsensusNode.MineBlocks(h.w.Address(), 1)
+		c.ConsensusNode.MineBlocks(t, h.w.Address(), 1)
 	}
-	c.ConsensusNode.MineBlocks(types.Address{}, c.ConsensusNode.network.MaturityDelay)
+	c.ConsensusNode.MineBlocks(t, types.Address{}, c.ConsensusNode.network.MaturityDelay)
 
 	for _, h := range hosts {
 		if res, err := h.w.Balance(); err != nil {

--- a/internal/testutils/consensusnode.go
+++ b/internal/testutils/consensusnode.go
@@ -1,0 +1,68 @@
+package testutils
+
+import (
+	"testing"
+	"time"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils"
+	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/testutil"
+	"go.uber.org/zap"
+)
+
+// ConsensusNode is a helper type that serves as the source of truth for
+// anything consensus-related during testing. It can be used to create test
+// types such as the Indexer or Wallet and will guarantee that a call to
+// `MineBlock` won't return before all created components are done subscribing
+// to the newly mined blocks.
+type ConsensusNode struct {
+	tb      testing.TB
+	cm      *chain.Manager
+	genesis types.Block
+	network *consensus.Network
+
+	syncFns []func()
+}
+
+// NewConsensusNode creates a new node ready for testing. It will mine enough
+// blocks to reach the V2 require height before returning.
+func NewConsensusNode(tb testing.TB, log *zap.Logger) *ConsensusNode {
+	network, genesis := testutil.V2Network()
+	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	if err != nil {
+		tb.Fatalf("failed to create chain store: %v", err)
+	}
+	cm := chain.NewManager(dbstore, tipState, chain.WithLog(log.Named("chain")))
+	c := &ConsensusNode{
+		cm:      cm,
+		tb:      tb,
+		genesis: genesis,
+		network: network,
+	}
+	c.MineBlocks(types.VoidAddress, network.HardforkV2.RequireHeight)
+	return c
+}
+
+// MineBlocks is a helper to mine blocks and broadcast the headers
+func (c *ConsensusNode) MineBlocks(addr types.Address, n uint64) {
+	c.tb.Helper()
+
+	for i := uint64(0); i < n; i++ {
+		b, ok := coreutils.MineBlock(c.cm, addr, 5*time.Second)
+		if !ok {
+			c.tb.Fatal("failed to mine block")
+		} else if err := c.cm.AddBlocks([]types.Block{b}); err != nil {
+			c.tb.Fatal(err)
+		}
+	}
+	for _, fn := range c.syncFns {
+		fn()
+	}
+}
+
+// Network returns the used network configuration of the ConsensusNode
+func (c *ConsensusNode) Network() *consensus.Network {
+	return c.network
+}

--- a/internal/testutils/consensusnode.go
+++ b/internal/testutils/consensusnode.go
@@ -18,7 +18,6 @@ import (
 // `MineBlock` won't return before all created components are done subscribing
 // to the newly mined blocks.
 type ConsensusNode struct {
-	tb      testing.TB
 	cm      *chain.Manager
 	genesis types.Block
 	network *consensus.Network
@@ -28,33 +27,32 @@ type ConsensusNode struct {
 
 // NewConsensusNode creates a new node ready for testing. It will mine enough
 // blocks to reach the V2 require height before returning.
-func NewConsensusNode(tb testing.TB, log *zap.Logger) *ConsensusNode {
+func NewConsensusNode(t testing.TB, log *zap.Logger) *ConsensusNode {
 	network, genesis := testutil.V2Network()
 	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
 	if err != nil {
-		tb.Fatalf("failed to create chain store: %v", err)
+		t.Fatalf("failed to create chain store: %v", err)
 	}
 	cm := chain.NewManager(dbstore, tipState, chain.WithLog(log.Named("chain")))
 	c := &ConsensusNode{
 		cm:      cm,
-		tb:      tb,
 		genesis: genesis,
 		network: network,
 	}
-	c.MineBlocks(types.VoidAddress, network.HardforkV2.RequireHeight)
+	c.MineBlocks(t, types.VoidAddress, network.HardforkV2.RequireHeight)
 	return c
 }
 
 // MineBlocks is a helper to mine blocks and broadcast the headers
-func (c *ConsensusNode) MineBlocks(addr types.Address, n uint64) {
-	c.tb.Helper()
+func (c *ConsensusNode) MineBlocks(t testing.TB, addr types.Address, n uint64) {
+	t.Helper()
 
 	for i := uint64(0); i < n; i++ {
 		b, ok := coreutils.MineBlock(c.cm, addr, 5*time.Second)
 		if !ok {
-			c.tb.Fatal("failed to mine block")
+			t.Fatal("failed to mine block")
 		} else if err := c.cm.AddBlocks([]types.Block{b}); err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 	}
 	for _, fn := range c.syncFns {
@@ -65,4 +63,10 @@ func (c *ConsensusNode) MineBlocks(addr types.Address, n uint64) {
 // Network returns the used network configuration of the ConsensusNode
 func (c *ConsensusNode) Network() *consensus.Network {
 	return c.network
+}
+
+// AddSyncFn adds a function to call whenever blocks are mined
+func (c *ConsensusNode) addSyncFn(fn func()) {
+	c.syncFns = append(c.syncFns, fn)
+	fn()
 }

--- a/internal/testutils/host.go
+++ b/internal/testutils/host.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/gateway"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -86,21 +85,15 @@ func (h *Host) PublicKey() types.PublicKey {
 }
 
 // NewHost creates a new host.
-func NewHost(t testing.TB, pk types.PrivateKey, n *consensus.Network, genesis types.Block, log *zap.Logger) *Host {
-	db, tipstate, err := chain.NewDBStore(chain.NewMemDB(), n, genesis)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cm := chain.NewManager(db, tipstate)
-
+func (c *ConsensusNode) NewHost(t testing.TB, pk types.PrivateKey, log *zap.Logger) *Host {
 	syncerListener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { syncerListener.Close() })
 
-	s := syncer.New(syncerListener, cm, testutil.NewEphemeralPeerStore(), gateway.Header{
-		GenesisID:  genesis.ID(),
+	s := syncer.New(syncerListener, c.cm, testutil.NewEphemeralPeerStore(), gateway.Header{
+		GenesisID:  c.genesis.ID(),
 		UniqueID:   gateway.GenerateUniqueID(),
 		NetAddress: syncerListener.Addr().String(),
 	},
@@ -112,7 +105,7 @@ func NewHost(t testing.TB, pk types.PrivateKey, n *consensus.Network, genesis ty
 	go s.Run()
 
 	ws := testutil.NewEphemeralWalletStore()
-	w, err := wallet.NewSingleAddressWallet(types.GeneratePrivateKey(), cm, ws)
+	w, err := wallet.NewSingleAddressWallet(types.GeneratePrivateKey(), c.cm, ws)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,34 +129,26 @@ func NewHost(t testing.TB, pk types.PrivateKey, n *consensus.Network, genesis ty
 		},
 	})
 	ss := testutil.NewEphemeralSectorStore()
-	c := testutil.NewEphemeralContractor(cm)
-	t.Cleanup(func() { c.Close() })
+	contractor := testutil.NewEphemeralContractor(c.cm)
+	t.Cleanup(func() { contractor.Close() })
 
-	reorgCh := make(chan struct{}, 1)
-	t.Cleanup(func() { close(reorgCh) })
-	go func() {
-		for range reorgCh {
-			reverted, applied, err := cm.UpdatesSince(w.Tip(), 1000)
-			if err != nil {
-				panic(err)
-			}
-
-			if err := ws.UpdateChainState(func(tx wallet.UpdateTx) error {
-				return w.UpdateChainState(tx, reverted, applied)
-			}); err != nil {
-				panic(err)
-			}
+	syncFn := func() {
+		c.tb.Helper()
+		reverted, applied, err := c.cm.UpdatesSince(w.Tip(), 1000)
+		if err != nil {
+			c.tb.Fatal(err)
 		}
-	}()
-	stop := cm.OnReorg(func(index types.ChainIndex) {
-		select {
-		case reorgCh <- struct{}{}:
-		default:
-		}
-	})
-	t.Cleanup(stop)
 
-	rs := rhp4.NewServer(pk, cm, s, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
+		if err := ws.UpdateChainState(func(tx wallet.UpdateTx) error {
+			return w.UpdateChainState(tx, reverted, applied)
+		}); err != nil {
+			c.tb.Fatal(err)
+		}
+	}
+	syncFn()
+	c.syncFns = append(c.syncFns, syncFn)
+
+	rs := rhp4.NewServer(pk, c.cm, s, contractor, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	rhp4Listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)
@@ -175,9 +160,9 @@ func NewHost(t testing.TB, pk types.PrivateKey, n *consensus.Network, genesis ty
 		pk: pk,
 		l:  rhp4Listener,
 
-		c:  c,
+		c:  contractor,
 		s:  s,
-		cm: cm,
+		cm: c.cm,
 		ss: ss,
 		sr: sr,
 		w:  w,

--- a/internal/testutils/host.go
+++ b/internal/testutils/host.go
@@ -133,20 +133,19 @@ func (c *ConsensusNode) NewHost(t testing.TB, pk types.PrivateKey, log *zap.Logg
 	t.Cleanup(func() { contractor.Close() })
 
 	syncFn := func() {
-		c.tb.Helper()
+		t.Helper()
 		reverted, applied, err := c.cm.UpdatesSince(w.Tip(), 1000)
 		if err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 
 		if err := ws.UpdateChainState(func(tx wallet.UpdateTx) error {
 			return w.UpdateChainState(tx, reverted, applied)
 		}); err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 	}
-	syncFn()
-	c.syncFns = append(c.syncFns, syncFn)
+	c.addSyncFn(syncFn)
 
 	rs := rhp4.NewServer(pk, c.cm, s, contractor, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	rhp4Listener, err := net.Listen("tcp", ":0")

--- a/internal/testutils/host_test.go
+++ b/internal/testutils/host_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/testutil"
 	rhp "go.sia.tech/indexd/internal/rhp/v4"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
@@ -16,8 +15,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestHost(t *testing.T) {
-	n, genesis := testutil.V2Network()
-	h := NewHost(t, types.GeneratePrivateKey(), n, genesis, zap.NewNop())
+	cn := NewConsensusNode(t, zap.NewNop())
+	h := cn.NewHost(t, types.GeneratePrivateKey(), zap.NewNop())
 
 	settings, err := rhp.New().Settings(context.Background(), h.PublicKey(), h.Addr())
 	if err != nil {

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -12,10 +12,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/gateway"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/testutil"
@@ -42,18 +40,12 @@ type Indexer struct {
 
 // NewIndexer creates a new indexer for testing that is automatically closed up
 // after the test is finished.
-func NewIndexer(t testing.TB, n *consensus.Network, genesis types.Block, log *zap.Logger) *Indexer {
+func (c *ConsensusNode) NewIndexer(t testing.TB, log *zap.Logger) *Indexer {
 	// prepare store
 	store := NewDB(t, log)
 
-	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesis)
-	if err != nil {
-		t.Fatalf("failed to create chain store: %v", err)
-	}
-	cm := chain.NewManager(dbstore, tipState, chain.WithLog(log.Named("chain")))
-
 	walletKey := types.GeneratePrivateKey()
-	wm, err := wallet.NewSingleAddressWallet(walletKey, cm, store, wallet.WithLogger(log.Named("wallet")), wallet.WithReservationDuration(3*time.Hour))
+	wm, err := wallet.NewSingleAddressWallet(walletKey, c.cm, store, wallet.WithLogger(log.Named("wallet")), wallet.WithReservationDuration(3*time.Hour))
 	if err != nil {
 		t.Fatalf("failed to create wallet: %v", err)
 	}
@@ -63,7 +55,16 @@ func NewIndexer(t testing.TB, n *consensus.Network, genesis types.Block, log *za
 		t.Fatalf("failed to create host manager: %v", err)
 	}
 
-	sub := subscriber.New(cm, hm, wm, store, subscriber.WithLogger(log.Named("subscriber")))
+	sub := subscriber.New(c.cm, hm, wm, store, subscriber.WithLogger(log.Named("subscriber")))
+
+	// sync subscriber
+	syncFn := func() {
+		c.tb.Helper()
+		if err := sub.Sync(); err != nil {
+			c.tb.Fatal(err)
+		}
+	}
+	c.syncFns = append(c.syncFns, syncFn)
 
 	syncerListener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
@@ -71,8 +72,8 @@ func NewIndexer(t testing.TB, n *consensus.Network, genesis types.Block, log *za
 	}
 
 	// peers will reject us if our hostname is empty or unspecified, so use loopback
-	s := syncer.New(syncerListener, cm, testutil.NewEphemeralPeerStore(), gateway.Header{
-		GenesisID:  genesis.ID(),
+	s := syncer.New(syncerListener, c.cm, testutil.NewEphemeralPeerStore(), gateway.Header{
+		GenesisID:  c.genesis.ID(),
 		UniqueID:   gateway.GenerateUniqueID(),
 		NetAddress: syncerListener.Addr().String(),
 	},
@@ -87,7 +88,7 @@ func NewIndexer(t testing.TB, n *consensus.Network, genesis types.Block, log *za
 
 	password := hex.EncodeToString(frand.Bytes(16))
 	web := http.Server{
-		Handler: jape.BasicAuth(password)(api.NewServer(cm, s, wm, store, apiOpts...)),
+		Handler: jape.BasicAuth(password)(api.NewServer(c.cm, s, wm, store, apiOpts...)),
 	}
 
 	httpListener, err := net.Listen("tcp4", "127.0.0.1:0")
@@ -125,58 +126,10 @@ func NewIndexer(t testing.TB, n *consensus.Network, genesis types.Block, log *za
 		Client: api.NewClient(fmt.Sprintf("http://%s", httpListener.Addr().String()), password),
 
 		db:     store,
-		cm:     cm,
+		cm:     c.cm,
 		syncer: s,
 		wallet: wm,
 	}
-}
-
-// BlockUntilSynced blocks until the indexer is synced with the peer.
-func (idx *Indexer) BlockUntilSynced(ctx context.Context, t testing.TB, peer interface {
-	Tip() (types.ChainIndex, error)
-}) {
-	t.Helper()
-
-	Retry(t, 100, 100*time.Millisecond, func() error {
-		if state, err := idx.State(ctx); err != nil {
-			t.Fatal(err)
-		} else if tip, err := peer.Tip(); err != nil {
-			t.Fatal(err)
-		} else if tip.Height != state.ScanHeight {
-			return fmt.Errorf("peer unsynced %d != %d", tip.Height, state.ScanHeight)
-		}
-		return nil
-	})
-}
-
-// MineBlocks is a helper to mine blocks and broadcast the headers
-func (idx *Indexer) MineBlocks(t testing.TB, addr types.Address, n uint64) {
-	t.Helper()
-
-	for i := uint64(0); i < n; i++ {
-		b, ok := coreutils.MineBlock(idx.cm, addr, 5*time.Second)
-		if !ok {
-			t.Fatal("failed to mine block")
-		} else if err := idx.cm.AddBlocks([]types.Block{b}); err != nil {
-			t.Fatal(err)
-		}
-
-		if b.V2 == nil {
-			idx.syncer.BroadcastHeader(b.Header())
-		} else {
-			idx.syncer.BroadcastV2BlockOutline(gateway.OutlineBlock(b, idx.cm.PoolTransactions(), idx.cm.V2PoolTransactions()))
-		}
-	}
-}
-
-// MineBlocksBlocking is a helper to mine blocks and broadcast the headers, this
-// method will block until the scan height reaches the target height after n
-// blocks got mined.
-func (idx *Indexer) MineBlocksBlocking(ctx context.Context, t testing.TB, addr types.Address, n uint64) {
-	t.Helper()
-
-	idx.MineBlocks(t, addr, n)
-	idx.BlockUntilSynced(ctx, t, idx)
 }
 
 // SyncerAddr returns the address of the syncer.

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -40,7 +40,7 @@ type Indexer struct {
 
 // NewIndexer creates a new indexer for testing that is automatically closed up
 // after the test is finished.
-func (c *ConsensusNode) NewIndexer(t testing.TB, log *zap.Logger) *Indexer {
+func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 	// prepare store
 	store := NewDB(t, log)
 
@@ -59,12 +59,12 @@ func (c *ConsensusNode) NewIndexer(t testing.TB, log *zap.Logger) *Indexer {
 
 	// sync subscriber
 	syncFn := func() {
-		c.tb.Helper()
+		t.Helper()
 		if err := sub.Sync(); err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 	}
-	c.syncFns = append(c.syncFns, syncFn)
+	c.addSyncFn(syncFn)
 
 	syncerListener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {

--- a/internal/testutils/indexer_test.go
+++ b/internal/testutils/indexer_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"testing"
 
-	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/indexd/api"
 	"go.uber.org/zap"
 )
 
 func TestIndexer(t *testing.T) {
-	n, genesis := testutil.V2Network()
-	indexer := NewIndexer(t, n, genesis, zap.NewNop())
+	c := NewConsensusNode(t, zap.NewNop())
+	indexer := c.NewIndexer(t, zap.NewNop())
 
 	state, err := indexer.State(context.Background())
 	if err != nil {

--- a/internal/testutils/indexer_test.go
+++ b/internal/testutils/indexer_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestIndexer(t *testing.T) {
 	c := NewConsensusNode(t, zap.NewNop())
-	indexer := c.NewIndexer(t, zap.NewNop())
+	indexer := NewIndexer(t, c, zap.NewNop())
 
 	state, err := indexer.State(context.Background())
 	if err != nil {

--- a/internal/testutils/wallet.go
+++ b/internal/testutils/wallet.go
@@ -1,96 +1,39 @@
 package testutils
 
 import (
-	"context"
-	"net"
-	"testing"
-	"time"
+	"math"
 
-	"go.sia.tech/core/consensus"
-	"go.sia.tech/core/gateway"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/coreutils/wallet"
 )
 
-type (
-	// Wallet is an ephemeral wallet that can be used for testing.
-	Wallet struct {
-		*wallet.SingleAddressWallet
-		s  *syncer.Syncer
-		ws *testutil.EphemeralWalletStore
-	}
-)
-
-// NewWallet creates a new ephemeral wallet.
-func NewWallet(t testing.TB, n *consensus.Network, genesis types.Block) *Wallet {
-	db, tipstate, err := chain.NewDBStore(chain.NewMemDB(), n, genesis)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cm := chain.NewManager(db, tipstate)
-
-	syncerListener, err := net.Listen("tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { syncerListener.Close() })
-
-	s := syncer.New(syncerListener, cm, testutil.NewEphemeralPeerStore(), gateway.Header{
-		GenesisID:  genesis.ID(),
-		UniqueID:   gateway.GenerateUniqueID(),
-		NetAddress: syncerListener.Addr().String(),
-	},
-		syncer.WithSendBlocksTimeout(2*time.Second),
-		syncer.WithRPCTimeout(2*time.Second),
-		syncer.WithSyncInterval(100*time.Millisecond),
-	)
-	t.Cleanup(func() { s.Close() })
-	go s.Run()
-
+func (c *ConsensusNode) NewWallet() *wallet.SingleAddressWallet {
 	ws := testutil.NewEphemeralWalletStore()
-	w, err := wallet.NewSingleAddressWallet(types.GeneratePrivateKey(), cm, ws)
+	w, err := wallet.NewSingleAddressWallet(types.GeneratePrivateKey(), c.cm, ws)
 	if err != nil {
-		t.Fatal(err)
+		c.tb.Fatal(err)
 	}
-	t.Cleanup(func() { w.Close() })
+	c.tb.Cleanup(func() { w.Close() })
 
-	reorgCh := make(chan struct{}, 1)
-	t.Cleanup(func() { close(reorgCh) })
-	go func() {
-		for range reorgCh {
-			reverted, applied, err := cm.UpdatesSince(w.Tip(), 1000)
-			if err != nil {
-				panic(err)
-			}
-
-			if err := ws.UpdateChainState(func(tx wallet.UpdateTx) error {
-				return w.UpdateChainState(tx, reverted, applied)
-			}); err != nil {
-				panic(err)
-			}
+	// sync the wallet
+	syncFn := func() {
+		c.tb.Helper()
+		index, err := ws.Tip()
+		if err != nil {
+			c.tb.Fatal(err)
 		}
-	}()
-	stop := cm.OnReorg(func(index types.ChainIndex) {
-		select {
-		case reorgCh <- struct{}{}:
-		default:
+		reverted, applied, err := c.cm.UpdatesSince(index, math.MaxInt)
+		if err != nil {
+			c.tb.Fatal(err)
 		}
-	})
-	t.Cleanup(stop)
-
-	return &Wallet{w, s, ws}
-}
-
-// Connect connects the wallet's syncer with the given peer.
-func (w *Wallet) Connect(ctx context.Context, addr string) error {
-	_, err := w.s.Connect(ctx, addr)
-	return err
-}
-
-// Tip returns the tip of the wallet.
-func (w *Wallet) Tip() (types.ChainIndex, error) {
-	return w.ws.Tip()
+		if err := ws.UpdateChainState(func(tx wallet.UpdateTx) error {
+			return w.UpdateChainState(tx, reverted, applied)
+		}); err != nil {
+			c.tb.Fatal(err)
+		}
+	}
+	syncFn()
+	c.syncFns = append(c.syncFns, syncFn)
+	return w
 }

--- a/internal/testutils/wallet.go
+++ b/internal/testutils/wallet.go
@@ -8,6 +8,8 @@ import (
 	"go.sia.tech/coreutils/wallet"
 )
 
+// NewWallet creates a new SingleAddressWallet for testing which is connected to
+// all the other components created via the ConsensusNode.
 func (c *ConsensusNode) NewWallet() *wallet.SingleAddressWallet {
 	ws := testutil.NewEphemeralWalletStore()
 	w, err := wallet.NewSingleAddressWallet(types.GeneratePrivateKey(), c.cm, ws)

--- a/internal/testutils/wallet.go
+++ b/internal/testutils/wallet.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"math"
+	"testing"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/testutil"
@@ -10,32 +11,31 @@ import (
 
 // NewWallet creates a new SingleAddressWallet for testing which is connected to
 // all the other components created via the ConsensusNode.
-func (c *ConsensusNode) NewWallet() *wallet.SingleAddressWallet {
+func NewWallet(t testing.TB, c *ConsensusNode) *wallet.SingleAddressWallet {
 	ws := testutil.NewEphemeralWalletStore()
 	w, err := wallet.NewSingleAddressWallet(types.GeneratePrivateKey(), c.cm, ws)
 	if err != nil {
-		c.tb.Fatal(err)
+		t.Fatal(err)
 	}
-	c.tb.Cleanup(func() { w.Close() })
+	t.Cleanup(func() { w.Close() })
 
 	// sync the wallet
 	syncFn := func() {
-		c.tb.Helper()
+		t.Helper()
 		index, err := ws.Tip()
 		if err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 		reverted, applied, err := c.cm.UpdatesSince(index, math.MaxInt)
 		if err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 		if err := ws.UpdateChainState(func(tx wallet.UpdateTx) error {
 			return w.UpdateChainState(tx, reverted, applied)
 		}); err != nil {
-			c.tb.Fatal(err)
+			t.Fatal(err)
 		}
 	}
-	syncFn()
-	c.syncFns = append(c.syncFns, syncFn)
+	c.addSyncFn(syncFn)
 	return w
 }

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -3,6 +3,7 @@ package subscriber
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"go.sia.tech/core/types"
@@ -52,6 +53,7 @@ type (
 type Subscriber struct {
 	updateBatchSize int
 	shutdownFn      func()
+	syncMu          sync.Mutex
 
 	cm    ChainManager
 	hm    HostManager
@@ -106,7 +108,7 @@ func New(cm ChainManager, hm HostManager, wm WalletManager, store Store, opts ..
 		for range reorgCh {
 			select {
 			case <-reorgCh:
-				err := s.syncDB()
+				err := s.Sync()
 				if err != nil {
 					s.log.Panic("failed to sync database", zap.Error(err))
 				}
@@ -118,7 +120,10 @@ func New(cm ChainManager, hm HostManager, wm WalletManager, store Store, opts ..
 	return s
 }
 
-func (s *Subscriber) syncDB() error {
+func (s *Subscriber) Sync() error {
+	s.syncMu.Lock()
+	defer s.syncMu.Unlock()
+
 	index, err := s.tip()
 	if err != nil {
 		return fmt.Errorf("failed to get last scanned index: %w", err)

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -120,6 +120,9 @@ func New(cm ChainManager, hm HostManager, wm WalletManager, store Store, opts ..
 	return s
 }
 
+// Sync syncs the subscriber with the chain manager. It's usually not necessary
+// to manually call this since the Subscriber will do that itself but it can be
+// used to guarantee the subscriber is synced at a given point in time.
 func (s *Subscriber) Sync() error {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()


### PR DESCRIPTION
This PR is based on https://github.com/SiaFoundation/indexd/pull/38 to demonstrate how it can potentially clean up our testing.

The idea here is to create a `ConsensusNode` type which is the source of truth for our tests when it comes to consensus. It can be used to mine blocks and will blockingly update all components that need to be subscribed to consensus.

This effectively eliminates the source of 90% of our NDFs while keeping our tests fast and avoiding a `Retry` altogether.

If we ever want to do a full stack integration test which relies only on the `Subscriber`s spawned goroutine, we can disable the manual sync by adding a config option to the `ConsensusNode` which prevents the implicit syncing. 

