### PR TITLE
RFC: Metadata Store

### DIFF
--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -222,7 +222,9 @@ CREATE TABLE contract_elements (
 ```postgresql
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
-    public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32)
+    public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
+    max_metadata_size BIGINT NOT NULL DEFAULT 1000000000000 CHECK (metadata_size <= max_metadata_size), -- 1GB of metadata
+    metadata_size BIGINT NOT NULL DEFAULT 0 -- sum of size of stored metadata (updated on insert and delete)
 );
 
 CREATE TABLE account_slabs (
@@ -276,4 +278,16 @@ CREATE INDEX sectors_contract_id_uploaded_at_idx ON host_sectors(contract_id, up
 
 -- index over contract_id and next_integrity_check since we only check pinned sectors
 CREATE INDEX sectors_contract_id_next_integrity_check_idx ON host_sectors(contract_id, next_integrity_check ASC)
+```
+
+### 2.7 Metadata
+
+```postgresql
+CREATE TABLE metadata (
+    id BIGSERIAL PRIMARY KEY,
+
+    account_id INTEGER REFERENCES accounts(id) NOT NULL,
+    key BYTEA NOT NULL,
+)
+CREATE UNIQUE INDEX metadata_account_id_key ON metadata(account_id, key)
 ```

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -289,5 +289,5 @@ CREATE TABLE metadata (
     account_id INTEGER REFERENCES accounts(id) NOT NULL,
     key BYTEA NOT NULL
 );
-CREATE UNIQUE INDEX metadata_account_id_key ON metadata(account_id, key)
+CREATE UNIQUE INDEX metadata_account_id_key_idx ON metadata(account_id, key)
 ```

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -223,7 +223,7 @@ CREATE TABLE contract_elements (
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
-    max_metadata_size BIGINT NOT NULL DEFAULT 1000000000000 CHECK (metadata_size <= max_metadata_size), -- 1GB of metadata
+    max_metadata_size BIGINT NOT NULL DEFAULT 1000000000 CHECK (metadata_size <= max_metadata_size), -- 1GB of metadata
     metadata_size BIGINT NOT NULL DEFAULT 0 -- sum of size of stored metadata (updated on insert and delete)
 );
 
@@ -287,7 +287,7 @@ CREATE TABLE metadata (
     id BIGSERIAL PRIMARY KEY,
 
     account_id INTEGER REFERENCES accounts(id) NOT NULL,
-    key BYTEA NOT NULL,
+    key BYTEA NOT NULL
 )
 CREATE UNIQUE INDEX metadata_account_id_key ON metadata(account_id, key)
 ```

--- a/doc/rfc/001_db_schema.md
+++ b/doc/rfc/001_db_schema.md
@@ -288,6 +288,6 @@ CREATE TABLE metadata (
 
     account_id INTEGER REFERENCES accounts(id) NOT NULL,
     key BYTEA NOT NULL
-)
+);
 CREATE UNIQUE INDEX metadata_account_id_key ON metadata(account_id, key)
 ```

--- a/doc/rfc/012_metadata_store.md
+++ b/doc/rfc/012_metadata_store.md
@@ -14,7 +14,7 @@ client-side encrypted, tamper-resistant data. To maximize privacy, there is no
 relation between these blobs of metadata and slabs that the indexer knows of.
 This severely limits the capability of the store as the indexer can't perform
 searches on this data, but the client can add any necessary complexity
-client-side while the metadata store serves as a pure backup mechanism.
+client-side while the metadata store serves purely as a backup mechanism.
 
 ## The Store
 

--- a/doc/rfc/012_metadata_store.md
+++ b/doc/rfc/012_metadata_store.md
@@ -1,0 +1,69 @@
+# Metadata Store
+
+## Abstract
+
+One of the advantages of the indexer is allowing users to outsource the
+responsibility of forming contracts, repairing data, acquiring Siacoin and
+running the service 24/7 themselves to a third party. However, without a way to
+back up metadata on top pinning slabs, there is no way for client applications
+to recover information about what slabs make up an object or additional metadata
+such as the object's content type.
+
+To add that behavior, the indexer offers a generic metadata store which holds
+client-side encrypted, tamper-resistant data. To maximize privacy, there is no
+relation between these blobs of metadata and slabs that the indexer knows of.
+This severely limits the capability of the store as the indexer can't perform
+searches on this data, but the client can add any necessary complexity
+client-side while the metadata store serves as a pure backup mechanism.
+
+## The Store
+
+The actual store is very straightforward. Apps can perform the following actions on it:
+
+- Store a value for a given 32-byte key (SHA-256 HMAC)
+- Retrieve a value for a given 32-byte key
+- Fetch all available keys with offset+limit
+
+While not important for the indexer implementation since it can't verify it, the
+key is intended to be a fingerprint of the value that only the client can
+create. To achieve that, we use an HMAC over the encrypted value.
+
+### HMAC Creation
+
+Clients already use ED25519 keys for authentication. To avoid increasing the
+complexity of using indexd, we try to keep the number of keys a client
+application needs to manage to one. To achieve that, we derive the key we use
+for the HMAC from the ED25519 private key since it's not considered safe to
+reuse the same key material for different cryptographic algorithms directly.
+
+For that, we use the key derivation function HKDF which is specifically made for
+use-cases where you already have entropy-rich input and quickly want to derive
+domain-specific keys. We then use the resulting key to create the HMAC over the
+encrypted value to store in the metadata store.
+
+### Value Encryption
+
+Similar to the HMAC creation, we derive another key for the encryption of the
+value with HKDF as well as a random nonce. Then we use CHACHA20-Poly1305 to
+encrypt the plaintext value and append the nonce to it. The nonce is appended
+since it mustn't be reused while we still need to know it when decrypting.
+
+### Limits and Abuse
+
+To prevent abuse by users just uploading arbitrary data to the metadata store,
+we enforce sane limits.
+
+If we assume the intended usage of the store is to store object metadata and
+that an object consists mostly of 48 bytes of metadata per 40MiB slab, 1MB per
+key should allow for a max object size of about 1TB, depending on how compact of
+a binary format is chosen.
+
+Since users hosting indexd themselves probably won't need to limit themselves,
+the default is set to 1GB of metadata per account, which should be enough for
+1PB of uploads per app. Entities building services on top of indexd might want
+to set this to lower values on a per-account, per-tier basis to prevent abuse.
+
+In addition to this per-account limit, we also limit the size of a single
+key-value pair to 5MB. This should be enough to cover objects of about 5TB in
+size which is quite generous and won't allow users to lock up our database with
+large insertions.

--- a/doc/rfc/012_metadata_store.md
+++ b/doc/rfc/012_metadata_store.md
@@ -38,15 +38,27 @@ reuse the same key material for different cryptographic algorithms directly.
 
 For that, we use the key derivation function HKDF which is specifically made for
 use-cases where you already have entropy-rich input and quickly want to derive
-domain-specific keys. We then use the resulting key to create the HMAC over the
-encrypted value to store in the metadata store.
+domain-specific keys. The salt/domain should be the string `MD-HMAC-SECRET`. We
+then use the resulting key to create the HMAC over the encrypted value to store
+in the metadata store.
 
 ### Value Encryption
 
 Similar to the HMAC creation, we derive another key for the encryption of the
-value with HKDF as well as a random nonce. Then we use CHACHA20-Poly1305 to
-encrypt the plaintext value and append the nonce to it. The nonce is appended
-since it mustn't be reused while we still need to know it when decrypting.
+value with HKDF as well as a random nonce. This time we use the salt
+`MD-ENCRYPTION-SECRET`. Then we use CHACHA20-Poly1305 to encrypt the plaintext
+value and append the nonce to it. The nonce is appended since it mustn't be
+reused while we still need to know it when decrypting.
+
+### Validation
+
+After fetching the value for a key from the store, validation works as follows:
+
+1. derive the needed keys again
+2. validate the value against the key (HMAC)
+3. extract the nonce from the value
+4. decrypt the value
+5. use the value
 
 ### Limits and Abuse
 

--- a/doc/rfc/012_metadata_store.md
+++ b/doc/rfc/012_metadata_store.md
@@ -46,17 +46,25 @@ in the metadata store.
 
 Similar to the HMAC creation, we derive another key for the encryption of the
 value with HKDF as well as a random nonce. This time we use the salt
-`MD-ENCRYPTION-SECRET`. Then we use CHACHA20-Poly1305 to encrypt the plaintext
-value and append the nonce to it. The nonce is appended since it mustn't be
-reused while we still need to know it when decrypting.
+`MD-ENCRYPTION-SECRET`. From that key we derive another one using a random 32
+byte salt. Then we use CHACHA20-Poly1305 to encrypt the plaintext
+value and append the salt to it.
+
+The reason for using a random salt rather than a random 12 byte nonce is to
+avoid nonce reuse. This will always result in a unique key for each stored value
+while reusing the nonce might become a problem when a user reaches billions of
+messages created from the same key since the probability is about 𝑛^2/2^96 for n
+messages.
+If we generate a unique key for each stored value, we can safely encrypt every
+value starting at nonce = 0.
 
 ### Validation
 
 After fetching the value for a key from the store, validation works as follows:
 
-1. derive the needed keys again
-2. validate the value against the key (HMAC)
-3. extract the nonce from the value
+1. derive the `MD-HMAC-SECRET` and `MD-ENCRYPTION-SECRET` keys
+2. validate the value against the HMAC
+3. extract the salt from the value and derive the key for decryption
 4. decrypt the value
 5. use the value
 


### PR DESCRIPTION
Adds the RFC for a generic, encrypted and tamper-resistant metadata store apps can use for backing up object metadata.

Closes https://github.com/SiaFoundation/indexd/issues/100