### PR TITLE
Merge `hosts` and `host_settings`

### DIFF
--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -109,15 +109,31 @@ CREATE INDEX syncer_bans_net_cidr_idx ON syncer_bans USING gist (net_cidr inet_o
 ```postgresql
 CREATE TABLE hosts (
     id SERIAL PRIMARY KEY,
-    public_key BYTEA UNIQUE NOT NULL,
-
+    public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
     total_scans INTEGER NOT NULL DEFAULT 0,
     failed_scans INTEGER NOT NULL DEFAULT 0,
     consecutive_failed_scans INTEGER NOT NULL DEFAULT 0,
     last_successful_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     last_announcement TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     next_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
-    lost_sectors INTEGER NOT NULL DEFAULT 0
+    lost_sectors INTEGER NOT NULL DEFAULT 0,
+
+    settings_protocol_version BYTEA NOT NULL DEFAULT '\x000000'::bytea CHECK (LENGTH(settings_protocol_version) = 3),
+    settings_release TEXT NOT NULL DEFAULT '',
+    settings_wallet_address BYTEA NOT NULL DEFAULT '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea CHECK (LENGTH(settings_wallet_address) = 32),
+    settings_accepting_contracts BOOLEAN NOT NULL DEFAULT FALSE,
+    settings_max_collateral NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_max_contract_duration NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_remaining_storage BIGINT NOT NULL DEFAULT 0,
+    settings_total_storage BIGINT NOT NULL DEFAULT 0,
+    settings_contract_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_collateral NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_storage_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_ingress_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_egress_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_free_sector_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_tip_height BIGINT NOT NULL DEFAULT 0,
+    settings_valid_until TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00'
 )
 
 CREATE TABLE host_addresses (
@@ -133,28 +149,6 @@ CREATE TABLE host_resolved_cidrs (
     host_id INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
 
     cidr CIDR NOT NULL
-)
-
-CREATE TABLE host_settings (
-    host_id INTEGER PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
-
-    protocol_version BYTEA NOT NULL,
-    release TEXT NOT NULL,
-    wallet_address BYTEA NOT NULL,
-    accepting_contracts BOOLEAN NOT NULL,
-    max_collateral NUMERIC(50,0) NOT NULL,
-    max_contract_duration NUMERIC(50,0) NOT NULL,
-    remaining_storage BIGINT NOT NULL,
-    total_storage BIGINT NOT NULL,
-
-    contract_price NUMERIC(50,0) NOT NULL,
-    collateral NUMERIC(50,0) NOT NULL,
-    storage_price NUMERIC(50,0) NOT NULL,
-    ingress_price NUMERIC(50,0) NOT NULL,
-    egress_price NUMERIC(50,0) NOT NULL,
-    free_sector_price NUMERIC(50,0) NOT NULL,
-    tip_height BIGINT NOT NULL,
-    valid_until TIMESTAMP WITH TIME ZONE NOT NULL
 )
 ```
 

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -49,34 +49,28 @@ func (u *updateTx) AddHostAnnouncement(hk types.PublicKey, ha chain.V2HostAnnoun
 func (s *Store) Host(ctx context.Context, hk types.PublicKey) (hosts.Host, error) {
 	var host hosts.Host
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		var hostID int64
-		err := tx.QueryRow(ctx, `SELECT id, public_key, last_announcement, total_scans, failed_scans, consecutive_failed_scans, last_successful_scan, next_scan FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)).Scan(
-			&hostID,
-			(*sqlPublicKey)(&host.PublicKey),
-			&host.LastAnnouncement,
-			&host.TotalScans,
-			&host.FailedScans,
-			&host.ConsecutiveFailedScans,
-			&host.LastSuccessfulScan,
-			&host.NextScan,
-		)
+		h, err := scanHost(tx.QueryRow(ctx, `
+SELECT
+	id, public_key, last_announcement, total_scans, failed_scans, consecutive_failed_scans, last_successful_scan, next_scan,
+	settings_protocol_version, settings_release, settings_wallet_address, settings_accepting_contracts,
+	settings_max_collateral, settings_max_contract_duration, settings_remaining_storage, settings_total_storage,
+	settings_contract_price, settings_collateral, settings_storage_price, settings_ingress_price, settings_egress_price,
+	settings_free_sector_price, settings_tip_height, settings_valid_until
+FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)))
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("host %q: %w", hk, ErrHostNotFound)
 		} else if err != nil {
 			return fmt.Errorf("failed to query host: %w", err)
 		}
