### PR TITLE
Add explorer API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -21,6 +21,11 @@ type (
 		V2TransactionSet(basis types.ChainIndex, txn types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error)
 	}
 
+	// Explorer retrieves data about the Sia network from an external source.
+	Explorer interface {
+		SiacoinExchangeRate(ctx context.Context, currency string) (rate float64, err error)
+	}
+
 	// A Store is a persistent store for the indexer.
 	Store interface {
 		BlockHosts(ctx context.Context, hks []types.PublicKey) error
@@ -52,11 +57,12 @@ type (
 type (
 	// An api provides an HTTP API for the indexer
 	api struct {
-		chain  ChainManager
-		store  Store
-		syncer Syncer
-		wallet Wallet
-		log    *zap.Logger
+		chain    ChainManager
+		explorer Explorer
+		store    Store
+		syncer   Syncer
+		wallet   Wallet
+		log      *zap.Logger
 	}
 )
 
@@ -75,6 +81,9 @@ func NewServer(chain ChainManager, syncer Syncer, wallet Wallet, store Store, op
 
 	return jape.Mux(map[string]jape.Handler{
 		"GET /state": a.handleGETState,
+
+		// explorer endpoints
+		"GET /explorer/exchange-rate/siacoin/:currency": a.handleGETExplorerSiacoinExchangeRate,
 
 		// host endpoints
 		"GET    /host/:hostkey": a.handleGETHost,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -13,6 +13,18 @@ import (
 	"go.uber.org/zap"
 )
 
+func TestExplorerAPI(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+
+	rate, err := indexer.ExplorerSiacoinExchangeRate(context.Background(), "usd")
+	if err != nil {
+		t.Fatal(err)
+	} else if rate == 0 {
+		t.Fatal("expected non-zero rate")
+	}
+}
+
 func TestHostsAPI(t *testing.T) {
 	// create cluster
 	c := testutils.NewConsensusNode(t, zap.NewNop())

--- a/api/client.go
+++ b/api/client.go
@@ -30,6 +30,12 @@ func (c *Client) State(ctx context.Context) (state State, err error) {
 	return
 }
 
+// ExplorerSiacoinExchangeRate returns the exchange rate for the given currency.
+func (c *Client) ExplorerSiacoinExchangeRate(ctx context.Context, currency string) (rate float64, err error) {
+	err = c.c.GET(ctx, fmt.Sprintf("/explorer/exchange-rate/siacoin/%s", currency), &rate)
+	return
+}
+
 // Host returns information about a particular host known to the indexer.
 func (c *Client) Host(ctx context.Context, hostKey types.PublicKey) (h hosts.Host, err error) {
 	err = c.c.GET(ctx, fmt.Sprintf("/host/%s", hostKey), &h)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -9,6 +9,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/build"
+	"go.sia.tech/indexd/explorer"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -54,6 +55,25 @@ func (a *api) handleGETState(jc jape.Context) {
 		},
 		ScanHeight: ci.Height,
 	})
+}
+
+func (a *api) handleGETExplorerSiacoinExchangeRate(jc jape.Context) {
+	if a.explorer == nil {
+		jc.Error(explorer.ErrDisabled, http.StatusServiceUnavailable)
+		return
+	}
+
+	var currency string
+	if jc.DecodeParam("currency", &currency) != nil {
+		return
+	}
+
+	rate, err := a.explorer.SiacoinExchangeRate(jc.Request.Context(), currency)
+	if jc.Check("failed to get siacoin exchange rate", err) != nil {
+		return
+	}
+
+	jc.Encode(rate)
 }
 
 func (a *api) handleGETHost(jc jape.Context) {

--- a/api/options.go
+++ b/api/options.go
@@ -10,6 +10,13 @@ import (
 // ServerOption is a functional option to configure an API server.
 type ServerOption func(*api)
 
+// WithExplorer sets the explorer for the API server.
+func WithExplorer(e Explorer) ServerOption {
+	return func(a *api) {
+		a.explorer = e
+	}
+}
+
 // WithLogger sets the logger for the API server.
 func WithLogger(log *zap.Logger) ServerOption {
 	return func(a *api) {

--- a/cmd/indexd/main.go
+++ b/cmd/indexd/main.go
@@ -43,6 +43,10 @@ var cfg = config.Config{
 		Network:        "mainnet",
 		IndexBatchSize: 1000,
 	},
+	Explorer: config.Explorer{
+		Enabled: true,
+		URL:     "https://api.siascan.com",
+	},
 	Log: config.Log{
 		File: config.FileLog{
 			Level:   zap.NewAtomicLevelAt(zapcore.InfoLevel), // the zero-value is Info, but better to be explicit

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -23,6 +23,7 @@ import (
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/config"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/explorer"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.sia.tech/indexd/subscriber"
@@ -123,6 +124,10 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 
 	apiOpts := []api.ServerOption{
 		api.WithLogger(log.Named("api")),
+	}
+
+	if cfg.Explorer.Enabled {
+		apiOpts = append(apiOpts, api.WithExplorer(explorer.New(cfg.Explorer.URL)))
 	}
 
 	web := http.Server{

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,12 @@ type (
 		IndexBatchSize int    `yaml:"indexBatchSize,omitempty"`
 	}
 
+	// Explorer contains the configuration for an external explorer.
+	Explorer struct {
+		Enabled bool   `yaml:"enabled,omitempty"`
+		URL     string `yaml:"url,omitempty"`
+	}
+
 	// FileLog configures the file output of the logger.
 	FileLog struct {
 		Enabled bool            `yaml:"enabled,omitempty"`
@@ -59,11 +65,12 @@ type (
 		Directory      string `yaml:"directory,omitempty"`
 		RecoveryPhrase string `yaml:"recoveryPhrase,omitempty"`
 
-		HTTP      HTTP                    `yaml:"http"`
-		Syncer    Syncer                  `yaml:"syncer"`
-		Consensus Consensus               `yaml:"consensus"`
-		Log       Log                     `yaml:"log"`
-		Database  postgres.ConnectionInfo `yaml:"database"`
+		HTTP      HTTP                    `yaml:"http,omitempty"`
+		Syncer    Syncer                  `yaml:"syncer,omitempty"`
+		Consensus Consensus               `yaml:"consensus,omitempty"`
+		Explorer  Explorer                `yaml:"explorer,omitempty"`
+		Log       Log                     `yaml:"log,omitempty"`
+		Database  postgres.ConnectionInfo `yaml:"database,omitempty"`
 	}
 )
 

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -1,7 +1,6 @@
 package explorer
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -36,46 +35,32 @@ func (e *Explorer) BaseURL() string {
 }
 
 // SiacoinExchangeRate returns the exchange rate for the given currency.
-func (e *Explorer) SiacoinExchangeRate(ctx context.Context, currency string) (rate float64, err error) {
-	err = request(ctx, http.MethodGet, fmt.Sprintf("%s/exchange-rate/siacoin/%s", e.url, currency), nil, &rate)
-	return
-}
-
-func drainAndClose(r io.ReadCloser) {
-	io.Copy(io.Discard, io.LimitReader(r, 1024*1024))
-	r.Close()
-}
-
-func request(ctx context.Context, method, url string, requestBody, response any) error {
-	var body io.Reader
-	if requestBody != nil {
-		js, _ := json.Marshal(requestBody)
-		body = bytes.NewReader(js)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, url, body)
+func (e *Explorer) SiacoinExchangeRate(ctx context.Context, currency string) (float64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/exchange-rate/siacoin/%s", e.url, currency), nil)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return 0, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to send request: %w", err)
+		return 0, fmt.Errorf("failed to send request: %w", err)
 	}
-	defer drainAndClose(resp.Body)
+	defer func() {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 1024*1024))
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		var errorMessage string
 		if err := json.NewDecoder(io.LimitReader(resp.Body, 1024)).Decode(&errorMessage); err != nil {
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			return 0, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 		}
-		return errors.New(errorMessage)
+		return 0, errors.New(errorMessage)
 	}
 
-	if response == nil {
-		return nil
-	} else if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
-		return fmt.Errorf("failed to decode response: %w", err)
+	var rate float64
+	if err := json.NewDecoder(resp.Body).Decode(&rate); err != nil {
+		return 0, fmt.Errorf("failed to decode response: %w", err)
 	}
-	return nil
+	return rate, nil
 }

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -37,7 +37,7 @@ func (e *Explorer) BaseURL() string {
 
 // SiacoinExchangeRate returns the exchange rate for the given currency.
 func (e *Explorer) SiacoinExchangeRate(ctx context.Context, currency string) (rate float64, err error) {
-	err = makeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/exchange-rate/siacoin/%s", e.url, currency), nil, &rate)
+	err = request(ctx, http.MethodGet, fmt.Sprintf("%s/exchange-rate/siacoin/%s", e.url, currency), nil, &rate)
 	return
 }
 
@@ -46,7 +46,7 @@ func drainAndClose(r io.ReadCloser) {
 	r.Close()
 }
 
-func makeRequest(ctx context.Context, method, url string, requestBody, response any) error {
+func request(ctx context.Context, method, url string, requestBody, response any) error {
 	var body io.Reader
 	if requestBody != nil {
 		js, _ := json.Marshal(requestBody)

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -1,0 +1,81 @@
+package explorer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+var (
+	// ErrDisabled is returned by the API when the explorer is disabled.
+	ErrDisabled = errors.New("explorer is disabled")
+
+	client = &http.Client{
+		Timeout: 30 * time.Second,
+	}
+)
+
+// An Explorer retrieves data about the Sia network from an external source.
+type Explorer struct {
+	url string
+}
+
+// New returns a new Explorer client.
+func New(url string) *Explorer {
+	return &Explorer{url: url}
+}
+
+// BaseURL returns the base URL of the Explorer.
+func (e *Explorer) BaseURL() string {
+	return e.url
+}
+
+// SiacoinExchangeRate returns the exchange rate for the given currency.
+func (e *Explorer) SiacoinExchangeRate(ctx context.Context, currency string) (rate float64, err error) {
+	err = makeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/exchange-rate/siacoin/%s", e.url, currency), nil, &rate)
+	return
+}
+
+func drainAndClose(r io.ReadCloser) {
+	io.Copy(io.Discard, io.LimitReader(r, 1024*1024))
+	r.Close()
+}
+
+func makeRequest(ctx context.Context, method, url string, requestBody, response any) error {
+	var body io.Reader
+	if requestBody != nil {
+		js, _ := json.Marshal(requestBody)
+		body = bytes.NewReader(js)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer drainAndClose(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errorMessage string
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 1024)).Decode(&errorMessage); err != nil {
+			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		}
+		return errors.New(errorMessage)
+	}
+
+	if response == nil {
+		return nil
+	} else if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -18,6 +18,7 @@ import (
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/explorer"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.sia.tech/indexd/subscriber"
@@ -91,6 +92,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 
 	apiOpts := []api.ServerOption{
 		api.WithLogger(log.Named("api")),
+		api.WithExplorer(explorer.New("https://api.siascan.com")),
 	}
 
 	password := hex.EncodeToString(frand.Bytes(16))


### PR DESCRIPTION
This PR adds the explorer API in preparation of price pinning. 

Small notes:
- `TestExplorerAPI` doesn't include a test to check for "explorer disabled", verified it manually, wanted to avoid overcomplicating the indexer test config
- config has `Enabled` instead of `Disable`, I feel this is more consistent with the config and it avoids `if !cfg.Explorer.disable`