### PR TITLE
Cleanup refresh code

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -212,7 +212,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		}
 		hostAddr := host.SiamuxAddr()
 
-		allowance, collateral := initialContractFunding(host.Settings.Prices, period)
+		allowance, collateral := initialContractFunding(host.Settings.Prices, host.Settings.MaxCollateral, period)
 		formationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		res, err := cm.contractor.FormContract(formationCtx, host.PublicKey, hostAddr, host.Settings, proto.RPCFormContractParams{
 			RenterPublicKey: cm.renterKey,
@@ -242,19 +242,25 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 	return nil
 }
 
-func initialContractFunding(prices proto.HostPrices, period uint64) (allowance, collateral types.Currency) {
+func initialContractFunding(prices proto.HostPrices, maxCollateral types.Currency, period uint64) (allowance, collateral types.Currency) {
 	// each 10GB of upload + download + storage
 	basePrice := prices.ContractPrice
 	writeUsage := prices.RPCWriteSectorCost(proto.SectorSize).Mul(10 * sectorsPerGiB)
 	readUsage := prices.RPCReadSectorCost(proto.SectorSize).Mul(10 * sectorsPerGiB)
 	storageUsage := prices.RPCAppendSectorsCost(10*sectorsPerGiB, period)
 	total := writeUsage.Add(readUsage).Add(storageUsage)
-	allowance, collateral = total.RenterCost().Add(basePrice), total.HostRiskedCollateral()
+	allowance = total.RenterCost().Add(basePrice)
 
 	// don't go below a sane minimum to make sure we can fill an account without
 	// immediately draining the contract and requiring a refresh.
 	if allowance.Cmp(minAllowance) < 0 {
 		allowance = minAllowance
+	}
+
+	// don't go beyond the host's max collateral limits
+	collateral = proto.MaxHostCollateral(prices, allowance)
+	if collateral.Cmp(maxCollateral) > 0 {
+		collateral = maxCollateral
 	}
 	return allowance, collateral
 }

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -229,7 +229,7 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
 		// assert params
-		allowance, collateral := initialContractFunding(goodSettings.Prices, period)
+		allowance, collateral := initialContractFunding(goodSettings.Prices, goodSettings.MaxCollateral, period)
 		if !call.params.Allowance.Equals(allowance) {
 			t.Fatalf("expected allowance %v, got %v", allowance, call.params.Allowance)
 		} else if !call.params.Collateral.Equals(collateral) {
@@ -394,7 +394,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
 		// assert params
-		allowance, collateral := initialContractFunding(goodSettings.Prices, period)
+		allowance, collateral := initialContractFunding(goodSettings.Prices, goodSettings.MaxCollateral, period)
 		if !call.params.Allowance.Equals(allowance) {
 			t.Fatalf("expected allowance %v, got %v", allowance, call.params.Allowance)
 		} else if !call.params.Collateral.Equals(collateral) {
@@ -431,6 +431,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 }
 
 func TestInitialContractFunding(t *testing.T) {
+	maxCollateral := types.MaxCurrency
 	prices := proto.HostPrices{
 		ContractPrice: types.Siacoins(1),
 		Collateral:    types.NewCurrency64(1),
@@ -447,20 +448,21 @@ func TestInitialContractFunding(t *testing.T) {
 	storageUsage := prices.RPCAppendSectorsCost(10*sectorsPerGiB, period)
 	total := writeUsage.Add(readUsage).Add(storageUsage)
 	expectedAllowance := total.RenterCost().Add(basePrice)
-	expectedCollateral := total.HostRiskedCollateral()
+	expectedCollateral := proto.MaxHostCollateral(prices, expectedAllowance)
 
-	allowance, collateral := initialContractFunding(prices, period)
+	allowance, collateral := initialContractFunding(prices, maxCollateral, period)
 	if !allowance.Equals(expectedAllowance) {
 		t.Fatalf("expected allowance %v, got %v", expectedAllowance, allowance)
 	} else if !collateral.Equals(expectedCollateral) {
 		t.Fatalf("expected collateral %v, got %v", expectedCollateral, collateral)
 	}
 
-	// make sure the allowance doesn't go below the minimum
-	allowance, collateral = initialContractFunding(proto.HostPrices{}, period)
+	// make sure the allowance doesn't go below the minimum allowance and stays
+	// at the max collateral when storage is cheap/free
+	allowance, collateral = initialContractFunding(proto.HostPrices{}, maxCollateral, period)
 	if allowance.Cmp(minAllowance) < 0 {
 		t.Fatalf("expected allowance %v, got %v", minAllowance, allowance)
-	} else if !collateral.IsZero() {
-		t.Fatalf("expected collateral %v, got %v", types.ZeroCurrency, collateral)
+	} else if !collateral.Equals(maxCollateral) {
+		t.Fatalf("expected collateral %v, got %v", maxCollateral, collateral)
 	}
 }

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -85,22 +85,27 @@ func (cm *ContractManager) performContractRefreshes(ctx context.Context, log *za
 			continue
 		}
 
-		var additionalAllowance, additionalCollateral types.Currency
-
-		if contract.OutOfFunds() {
-			additionalAllowance = contract.InitialAllowance.Mul64(11).Div64(10) // add 10%
-		}
-		if contract.OutOfCollateral() {
-			additionalCollateral = contract.TotalCollateral.Mul64(11).Div64(10) // add 10%
-			if contract.TotalCollateral.Add(additionalCollateral).Cmp(host.Settings.MaxCollateral) > 0 {
-				var underflow bool
-				additionalCollateral, underflow = host.Settings.MaxCollateral.SubWithUnderflow(contract.TotalCollateral)
-				if underflow {
-					additionalCollateral = types.ZeroCurrency
-				}
-				contractLog.Debug("capping additional collateral since total would exceed max collateral of host",
-					zap.Stringer("additionalCollateral", additionalCollateral))
+		capCollateral := func(additionalCollateral types.Currency) types.Currency {
+			if contract.TotalCollateral.Add(additionalCollateral).Cmp(host.Settings.MaxCollateral) <= 0 {
+				return additionalCollateral // nothing to do
 			}
+			var underflow bool
+			additionalCollateral, underflow = host.Settings.MaxCollateral.SubWithUnderflow(contract.TotalCollateral)
+			if underflow {
+				additionalCollateral = types.ZeroCurrency
+			}
+			contractLog.Debug("capping additional collateral since total would exceed max collateral of host",
+				zap.Stringer("additionalCollateral", additionalCollateral))
+			return additionalCollateral
+		}
+
+		var additionalAllowance, additionalCollateral types.Currency
+		if contract.OutOfFunds() {
+			additionalAllowance = contract.InitialAllowance.Mul64(11).Div64(10)                                      // add 10%
+			additionalCollateral = capCollateral(proto.MaxHostCollateral(host.Settings.Prices, additionalAllowance)) // max possible
+		} else if contract.OutOfCollateral() {
+			additionalCollateral = capCollateral(contract.TotalCollateral.Mul64(11).Div64(10))         // add 10%
+			additionalAllowance = proto.MinRenterAllowance(host.Settings.Prices, additionalCollateral) // min possible
 		}
 
 		// only refresh if either allowance or collateral increases

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -85,26 +85,21 @@ func (cm *ContractManager) performContractRefreshes(ctx context.Context, log *za
 			continue
 		}
 
-		capCollateral := func(additionalCollateral types.Currency) types.Currency {
-			if contract.TotalCollateral.Add(additionalCollateral).Cmp(host.Settings.MaxCollateral) <= 0 {
-				return additionalCollateral // nothing to do
-			}
-			var underflow bool
-			additionalCollateral, underflow = host.Settings.MaxCollateral.SubWithUnderflow(contract.TotalCollateral)
-			if underflow {
-				additionalCollateral = types.ZeroCurrency
-			}
-			contractLog.Debug("capping additional collateral since total would exceed max collateral of host",
-				zap.Stringer("additionalCollateral", additionalCollateral))
-			return additionalCollateral
-		}
-
 		var additionalAllowance, additionalCollateral types.Currency
 		if contract.OutOfFunds() {
-			additionalAllowance = contract.InitialAllowance.Mul64(11).Div64(10)                                      // add 10%
-			additionalCollateral = capCollateral(proto.MaxHostCollateral(host.Settings.Prices, additionalAllowance)) // max possible
+			additionalAllowance = contract.InitialAllowance.Mul64(11).Div64(10) // add 10%
+			additionalCollateral = types.ZeroCurrency                           // don't need additional collateral
 		} else if contract.OutOfCollateral() {
-			additionalCollateral = capCollateral(contract.TotalCollateral.Mul64(11).Div64(10))         // add 10%
+			additionalCollateral = contract.TotalCollateral.Mul64(11).Div64(10) // add 10%
+			if contract.TotalCollateral.Add(additionalCollateral).Cmp(host.Settings.MaxCollateral) > 0 {
+				var underflow bool
+				additionalCollateral, underflow = host.Settings.MaxCollateral.SubWithUnderflow(contract.TotalCollateral)
+				if underflow {
+					additionalCollateral = types.ZeroCurrency
+				}
+				contractLog.Debug("capping additional collateral since total would exceed max collateral of host",
+					zap.Stringer("additionalCollateral", additionalCollateral))
+			}
 			additionalAllowance = proto.MinRenterAllowance(host.Settings.Prices, additionalCollateral) // min possible
 		}
 

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -173,10 +173,10 @@ func TestPerformContractRefreshes(t *testing.T) {
 	} else if len(contractor.refreshCalls) != 4 {
 		t.Fatalf("expected 4 refreshes, got %v", len(contractor.refreshCalls))
 	}
-	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, contractor.refreshCalls[0])
-	assertRefresh(good, types.ZeroCurrency, types.Siacoins(110), types.FileContractID{3}, contractor.refreshCalls[1])
+	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{2}, contractor.refreshCalls[0])
+	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{3}, contractor.refreshCalls[1])
 	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{4}, contractor.refreshCalls[2])
-	assertRefresh(good, types.ZeroCurrency, types.Siacoins(1), types.FileContractID{6}, contractor.refreshCalls[3])
+	assertRefresh(good, types.Siacoins(1), types.Siacoins(1), types.FileContractID{6}, contractor.refreshCalls[3])
 
 	// assert refreshes made it into the store leading to 8 existing + 4 refreshed
 	// contracts in the store
@@ -189,15 +189,15 @@ func TestPerformContractRefreshes(t *testing.T) {
 		switch contract.RenewedFrom {
 		case types.FileContractID{2}:
 			initialAllowance = types.Siacoins(110)
-			totalCollateral = types.ZeroCurrency
+			totalCollateral = types.Siacoins(110)
 		case types.FileContractID{3}:
-			initialAllowance = types.ZeroCurrency
+			initialAllowance = types.Siacoins(110)
 			totalCollateral = types.Siacoins(110)
 		case types.FileContractID{4}:
 			initialAllowance = types.Siacoins(110)
 			totalCollateral = types.Siacoins(110)
 		case types.FileContractID{6}:
-			initialAllowance = types.ZeroCurrency
+			initialAllowance = types.Siacoins(1)
 			totalCollateral = types.Siacoins(1)
 		default:
 			continue // only check refreshed contracts
@@ -217,7 +217,7 @@ func TestPerformContractRefreshes(t *testing.T) {
 		} else if !contract.MinerFee.Equals(types.Siacoins(1)) {
 			t.Fatalf("expected miner fee to be 1SC")
 		} else if !contract.TotalCollateral.Equals(totalCollateral) {
-			t.Fatalf("expected total collateral %v, got %v", initialAllowance, contract.TotalCollateral)
+			t.Fatalf("expected total collateral %v, got %v", totalCollateral, contract.TotalCollateral)
 		}
 	}
 }

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -173,9 +173,9 @@ func TestPerformContractRefreshes(t *testing.T) {
 	} else if len(contractor.refreshCalls) != 4 {
 		t.Fatalf("expected 4 refreshes, got %v", len(contractor.refreshCalls))
 	}
-	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{2}, contractor.refreshCalls[0])
+	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, contractor.refreshCalls[0])
 	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{3}, contractor.refreshCalls[1])