-		host.Addresses, err = queryHostAddresses(ctx, tx, hostID)
+		h.Addresses, err = queryHostAddresses(ctx, tx, h.id)
 		if err != nil {
 			return err
 		}
-		host.Networks, err = queryHostNetworks(ctx, tx, hostID)
+		h.Networks, err = queryHostNetworks(ctx, tx, h.id)
 		if err != nil {
 			return err
 		}
-		host.Settings, err = queryHostSettings(ctx, tx, hostID)
-		if err != nil {
-			return err
-		}
+		host = h.Host
 		return nil
 	}); err != nil {
 		return hosts.Host{}, err
@@ -104,7 +98,7 @@ func (s *Store) Hosts(ctx context.Context, offset, limit int) ([]hosts.Host, err
 			if err != nil {
 				return err
 			}
-			h.Settings, err = queryHostSettings(ctx, tx, h.id)
+			h.Networks, err = queryHostNetworks(ctx, tx, h.id)
 			if err != nil {
 				return err
 			}
@@ -166,48 +160,46 @@ func (s *Store) PruneHosts(ctx context.Context, minLastSuccessfulScan time.Time,
 // UpdateHost updates a host in the database, the given parameters are the result of scanning the host.
 func (s *Store) UpdateHost(ctx context.Context, hk types.PublicKey, networks []net.IPNet, hs proto4.HostSettings, scanSucceeded bool, nextScan time.Time) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		var query string
-		if scanSucceeded {
-			query = `UPDATE hosts SET total_scans = total_scans + 1, consecutive_failed_scans = 0, last_successful_scan = NOW(), next_scan = $1 WHERE public_key = $2 RETURNING id`
-		} else {
-			query = `UPDATE hosts SET total_scans = total_scans + 1, failed_scans = failed_scans + 1, consecutive_failed_scans = consecutive_failed_scans + 1,next_scan = $1 WHERE public_key = $2 RETURNING id`
-		}
-
-		var hostID int64
-		err := tx.QueryRow(ctx, query, nextScan, sqlPublicKey(hk)).Scan(&hostID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return ErrHostNotFound
-		} else if err != nil {
-			return fmt.Errorf("failed to update host with scan: %w", err)
-		} else if !scanSucceeded {
+		if !scanSucceeded {
+			if res, err := tx.Exec(ctx, `
+UPDATE hosts SET 
+	total_scans = total_scans + 1,
+	failed_scans = failed_scans + 1,
+	consecutive_failed_scans = consecutive_failed_scans + 1,
+	next_scan = $1 
+WHERE public_key = $2`, nextScan, sqlPublicKey(hk)); err != nil {
+				return err
+			} else if res.RowsAffected() == 0 {
+				return ErrHostNotFound
+			}
 			return nil
 		}
 
-		if _, err := tx.Exec(ctx, `INSERT INTO host_settings (
-host_id, protocol_version, release, wallet_address, accepting_contracts, 
-max_collateral, max_contract_duration, remaining_storage, total_storage, 
-contract_price, collateral, storage_price, ingress_price, egress_price, 
-free_sector_price, tip_height, valid_until) 
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-ON CONFLICT (host_id) 
-DO UPDATE SET 
-    protocol_version = EXCLUDED.protocol_version,
-    release = EXCLUDED.release,
-    wallet_address = EXCLUDED.wallet_address,
-    accepting_contracts = EXCLUDED.accepting_contracts,
-    max_collateral = EXCLUDED.max_collateral,
-    max_contract_duration = EXCLUDED.max_contract_duration,
-    remaining_storage = EXCLUDED.remaining_storage,
-    total_storage = EXCLUDED.total_storage,
-    contract_price = EXCLUDED.contract_price,
-    collateral = EXCLUDED.collateral,
-    storage_price = EXCLUDED.storage_price,
-    ingress_price = EXCLUDED.ingress_price,
-    egress_price = EXCLUDED.egress_price,
-    free_sector_price = EXCLUDED.free_sector_price,
-    tip_height = EXCLUDED.tip_height,
-    valid_until = EXCLUDED.valid_until;`,
-			hostID,
+		var hostID int64
+		err := tx.QueryRow(ctx, `
+UPDATE hosts SET 
+	total_scans = total_scans + 1,
+	consecutive_failed_scans = 0,
+	last_successful_scan = NOW(),
+	next_scan = $1,
+	settings_protocol_version = $2,
+	settings_release = $3,
+	settings_wallet_address = $4,
+	settings_accepting_contracts = $5,
+	settings_max_collateral = $6,
+	settings_max_contract_duration = $7,
+	settings_remaining_storage = $8,
+	settings_total_storage = $9,
+	settings_contract_price = $10,
+	settings_collateral = $11,
+	settings_storage_price = $12,
+	settings_ingress_price = $13,
+	settings_egress_price = $14,
+	settings_free_sector_price = $15,
+	settings_tip_height = $16,
+	settings_valid_until = $17
+WHERE public_key = $18 RETURNING id`,
+			nextScan,
 			sqlProtocolVersion(hs.ProtocolVersion),
 			hs.Release,
 			sqlHash256(hs.WalletAddress),
@@ -224,8 +216,12 @@ DO UPDATE SET
 			sqlCurrency(hs.Prices.FreeSectorPrice),
 			hs.Prices.TipHeight,
 			hs.Prices.ValidUntil,
-		); err != nil {
-			return err
+			sqlPublicKey(hk),
+		).Scan(&hostID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrHostNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to update host with scan: %w", err)
 		}
 
 		_, err = tx.Exec(ctx, `DELETE FROM host_resolved_cidrs WHERE host_id = $1`, hostID)
@@ -245,7 +241,14 @@ DO UPDATE SET
 }
 
 func queryHosts(ctx context.Context, tx *txn, offset, limit int) ([]dbHost, error) {
-	rows, err := tx.Query(ctx, `SELECT id, public_key, last_announcement, total_scans, failed_scans, last_successful_scan, next_scan  FROM hosts LIMIT $1 OFFSET $2`, limit, offset)
+	rows, err := tx.Query(ctx, `
+SELECT 
+	id, public_key, last_announcement, total_scans, failed_scans, consecutive_failed_scans, last_successful_scan, next_scan,
+	settings_protocol_version, settings_release, settings_wallet_address, settings_accepting_contracts,
+	settings_max_collateral, settings_max_contract_duration, settings_remaining_storage, settings_total_storage,
+	settings_contract_price, settings_collateral, settings_storage_price, settings_ingress_price, settings_egress_price,
+	settings_free_sector_price, settings_tip_height, settings_valid_until
+FROM hosts LIMIT $1 OFFSET $2`, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query hosts: %w", err)
 	}
@@ -253,16 +256,8 @@ func queryHosts(ctx context.Context, tx *txn, offset, limit int) ([]dbHost, erro
 
 	var hosts []dbHost
 	for rows.Next() {
-		var host dbHost
-		if err := rows.Scan(
-			&host.id,
-			(*sqlPublicKey)(&host.PublicKey),
-			&host.LastAnnouncement,
-			&host.TotalScans,
-			&host.FailedScans,
-			&host.LastSuccessfulScan,
-			&host.NextScan,
-		); err != nil {
+		host, err := scanHost(rows)
+		if err != nil {
 			return nil, fmt.Errorf("failed to scan host: %w", err)
 		}
 		hosts = append(hosts, host)
@@ -318,30 +313,31 @@ func queryHostNetworks(ctx context.Context, tx *txn, hostID int64) ([]net.IPNet,
 	return networks, nil
 }
 
-func queryHostSettings(ctx context.Context, tx *txn, hostID int64) (proto4.HostSettings, error) {
-	var hs proto4.HostSettings
-	err := tx.QueryRow(ctx, `SELECT protocol_version, release, wallet_address, accepting_contracts, max_collateral, max_contract_duration, remaining_storage, total_storage, contract_price, collateral, storage_price, ingress_price, egress_price, free_sector_price, tip_height, valid_until FROM host_settings WHERE host_id = $1`, hostID).Scan(
-		(*sqlProtocolVersion)(&hs.ProtocolVersion),
-		&hs.Release,
-		(*sqlHash256)(&hs.WalletAddress),
-		&hs.AcceptingContracts,
-		(*sqlCurrency)(&hs.MaxCollateral),
-		&hs.MaxContractDuration,
-		&hs.RemainingStorage,
-		&hs.TotalStorage,
-		(*sqlCurrency)(&hs.Prices.ContractPrice),
-		(*sqlCurrency)(&hs.Prices.Collateral),
-		(*sqlCurrency)(&hs.Prices.StoragePrice),
-		(*sqlCurrency)(&hs.Prices.IngressPrice),
-		(*sqlCurrency)(&hs.Prices.EgressPrice),
-		(*sqlCurrency)(&hs.Prices.FreeSectorPrice),
-		&hs.Prices.TipHeight,
-		&hs.Prices.ValidUntil,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return proto4.HostSettings{}, nil
-	} else if err != nil {
-		return proto4.HostSettings{}, fmt.Errorf("failed to query host settings: %w", err)
-	}
-	return hs, nil
+func scanHost(s scanner) (host dbHost, err error) {
+	err = s.Scan(
+		&host.id,
+		(*sqlPublicKey)(&host.PublicKey),
+		&host.LastAnnouncement,
+		&host.TotalScans,
+		&host.FailedScans,
+		&host.ConsecutiveFailedScans,
+		&host.LastSuccessfulScan,
+		&host.NextScan,
+		(*sqlProtocolVersion)(&host.Settings.ProtocolVersion),
+		&host.Settings.Release,
+		(*sqlHash256)(&host.Settings.WalletAddress),
+		&host.Settings.AcceptingContracts,
+		(*sqlCurrency)(&host.Settings.MaxCollateral),
+		&host.Settings.MaxContractDuration,
+		&host.Settings.RemainingStorage,
+		&host.Settings.TotalStorage,
+		(*sqlCurrency)(&host.Settings.Prices.ContractPrice),
+		(*sqlCurrency)(&host.Settings.Prices.Collateral),
+		(*sqlCurrency)(&host.Settings.Prices.StoragePrice),
+		(*sqlCurrency)(&host.Settings.Prices.IngressPrice),
+		(*sqlCurrency)(&host.Settings.Prices.EgressPrice),
+		(*sqlCurrency)(&host.Settings.Prices.FreeSectorPrice),
+		&host.Settings.Prices.TipHeight,
+		&host.Settings.Prices.ValidUntil)
+	return
 }

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -80,7 +80,7 @@ func TestHost(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	db := initPostgres(t, log.Named("postgres"))
 
-	hk := types.PublicKey{1}
+	hk := types.GeneratePrivateKey().PublicKey()
 	hs := testHostSettings(hk)
 
 	// assert [ErrHostNotFound] is returned
@@ -108,7 +108,7 @@ func TestHost(t *testing.T) {
 	if h, err := db.Host(context.Background(), hk); err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(h.Settings, hs) {
-		t.Fatal("expected settings to match")
+		t.Fatal("expected settings to match", h.Settings)
 	} else if len(h.Addresses) != 1 {
 		t.Fatal("unexpected", len(h.Addresses))
 	} else if len(h.Networks) != 1 {
@@ -304,7 +304,7 @@ func TestUpdateHost(t *testing.T) {
 	db := initPostgres(t, log.Named("postgres"))
 
 	// assert [ErrHostNotFound] is returned
-	hk := types.PublicKey{1}
+	hk := types.GeneratePrivateKey().PublicKey()
 	err := db.UpdateHost(context.Background(), hk, nil, proto4.HostSettings{}, false, time.Time{})
 	if !errors.Is(err, ErrHostNotFound) {
 		t.Fatal("expected ErrHostNotFound, got", err)
@@ -324,8 +324,8 @@ func TestUpdateHost(t *testing.T) {
 		t.Fatal(err)
 	} else if h, err := db.Host(context.Background(), hk); err != nil {
 		t.Fatal(err)
-	} else if h.Settings != (proto4.HostSettings{}) {
-		t.Fatal("expected no settings")
+	} else if h.Settings != (proto4.HostSettings{Prices: proto4.HostPrices{ValidUntil: time.Time{}.Local()}}) {
+		t.Fatal("expected no settings", h.Settings, proto4.HostSettings{})
 	} else if !h.LastSuccessfulScan.IsZero() {
 		t.Fatal("expected no last successful scan")
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -7,7 +7,24 @@ CREATE TABLE hosts (
     last_successful_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     last_announcement TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
     next_scan TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00',
-    lost_sectors INTEGER NOT NULL DEFAULT 0
+    lost_sectors INTEGER NOT NULL DEFAULT 0,
+
+    settings_protocol_version BYTEA NOT NULL DEFAULT '\x000000'::bytea CHECK (LENGTH(settings_protocol_version) = 3),
+    settings_release TEXT NOT NULL DEFAULT '',
+    settings_wallet_address BYTEA NOT NULL DEFAULT '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea CHECK (LENGTH(settings_wallet_address) = 32),
+    settings_accepting_contracts BOOLEAN NOT NULL DEFAULT FALSE,
+    settings_max_collateral NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_max_contract_duration NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_remaining_storage BIGINT NOT NULL DEFAULT 0,
+    settings_total_storage BIGINT NOT NULL DEFAULT 0,
+    settings_contract_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_collateral NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_storage_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_ingress_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_egress_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_free_sector_price NUMERIC(50,0) NOT NULL DEFAULT 0,
+    settings_tip_height BIGINT NOT NULL DEFAULT 0,
+    settings_valid_until TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT '0001-01-01 00:00:00+00'
 );
 CREATE INDEX idx_hosts_next_scan_idx ON hosts(next_scan);
 
@@ -23,26 +40,6 @@ CREATE TABLE host_resolved_cidrs (
     id SERIAL PRIMARY KEY,
     host_id INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
     cidr CIDR NOT NULL
-);
-
-CREATE TABLE host_settings (
-    host_id INTEGER PRIMARY KEY REFERENCES hosts(id) ON DELETE CASCADE,
-    protocol_version BYTEA NOT NULL CHECK (LENGTH(protocol_version) = 3),
-    release TEXT NOT NULL,
-    wallet_address BYTEA NOT NULL CHECK (LENGTH(wallet_address) = 32),
-    accepting_contracts BOOLEAN NOT NULL,
-    max_collateral NUMERIC(50,0) NOT NULL,
-    max_contract_duration NUMERIC(50,0) NOT NULL,
-    remaining_storage BIGINT NOT NULL,
-    total_storage BIGINT NOT NULL,
-    contract_price NUMERIC(50,0) NOT NULL,
-    collateral NUMERIC(50,0) NOT NULL,
-    storage_price NUMERIC(50,0) NOT NULL,
-    ingress_price NUMERIC(50,0) NOT NULL,
-    egress_price NUMERIC(50,0) NOT NULL,
-    free_sector_price NUMERIC(50,0) NOT NULL,
-    tip_height BIGINT NOT NULL,
-    valid_until TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 CREATE TABLE syncer_peers (


### PR DESCRIPTION
This PR combines the host with its settings which avoids a nasty `LEFT JOIN` when retrieving hosts from the database. I was a little apprehensive at first but providing a default value for every settings makes it so we don't even have to change anything on insert. When we process host scans we usually have to update both the `hosts` and the `host_settings` table anyway so this is definitely an improvement I would say.