### PR TITLE
Slabs performance

### DIFF
--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -78,65 +78,74 @@ func (s *Store) Slabs(ctx context.Context, accountID proto.Account, slabIDs []sl
 		return nil, nil
 	}
 
-	result := make([]slabs.Slab, 0, len(slabIDs))
+	results := make([]slabs.Slab, len(slabIDs))
+	slabIDMap := make(map[slabs.SlabID]int)
+	for i, slabID := range slabIDs {
+		slabIDMap[slabID] = i
+	}
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		for _, slabID := range slabIDs {
-			// query slab
-			var sid int64
-			slab := slabs.Slab{ID: slabID}
-			err := tx.QueryRow(ctx, `
-				SELECT slabs.id, encryption_key, min_shards
-				FROM slabs
-				INNER JOIN account_slabs ON slabs.id = account_slabs.slab_id
-				INNER JOIN accounts a ON a.id = account_slabs.account_id
-				WHERE digest = $1 AND a.public_key = $2
-			`, sqlHash256(slabID), sqlPublicKey(accountID)).Scan(&sid, (*sqlHash256)(&slab.EncryptionKey), &slab.MinShards)
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("%w: %v", slabs.ErrSlabNotFound, slabID)
-			} else if err != nil {
-				return fmt.Errorf("failed to query slab %s: %w", slabID, err)
-			}
-
-			// query sectors
-			err = func() error {
-				rows, err := tx.Query(ctx, `
-					SELECT sector_root, h.public_key, c.contract_id
-					FROM sectors
-					LEFT JOIN hosts h ON h.id = sectors.host_id
-					LEFT JOIN contracts c ON c.id = sectors.contract_id
-					WHERE slab_id = $1
-					ORDER BY slab_index ASC
-				`, sid)
-				if err != nil {
-					return fmt.Errorf("failed to query sectors for slab %s: %w", slabID, err)
+		dbIDMap := make(map[int64]int)
+		var dbIDs []int64
+		slabBatch := &pgx.Batch{}
+		for i, slabID := range slabIDs {
+			slabBatch.Queue(`SELECT s.id, s.encryption_key, s.min_shards
+				FROM slabs s
+				INNER JOIN account_slabs ac ON s.id = ac.slab_id
+				INNER JOIN accounts a ON a.id = ac.account_id
+				WHERE digest = $1 AND a.public_key = $2`, sqlHash256(slabID), sqlPublicKey(accountID)).QueryRow(func(row pgx.Row) error {
+				results[i].ID = slabID
+				var dbID int64
+				if err := row.Scan(&dbID, (*sqlHash256)(&results[i].EncryptionKey), &results[i].MinShards); err != nil {
+					if errors.Is(err, sql.ErrNoRows) {
+						err = slabs.ErrSlabNotFound
+					}
+					return fmt.Errorf("failed to get slab %q: %w", slabID, err)
 				}
+				dbIDs = append(dbIDs, dbID)
+				dbIDMap[dbID] = i
+				return nil
+			})
+		}
+		if err := tx.Tx.SendBatch(ctx, slabBatch).Close(); err != nil {
+			return fmt.Errorf("failed to get slabs: %w", err)
+		}
+
+		sectorsBatch := &pgx.Batch{}
+		for _, slabID := range dbIDs {
+			sectorsBatch.Queue(`SELECT s.sector_root, h.public_key, c.contract_id 
+FROM sectors s
+LEFT JOIN hosts h ON h.id = s.host_id
+LEFT JOIN contracts c ON c.id = s.contract_id
+WHERE s.slab_id = $1
+ORDER BY s.slab_index ASC`, slabID).Query(func(rows pgx.Rows) error {
 				defer rows.Close()
 				for rows.Next() {
 					var sector slabs.Sector
 					var hostKey sql.Null[sqlPublicKey]
 					var contractID sql.Null[sqlHash256]
-					err = rows.Scan((*sqlHash256)(&sector.Root), asNullable(&hostKey), &contractID)
-					if err != nil {
+
+					if err := rows.Scan((*sqlHash256)(&sector.Root), &hostKey, &contractID); err != nil {
 						return fmt.Errorf("failed to scan sector: %w", err)
 					}
+
 					if hostKey.Valid {
 						sector.HostKey = (*types.PublicKey)(&hostKey.V)
 					}
 					if contractID.Valid {
 						sector.ContractID = (*types.FileContractID)(&contractID.V)
 					}
-					slab.Sectors = append(slab.Sectors, sector)
+					results[dbIDMap[slabID]].Sectors = append(results[dbIDMap[slabID]].Sectors, sector)
 				}
 				return rows.Err()
-			}()
-			if err != nil {
-				return err
-			}
-			result = append(result, slab)
+			})
 		}
+		if err := tx.Tx.SendBatch(ctx, sectorsBatch).Close(); err != nil {
+			return fmt.Errorf("failed to get slab sectors: %w", err)
+		}
+
 		return nil
 	})
