### PR TITLE
Add GoodUsability

### DIFF
--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -155,7 +155,7 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 				},
 			},
 			Settings:  goodSettings, // default to good settings to consider every host
-			Usability: goodUsability,
+			Usability: hosts.GoodUsability,
 		}
 	}
 
@@ -305,7 +305,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 				},
 			},
 			Settings:  goodSettings, // default to good settings to consider every host
-			Usability: goodUsability,
+			Usability: hosts.GoodUsability,
 		}
 	}
 

--- a/contracts/manager_test.go
+++ b/contracts/manager_test.go
@@ -9,27 +9,11 @@ import (
 	"go.sia.tech/indexd/hosts"
 )
 
-var goodUsability = hosts.Usability{
-	Uptime:              true,
-	MaxContractDuration: true,
-	MaxCollateral:       true,
-	ProtocolVersion:     true,
-	PriceValidity:       true,
-	AcceptingContracts:  true,
-
-	ContractPrice:   true,
-	Collateral:      true,
-	StoragePrice:    true,
-	IngressPrice:    true,
-	EgressPrice:     true,
-	FreeSectorPrice: true,
-}
-
 func TestBlockBadHosts(t *testing.T) {
 	store := &storeMock{}
 	contracts := newContractManager(types.PublicKey{}, nil, nil, nil, store, nil, nil)
 
-	goodHost := hosts.Host{PublicKey: types.PublicKey{1}, Usability: goodUsability, Blocked: false}
+	goodHost := hosts.Host{PublicKey: types.PublicKey{1}, Usability: hosts.GoodUsability, Blocked: false}
 	badHost := hosts.Host{PublicKey: types.PublicKey{2}, Usability: hosts.Usability{}, Blocked: false}
 	unusedBadHost := hosts.Host{PublicKey: types.PublicKey{3}, Usability: hosts.Usability{}, Blocked: false}
 

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -76,7 +76,7 @@ func TestPerformContractRefreshes(t *testing.T) {
 		return hosts.Host{
 			PublicKey: types.PublicKey{byte(i)},
 			Settings:  goodSettings,
-			Usability: goodUsability,
+			Usability: hosts.GoodUsability,
 		}
 	}
 

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -72,7 +72,7 @@ func TestPerformContractRenewals(t *testing.T) {
 		return hosts.Host{
 			PublicKey: types.PublicKey{byte(i)},
 			Settings:  badSettings, // will be updated by scan to good settings
-			Usability: goodUsability,
+			Usability: hosts.GoodUsability,
 		}
 	}
 

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -105,8 +105,24 @@ type (
 	}
 )
 
+// GoodUsability is the usability struct indicating that all checks passed.
+var GoodUsability = Usability{
+	Uptime:              true,
+	MaxContractDuration: true,
+	MaxCollateral:       true,
+	ProtocolVersion:     true,
+	PriceValidity:       true,
+	AcceptingContracts:  true,
+
+	ContractPrice:   true,
+	Collateral:      true,
+	StoragePrice:    true,
+	IngressPrice:    true,
+	EgressPrice:     true,
+	FreeSectorPrice: true,
+}
+
 // Usable returns true if all checks passed.
 func (u Usability) Usable() bool {
-	return u.Uptime && u.MaxContractDuration && u.MaxCollateral && u.ProtocolVersion && u.PriceValidity && u.AcceptingContracts &&
-		u.ContractPrice && u.Collateral && u.StoragePrice && u.IngressPrice && u.EgressPrice && u.FreeSectorPrice
+	return u == GoodUsability
 }


### PR DESCRIPTION
Minor cleanup to allow us to get rid from various `goodUsability` globals we have 