### PR TITLE
Add offline check to host scans

### DIFF
--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -55,12 +55,6 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer wm.Close()
 
-	hm, err := hosts.NewManager(store, hosts.WithLogger(log.Named("hosts")))
-	if err != nil {
-		return fmt.Errorf("failed to create host manager: %w", err)
-	}
-	defer hm.Close()
-
 	syncerListener, err := net.Listen("tcp", cfg.Syncer.Address)
 	if err != nil {
 		return fmt.Errorf("failed to listen on syncer address: %w", err)
@@ -102,6 +96,12 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}, syncer.WithLogger(log.Named("syncer")))
 	go s.Run()
 	defer s.Close()
+
+	hm, err := hosts.NewManager(s, store, hosts.WithLogger(log.Named("hosts")))
+	if err != nil {
+		return fmt.Errorf("failed to create host manager: %w", err)
+	}
+	defer hm.Close()
 
 	contracts, err := contracts.NewManager(cm, store, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -13,6 +13,7 @@ import (
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/threadgroup"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
@@ -46,20 +47,20 @@ type (
 		scanFrequency      time.Duration
 		scanInterval       time.Duration
 
-		pinger   Pinger
-		resolver Resolver
-		scanner  Scanner
-		store    Store
+		onlineChecker OnlineChecker
+		resolver      Resolver
+		scanner       Scanner
+		store         Store
 
 		tg  *threadgroup.ThreadGroup
 		log *zap.Logger
 	}
 
-	// Pinger defines an interface to check whether the indexer is online. It's
+	// OnlineChecker defines an interface to check whether the indexer is online. It's
 	// used to ensure hosts aren't punished for failing a scan if the indexer is
 	// offline.
-	Pinger interface {
-		Online() bool
+	OnlineChecker interface {
+		IsOnline() bool
 	}
 
 	// Resolver defines an interface to resolve hostnames.
@@ -81,6 +82,11 @@ type (
 		UpdateHost(ctx context.Context, hk types.PublicKey, networks []net.IPNet, hs proto4.HostSettings, scanSucceeded bool, nextScan time.Time) error
 	}
 
+	// Syncer defines an interface that exposes the Peers method.
+	Syncer interface {
+		Peers() []*syncer.Peer
+	}
+
 	// UpdateTx defines what the host manager needs to atomically process a
 	// chain update in the database.
 	UpdateTx interface {
@@ -89,18 +95,18 @@ type (
 )
 
 // NewManager creates a new host manager.
-func NewManager(store Store, opts ...Option) (*HostManager, error) {
+func NewManager(syncer Syncer, store Store, opts ...Option) (*HostManager, error) {
 	m := &HostManager{
 		announcementMaxAge: time.Hour * 24 * 365,
 		scanFrequency:      time.Hour,
 		scanInterval:       time.Hour * 24,
 
-		pinger:   pinger{},
-		resolver: &net.Resolver{},
-		scanner:  &scanner{},
-		store:    store,
-		tg:       threadgroup.New(),
-		log:      zap.NewNop(),
+		onlineChecker: &onlineChecker{addresses: fallbackSites, syncer: syncer},
+		resolver:      &net.Resolver{},
+		scanner:       &scanner{},
+		store:         store,
+		tg:            threadgroup.New(),
+		log:           zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -161,7 +167,7 @@ func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (proto4.
 	scanCtx, cancel := context.WithTimeout(ctx, scanTimeout)
 	defer cancel()
 
-	addrs, networks, err := resolveHost(scanCtx, m.pinger, m.resolver, host.Addresses, logger)
+	addrs, networks, err := resolveHost(scanCtx, m.resolver, host.Addresses, logger)
 	if err != nil {
 		return proto4.HostSettings{}, fmt.Errorf("failed to resolve host, %w", err)
 	}
@@ -173,7 +179,9 @@ func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (proto4.
 
 	consecutiveFailures := host.ConsecutiveFailedScans
 	success := settings != (proto4.HostSettings{})
-	if !success {
+	if !success && !m.onlineChecker.IsOnline() {
+		return proto4.HostSettings{}, errNodeOffline
+	} else if !success {
 		consecutiveFailures++
 	}
 
@@ -350,7 +358,7 @@ func calculateNextScanTime(lastScan time.Time, success bool, consecScanFailures 
 // and/or private addresses, and a list of networks in CIDR notation. The only
 // error this function returns is [context.Canceled], other errors that occur
 // during the resolving and parsing are debug logged but otherwise ignored.
-func resolveHost(ctx context.Context, pinger Pinger, resolver Resolver, addresses []chain.NetAddress, log *zap.Logger) ([]chain.NetAddress, []net.IPNet, error) {
+func resolveHost(ctx context.Context, resolver Resolver, addresses []chain.NetAddress, log *zap.Logger) ([]chain.NetAddress, []net.IPNet, error) {
 	var filtered []chain.NetAddress
 	var networks []net.IPNet
 	for _, na := range addresses {
@@ -364,9 +372,6 @@ func resolveHost(ctx context.Context, pinger Pinger, resolver Resolver, addresse
 		if errors.Is(err, context.Canceled) {
 			return nil, nil, err
 		} else if err != nil {
-			if !pinger.Online() {
-				return nil, nil, errNodeOffline
-			}
 			log.Debug("failed to resolve host", zap.String("host", host), zap.Error(err))
 			continue
 		}

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -35,6 +35,10 @@ const (
 	scanExponentialBackoffMaxHours = 128
 )
 
+var (
+	errNodeOffline = errors.New("node is offline")
+)
+
 type (
 	// HostManager manages the host announcements.
 	HostManager struct {
@@ -42,12 +46,20 @@ type (
 		scanFrequency      time.Duration
 		scanInterval       time.Duration
 
+		pinger   Pinger
 		resolver Resolver
 		scanner  Scanner
 		store    Store
 
 		tg  *threadgroup.ThreadGroup
 		log *zap.Logger
+	}
+
+	// Pinger defines an interface to check whether the indexer is online. It's
+	// used to ensure hosts aren't punished for failing a scan if the indexer is
+	// offline.
+	Pinger interface {
+		Online() bool
 	}
 
 	// Resolver defines an interface to resolve hostnames.
@@ -83,6 +95,7 @@ func NewManager(store Store, opts ...Option) (*HostManager, error) {
 		scanFrequency:      time.Hour,
 		scanInterval:       time.Hour * 24,
 
+		pinger:   pinger{},
 		resolver: &net.Resolver{},
 		scanner:  &scanner{},
 		store:    store,
@@ -148,7 +161,7 @@ func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (proto4.
 	scanCtx, cancel := context.WithTimeout(ctx, scanTimeout)
 	defer cancel()
 
-	addrs, networks, err := resolveHost(scanCtx, m.resolver, host.Addresses, logger)
+	addrs, networks, err := resolveHost(scanCtx, m.pinger, m.resolver, host.Addresses, logger)
 	if err != nil {
 		return proto4.HostSettings{}, fmt.Errorf("failed to resolve host, %w", err)
 	}
@@ -264,7 +277,7 @@ func (m *HostManager) scanHosts(ctx context.Context) {
 				wg.Done()
 			}()
 
-			if _, err := m.ScanHost(ctx, hk); errors.Is(err, context.Canceled) {
+			if _, err := m.ScanHost(ctx, hk); errors.Is(err, context.Canceled) || errors.Is(err, errNodeOffline) {
 				return
 			} else if err != nil {
 				m.log.Error("failed to perform host scan", zap.Stringer("hk", hk), zap.Error(err))
@@ -333,7 +346,7 @@ func calculateNextScanTime(lastScan time.Time, success bool, consecScanFailures 
 // and/or private addresses, and a list of networks in CIDR notation. The only
 // error this function returns is [context.Canceled], other errors that occur
 // during the resolving and parsing are debug logged but otherwise ignored.
-func resolveHost(ctx context.Context, resolver Resolver, addresses []chain.NetAddress, log *zap.Logger) ([]chain.NetAddress, []net.IPNet, error) {
+func resolveHost(ctx context.Context, pinger Pinger, resolver Resolver, addresses []chain.NetAddress, log *zap.Logger) ([]chain.NetAddress, []net.IPNet, error) {
 	var filtered []chain.NetAddress
 	var networks []net.IPNet
 	for _, na := range addresses {
@@ -347,6 +360,10 @@ func resolveHost(ctx context.Context, resolver Resolver, addresses []chain.NetAd
 		if errors.Is(err, context.Canceled) {
 			return nil, nil, err
 		} else if err != nil {
+			if !pinger.Online() {
+				log.Warn("indexer is offline")
+				return nil, nil, errNodeOffline
+			}
 			log.Debug("failed to resolve host", zap.String("host", host), zap.Error(err))
 			continue
 		}

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -262,6 +262,7 @@ func (m *HostManager) scanHosts(ctx context.Context) {
 	sema := make(chan struct{}, scanThreads)
 	defer close(sema)
 
+	var once sync.Once
 	var wg sync.WaitGroup
 	for _, hk := range hosts {
 		select {
@@ -277,7 +278,10 @@ func (m *HostManager) scanHosts(ctx context.Context) {
 				wg.Done()
 			}()
 
-			if _, err := m.ScanHost(ctx, hk); errors.Is(err, context.Canceled) || errors.Is(err, errNodeOffline) {
+			if _, err := m.ScanHost(ctx, hk); errors.Is(err, context.Canceled) {
+				return
+			} else if errors.Is(err, errNodeOffline) {
+				once.Do(func() { m.log.Warn("indexer is offline, skipping scans") })
 				return
 			} else if err != nil {
 				m.log.Error("failed to perform host scan", zap.Stringer("hk", hk), zap.Error(err))
@@ -361,7 +365,6 @@ func resolveHost(ctx context.Context, pinger Pinger, resolver Resolver, addresse
 			return nil, nil, err
 		} else if err != nil {
 			if !pinger.Online() {
-				log.Warn("indexer is offline")
 				return nil, nil, errNodeOffline
 			}
 			log.Debug("failed to resolve host", zap.String("host", host), zap.Error(err))

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/coreutils/syncer"
 	"go.uber.org/zap"
 )
 
@@ -48,12 +49,6 @@ func (s *mockStore) PruneHosts(ctx context.Context, lastSuccessfulScanCutoff tim
 
 func (s *mockStore) UpdateHost(ctx context.Context, hk types.PublicKey, networks []net.IPNet, hs proto4.HostSettings, scanSucceeded bool, nextScan time.Time) error {
 	return nil
-}
-
-type mockPinger struct{ online bool }
-
-func (p mockPinger) Online() bool {
-	return p.online
 }
 
 // mockResolver is a mock that implements the Resolver interface.
@@ -99,7 +94,7 @@ func TestHostManager(t *testing.T) {
 	db := &mockStore{hosts: make(map[types.PublicKey]Host)}
 
 	// create host manager
-	mgr, err := NewManager(db, WithAnnouncementMaxAge(time.Minute))
+	mgr, err := NewManager(&mockSyncer{peers: []*syncer.Peer{{}}}, db, WithAnnouncementMaxAge(time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +290,6 @@ func TestCalculateNextScanTime(t *testing.T) {
 
 // TestResolveHost unit tests the functionality of ResolveHost.
 func TestResolveHost(t *testing.T) {
-	p := mockPinger{}
 	r := &mockResolver{
 		ips: map[string][]net.IPAddr{
 			"h1.com": {{IP: net.IPv4(127, 0, 0, 1)}, {IP: net.IPv4(1, 2, 3, 4)}},
@@ -304,13 +298,13 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert [context.Cancelled] is returned when context is cancelled
-	_, _, err := resolveHost(cancelledCtx, p, r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
+	_, _, err := resolveHost(cancelledCtx, r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 
 	// assert incorrect addresses are filtered out
-	addrs, _, err := resolveHost(context.Background(), p, r, []chain.NetAddress{testMuxAddr("h1.com")}, zap.NewNop())
+	addrs, _, err := resolveHost(context.Background(), r, []chain.NetAddress{testMuxAddr("h1.com")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 0 {
@@ -318,7 +312,7 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert net addresses with private IPs are filtered out
-	addrs, _, err = resolveHost(context.Background(), p, r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
+	addrs, _, err = resolveHost(context.Background(), r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 0 {
@@ -326,21 +320,13 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert net addresses get resolved and networks are returned
-	addrs, networks, err := resolveHost(context.Background(), p, r, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
+	addrs, networks, err := resolveHost(context.Background(), r, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 1 {
 		t.Fatal("unexpected", len(addrs))
 	} else if len(networks) != 1 {
 		t.Fatal("unexpected", len(networks))
-	}
-
-	// assert [errNodeOffline] is returned when the indexer is offline
-	r.fail = true
-	p.online = false
-	_, _, err = resolveHost(cancelledCtx, p, r, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
-	if !errors.Is(err, errNodeOffline) {
-		t.Fatal("unexpected error", err)
 	}
 }
 

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -50,12 +50,23 @@ func (s *mockStore) UpdateHost(ctx context.Context, hk types.PublicKey, networks
 	return nil
 }
 
+type mockPinger struct{ online bool }
+
+func (p mockPinger) Online() bool {
+	return p.online
+}
+
 // mockResolver is a mock that implements the Resolver interface.
 type mockResolver struct {
-	ips map[string][]net.IPAddr
+	fail bool
+	ips  map[string][]net.IPAddr
 }
 
 func (r *mockResolver) LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error) {
+	if r.fail {
+		return nil, errors.New("lookup failed")
+	}
+
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -284,6 +295,7 @@ func TestCalculateNextScanTime(t *testing.T) {
 
 // TestResolveHost unit tests the functionality of ResolveHost.
 func TestResolveHost(t *testing.T) {
+	p := mockPinger{}
 	r := &mockResolver{
 		ips: map[string][]net.IPAddr{
 			"h1.com": {{IP: net.IPv4(127, 0, 0, 1)}, {IP: net.IPv4(1, 2, 3, 4)}},
@@ -292,13 +304,13 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert [context.Cancelled] is returned when context is cancelled
-	_, _, err := resolveHost(cancelledCtx, r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
+	_, _, err := resolveHost(cancelledCtx, p, r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 
 	// assert incorrect addresses are filtered out
-	addrs, _, err := resolveHost(context.Background(), r, []chain.NetAddress{testMuxAddr("h1.com")}, zap.NewNop())
+	addrs, _, err := resolveHost(context.Background(), p, r, []chain.NetAddress{testMuxAddr("h1.com")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 0 {
@@ -306,7 +318,7 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert net addresses with private IPs are filtered out
-	addrs, _, err = resolveHost(context.Background(), r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
+	addrs, _, err = resolveHost(context.Background(), p, r, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 0 {
@@ -314,13 +326,21 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert net addresses get resolved and networks are returned
-	addrs, networks, err := resolveHost(context.Background(), r, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
+	addrs, networks, err := resolveHost(context.Background(), p, r, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 1 {
 		t.Fatal("unexpected", len(addrs))
 	} else if len(networks) != 1 {
 		t.Fatal("unexpected", len(networks))
+	}
+
+	// assert [errNodeOffline] is returned when the indexer is offline
+	r.fail = true
+	p.online = false
+	_, _, err = resolveHost(cancelledCtx, p, r, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
+	if !errors.Is(err, errNodeOffline) {
+		t.Fatal("unexpected error", err)
 	}
 }
 

--- a/hosts/scanner.go
+++ b/hosts/scanner.go
@@ -3,6 +3,10 @@ package hosts
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
+
+	"slices"
 
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -21,4 +25,27 @@ func (c *scanner) Settings(ctx context.Context, hk types.PublicKey, addr string)
 	defer t.Close()
 
 	return rhp.RPCSettings(ctx, t)
+}
+
+var fallbackSites = []string{
+	"https://1.1.1.1", // cloudflare
+	"https://www.google.com",
+	"https://www.amazon.com",
+}
+
+type pinger struct{}
+
+// Online returns true if any of the fallback sites are reachable.
+func (pinger) Online() bool {
+	return slices.ContainsFunc(fallbackSites, isReachable)
+}
+
+// isReachable checks if the given URL is reachable via an HTTP HEAD request
+func isReachable(url string) bool {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Head(url)
+	if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		return true
+	}
+	return false
 }

--- a/hosts/scanner.go
+++ b/hosts/scanner.go
@@ -3,7 +3,7 @@ package hosts
 import (
 	"context"
 	"fmt"
-	"net/http"
+	"net"
 	"time"
 
 	"slices"
@@ -28,9 +28,9 @@ func (c *scanner) Settings(ctx context.Context, hk types.PublicKey, addr string)
 }
 
 var fallbackSites = []string{
-	"https://1.1.1.1", // cloudflare
-	"https://www.google.com",
-	"https://www.amazon.com",
+	"1.1.1.1:80", // Cloudflare
+	"www.google.com:80",
+	"www.amazon.com:80",
 }
 
 type pinger struct{}
@@ -40,12 +40,12 @@ func (pinger) Online() bool {
 	return slices.ContainsFunc(fallbackSites, isReachable)
 }
 
-// isReachable checks if the given URL is reachable via an HTTP HEAD request
-func isReachable(url string) bool {
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Head(url)
-	if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 400 {
-		return true
+// isReachable attempts to establish a TCP connection to the given host with a short timeout.
+func isReachable(address string) bool {
+	conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+	if err != nil {
+		return false
 	}
-	return false
+	_ = conn.Close()
+	return true
 }

--- a/hosts/utils.go
+++ b/hosts/utils.go
@@ -28,16 +28,20 @@ func (c *scanner) Settings(ctx context.Context, hk types.PublicKey, addr string)
 }
 
 var fallbackSites = []string{
-	"1.1.1.1:80", // Cloudflare
-	"www.google.com:80",
-	"www.amazon.com:80",
+	"1.1.1.1:443", // Cloudflare
+	"www.google.com:443",
+	"www.amazon.com:443",
 }
 
-type pinger struct{}
+type onlineChecker struct {
+	syncer    Syncer
+	addresses []string
+}
 
-// Online returns true if any of the fallback sites are reachable.
-func (pinger) Online() bool {
-	return slices.ContainsFunc(fallbackSites, isReachable)
+// IsOnline returns true if the syncer has peers or if any of the fallback sites
+// are reachable.
+func (p *onlineChecker) IsOnline() bool {
+	return len(p.syncer.Peers()) > 0 || slices.ContainsFunc(p.addresses, isReachable)
 }
 
 // isReachable attempts to establish a TCP connection to the given host with a short timeout.

--- a/hosts/utils_test.go
+++ b/hosts/utils_test.go
@@ -1,0 +1,44 @@
+package hosts
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.sia.tech/coreutils/syncer"
+)
+
+type mockSyncer struct{ peers []*syncer.Peer }
+
+func (s *mockSyncer) Peers() []*syncer.Peer { return s.peers }
+
+func TestOnlineChecker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+	defer server.Close()
+
+	// assert offline if no peers or fallback sites
+	s := &mockSyncer{}
+	c := &onlineChecker{syncer: s}
+	if c.IsOnline() {
+		t.Fatal("unexpected")
+	}
+
+	// assert offline if unreachable fallback site
+	c.addresses = []string{"192.0.2.1:443"}
+	if c.IsOnline() {
+		t.Fatal("unexpected")
+	}
+
+	// assert online if reachable fallback site
+	c.addresses = append(c.addresses, server.Listener.Addr().String())
+	if !c.IsOnline() {
+		t.Fatal("expected")
+	}
+	c.addresses = []string{"192.0.2.1:443"} // reset
+
+	// assert online if peers
+	s.peers = append(s.peers, &syncer.Peer{})
+	if !c.IsOnline() {
+		t.Fatal("expected")
+	}
+}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -65,7 +65,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		t.Fatalf("failed to create wallet: %v", err)
 	}
 
-	hm, err := hosts.NewManager(store, hosts.WithLogger(log.Named("hosts")), hosts.WithScanFrequency(500*time.Millisecond), hosts.WithScanInterval(time.Second))
+	hm, err := hosts.NewManager(s, store, hosts.WithLogger(log.Named("hosts")), hosts.WithScanFrequency(500*time.Millisecond), hosts.WithScanInterval(time.Second))
 	if err != nil {
 		t.Fatalf("failed to create host manager: %v", err)
 	}


### PR DESCRIPTION
This is not really what the issue describes, but it just works ™. I don't see why the syncer peers check needs be included in the online check. It also complicates the dependency injection part of it. If we're offline I stop scanning too.

Fixes https://github.com/SiaFoundation/indexd/issues/77