-	return result, err
+	return results, err
 }
 
 func (s *Store) pinSlab(ctx context.Context, tx *txn, accountID int64, nextIntegrityCheck time.Time, slab slabs.SlabPinParams) (slabs.SlabID, error) {

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -79,10 +79,6 @@ func (s *Store) Slabs(ctx context.Context, accountID proto.Account, slabIDs []sl
 	}
 
 	results := make([]slabs.Slab, len(slabIDs))
-	slabIDMap := make(map[slabs.SlabID]int)
-	for i, slabID := range slabIDs {
-		slabIDMap[slabID] = i
-	}
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		dbIDMap := make(map[int64]int)
 		var dbIDs []int64

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -119,7 +119,7 @@ func TestPinSlabs(t *testing.T) {
 
 	// pin without an account
 	nextCheck := time.Now().Round(time.Microsecond).Add(time.Hour)
-	slabIDs, err := store.PinSlabs(context.Background(), account, nextCheck, []slabs.SlabPinParams{{}})
+	_, err := store.PinSlabs(context.Background(), account, nextCheck, []slabs.SlabPinParams{{}})
 	if !errors.Is(err, accounts.ErrNotFound) {
 		t.Fatal("expected ErrNotFound, got", err)
 	}
@@ -175,7 +175,7 @@ func TestPinSlabs(t *testing.T) {
 	slab2ID, slab2 := newSlab(2)
 	toPin := []slabs.SlabPinParams{slab1, slab2}
 	expectedIDs := []slabs.SlabID{slab1ID, slab2ID}
-	slabIDs, err = store.PinSlabs(context.Background(), proto.Account{1}, nextCheck, toPin)
+	slabIDs, err := store.PinSlabs(context.Background(), proto.Account{1}, nextCheck, toPin)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(slabIDs) != len(toPin) {
@@ -267,13 +267,13 @@ func TestPinSlabs(t *testing.T) {
 // upload/download throughput.
 //
 // Hardware |     Benchmark   |  ms/op  | Throughput   |
-// M2 Pro   | PinSlabs-40MiB  |  1.4ms | 28472.56 MB/s |
-// M2 Pro   | PinSlabs-400MiB |  8.9ms |  4698.53 MB/s |
-// M2 Pro   | PinSlabs-4GiB   | 89.6ms |   467.67 MB/s |
+// M2 Pro   | PinSlabs-40MiB  |  1.2ms | 33885.23 MB/s |
+// M2 Pro   | PinSlabs-400MiB |  8.6ms |  4875.42 MB/s |
+// M2 Pro   | PinSlabs-4GiB   | 86.7ms |   483.63 MB/s |
 //
-// M2 Pro   | Slabs-40MiB  |  0.6ms |    63029.04 MB/s |
-// M2 Pro   | Slabs-400MiB |  3.1ms |    13181.86 MB/s |
-// M2 Pro   | Slabs-4GiB   | 29.8ms |     1404.40 MB/s |
+// M2 Pro   | Slabs-40MiB  |  0.5ms |    70382.04 MB/s |
+// M2 Pro   | Slabs-400MiB |  0.8ms |    52154.24 MB/s |
+// M2 Pro   | Slabs-4GiB   |  3.3ms |    12668.21 MB/s |
 func BenchmarkSlabs(b *testing.B) {
 	store := initPostgres(b, zaptest.NewLogger(b).Named("postgres"))
 	account := proto.Account{1}


### PR DESCRIPTION
Changes the `Slabs` function to batch the queries together instead of sending individually for a significant performance increase. I also tried `SELECT ... WHERE digest=any()`, but it was slower than the for loop. Could be a missing index, but didn't look too deeply. 

for loop:
```
BenchmarkSlabs/Slabs-40MiB-16            	    1879	    606584 ns/op	69146.27 MB/s	   17470 B/op	     358 allocs/op
BenchmarkSlabs/Slabs-400MiB-16           	     403	   2880423 ns/op	14561.42 MB/s	  159722 B/op	    3427 allocs/op
BenchmarkSlabs/Slabs-4GiB-16             	      46	  25039947 ns/op	1675.05 MB/s	 1581877 B/op	   34121 allocs/op
```

Batch queries:
```
BenchmarkSlabs/Slabs-40MiB-16            	    1940	    595934 ns/op	70382.04 MB/s	   18943 B/op	     384 allocs/op
BenchmarkSlabs/Slabs-400MiB-16           	    1333	    804212 ns/op	52154.24 MB/s	  173310 B/op	    3548 allocs/op
BenchmarkSlabs/Slabs-4GiB-16             	     356	   3310889 ns/op	12668.21 MB/s	 1763392 B/op	   34990 allocs/op
```