### PR TITLE
Update contract element proofs 

### DIFF
--- a/contracts/chain.go
+++ b/contracts/chain.go
@@ -6,6 +6,7 @@ import (
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/wallet"
 	"go.uber.org/zap"
 )
 
@@ -13,8 +14,9 @@ type (
 	// UpdateTx defines what the contract manager needs to atomically process a
 	// chain update in the database.
 	UpdateTx interface {
+		ContractElements() ([]types.V2FileContractElement, error)
 		IsKnownContract(contractID types.FileContractID) (bool, error)
-		UpdateContractElement(fce types.V2FileContractElement) error
+		UpdateContractElements(fces ...types.V2FileContractElement) error
 		UpdateContractState(contractID types.FileContractID, state ContractState) error
 	}
 
@@ -59,8 +61,6 @@ func (m *ContractManager) UpdateChainState(tx UpdateTx, reverted []chain.RevertU
 		}
 	}
 
-	// TODO: update file contract element proofs
-
 	// TODO: reject all contracts that have been pending for more than 'contractRejectBuffer'
 
 	// TODO: broadcast resolutions for expired contracts
@@ -84,7 +84,9 @@ func (m *ContractManager) applyChainUpdate(tx *updateTx, cau chain.ApplyUpdate) 
 			return fmt.Errorf("failed to apply contract diff: %w", err)
 		}
 	}
