### PR TITLE
Subscriber fixes

### DIFF
--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -67,8 +67,11 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer contracts.Close()
 
-	sub := subscriber.New(cm, hm, contracts, wm, store, subscriber.WithLogger(log.Named("subscriber")))
-	defer sub.Close()
+	subscriber, err := subscriber.New(cm, hm, contracts, wm, store, subscriber.WithLogger(log.Named("subscriber")))
+	if err != nil {
+		return fmt.Errorf("failed to create subscriber: %w", err)
+	}
+	defer subscriber.Close()
 
 	httpListener, err := startLocalhostListener(cfg.HTTP.Address, log.Named("listener"))
 	if err != nil {

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -59,12 +59,15 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}
 
-	sub := subscriber.New(c.cm, hm, contracts, wm, store, subscriber.WithLogger(log.Named("subscriber")))
+	subscriber, err := subscriber.New(c.cm, hm, contracts, wm, store, subscriber.WithLogger(log.Named("subscriber")))
+	if err != nil {
+		t.Fatalf("failed to create subscriber: %v", err)
+	}
 
 	// sync subscriber
 	syncFn := func() {
 		t.Helper()
-		if err := sub.Sync(); err != nil {
+		if err := subscriber.Sync(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -122,7 +125,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		if err := closeWithTimeout(contracts.Close); err != nil {
 			t.Errorf("failed to close contract manager: %v", err)
 		}
-		if err := closeWithTimeout(sub.Close); err != nil {
+		if err := closeWithTimeout(subscriber.Close); err != nil {
 			t.Errorf("failed to close subscriber: %v", err)
 		}
 		if err := closeWithTimeout(store.Close); err != nil {

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -115,12 +115,15 @@ func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletMa
 	}
 	go func() {
 		defer cancel()
-		for range reorgCh {
+		for {
 			select {
 			case <-reorgCh:
-				if err := s.Sync(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				err := s.Sync(ctx)
+				if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, threadgroup.ErrClosed) {
 					s.log.Panic("failed to sync database", zap.Error(err))
 				}
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
@@ -133,6 +136,12 @@ func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletMa
 // to manually call this since the Subscriber will do that itself but it can be
 // used to guarantee the subscriber is synced at a given point in time.
 func (s *Subscriber) Sync(ctx context.Context) error {
+	ctx, cancel, err := s.tg.AddContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
 
@@ -158,7 +167,7 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 		}
 
 		updateCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-		if err := s.store.UpdateChainState(updateCtx, func(tx UpdateTx) error {
+		err = s.store.UpdateChainState(updateCtx, func(tx UpdateTx) error {
 			if err := s.hm.UpdateChainState(tx, aus); err != nil {
 				return fmt.Errorf("failed to update host chain state: %w", err)
 			} else if err := s.contracts.UpdateChainState(tx, rus, aus); err != nil {
@@ -173,15 +182,15 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 				index = rus[len(rus)-1].State.Index
 			}
 
-			if err := tx.UpdateLastScannedIndex(updateCtx, aus[len(aus)-1].State.Index); err != nil {
+			if err := tx.UpdateLastScannedIndex(updateCtx, index); err != nil {
 				return fmt.Errorf("failed to update last scanned index: %w", err)
 			}
 			return nil
-		}); err != nil {
-			cancel()
+		})
+		cancel()
+		if err != nil {
 			return fmt.Errorf("failed to apply updates: %w", err)
 		}
-		cancel()
 
 		if time.Since(lastUpdate) > 5*time.Minute {
 			s.log.Debug("syncing", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID))

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -2,6 +2,7 @@ package subscriber
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -82,7 +83,7 @@ func (s *Subscriber) Close() error {
 
 // New creates a new chain subscriber. The returned subscriber is already
 // processing chain updates and needs to be closed.
-func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletManager, store Store, opts ...Option) *Subscriber {
+func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletManager, store Store, opts ...Option) (*Subscriber, error) {
 	s := &Subscriber{
 		cm:        cm,
 		contracts: contracts,
@@ -108,17 +109,16 @@ func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletMa
 		close(reorgCh)
 	}
 
-	done, err := s.tg.Add()
+	ctx, cancel, err := s.tg.AddContext(context.Background())
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	go func() {
-		defer done()
+		defer cancel()
 		for range reorgCh {
 			select {
 			case <-reorgCh:
-				err := s.Sync()
-				if err != nil {
+				if err := s.Sync(ctx); err != nil && !errors.Is(err, context.Canceled) {
 					s.log.Panic("failed to sync database", zap.Error(err))
 				}
 			}
@@ -126,17 +126,17 @@ func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletMa
 	}()
 
 	reorgCh <- struct{}{} // trigger initial sync
-	return s
+	return s, nil
 }
 
 // Sync syncs the subscriber with the chain manager. It's usually not necessary
 // to manually call this since the Subscriber will do that itself but it can be
 // used to guarantee the subscriber is synced at a given point in time.
-func (s *Subscriber) Sync() error {
+func (s *Subscriber) Sync(ctx context.Context) error {
 	s.syncMu.Lock()
 	defer s.syncMu.Unlock()
 
-	index, err := s.tip()
+	index, err := s.store.LastScannedIndex(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get last scanned index: %w", err)
 	}
@@ -145,7 +145,7 @@ func (s *Subscriber) Sync() error {
 	s.log.Debug("syncing", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID))
 	for index != s.cm.Tip() {
 		select {
-		case <-s.tg.Done():
+		case <-ctx.Done():
 			break
 		default:
 		}
@@ -157,8 +157,8 @@ func (s *Subscriber) Sync() error {
 			break
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		if err := s.store.UpdateChainState(ctx, func(tx UpdateTx) error {
+		updateCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		if err := s.store.UpdateChainState(updateCtx, func(tx UpdateTx) error {
 			if err := s.hm.UpdateChainState(tx, aus); err != nil {
 				return fmt.Errorf("failed to update host chain state: %w", err)
 			} else if err := s.contracts.UpdateChainState(tx, rus, aus); err != nil {
@@ -173,7 +173,7 @@ func (s *Subscriber) Sync() error {
 				index = rus[len(rus)-1].State.Index
 			}
 
-			if err := tx.UpdateLastScannedIndex(ctx, aus[len(aus)-1].State.Index); err != nil {
+			if err := tx.UpdateLastScannedIndex(updateCtx, aus[len(aus)-1].State.Index); err != nil {
 				return fmt.Errorf("failed to update last scanned index: %w", err)
 			}
 			return nil
@@ -191,10 +191,4 @@ func (s *Subscriber) Sync() error {
 
 	s.log.Debug("synced", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID))
 	return nil
-}
-
-func (s *Subscriber) tip() (types.ChainIndex, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-	return s.store.LastScannedIndex(ctx)
 }


### PR DESCRIPTION
I was updating the subscriber at one point and then reverted it again, I want to keep these small changes though. Using `AddContext` makes it consistent with the host manager and it's just cleaner to pass a context to `Sync`