-	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{4}, contractor.refreshCalls[2])
+	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{4}, contractor.refreshCalls[2])
 	assertRefresh(good, types.Siacoins(1), types.Siacoins(1), types.FileContractID{6}, contractor.refreshCalls[3])
 
 	// assert refreshes made it into the store leading to 8 existing + 4 refreshed
@@ -189,13 +189,13 @@ func TestPerformContractRefreshes(t *testing.T) {
 		switch contract.RenewedFrom {
 		case types.FileContractID{2}:
 			initialAllowance = types.Siacoins(110)
-			totalCollateral = types.Siacoins(110)
+			totalCollateral = types.ZeroCurrency
 		case types.FileContractID{3}:
 			initialAllowance = types.Siacoins(110)
 			totalCollateral = types.Siacoins(110)
 		case types.FileContractID{4}:
 			initialAllowance = types.Siacoins(110)
-			totalCollateral = types.Siacoins(110)
+			totalCollateral = types.ZeroCurrency
 		case types.FileContractID{6}:
 			initialAllowance = types.Siacoins(1)
 			totalCollateral = types.Siacoins(1)


### PR DESCRIPTION
This makes sure that we don't run into issues with hosts expecting more allowance when refreshing contracts.
This PR also adds `MaxHostCollateral` when computing the initial funding of a contract to be on the safe side and get a little bit more collateral into fresh contracts.