-	return nil
+
+	// update state element proofs
+	return updateContractElementProofs(tx, cau)
 }
 
 func (m *ContractManager) applyContractDiff(tx *updateTx, diff consensus.V2FileContractElementDiff) error {
@@ -111,7 +113,7 @@ func (m *ContractManager) applyContractDiff(tx *updateTx, diff consensus.V2FileC
 	if rev, ok := diff.V2RevisionElement(); ok {
 		fce = rev
 	}
-	if err := tx.UpdateContractElement(fce); err != nil {
+	if err := tx.UpdateContractElements(fce); err != nil {
 		return fmt.Errorf("failed to update contract element: %w", err)
 	}
 	return nil
@@ -128,7 +130,7 @@ func (m *ContractManager) revertChainUpdate(tx *updateTx, cru chain.RevertUpdate
 			return fmt.Errorf("failed to apply contract diff: %w", err)
 		}
 	}
-	return nil
+	return updateContractElementProofs(tx, cru)
 }
 
 func (m *ContractManager) revertContractDiff(tx *updateTx, diff consensus.V2FileContractElementDiff) error {
@@ -155,8 +157,22 @@ func (m *ContractManager) revertContractDiff(tx *updateTx, diff consensus.V2File
 	if rev, ok := diff.V2RevisionElement(); ok {
 		fce = rev
 	}
-	if err := tx.UpdateContractElement(fce); err != nil {
+	if err := tx.UpdateContractElements(fce); err != nil {
 		return fmt.Errorf("failed to update contract element: %w", err)
+	}
+	return nil
+}
+
+func updateContractElementProofs(tx *updateTx, updater wallet.ProofUpdater) error {
+	fces, err := tx.ContractElements()
+	if err != nil {
+		return err
+	}
+	for i := range fces {
+		updater.UpdateElementProof(&fces[i].StateElement)
+	}
+	if err := tx.UpdateContractElements(fces...); err != nil {
+		return fmt.Errorf("failed to update contract state elements: %w", err)
 	}
 	return nil
 }

--- a/contracts/chain.go
+++ b/contracts/chain.go
@@ -17,7 +17,7 @@ type (
 	UpdateTx interface {
 		ContractElements() ([]types.V2FileContractElement, error)
 		IsKnownContract(contractID types.FileContractID) (bool, error)
-		RejectPendingContracts(maxAge time.Duration) error
+		RejectPendingContracts(maxFormation time.Time) error
 		UpdateContractElements(fces ...types.V2FileContractElement) error
 		UpdateContractState(contractID types.FileContractID, state ContractState) error
 	}
@@ -64,7 +64,8 @@ func (m *ContractManager) UpdateChainState(tx UpdateTx, reverted []chain.RevertU
 	}
 
 	// reject all contracts that have been pending for more than 'contractRejectBuffer'
-	if err := tx.RejectPendingContracts(m.contractRejectBuffer); err != nil {
+	maxFormation := time.Now().Add(-m.contractRejectBuffer)
+	if err := tx.RejectPendingContracts(maxFormation); err != nil {
 		return fmt.Errorf("failed to reject pending contracts: %w", err)
 	}
 

--- a/contracts/chain.go
+++ b/contracts/chain.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"time"
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
@@ -16,6 +17,7 @@ type (
 	UpdateTx interface {
 		ContractElements() ([]types.V2FileContractElement, error)
 		IsKnownContract(contractID types.FileContractID) (bool, error)
+		RejectPendingContracts(maxAge time.Duration) error
 		UpdateContractElements(fces ...types.V2FileContractElement) error
 		UpdateContractState(contractID types.FileContractID, state ContractState) error
 	}
@@ -61,7 +63,10 @@ func (m *ContractManager) UpdateChainState(tx UpdateTx, reverted []chain.RevertU
 		}
 	}
 
-	// TODO: reject all contracts that have been pending for more than 'contractRejectBuffer'
+	// reject all contracts that have been pending for more than 'contractRejectBuffer'
+	if err := tx.RejectPendingContracts(m.contractRejectBuffer); err != nil {
+		return fmt.Errorf("failed to reject pending contracts: %w", err)
+	}
 
 	// TODO: broadcast resolutions for expired contracts
 	// 'expiredContractBroadcastBuffer' blocks after their window end to give

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -10,6 +10,20 @@ import (
 	"go.sia.tech/coreutils/wallet"
 )
 
+type mockProofUpdater struct {
+	updateFn func(*types.StateElement)
+}
+
+func (u *mockProofUpdater) UpdateElementProof(stateElement *types.StateElement) {
+	u.updateFn(stateElement)
+}
+
+// newMockProofUpdater creates a mock implementation of ProofUpdater with a custom
+// update function.
+func newMockProofUpdater(updateFn func(*types.StateElement)) wallet.ProofUpdater {
+	return &mockProofUpdater{updateFn}
+}
+
 // mockUpdateTx is a mocked implementation of UpdateTx which allows for unit
 // testing the contract manager's chain updates without a full database.
 type mockUpdateTx struct {
@@ -17,6 +31,7 @@ type mockUpdateTx struct {
 	state     map[types.FileContractID]ContractState
 }
 
+// newMockUpdateTx creates a new mock UpdateTx.
 func newMockUpdateTx() *mockUpdateTx {
 	return &mockUpdateTx{
 		contracts: make(map[types.FileContractID]types.V2FileContractElement),
@@ -182,4 +197,41 @@ func TestApplyRevertDiff(t *testing.T) {
 		V2FileContractElement: fce,
 	})
 	assertContract(ContractStatePending)
+}
+
+func TestUpdateContractElementProofs(t *testing.T) {
+	contract := types.V2FileContractElement{
+		ID: types.FileContractID{1},
+		StateElement: types.StateElement{
+			LeafIndex:   uint64(1),
+			MerkleProof: []types.Hash256{{1}},
+		},
+		V2FileContract: types.V2FileContract{
+			HostPublicKey:   types.PublicKey{1},
+			RenterPublicKey: types.PublicKey{1},
+		},
+	}
+
+	// mock the update tx and add a contract
+	mock := newMockUpdateTx()
+	mock.AddContract(contract)
+	updateTx := &updateTx{
+		UpdateTx:       mock,
+		knownContracts: make(map[types.FileContractID]bool),
+	}
+
+	// check initial contract
+	if fce, _ := mock.Contract(contract.ID); !reflect.DeepEqual(fce, contract) {
+		t.Fatalf("mismatch \n%+v\n%+v", fce, contract)
+	}
+
+	// update proof on contract
+	contract2 := contract
+	contract2.StateElement.MerkleProof = []types.Hash256{{2}}
+	updateContractElementProofs(updateTx, &mockProofUpdater{updateFn: func(stateElement *types.StateElement) {
+		stateElement.MerkleProof = contract2.StateElement.MerkleProof
+	}})
+	if fce, _ := mock.Contract(contract2.ID); !reflect.DeepEqual(fce, contract2) {
+		t.Fatalf("mismatch \n%+v\n%+v", fce, contract2)
+	}
 }

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -70,7 +70,7 @@ func (tx *mockUpdateTx) IsKnownContract(contractID types.FileContractID) (bool, 
 	return ok, nil
 }
 
-func (tx *mockUpdateTx) RejectPendingContracts(time.Duration) error {
+func (tx *mockUpdateTx) RejectPendingContracts(time.Time) error {
 	panic("not implemented")
 }
 

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -24,6 +24,14 @@ func newMockUpdateTx() *mockUpdateTx {
 	}
 }
 
+func (tx *mockUpdateTx) ContractElements() ([]types.V2FileContractElement, error) {
+	var stateElements []types.V2FileContractElement
+	for _, fce := range tx.contracts {
+		stateElements = append(stateElements, fce)
+	}
+	return stateElements, nil
+}
+
 func (tx *mockUpdateTx) AddContract(fce types.V2FileContractElement) {
 	tx.contracts[fce.ID] = fce
 	tx.state[fce.ID] = ContractStatePending
@@ -46,8 +54,10 @@ func (tx *mockUpdateTx) IsKnownContract(contractID types.FileContractID) (bool, 
 	return ok, nil
 }
 
-func (tx *mockUpdateTx) UpdateContractElement(fce types.V2FileContractElement) error {
-	tx.contracts[fce.ID] = fce
+func (tx *mockUpdateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {
+	for _, fce := range fces {
+		tx.contracts[fce.ID] = fce
+	}
 	return nil
 }
 

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -18,12 +18,6 @@ func (u *mockProofUpdater) UpdateElementProof(stateElement *types.StateElement) 
 	u.updateFn(stateElement)
 }
 
-// newMockProofUpdater creates a mock implementation of ProofUpdater with a custom
-// update function.
-func newMockProofUpdater(updateFn func(*types.StateElement)) wallet.ProofUpdater {
-	return &mockProofUpdater{updateFn}
-}
-
 // mockUpdateTx is a mocked implementation of UpdateTx which allows for unit
 // testing the contract manager's chain updates without a full database.
 type mockUpdateTx struct {

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
@@ -39,17 +40,17 @@ func newMockUpdateTx() *mockUpdateTx {
 	}
 }
 
+func (tx *mockUpdateTx) AddContract(fce types.V2FileContractElement) {
+	tx.contracts[fce.ID] = fce
+	tx.state[fce.ID] = ContractStatePending
+}
+
 func (tx *mockUpdateTx) ContractElements() ([]types.V2FileContractElement, error) {
 	var stateElements []types.V2FileContractElement
 	for _, fce := range tx.contracts {
 		stateElements = append(stateElements, fce)
 	}
 	return stateElements, nil
-}
-
-func (tx *mockUpdateTx) AddContract(fce types.V2FileContractElement) {
-	tx.contracts[fce.ID] = fce
-	tx.state[fce.ID] = ContractStatePending
 }
 
 func (tx *mockUpdateTx) Contract(contractID types.FileContractID) (types.V2FileContractElement, ContractState) {
@@ -67,6 +68,10 @@ func (tx *mockUpdateTx) Contract(contractID types.FileContractID) (types.V2FileC
 func (tx *mockUpdateTx) IsKnownContract(contractID types.FileContractID) (bool, error) {
 	_, ok := tx.contracts[contractID]
 	return ok, nil
+}
+
+func (tx *mockUpdateTx) RejectPendingContracts(time.Duration) error {
+	panic("not implemented")
 }
 
 func (tx *mockUpdateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"time"
 
 	"go.sia.tech/core/types"
 )
@@ -39,6 +40,7 @@ type (
 		ID      types.FileContractID `json:"id"`
 		HostKey types.PublicKey      `json:"hostKey"`
 
+		Formation        time.Time            `json:"formation"`
 		ProofHeight      uint64               `json:"proofHeight"`      // start of the contract's proof window
 		ExpirationHeight uint64               `json:"expirationHeight"` // end of the contract's proof window
 		RenewedFrom      types.FileContractID `json:"renewedFrom"`

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -170,6 +170,7 @@ CREATE TABLE contracts (
   contract_id BYTEA NOT NULL UNIQUE DEFERRABLE,
 
   -- lifetime related columns
+  formation TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   proof_height BIGINT NOT NULL, -- start of proof window
   expiration_height BIGINT NOT NULL, -- end of proof window
   renewed_from INTEGER REFERENCES contracts(id) UNIQUE DEFERRABLE,
@@ -194,6 +195,7 @@ CREATE TABLE contracts (
   fund_account_spending DECIMAL(50, 0) NOT NULL DEFAULT 0,
   sector_roots_spending DECIMAL(50, 0) NOT NULL DEFAULT 0
 );
+CREATE INDEX contracts_state_formation_idx ON contracts(state, formation); -- for rejecting expired contracts
 
 CREATE TABLE contract_elements (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"go.sia.tech/core/types"
@@ -122,7 +123,7 @@ func (s *Store) Contract(ctx context.Context, contractID types.FileContractID) (
 	var contract contracts.Contract
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		contract, err = scanContract(tx.QueryRow(ctx, `
-SELECT c.contract_id, h.public_key, c.proof_height, c.expiration_height, c_from.contract_id, c_to.contract_id, c.state, c.capacity, c.size, c.contract_price, c.initial_allowance, c.miner_fee, c.good, c.append_sector_spending, c.free_sector_spending, c.fund_account_spending, c.sector_roots_spending
+SELECT c.contract_id, c.formation, h.public_key, c.proof_height, c.expiration_height, c_from.contract_id, c_to.contract_id, c.state, c.capacity, c.size, c.contract_price, c.initial_allowance, c.miner_fee, c.good, c.append_sector_spending, c.free_sector_spending, c.fund_account_spending, c.sector_roots_spending
 FROM contracts c
 INNER JOIN hosts h ON c.host_id = h.id
 LEFT JOIN contracts c_from ON c.renewed_from = c_from.id
@@ -180,6 +181,12 @@ func (tx *updateTx) IsKnownContract(contractID types.FileContractID) (bool, erro
 	return exists, nil
 }
 
+func (tx *updateTx) RejectPendingContracts(maxAge time.Duration) error {
+	_, err := tx.tx.Exec(tx.ctx, `UPDATE contracts SET state = $1 WHERE state = $2 AND NOW() > formation + $3`,
+		sqlContractState(contracts.ContractStateRejected), sqlContractState(contracts.ContractStatePending), maxAge)
+	return err
+}
+
 func (tx *updateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {
 	for _, fce := range fces {
 		_, err := tx.tx.Exec(tx.ctx, `
@@ -208,6 +215,7 @@ func (tx *updateTx) UpdateContractState(contractID types.FileContractID, state c
 func scanContract(row scanner) (contracts.Contract, error) {
 	var c contracts.Contract
 	err := row.Scan((*sqlHash256)(&c.ID),
+		&c.Formation,
 		(*sqlPublicKey)(&c.HostKey),
 		&c.ProofHeight, &c.ExpirationHeight,
 		asNullable((*sqlHash256)(&c.RenewedFrom)),

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -154,6 +154,22 @@ func (s *Store) SetContractBad(contractID types.FileContractID) error {
 	})
 }
 
+func (tx *updateTx) ContractElements() ([]types.V2FileContractElement, error) {
+	rows, err := tx.tx.Query(tx.ctx, `SELECT contract_id, contract, leaf_index, merkle_proof FROM contract_elements`)
+	if err != nil {
+		return nil, err
+	}
+	var fces []types.V2FileContractElement
+	for rows.Next() {
+		fce, err := scanContractElement(rows)
+		if err != nil {
+			return nil, err
+		}
+		fces = append(fces, fce)
+	}
+	return fces, rows.Err()
+}
+
 func (tx *updateTx) IsKnownContract(contractID types.FileContractID) (bool, error) {
 	var exists bool
 	err := tx.tx.QueryRow(tx.ctx, `SELECT EXISTS (SELECT 1 FROM contracts WHERE contract_id = $1)`, sqlHash256(contractID)).
@@ -164,15 +180,20 @@ func (tx *updateTx) IsKnownContract(contractID types.FileContractID) (bool, erro
 	return exists, nil
 }
 
-func (tx *updateTx) UpdateContractElement(fce types.V2FileContractElement) error {
-	_, err := tx.tx.Exec(tx.ctx, `
+func (tx *updateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {
+	for _, fce := range fces {
+		_, err := tx.tx.Exec(tx.ctx, `
 INSERT INTO contract_elements (contract_id, contract, leaf_index, merkle_proof)
 VALUES (
   (SELECT id FROM contracts WHERE contract_id = $1),
   $2, $3, $4
 ) ON CONFLICT (contract_id) DO UPDATE SET contract = EXCLUDED.contract, leaf_index = EXCLUDED.leaf_index, merkle_proof = EXCLUDED.merkle_proof
 `, sqlHash256(fce.ID), (*sqlFileContract)(&fce.V2FileContract), fce.StateElement.LeafIndex, sqlMerkleProof(fce.StateElement.MerkleProof))
-	return err
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // UpdateContractState updates the state of a contract to the provided one.

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -155,7 +155,11 @@ func (s *Store) SetContractBad(contractID types.FileContractID) error {
 }
 
 func (tx *updateTx) ContractElements() ([]types.V2FileContractElement, error) {
-	rows, err := tx.tx.Query(tx.ctx, `SELECT contract_id, contract, leaf_index, merkle_proof FROM contract_elements`)
+	rows, err := tx.tx.Query(tx.ctx, `
+SELECT c.contract_id, fces.contract, fces.leaf_index, fces.merkle_proof
+FROM contract_elements fces
+INNER JOIN contracts c ON fces.contract_id = c.id
+`)
 	if err != nil {
 		return nil, err
 	}

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -181,9 +181,9 @@ func (tx *updateTx) IsKnownContract(contractID types.FileContractID) (bool, erro
 	return exists, nil
 }
 
-func (tx *updateTx) RejectPendingContracts(maxAge time.Duration) error {
-	_, err := tx.tx.Exec(tx.ctx, `UPDATE contracts SET state = $1 WHERE state = $2 AND NOW() > formation + $3`,
-		sqlContractState(contracts.ContractStateRejected), sqlContractState(contracts.ContractStatePending), maxAge)
+func (tx *updateTx) RejectPendingContracts(maxFormation time.Time) error {
+	_, err := tx.tx.Exec(tx.ctx, `UPDATE contracts SET state = $1 WHERE state = $2 AND formation < $3`,
+		sqlContractState(contracts.ContractStateRejected), sqlContractState(contracts.ContractStatePending), maxFormation)
 	return err
 }
 

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -167,7 +167,7 @@ INNER JOIN contracts c ON fces.contract_id = c.id
 	for rows.Next() {
 		fce, err := scanContractElement(rows)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to scan contract element: %w", err)
 		}
 		fces = append(fces, fce)
 	}
@@ -194,7 +194,7 @@ VALUES (
 ) ON CONFLICT (contract_id) DO UPDATE SET contract = EXCLUDED.contract, leaf_index = EXCLUDED.leaf_index, merkle_proof = EXCLUDED.merkle_proof
 `, sqlHash256(fce.ID), (*sqlFileContract)(&fce.V2FileContract), fce.StateElement.LeafIndex, sqlMerkleProof(fce.StateElement.MerkleProof))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to update contract element for contract %v: %w", fce.ID, err)
 		}
 	}
 	return nil

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -263,7 +263,7 @@ func TestUpdateContractElement(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		} else if !reflect.DeepEqual(ele, fce) {
-			t.Fatalf("mismatch: \n%v+\n%v+", fce, ele)
+			t.Fatalf("mismatch: \n%+v\n%+v", fce, ele)
 		}
 	}
 

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestFormRenewContract(t *testing.T) {
+	start := time.Now()
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
@@ -32,7 +33,11 @@ func TestFormRenewContract(t *testing.T) {
 		contract, err := store.Contract(context.Background(), id)
 		if err != nil {
 			t.Fatal("failed to fetch contract", err)
-		} else if !reflect.DeepEqual(contract, expected) {
+		} else if contract.Formation.Before(start) || contract.Formation.After(time.Now()) {
+			t.Fatalf("expected formation time to be after start time but not in the future")
+		}
+		contract.Formation = time.Time{}
+		if !reflect.DeepEqual(contract, expected) {
 			t.Fatalf("mismatch: \n%+v\n%+v", contract, expected)
 		}
 	}

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -292,7 +292,7 @@ func TestUpdateContractElement(t *testing.T) {
 	updateElement := func() {
 		t.Helper()
 		err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.UpdateContractElement(fce)
+			return tx.UpdateContractElements(fce)
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestFormRenewContract(t *testing.T) {
-	start := time.Now()
+	start := time.Now().Round(time.Microsecond)
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
@@ -33,7 +33,7 @@ func TestFormRenewContract(t *testing.T) {
 		contract, err := store.Contract(context.Background(), id)
 		if err != nil {
 			t.Fatal("failed to fetch contract", err)
-		} else if contract.Formation.Before(start) || contract.Formation.After(time.Now()) {
+		} else if contract.Formation.Before(start) || contract.Formation.After(time.Now().Round(time.Microsecond)) {
 			t.Fatalf("expected formation time to be after start time but not in the future")
 		}
 		contract.Formation = time.Time{}
@@ -202,7 +202,7 @@ func TestRejectContracts(t *testing.T) {
 
 	// form 3 contracts
 	now := time.Now()
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		contractID := types.FileContractID{byte(i + 1)}
 		err = store.AddFormedContract(context.Background(), contractID, hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
@@ -228,16 +228,13 @@ func TestRejectContracts(t *testing.T) {
 
 	// reject pending contracts older than 30 minutes
 	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.RejectPendingContracts(30 * time.Minute)
+		return tx.RejectPendingContracts(now.Add(-30 * time.Minute))
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// assert state of contracts after rejection
-	// 'recentID' should still be pending
-	// 'oldID' should be rejected
-	// 'activeID' should still be active
 	assertContractState(recentID, contracts.ContractStatePending)
 	assertContractState(oldID, contracts.ContractStateRejected)
 	assertContractState(activeID, contracts.ContractStateActive)

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -159,6 +159,90 @@ func TestFormRenewContract(t *testing.T) {
 	assertContract(expectedRenewed.ID, expectedRenewed)
 }
 
+func TestRejectContracts(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// add a host
+	hk := types.PublicKey{1, 1, 1}
+	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// helper to assert contract state
+	assertContractState := func(id types.FileContractID, state contracts.ContractState) {
+		t.Helper()
+		contract, err := store.Contract(context.Background(), id)
+		if err != nil {
+			t.Fatal("failed to fetch contract", err)
+		} else if contract.State != state {
+			t.Fatalf("expected state %v, got %v", state, contract.State)
+		}
+	}
+
+	// helper to modify contract
+	updateStateAndFormation := func(id types.FileContractID, state contracts.ContractState, formation time.Time) {
+		t.Helper()
+		err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.UpdateContractState(id, state)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
+			_, err := tx.Exec(ctx, `UPDATE contracts SET formation = $1 WHERE contract_id = $2`, formation, sqlHash256(id))
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// form 3 contracts
+	now := time.Now()
+	for i := 0; i < 3; i++ {
+		contractID := types.FileContractID{byte(i + 1)}
+		err = store.AddFormedContract(context.Background(), contractID, hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
+		if err != nil {
+			t.Fatal("failed to add formed contract", err)
+		}
+		switch i {
+		case 0:
+			updateStateAndFormation(contractID, contracts.ContractStatePending, now) // recently formed
+		case 1:
+			updateStateAndFormation(contractID, contracts.ContractStatePending, now.Add(-time.Hour)) // formed an hour ago
+		case 2:
+			updateStateAndFormation(contractID, contracts.ContractStateActive, now.Add(-time.Hour)) // formed an hour ago but active
+		}
+	}
+
+	// assert initial state of contracts
+	recentID := types.FileContractID{1}
+	assertContractState(recentID, contracts.ContractStatePending)
+	oldID := types.FileContractID{2}
+	assertContractState(oldID, contracts.ContractStatePending)
+	activeID := types.FileContractID{3}
+	assertContractState(activeID, contracts.ContractStateActive)
+
+	// reject pending contracts older than 30 minutes
+	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return tx.RejectPendingContracts(30 * time.Minute)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert state of contracts after rejection
+	// 'recentID' should still be pending
+	// 'oldID' should be rejected
+	// 'activeID' should still be active
+	assertContractState(recentID, contracts.ContractStatePending)
+	assertContractState(oldID, contracts.ContractStateRejected)
+	assertContractState(activeID, contracts.ContractStateActive)
+}
+
 func TestSetContractGood(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -265,6 +265,20 @@ func TestUpdateContractElement(t *testing.T) {
 		} else if !reflect.DeepEqual(ele, fce) {
 			t.Fatalf("mismatch: \n%+v\n%+v", fce, ele)
 		}
+		var fces []types.V2FileContractElement
+		err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) (err error) {
+			fces, err = tx.ContractElements()
+			return
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, ele := range fces {
+			if reflect.DeepEqual(ele, fce) {
+				return // found
+			}
+		}
+		t.Fatal("contract element not found")
 	}
 
 	// contract shouldn't exist

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -95,6 +95,7 @@ CREATE TABLE contracts (
   fund_account_spending DECIMAL(50, 0) NOT NULL DEFAULT 0,
   sector_roots_spending DECIMAL(50, 0) NOT NULL DEFAULT 0
 );
+CREATE INDEX contracts_state_formation_idx ON contracts(state, formation); -- for rejecting expired contracts
 
 CREATE TABLE contract_elements (
     id SERIAL PRIMARY KEY,


### PR DESCRIPTION
This PR adds updating of contract element proofs via a `updateContractElementProofs` function which is unit tested using a mocked store and proof updater.
Whether the function is called as part of a consensus update will become apparent when we have integration tests actually forming contracts.