### PR TITLE
Add `used_collateral` to database

### DIFF
--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -55,6 +55,22 @@ func WithRevisable(revisable bool) ContractQueryOpt {
 }
 
 type (
+	// AddRenewedContractParams contains the parameters for adding a renewed
+	// contract to the store
+	AddRenewedContractParams struct {
+		RenewedFrom      types.FileContractID
+		RenewedTo        types.FileContractID
+		ProofHeight      uint64
+		ExpirationHeight uint64
+		ContractPrice    types.Currency
+		Allowance        types.Currency
+		MinerFee         types.Currency
+		UsedCollateral   types.Currency
+		TotalCollateral  types.Currency
+	}
+)
+
+type (
 	// ContractState describes the current state of the contract on the network
 	// - pending: the contract has not yet been seen on-chain
 	// - active: the contract was mined on-chain

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -186,6 +186,7 @@ CREATE TABLE contracts (
   contract_price DECIMAL(50, 0) NOT NULL, -- used to display cost of forming contract
   initial_allowance DECIMAL(50, 0) NOT NULL, -- used when refreshing contract to increase budget
   miner_fee DECIMAL(50, 0) NOT NULL, -- miner fee added when forming/renewing contract
+  used_collateral DECIMAL(50, 0) NOT NULL DEFAULT 0 CHECK(used_collateral <= total_collateral), -- collateral (allocated)
   total_collateral DECIMAL(50, 0) NOT NULL, -- total collateral (allocated+unallocated)
 
   -- contract state

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -37,7 +37,7 @@ func (s *Store) AddFormedContract(ctx context.Context, contractID types.FileCont
 // - Duplicate the existing contract/row and point the copy to the original
 // - Update a potential row that referenced the existing contract in renewed_to to point to the new row
 // - Overwrite the existing contract to match the renewed contract
-func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, proofHeight, expirationHeight uint64, contractPrice, allowance, minerFee, usedCollateral, totalCollateral types.Currency) error {
+func (s *Store) AddRenewedContract(ctx context.Context, params contracts.AddRenewedContractParams) error {
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		// defer the evaluation of the UNIQUE constraints while swapping contracts
 		if _, err := tx.Exec(ctx, "SET CONSTRAINTS contracts_contract_id_key, contracts_renewed_from_key, contracts_renewed_to_key DEFERRED"); err != nil {
@@ -46,8 +46,8 @@ func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo t
 
 		// fetch the existing row of the contract
 		var existingID int64
-		if err := tx.QueryRow(ctx, `SELECT id FROM contracts WHERE contract_id = $1`, sqlHash256(renewedFrom)).Scan(&existingID); errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("contract %q: %w", renewedFrom, contracts.ErrNotFound)
+		if err := tx.QueryRow(ctx, `SELECT id FROM contracts WHERE contract_id = $1`, sqlHash256(params.RenewedFrom)).Scan(&existingID); errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("contract %q: %w", params.RenewedFrom, contracts.ErrNotFound)
 		} else if err != nil {
 			return fmt.Errorf("failed to fetch existing contract: %w", err)
 		}
@@ -73,7 +73,7 @@ INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, re
 		// update the existing row to match the new contract
 		resp, err := tx.Exec(ctx, `
 UPDATE contracts SET contract_id = $1, formation = NOW(), proof_height = $2, expiration_height = $3, renewed_from = $4, renewed_to = NULL, state = 0, capacity = CASE WHEN $2 = contracts.proof_height THEN contracts.capacity ELSE contracts.size END, contract_price = $5, initial_allowance = $6, miner_fee = $7, used_collateral = $8, total_collateral = $9, good = TRUE, append_sector_spending = 0, free_sector_spending = 0, fund_account_spending = 0, sector_roots_spending = 0
-WHERE id = $10`, sqlHash256(renewedTo), proofHeight, expirationHeight, newID, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(usedCollateral), sqlCurrency(totalCollateral), existingID)
+WHERE id = $10`, sqlHash256(params.RenewedTo), params.ProofHeight, params.ExpirationHeight, newID, sqlCurrency(params.ContractPrice), sqlCurrency(params.Allowance), sqlCurrency(params.MinerFee), sqlCurrency(params.UsedCollateral), sqlCurrency(params.TotalCollateral), existingID)
 		if err != nil {
 			return fmt.Errorf("failed to init renewed contract: %w", err)
 		} else if resp.RowsAffected() != 1 {

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -37,7 +37,7 @@ func (s *Store) AddFormedContract(ctx context.Context, contractID types.FileCont
 // - Duplicate the existing contract/row and point the copy to the original
 // - Update a potential row that referenced the existing contract in renewed_to to point to the new row
 // - Overwrite the existing contract to match the renewed contract
-func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, proofHeight, expirationHeight uint64, contractPrice, allowance, minerFee, totalCollateral types.Currency) error {
+func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, proofHeight, expirationHeight uint64, contractPrice, allowance, minerFee, usedCollateral, totalCollateral types.Currency) error {
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		// defer the evaluation of the UNIQUE constraints while swapping contracts
 		if _, err := tx.Exec(ctx, "SET CONSTRAINTS contracts_contract_id_key, contracts_renewed_from_key, contracts_renewed_to_key DEFERRED"); err != nil {
@@ -55,8 +55,8 @@ func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo t
 		// duplicate it and make sure the new row renews to the existing row
 		var newID int64
 		if err := tx.QueryRow(ctx, `
-INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, renewed_from, renewed_to, state, capacity, size, contract_price, initial_allowance, miner_fee, total_collateral, good, append_sector_spending, free_sector_spending, fund_account_spending, sector_roots_spending) (
-	SELECT host_id, contract_id, proof_height, expiration_height, renewed_from, $1, state, capacity, size, contract_price, initial_allowance, miner_fee, total_collateral, good, append_sector_spending, free_sector_spending, fund_account_spending, sector_roots_spending
+INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, renewed_from, renewed_to, state, capacity, size, contract_price, initial_allowance, miner_fee, used_collateral, total_collateral, good, append_sector_spending, free_sector_spending, fund_account_spending, sector_roots_spending) (
+	SELECT host_id, contract_id, proof_height, expiration_height, renewed_from, $1, state, capacity, size, contract_price, initial_allowance, miner_fee, used_collateral, total_collateral, good, append_sector_spending, free_sector_spending, fund_account_spending, sector_roots_spending
 	FROM contracts
 	WHERE contracts.id = $1
 ) RETURNING id
@@ -72,8 +72,8 @@ INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, re
 
 		// update the existing row to match the new contract
 		resp, err := tx.Exec(ctx, `
-UPDATE contracts SET contract_id = $1, formation = NOW(), proof_height = $2, expiration_height = $3, renewed_from = $4, renewed_to = NULL, state = 0, capacity = CASE WHEN $2 = contracts.proof_height THEN contracts.capacity ELSE contracts.size END, contract_price = $5, initial_allowance = $6, miner_fee = $7, total_collateral = $8, good = TRUE, append_sector_spending = 0, free_sector_spending = 0, fund_account_spending = 0, sector_roots_spending = 0
-WHERE id = $9`, sqlHash256(renewedTo), proofHeight, expirationHeight, newID, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(totalCollateral), existingID)
+UPDATE contracts SET contract_id = $1, formation = NOW(), proof_height = $2, expiration_height = $3, renewed_from = $4, renewed_to = NULL, state = 0, capacity = CASE WHEN $2 = contracts.proof_height THEN contracts.capacity ELSE contracts.size END, contract_price = $5, initial_allowance = $6, miner_fee = $7, used_collateral = $8, total_collateral = $9, good = TRUE, append_sector_spending = 0, free_sector_spending = 0, fund_account_spending = 0, sector_roots_spending = 0
+WHERE id = $10`, sqlHash256(renewedTo), proofHeight, expirationHeight, newID, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(usedCollateral), sqlCurrency(totalCollateral), existingID)
 		if err != nil {
 			return fmt.Errorf("failed to init renewed contract: %w", err)
 		} else if resp.RowsAffected() != 1 {
@@ -91,7 +91,7 @@ func (s *Store) Contract(ctx context.Context, contractID types.FileContractID) (
 	var contract contracts.Contract
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		contract, err = scanContract(tx.QueryRow(ctx, `
-SELECT c.contract_id, c.formation, h.public_key, c.proof_height, c.expiration_height, c_from.contract_id, c_to.contract_id, c.state, c.capacity, c.size, c.contract_price, c.initial_allowance, c.miner_fee, c.total_collateral, c.good, c.append_sector_spending, c.free_sector_spending, c.fund_account_spending, c.sector_roots_spending
+SELECT c.contract_id, c.formation, h.public_key, c.proof_height, c.expiration_height, c_from.contract_id, c_to.contract_id, c.state, c.capacity, c.size, c.contract_price, c.initial_allowance, c.miner_fee, c.used_collateral, c.total_collateral, c.good, c.append_sector_spending, c.free_sector_spending, c.fund_account_spending, c.sector_roots_spending
 FROM contracts c
 INNER JOIN hosts h ON c.host_id = h.id
 LEFT JOIN contracts c_from ON c.renewed_from = c_from.id
@@ -266,6 +266,7 @@ func scanContract(row scanner) (contracts.Contract, error) {
 		(*sqlCurrency)(&c.ContractPrice),
 		(*sqlCurrency)(&c.InitialAllowance),
 		(*sqlCurrency)(&c.MinerFee),
+		(*sqlCurrency)(&c.UsedCollateral),
 		(*sqlCurrency)(&c.TotalCollateral),
 		&c.Good,
 		(*sqlCurrency)(&c.Spending.AppendSector),

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -287,7 +287,17 @@ func TestFormRenewContract(t *testing.T) {
 		UsedCollateral:   types.Siacoins(4),
 		TotalCollateral:  types.Siacoins(5),
 	}
-	err = store.AddRenewedContract(context.Background(), expectedRefreshed.RenewedFrom, expectedRefreshed.ID, expectedRefreshed.ProofHeight, expectedRefreshed.ExpirationHeight, expectedRefreshed.ContractPrice, expectedRefreshed.InitialAllowance, expectedRefreshed.MinerFee, expectedRefreshed.UsedCollateral, expectedRefreshed.TotalCollateral)
+	err = store.AddRenewedContract(context.Background(), contracts.AddRenewedContractParams{
+		RenewedFrom:      expectedRefreshed.RenewedFrom,
+		RenewedTo:        expectedRefreshed.ID,
+		ProofHeight:      expectedRefreshed.ProofHeight,
+		ExpirationHeight: expectedRefreshed.ExpirationHeight,
+		ContractPrice:    expectedRefreshed.ContractPrice,
+		Allowance:        expectedRefreshed.InitialAllowance,
+		MinerFee:         expectedRefreshed.MinerFee,
+		UsedCollateral:   expectedRefreshed.UsedCollateral,
+		TotalCollateral:  expectedRefreshed.TotalCollateral,
+	})
 	if err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}
@@ -327,7 +337,17 @@ func TestFormRenewContract(t *testing.T) {
 		UsedCollateral:   types.Siacoins(4),
 		TotalCollateral:  types.Siacoins(5),
 	}
-	err = store.AddRenewedContract(context.Background(), expectedRenewed.RenewedFrom, expectedRenewed.ID, expectedRenewed.ProofHeight, expectedRenewed.ExpirationHeight, expectedRenewed.ContractPrice, expectedRenewed.InitialAllowance, expectedRenewed.MinerFee, expectedRenewed.UsedCollateral, expectedRenewed.TotalCollateral)
+	err = store.AddRenewedContract(context.Background(), contracts.AddRenewedContractParams{
+		RenewedFrom:      expectedRenewed.RenewedFrom,
+		RenewedTo:        expectedRenewed.ID,
+		ProofHeight:      expectedRenewed.ProofHeight,
+		ExpirationHeight: expectedRenewed.ExpirationHeight,
+		ContractPrice:    expectedRenewed.ContractPrice,
+		Allowance:        expectedRenewed.InitialAllowance,
+		MinerFee:         expectedRenewed.MinerFee,
+		UsedCollateral:   expectedRenewed.UsedCollateral,
+		TotalCollateral:  expectedRenewed.TotalCollateral,
+	})
 	if err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -284,9 +284,10 @@ func TestFormRenewContract(t *testing.T) {
 		Good:             true,                            // refreshed contract is good
 		RenewedFrom:      expectedFormed.ID,               // refreshed from formed contract
 		Spending:         contracts.ContractSpending{},    // spending is reset
+		UsedCollateral:   types.Siacoins(4),
 		TotalCollateral:  types.Siacoins(5),
 	}
-	err = store.AddRenewedContract(context.Background(), expectedRefreshed.RenewedFrom, expectedRefreshed.ID, expectedRefreshed.ProofHeight, expectedRefreshed.ExpirationHeight, expectedRefreshed.ContractPrice, expectedRefreshed.InitialAllowance, expectedRefreshed.MinerFee, expectedRefreshed.TotalCollateral)
+	err = store.AddRenewedContract(context.Background(), expectedRefreshed.RenewedFrom, expectedRefreshed.ID, expectedRefreshed.ProofHeight, expectedRefreshed.ExpirationHeight, expectedRefreshed.ContractPrice, expectedRefreshed.InitialAllowance, expectedRefreshed.MinerFee, expectedRefreshed.UsedCollateral, expectedRefreshed.TotalCollateral)
 	if err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}
@@ -323,8 +324,10 @@ func TestFormRenewContract(t *testing.T) {
 		Good:             true,                                   // renewed contract is good
 		RenewedFrom:      expectedRefreshed.ID,                   // renewed from refreshed contract
 		Spending:         contracts.ContractSpending{},           // spending is reset
+		UsedCollateral:   types.Siacoins(4),
+		TotalCollateral:  types.Siacoins(5),
 	}
-	err = store.AddRenewedContract(context.Background(), expectedRenewed.RenewedFrom, expectedRenewed.ID, expectedRenewed.ProofHeight, expectedRenewed.ExpirationHeight, expectedRenewed.ContractPrice, expectedRenewed.InitialAllowance, expectedRenewed.MinerFee, expectedRenewed.TotalCollateral)
+	err = store.AddRenewedContract(context.Background(), expectedRenewed.RenewedFrom, expectedRenewed.ID, expectedRenewed.ProofHeight, expectedRenewed.ExpirationHeight, expectedRenewed.ContractPrice, expectedRenewed.InitialAllowance, expectedRenewed.MinerFee, expectedRenewed.UsedCollateral, expectedRenewed.TotalCollateral)
 	if err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -135,6 +135,7 @@ CREATE TABLE contracts (
   contract_price DECIMAL(50, 0) NOT NULL, -- used to display cost of forming contract
   initial_allowance DECIMAL(50, 0) NOT NULL, -- used when refreshing contract to increase budget
   miner_fee DECIMAL(50, 0) NOT NULL, -- miner fee added when forming/renewing contract
+  used_collateral DECIMAL(50, 0) NOT NULL DEFAULT 0 CHECK(used_collateral <= total_collateral), -- collateral (allocated)
   total_collateral DECIMAL(50, 0) NOT NULL, -- total collateral (allocated+unallocated)
 
   -- contract state


### PR DESCRIPTION
Adds the `used_collateral` field to the database. Needed to determine whether a contract is running low on collateral or whether it already uses more collateral than the host's most recent `MaxCollateral` settings.