### PR TITLE
Add service accounts to account manager

### DIFF
--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -36,7 +36,6 @@ type (
 		cm     ChainManager
 		host   HostClient
 		signer rhp.ContractSigner
-		target types.Currency
 	}
 )
 
@@ -55,11 +54,10 @@ func (c *hostClient) RPCReplenishAccounts(ctx context.Context, t rhp.TransportCl
 }
 
 // NewFunder creates a new Funder.
-func NewFunder(cm ChainManager, signer rhp.ContractSigner, target types.Currency) *Funder {
+func NewFunder(cm ChainManager, signer rhp.ContractSigner) *Funder {
 	return &Funder{
 		cm:     cm,
 		signer: signer,
-		target: target,
 		host:   &hostClient{},
 	}
 }
@@ -71,7 +69,7 @@ func NewFunder(cm ChainManager, signer rhp.ContractSigner, target types.Currency
 // the number of contracts that were drained. Consecutive calls for the same
 // host should take this into account and adjust the contract IDs that are being
 // passed in.
-func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, accounts []HostAccount, contractIDs []types.FileContractID, log *zap.Logger) (funded int, drained int, _ error) {
+func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, accounts []HostAccount, contractIDs []types.FileContractID, target types.Currency, log *zap.Logger) (funded int, drained int, _ error) {
 	// sanity check
 	if len(accounts) > proto.MaxAccountBatchSize {
 		return 0, 0, errors.New("too many accounts") // developer error
@@ -106,21 +104,21 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, accounts []H
 			contractLog.Debug("contract is not revisable") // sanity check
 			drained++
 			continue
-		} else if rev.Contract.RenterOutput.Value.Cmp(f.target) < 0 {
+		} else if rev.Contract.RenterOutput.Value.Cmp(target) < 0 {
 			contractLog.Debug("contract has insufficient funds")
 			drained++
 			continue
 		}
 
 		// prepare batch
-		batchSize := int(min(rev.Contract.RenterOutput.Value.Div(f.target).Big().Uint64(), proto.MaxAccountBatchSize))
+		batchSize := int(min(rev.Contract.RenterOutput.Value.Div(target).Big().Uint64(), proto.MaxAccountBatchSize))
 		batchEndIdx := min(batchSize+funded, len(accounts))
 
 		// prepare replenish RPC params
 		revision := rhp.ContractRevision{ID: fcid, Revision: rev.Contract}
 		params := rhp.RPCReplenishAccountsParams{
 			Accounts: accountKeys[funded:batchEndIdx],
-			Target:   f.target,
+			Target:   target,
 			Contract: revision,
 		}
 
@@ -129,7 +127,7 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, accounts []H
 		if err != nil {
 			contractLog.Debug("failed to replenish accounts", zap.Error(err))
 			continue
-		} else if res.Revision.RenterOutput.Value.Cmp(f.target) < 0 {
+		} else if res.Revision.RenterOutput.Value.Cmp(target) < 0 {
 			contractLog.Debug("contract was drained by replenish RPC")
 			drained++
 		}

--- a/accounts/funder_test.go
+++ b/accounts/funder_test.go
@@ -75,13 +75,13 @@ func TestFunder(t *testing.T) {
 	}}
 
 	// prepare funder
-	f := NewFunder(&cmMock{}, nil, target)
+	f := NewFunder(&cmMock{}, nil)
 	f.host = h
 
 	// assert contract checks
 	core, logs := observer.New(zapcore.DebugLevel)
 	contractIDs := []types.FileContractID{{}, {1}, {2}}
-	funded, drained, err := f.FundAccounts(context.Background(), hosts.Host{}, nil, contractIDs, zap.New(core))
+	funded, drained, err := f.FundAccounts(context.Background(), hosts.Host{}, nil, contractIDs, target, zap.New(core))
 	if err != nil {
 		t.Fatal("unexpected", err)
 	} else if funded != 0 {
@@ -118,7 +118,7 @@ func TestFunder(t *testing.T) {
 
 	contractIDs = []types.FileContractID{{3}, badContractId, {4}}
 	accounts := []HostAccount{{AccountKey: proto.Account{1}}, {AccountKey: proto.Account{2}}, {AccountKey: proto.Account{3}}, {AccountKey: proto.Account{4}}}
-	funded, drained, err = f.FundAccounts(context.Background(), hosts.Host{}, accounts, contractIDs, zap.NewNop())
+	funded, drained, err = f.FundAccounts(context.Background(), hosts.Host{}, accounts, contractIDs, target, zap.NewNop())
 	if err != nil {
 		t.Fatal("unexpected", err)
 	} else if funded != 3 {

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -26,8 +26,8 @@ type (
 		Host(ctx context.Context, hostKey types.PublicKey) (hosts.Host, error)
 		HostAccountsForFunding(ctx context.Context, hk types.PublicKey, limit int) ([]HostAccount, error)
 		UpdateHostAccounts(ctx context.Context, accounts []HostAccount) error
-		UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error
-		ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error)
+		UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error
+		ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error)
 	}
 
 	// AccountFunder defines an interface to fund accounts.
@@ -43,7 +43,7 @@ type (
 		log        *zap.Logger
 
 		serviceAccountsMu sync.Mutex
-		serviceAccounts   map[proto.Account]map[types.PublicKey]*serviceAccount
+		serviceAccounts   map[proto.Account]map[types.PublicKey]struct{}
 	}
 )
 
@@ -60,7 +60,7 @@ func WithLogger(l *zap.Logger) Option {
 // NewManager creates a new AccountManager.
 func NewManager(store Store, funder AccountFunder, opts ...Option) *AccountManager {
 	m := &AccountManager{
-		serviceAccounts: make(map[proto.Account]map[types.PublicKey]*serviceAccount),
+		serviceAccounts: make(map[proto.Account]map[types.PublicKey]struct{}),
 		store:           store,
 		funder:          funder,
 		fundTarget:      types.Siacoins(1),
@@ -104,45 +104,22 @@ func (m *AccountManager) FundAccounts(ctx context.Context, host hosts.Host, cont
 			break
 		}
 
-		var funded, drained int
-		err = func() error {
-			// lock service accounts
-			serviceAccounts := m.lockServiceAccounts(accounts)
-			defer func() {
-				for _, acc := range serviceAccounts {
-					acc.Unlock()
-				}
-			}()
-
-			// fund accounts
-			funded, drained, err = m.funder.FundAccounts(ctx, host, accounts, contractIDs, m.fundTarget, log)
-			if err != nil {
-				return fmt.Errorf("failed to fund accounts: %w", err)
-			}
-
-			// update funded accounts
-			updateFundedAccounts(accounts, funded)
-			err = m.store.UpdateHostAccounts(ctx, accounts)
-			if err != nil {
-				return fmt.Errorf("failed to update accounts: %w", err)
-			}
-
-			// update service accounts
-			fundedAccs := make(map[proto.Account]struct{})
-			for _, acc := range accounts[:funded] {
-				fundedAccs[acc.AccountKey] = struct{}{}
-			}
-			for _, serviceAccount := range serviceAccounts {
-				if _, ok := fundedAccs[serviceAccount.Account]; ok {
-					if err := m.UpdateServiceAccountBalance(ctx, serviceAccount, m.fundTarget); err != nil {
-						m.log.Warn("failed to update service account balance", zap.Error(err))
-					}
-				}
-			}
-			return nil
-		}()
+		// fund accounts
+		funded, drained, err := m.funder.FundAccounts(ctx, host, accounts, contractIDs, m.fundTarget, log)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to fund accounts: %w", err)
+		}
+
+		// update funded accounts
+		updateFundedAccounts(accounts, funded)
+		err = m.store.UpdateHostAccounts(ctx, accounts)
+		if err != nil {
+			return fmt.Errorf("failed to update accounts: %w", err)
+		}
+
+		// update service accounts
+		if err := m.updateServiceAccounts(ctx, accounts[:funded], m.fundTarget); err != nil {
+			m.log.Warn("failed to update service account balance", zap.Error(err))
 		}
 
 		contractIDs = contractIDs[drained:]

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -26,6 +26,8 @@ type (
 		Host(ctx context.Context, hostKey types.PublicKey) (hosts.Host, error)
 		HostAccountsForFunding(ctx context.Context, hk types.PublicKey, limit int) ([]HostAccount, error)
 		UpdateHostAccounts(ctx context.Context, accounts []HostAccount) error
+		UpdateServiceAccountBalance(ctx context.Context, account proto.Account, balance types.Currency) error
+		ServiceAccountBalance(ctx context.Context, account proto.Account) (types.Currency, error)
 	}
 
 	// AccountFunder defines an interface to fund accounts.
@@ -132,7 +134,7 @@ func (m *AccountManager) FundAccounts(ctx context.Context, host hosts.Host, cont
 			}
 			for _, serviceAccount := range serviceAccounts {
 				if _, ok := fundedAccs[serviceAccount.Account]; ok {
-					if err := m.UpdateServiceAccountBalance(serviceAccount); err != nil {
+					if err := m.UpdateServiceAccountBalance(ctx, serviceAccount, m.fundTarget); err != nil {
 						m.log.Warn("failed to update service account balance", zap.Error(err))
 					}
 				}

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -26,8 +26,8 @@ type (
 		Host(ctx context.Context, hostKey types.PublicKey) (hosts.Host, error)
 		HostAccountsForFunding(ctx context.Context, hk types.PublicKey, limit int) ([]HostAccount, error)
 		UpdateHostAccounts(ctx context.Context, accounts []HostAccount) error
-		UpdateServiceAccountBalance(ctx context.Context, account proto.Account, balance types.Currency) error
-		ServiceAccountBalance(ctx context.Context, account proto.Account) (types.Currency, error)
+		UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error
+		ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error)
 	}
 
 	// AccountFunder defines an interface to fund accounts.
@@ -43,7 +43,7 @@ type (
 		log        *zap.Logger
 
 		serviceAccountsMu sync.Mutex
-		serviceAccounts   map[proto.Account]*serviceAccount
+		serviceAccounts   map[proto.Account]map[types.PublicKey]*serviceAccount
 	}
 )
 
@@ -60,7 +60,7 @@ func WithLogger(l *zap.Logger) Option {
 // NewManager creates a new AccountManager.
 func NewManager(store Store, funder AccountFunder, opts ...Option) *AccountManager {
 	m := &AccountManager{
-		serviceAccounts: make(map[proto.Account]*serviceAccount),
+		serviceAccounts: make(map[proto.Account]map[types.PublicKey]*serviceAccount),
 		store:           store,
 		funder:          funder,
 		fundTarget:      types.Siacoins(1),

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -29,14 +30,18 @@ type (
 
 	// AccountFunder defines an interface to fund accounts.
 	AccountFunder interface {
-		FundAccounts(ctx context.Context, host hosts.Host, accounts []HostAccount, contractIDs []types.FileContractID, log *zap.Logger) (int, int, error)
+		FundAccounts(ctx context.Context, host hosts.Host, accounts []HostAccount, contractIDs []types.FileContractID, target types.Currency, log *zap.Logger) (int, int, error)
 	}
 
 	// AccountManager manages accounts.
 	AccountManager struct {
-		store  Store
-		funder AccountFunder
-		log    *zap.Logger
+		store      Store
+		funder     AccountFunder
+		fundTarget types.Currency
+		log        *zap.Logger
+
+		serviceAccountsMu sync.Mutex
+		serviceAccounts   map[proto.Account]*serviceAccount
 	}
 )
 
@@ -53,9 +58,11 @@ func WithLogger(l *zap.Logger) Option {
 // NewManager creates a new AccountManager.
 func NewManager(store Store, funder AccountFunder, opts ...Option) *AccountManager {
 	m := &AccountManager{
-		store:  store,
-		funder: funder,
-		log:    zap.NewNop(),
+		serviceAccounts: make(map[proto.Account]*serviceAccount),
+		store:           store,
+		funder:          funder,
+		fundTarget:      types.Siacoins(1),
+		log:             zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -95,15 +102,45 @@ func (m *AccountManager) FundAccounts(ctx context.Context, host hosts.Host, cont
 			break
 		}
 
-		funded, drained, err := m.funder.FundAccounts(ctx, host, accounts, contractIDs, log)
-		if err != nil {
-			return fmt.Errorf("failed to fund accounts: %w", err)
-		}
+		var funded, drained int
+		err = func() error {
+			// lock service accounts
+			serviceAccounts := m.lockServiceAccounts(accounts)
+			defer func() {
+				for _, acc := range serviceAccounts {
+					acc.Unlock()
+				}
+			}()
 
-		updateFundedAccounts(accounts, funded)
-		err = m.store.UpdateHostAccounts(ctx, accounts)
+			// fund accounts
+			funded, drained, err = m.funder.FundAccounts(ctx, host, accounts, contractIDs, m.fundTarget, log)
+			if err != nil {
+				return fmt.Errorf("failed to fund accounts: %w", err)
+			}
+
+			// update funded accounts
+			updateFundedAccounts(accounts, funded)
+			err = m.store.UpdateHostAccounts(ctx, accounts)
+			if err != nil {
+				return fmt.Errorf("failed to update accounts: %w", err)
+			}
+
+			// update service accounts
+			fundedAccs := make(map[proto.Account]struct{})
+			for _, acc := range accounts[:funded] {
+				fundedAccs[acc.AccountKey] = struct{}{}
+			}
+			for _, serviceAccount := range serviceAccounts {
+				if _, ok := fundedAccs[serviceAccount.Account]; ok {
+					if err := m.UpdateServiceAccountBalance(serviceAccount); err != nil {
+						m.log.Warn("failed to update service account balance", zap.Error(err))
+					}
+				}
+			}
+			return nil
+		}()
 		if err != nil {
-			return fmt.Errorf("failed to update accounts: %w", err)
+			return err
 		}
 
 		contractIDs = contractIDs[drained:]

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -26,6 +26,8 @@ type (
 		Host(ctx context.Context, hostKey types.PublicKey) (hosts.Host, error)
 		HostAccountsForFunding(ctx context.Context, hk types.PublicKey, limit int) ([]HostAccount, error)
 		UpdateHostAccounts(ctx context.Context, accounts []HostAccount) error
+
+		DebitServiceAccount(ctx context.Context, hostKey types.PublicKey, account proto.Account, amount types.Currency) error
 		UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error
 		ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error)
 	}
@@ -43,7 +45,7 @@ type (
 		log        *zap.Logger
 
 		serviceAccountsMu sync.Mutex
-		serviceAccounts   map[proto.Account]map[types.PublicKey]struct{}
+		serviceAccounts   map[proto.Account]struct{}
 	}
 )
 
@@ -60,7 +62,7 @@ func WithLogger(l *zap.Logger) Option {
 // NewManager creates a new AccountManager.
 func NewManager(store Store, funder AccountFunder, opts ...Option) *AccountManager {
 	m := &AccountManager{
-		serviceAccounts: make(map[proto.Account]map[types.PublicKey]struct{}),
+		serviceAccounts: make(map[proto.Account]struct{}),
 		store:           store,
 		funder:          funder,
 		fundTarget:      types.Siacoins(1),

--- a/accounts/manager_test.go
+++ b/accounts/manager_test.go
@@ -107,6 +107,16 @@ func (s *mockStore) UpdateHostAccounts(ctx context.Context, accounts []HostAccou
 	return nil
 }
 
+// UpdateServiceAccountBalance updates the balance of a service account.
+func (s *mockStore) UpdateServiceAccountBalance(ctx context.Context, account proto.Account, balance types.Currency) error {
+	return nil // not implemented
+}
+
+// ServiceAccountBalance returns the balance of a service account.
+func (s *mockStore) ServiceAccountBalance(ctx context.Context, account proto.Account) (types.Currency, error) {
+	return types.Currency{}, nil // not implemented
+}
+
 func (s *mockStore) resetNextFund() {
 	for _, eas := range s.eas {
 		for _, ea := range eas {

--- a/accounts/manager_test.go
+++ b/accounts/manager_test.go
@@ -39,16 +39,18 @@ var (
 var _ Store = (*mockStore)(nil)
 
 type mockStore struct {
-	accounts map[types.PublicKey]struct{}
-	hosts    map[types.PublicKey]hosts.Host
-	eas      map[types.PublicKey]map[types.PublicKey]*HostAccount
+	accounts        map[types.PublicKey]struct{}
+	hosts           map[types.PublicKey]hosts.Host
+	eas             map[types.PublicKey]map[types.PublicKey]*HostAccount
+	serviceAccounts map[proto.Account]map[types.PublicKey]types.Currency
 }
 
 func newMockStore() *mockStore {
 	return &mockStore{
-		accounts: make(map[types.PublicKey]struct{}),
-		hosts:    make(map[types.PublicKey]hosts.Host),
-		eas:      make(map[types.PublicKey]map[types.PublicKey]*HostAccount),
+		accounts:        make(map[types.PublicKey]struct{}),
+		hosts:           make(map[types.PublicKey]hosts.Host),
+		eas:             make(map[types.PublicKey]map[types.PublicKey]*HostAccount),
+		serviceAccounts: make(map[proto.Account]map[types.PublicKey]types.Currency),
 	}
 }
 
@@ -105,16 +107,6 @@ func (s *mockStore) UpdateHostAccounts(ctx context.Context, accounts []HostAccou
 		s.eas[acc.HostKey][types.PublicKey(acc.AccountKey)] = &acc
 	}
 	return nil
-}
-
-// UpdateServiceAccountBalance updates the balance of a service account.
-func (s *mockStore) UpdateServiceAccountBalance(ctx context.Context, account proto.Account, balance types.Currency) error {
-	return nil // not implemented
-}
-
-// ServiceAccountBalance returns the balance of a service account.
-func (s *mockStore) ServiceAccountBalance(ctx context.Context, account proto.Account) (types.Currency, error) {
-	return types.Currency{}, nil // not implemented
 }
 
 func (s *mockStore) resetNextFund() {

--- a/accounts/manager_test.go
+++ b/accounts/manager_test.go
@@ -119,6 +119,7 @@ type fundAccountCall struct {
 	host        hosts.Host
 	accounts    []HostAccount
 	contractIDs []types.FileContractID
+	target      types.Currency
 }
 
 type mockFunder struct {
@@ -126,11 +127,12 @@ type mockFunder struct {
 	fail  bool
 }
 
-func (f *mockFunder) FundAccounts(ctx context.Context, host hosts.Host, accounts []HostAccount, contractIDs []types.FileContractID, log *zap.Logger) (funded int, drained int, _ error) {
+func (f *mockFunder) FundAccounts(ctx context.Context, host hosts.Host, accounts []HostAccount, contractIDs []types.FileContractID, target types.Currency, log *zap.Logger) (funded int, drained int, _ error) {
 	f.calls = append(f.calls, fundAccountCall{
 		host:        host,
 		accounts:    accounts,
 		contractIDs: contractIDs,
+		target:      target,
 	})
 	if f.fail {
 		return 0, 0, nil
@@ -237,6 +239,10 @@ func TestAccountManager(t *testing.T) {
 		t.Fatal("expected first call to have two contract IDs")
 	} else if len(f.calls[1].contractIDs) != 1 {
 		t.Fatal("expected second call to have one contract ID")
+	} else if !f.calls[0].target.Equals(types.Siacoins(1)) {
+		t.Fatalf("expected target to be %v, got %v", types.Siacoins(1), f.calls[0].target)
+	} else if !f.calls[1].target.Equals(types.Siacoins(1)) {
+		t.Fatalf("expected target to be %v, got %v", types.Siacoins(1), f.calls[0].target)
 	}
 
 	// assert all accounts next fund was updated and consecutive failed funds was reset

--- a/accounts/serviceaccounts.go
+++ b/accounts/serviceaccounts.go
@@ -1,6 +1,7 @@
 package accounts
 
 import (
+	"context"
 	"sync"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -56,30 +57,33 @@ func (m *AccountManager) RegisterServiceAccount(account proto.Account) {
 }
 
 // ServiceAccountBalance returns the balance of a locked service account.
-func (m *AccountManager) ServiceAccountBalance(account LockedServiceAccount) (types.Currency, error) {
-	return types.ZeroCurrency, nil // read balance from database
+func (m *AccountManager) ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error) {
+	return m.store.ServiceAccountBalance(ctx, account.Account)
 }
 
 // UpdateServiceAccountBalance updates the balance of a locked service account.
-func (m *AccountManager) UpdateServiceAccountBalance(account LockedServiceAccount) error {
-	return nil // update balance in database
+func (m *AccountManager) UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error {
+	return m.store.UpdateServiceAccountBalance(ctx, account.Account, balance)
 }
 
 // lockServiceAccounts locks all service accounts in the list of accounts.
 // Non-service accounts are ignored.
 func (m *AccountManager) lockServiceAccounts(accounts []HostAccount) []LockedServiceAccount {
 	m.serviceAccountsMu.Lock()
-	defer m.serviceAccountsMu.Unlock()
-
-	var locked []LockedServiceAccount
+	var toLock []LockedServiceAccount
 	for _, account := range accounts {
 		if serviceAcc, ok := m.serviceAccounts[account.AccountKey]; ok {
-			serviceAcc.mu.Lock()
-			locked = append(locked, LockedServiceAccount{
+			toLock = append(toLock, LockedServiceAccount{
 				Account:        account.AccountKey,
 				serviceAccount: serviceAcc,
 			})
 		}
 	}
-	return locked
+	m.serviceAccountsMu.Unlock()
+
+	// lock accounts outside of the manager's mutex
+	for _, account := range toLock {
+		account.serviceAccount.mu.Lock()
+	}
+	return toLock
 }

--- a/accounts/serviceaccounts.go
+++ b/accounts/serviceaccounts.go
@@ -2,56 +2,10 @@ package accounts
 
 import (
 	"context"
-	"sync"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 )
-
-type (
-	// LockedServiceAccount wraps a service account for use in other packages.
-	// It can be obtained by calling 'LockAccount' on the AccountManager.
-	LockedServiceAccount struct {
-		serviceAccount *serviceAccount
-
-		Account proto.Account
-		HostKey types.PublicKey
-	}
-
-	serviceAccount struct {
-		mu sync.Mutex
-	}
-)
-
-// Unlock unlocks an account.
-func (a LockedServiceAccount) Unlock() {
-	a.serviceAccount.mu.Unlock()
-}
-
-// LockAccount locks an account which allows for updating its balance. The
-// returned account needs to be unlocked using its 'Unlock' method.
-func (m *AccountManager) LockAccount(account proto.Account, hostKey types.PublicKey) (LockedServiceAccount, error) {
-	m.serviceAccountsMu.Lock()
-	serviceAccs, ok := m.serviceAccounts[account]
-	if !ok {
-		m.serviceAccountsMu.Unlock()
-		return LockedServiceAccount{}, ErrNotFound
-	}
-	acc, ok := serviceAccs[hostKey]
-	if !ok {
-		serviceAccs[hostKey] = &serviceAccount{}
-		acc = serviceAccs[hostKey]
-	}
-
-	m.serviceAccountsMu.Unlock()
-	acc.mu.Lock()
-
-	return LockedServiceAccount{
-		serviceAccount: acc,
-		Account:        account,
-		HostKey:        hostKey,
-	}, nil
-}
 
 // RegisterServiceAccount signals to the account manager that a specific
 // account is for internal use. The account first needs to be added. A service
@@ -62,45 +16,43 @@ func (m *AccountManager) RegisterServiceAccount(account proto.Account) {
 	if _, exists := m.serviceAccounts[account]; exists {
 		panic("service account already registered") // developer error
 	}
-	m.serviceAccounts[account] = make(map[types.PublicKey]*serviceAccount)
+	m.serviceAccounts[account] = make(map[types.PublicKey]struct{})
+}
+
+// ResetAccountBalance resets the account balance of a service account to 0.
+// This should only be called when a host reports that an RPC failed due to
+// insufficient balance.
+func (m *AccountManager) ResetAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) error {
+	return m.store.UpdateServiceAccountBalance(ctx, hostKey, account, types.ZeroCurrency)
 }
 
 // ServiceAccountBalance returns the balance of a locked service account.
-func (m *AccountManager) ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error) {
-	return m.store.ServiceAccountBalance(ctx, account)
+func (m *AccountManager) ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
+	return m.store.ServiceAccountBalance(ctx, hostKey, account)
 }
 
-// UpdateServiceAccountBalance updates the balance of a locked service account.
-func (m *AccountManager) UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error {
-	return m.store.UpdateServiceAccountBalance(ctx, account, balance)
-}
-
-// lockServiceAccounts locks all service accounts in the list of accounts.
-// Non-service accounts are ignored.
-func (m *AccountManager) lockServiceAccounts(accounts []HostAccount) []LockedServiceAccount {
+// updateServiceAccounts updates the balance of all accounts registered as
+// service accounts to 'balance'.
+func (m *AccountManager) updateServiceAccounts(ctx context.Context, accounts []HostAccount, balance types.Currency) error {
 	m.serviceAccountsMu.Lock()
-	var toLock []LockedServiceAccount
+	var toUpdate []HostAccount
 	for _, account := range accounts {
 		serviceAccs, ok := m.serviceAccounts[account.AccountKey]
 		if !ok {
 			continue
 		}
-		acc, ok := serviceAccs[account.HostKey]
+		_, ok = serviceAccs[account.HostKey]
 		if !ok {
-			serviceAccs[account.HostKey] = &serviceAccount{}
-			acc = serviceAccs[account.HostKey]
+			continue
 		}
-		toLock = append(toLock, LockedServiceAccount{
-			serviceAccount: acc,
-			Account:        account.AccountKey,
-			HostKey:        account.HostKey,
-		})
+		toUpdate = append(toUpdate, account)
 	}
 	m.serviceAccountsMu.Unlock()
 
-	// lock accounts outside of the manager's mutex
-	for _, account := range toLock {
-		account.serviceAccount.mu.Lock()
+	for _, account := range toUpdate {
+		if err := m.store.UpdateServiceAccountBalance(ctx, account.HostKey, account.AccountKey, balance); err != nil {
+			return err
+		}
 	}
-	return toLock
+	return nil
 }

--- a/accounts/serviceaccounts.go
+++ b/accounts/serviceaccounts.go
@@ -15,6 +15,7 @@ type (
 		serviceAccount *serviceAccount
 
 		Account proto.Account
+		HostKey types.PublicKey
 	}
 
 	serviceAccount struct {
@@ -29,18 +30,26 @@ func (a LockedServiceAccount) Unlock() {
 
 // LockAccount locks an account which allows for updating its balance. The
 // returned account needs to be unlocked using its 'Unlock' method.
-func (m *AccountManager) LockAccount(account proto.Account) (LockedServiceAccount, error) {
+func (m *AccountManager) LockAccount(account proto.Account, hostKey types.PublicKey) (LockedServiceAccount, error) {
 	m.serviceAccountsMu.Lock()
-	sa, ok := m.serviceAccounts[account]
+	serviceAccs, ok := m.serviceAccounts[account]
 	if !ok {
 		m.serviceAccountsMu.Unlock()
 		return LockedServiceAccount{}, ErrNotFound
 	}
+	acc, ok := serviceAccs[hostKey]
+	if !ok {
+		serviceAccs[hostKey] = &serviceAccount{}
+		acc = serviceAccs[hostKey]
+	}
+
 	m.serviceAccountsMu.Unlock()
-	sa.mu.Lock()
+	acc.mu.Lock()
 
 	return LockedServiceAccount{
-		Account: account,
+		serviceAccount: acc,
+		Account:        account,
+		HostKey:        hostKey,
 	}, nil
 }
 
@@ -53,17 +62,17 @@ func (m *AccountManager) RegisterServiceAccount(account proto.Account) {
 	if _, exists := m.serviceAccounts[account]; exists {
 		panic("service account already registered") // developer error
 	}
-	m.serviceAccounts[account] = &serviceAccount{}
+	m.serviceAccounts[account] = make(map[types.PublicKey]*serviceAccount)
 }
 
 // ServiceAccountBalance returns the balance of a locked service account.
 func (m *AccountManager) ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error) {
-	return m.store.ServiceAccountBalance(ctx, account.Account)
+	return m.store.ServiceAccountBalance(ctx, account)
 }
 
 // UpdateServiceAccountBalance updates the balance of a locked service account.
 func (m *AccountManager) UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error {
-	return m.store.UpdateServiceAccountBalance(ctx, account.Account, balance)
+	return m.store.UpdateServiceAccountBalance(ctx, account, balance)
 }
 
 // lockServiceAccounts locks all service accounts in the list of accounts.
@@ -72,12 +81,20 @@ func (m *AccountManager) lockServiceAccounts(accounts []HostAccount) []LockedSer
 	m.serviceAccountsMu.Lock()
 	var toLock []LockedServiceAccount
 	for _, account := range accounts {
-		if serviceAcc, ok := m.serviceAccounts[account.AccountKey]; ok {
-			toLock = append(toLock, LockedServiceAccount{
-				Account:        account.AccountKey,
-				serviceAccount: serviceAcc,
-			})
+		serviceAccs, ok := m.serviceAccounts[account.AccountKey]
+		if !ok {
+			continue
 		}
+		acc, ok := serviceAccs[account.HostKey]
+		if !ok {
+			serviceAccs[account.HostKey] = &serviceAccount{}
+			acc = serviceAccs[account.HostKey]
+		}
+		toLock = append(toLock, LockedServiceAccount{
+			serviceAccount: acc,
+			Account:        account.AccountKey,
+			HostKey:        account.HostKey,
+		})
 	}
 	m.serviceAccountsMu.Unlock()
 

--- a/accounts/serviceaccounts.go
+++ b/accounts/serviceaccounts.go
@@ -16,19 +16,41 @@ func (m *AccountManager) RegisterServiceAccount(account proto.Account) {
 	if _, exists := m.serviceAccounts[account]; exists {
 		panic("service account already registered") // developer error
 	}
-	m.serviceAccounts[account] = make(map[types.PublicKey]struct{})
+	m.serviceAccounts[account] = struct{}{}
 }
 
 // ResetAccountBalance resets the account balance of a service account to 0.
 // This should only be called when a host reports that an RPC failed due to
 // insufficient balance.
 func (m *AccountManager) ResetAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) error {
+	if !m.serviceAccountExists(account) {
+		return ErrNotFound
+	}
 	return m.store.UpdateServiceAccountBalance(ctx, hostKey, account, types.ZeroCurrency)
 }
 
 // ServiceAccountBalance returns the balance of a locked service account.
 func (m *AccountManager) ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
+	if !m.serviceAccountExists(account) {
+		return types.ZeroCurrency, ErrNotFound
+	}
 	return m.store.ServiceAccountBalance(ctx, hostKey, account)
+}
+
+// DebitServiceAccount withdraws from a service account. This should be used
+// after successfully withdrawing from an account.
+func (m *AccountManager) DebitServiceAccount(ctx context.Context, hostKey types.PublicKey, account proto.Account, amount types.Currency) error {
+	if !m.serviceAccountExists(account) {
+		return ErrNotFound
+	}
+	return m.store.DebitServiceAccount(ctx, hostKey, account, amount)
+}
+
+func (m *AccountManager) serviceAccountExists(account proto.Account) bool {
+	m.serviceAccountsMu.Lock()
+	defer m.serviceAccountsMu.Unlock()
+	_, exists := m.serviceAccounts[account]
+	return exists
 }
 
 // updateServiceAccounts updates the balance of all accounts registered as
@@ -37,11 +59,7 @@ func (m *AccountManager) updateServiceAccounts(ctx context.Context, accounts []H
 	m.serviceAccountsMu.Lock()
 	var toUpdate []HostAccount
 	for _, account := range accounts {
-		serviceAccs, ok := m.serviceAccounts[account.AccountKey]
-		if !ok {
-			continue
-		}
-		_, ok = serviceAccs[account.HostKey]
+		_, ok := m.serviceAccounts[account.AccountKey]
 		if !ok {
 			continue
 		}

--- a/accounts/serviceaccounts.go
+++ b/accounts/serviceaccounts.go
@@ -1,0 +1,85 @@
+package accounts
+
+import (
+	"sync"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+)
+
+type (
+	// LockedServiceAccount wraps a service account for use in other packages.
+	// It can be obtained by calling 'LockAccount' on the AccountManager.
+	LockedServiceAccount struct {
+		serviceAccount *serviceAccount
+
+		Account proto.Account
+	}
+
+	serviceAccount struct {
+		mu sync.Mutex
+	}
+)
+
+// Unlock unlocks an account.
+func (a LockedServiceAccount) Unlock() {
+	a.serviceAccount.mu.Unlock()
+}
+
+// LockAccount locks an account which allows for updating its balance. The
+// returned account needs to be unlocked using its 'Unlock' method.
+func (m *AccountManager) LockAccount(account proto.Account) (LockedServiceAccount, error) {
+	m.serviceAccountsMu.Lock()
+	sa, ok := m.serviceAccounts[account]
+	if !ok {
+		m.serviceAccountsMu.Unlock()
+		return LockedServiceAccount{}, ErrNotFound
+	}
+	m.serviceAccountsMu.Unlock()
+	sa.mu.Lock()
+
+	return LockedServiceAccount{
+		Account: account,
+	}, nil
+}
+
+// RegisterServiceAccount signals to the account manager that a specific
+// account is for internal use. The account first needs to be added. A service
+// account will have its balance tracked.
+func (m *AccountManager) RegisterServiceAccount(account proto.Account) {
+	m.serviceAccountsMu.Lock()
+	defer m.serviceAccountsMu.Unlock()
+	if _, exists := m.serviceAccounts[account]; exists {
+		panic("service account already registered") // developer error
+	}
+	m.serviceAccounts[account] = &serviceAccount{}
+}
+
+// ServiceAccountBalance returns the balance of a locked service account.
+func (m *AccountManager) ServiceAccountBalance(account LockedServiceAccount) (types.Currency, error) {
+	return types.ZeroCurrency, nil // read balance from database
+}
+
+// UpdateServiceAccountBalance updates the balance of a locked service account.
+func (m *AccountManager) UpdateServiceAccountBalance(account LockedServiceAccount) error {
+	return nil // update balance in database
+}
+
+// lockServiceAccounts locks all service accounts in the list of accounts.
+// Non-service accounts are ignored.
+func (m *AccountManager) lockServiceAccounts(accounts []HostAccount) []LockedServiceAccount {
+	m.serviceAccountsMu.Lock()
+	defer m.serviceAccountsMu.Unlock()
+
+	var locked []LockedServiceAccount
+	for _, account := range accounts {
+		if serviceAcc, ok := m.serviceAccounts[account.AccountKey]; ok {
+			serviceAcc.mu.Lock()
+			locked = append(locked, LockedServiceAccount{
+				Account:        account.AccountKey,
+				serviceAccount: serviceAcc,
+			})
+		}
+	}
+	return locked
+}

--- a/accounts/serviceaccounts_test.go
+++ b/accounts/serviceaccounts_test.go
@@ -2,152 +2,145 @@ package accounts
 
 import (
 	"context"
-	"errors"
-	"testing"
-	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
-	"go.sia.tech/indexd/hosts"
-	"lukechampine.com/frand"
 )
 
 // UpdateServiceAccountBalance updates the balance of a service account.
-func (s *mockStore) UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error {
-	accs, ok := s.serviceAccounts[account.Account]
+func (s *mockStore) UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error {
+	accs, ok := s.serviceAccounts[account]
 	if !ok {
-		s.serviceAccounts[account.Account] = make(map[types.PublicKey]types.Currency)
-		accs = s.serviceAccounts[account.Account]
+		s.serviceAccounts[account] = make(map[types.PublicKey]types.Currency)
+		accs = s.serviceAccounts[account]
 	}
-	accs[account.HostKey] = balance
+	accs[hostKey] = balance
 	return nil
 }
 
 // ServiceAccountBalance returns the balance of a service account.
-func (s *mockStore) ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error) {
-	accs, ok := s.serviceAccounts[account.Account]
+func (s *mockStore) ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
+	accs, ok := s.serviceAccounts[account]
 	if !ok {
 		return types.ZeroCurrency, nil
 	}
-	return accs[account.HostKey], nil
+	return accs[hostKey], nil
 }
 
-func TestServiceAccounts(t *testing.T) {
-	s := newMockStore()
-
-	// add host
-	host := hosts.Host{
-		PublicKey: types.GeneratePrivateKey().PublicKey(),
-		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "foo"}},
-		Usability: goodUsability,
-	}
-	s.hosts[host.PublicKey] = host
-
-	// add accounts
-	account1 := proto.Account(types.GeneratePrivateKey().PublicKey())
-	account2 := proto.Account(types.GeneratePrivateKey().PublicKey())
-	s.accounts[types.PublicKey(account1)] = struct{}{}
-	s.accounts[types.PublicKey(account2)] = struct{}{}
-
-	f := &mockFunder{}
-	am := NewManager(s, f)
-	defer am.Close()
-
-	// try to fetch the service account before registering it
-	_, err := am.LockAccount(account1, host.PublicKey)
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatal(err)
-	}
-
-	am.RegisterServiceAccount(account1) // register
-
-	// helper to assert the account is locked
-	assertLocked := func(account proto.Account) func() {
-		t.Helper()
-		done := make(chan struct{})
-		go func() {
-			lockedAcc, err := am.LockAccount(account, host.PublicKey)
-			if err != nil {
-				t.Error(err)
-			}
-			lockedAcc.Unlock()
-			done <- struct{}{}
-		}()
-
-		select {
-		case <-time.After(100 * time.Millisecond):
-		case <-done:
-			t.Fatal("expected account to be locked")
-		}
-		return func() {
-			select {
-			case <-time.After(100 * time.Millisecond):
-				t.Fatal("expected account to be unlocked")
-			case <-done:
-			}
-		}
-	}
-
-	// helper to update balance
-	updateBalance := func(account LockedServiceAccount, balance types.Currency) {
-		t.Helper()
-		if err := am.UpdateServiceAccountBalance(context.Background(), account, balance); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	am.RegisterServiceAccount(account2) // register
-
-	// Lock the account and make sure it is locked and can be unlocked
-	lockedAcc, err := am.LockAccount(account1, host.PublicKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wait := assertLocked(account1)
-	updateBalance(lockedAcc, types.Siacoins(1))
-	lockedAcc.Unlock()
-	wait()
-
-	// Same thing with the batched functions
-	lockedAccs := am.lockServiceAccounts([]HostAccount{
-		{
-			// known account
-			AccountKey: account2,
-			HostKey:    host.PublicKey,
-		},
-		{
-			// unknown account
-			AccountKey: proto.Account(frand.Entropy256()),
-			HostKey:    types.PublicKey(frand.Entropy256()),
-		},
-	})
-	if len(lockedAccs) != 1 {
-		t.Fatal("expected 1 locked account")
-	}
-	lockedAcc2 := lockedAccs[0]
-	wait = assertLocked(account2)
-	updateBalance(lockedAcc2, types.Siacoins(2))
-	lockedAcc2.Unlock()
-	wait()
-
-	// Assert balances of accounts
-	assertBalance := func(account proto.Account, expected types.Currency) {
-		t.Helper()
-		lockedAcc, err := am.LockAccount(account, host.PublicKey)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer lockedAcc.Unlock()
-
-		balance, err := am.ServiceAccountBalance(context.Background(), lockedAcc)
-		if err != nil {
-			t.Fatal(err)
-		} else if !balance.Equals(expected) {
-			t.Fatalf("expected balance %v, got %v", expected, balance)
-		}
-	}
-	assertBalance(account1, types.Siacoins(1))
-	assertBalance(account2, types.Siacoins(2))
-}
+//func TestServiceAccounts(t *testing.T) {
+//	s := newMockStore()
+//
+//	// add host
+//	host := hosts.Host{
+//		PublicKey: types.GeneratePrivateKey().PublicKey(),
+//		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "foo"}},
+//		Usability: goodUsability,
+//	}
+//	s.hosts[host.PublicKey] = host
+//
+//	// add accounts
+//	account1 := proto.Account(types.GeneratePrivateKey().PublicKey())
+//	account2 := proto.Account(types.GeneratePrivateKey().PublicKey())
+//	s.accounts[types.PublicKey(account1)] = struct{}{}
+//	s.accounts[types.PublicKey(account2)] = struct{}{}
+//
+//	f := &mockFunder{}
+//	am := NewManager(s, f)
+//	defer am.Close()
+//
+//	// try to fetch the service account before registering it
+//	_, err := am.LockAccount(account1, host.PublicKey)
+//	if !errors.Is(err, ErrNotFound) {
+//		t.Fatal(err)
+//	}
+//
+//	am.RegisterServiceAccount(account1) // register
+//
+//	// helper to assert the account is locked
+//	assertLocked := func(account proto.Account) func() {
+//		t.Helper()
+//		done := make(chan struct{})
+//		go func() {
+//			lockedAcc, err := am.LockAccount(account, host.PublicKey)
+//			if err != nil {
+//				t.Error(err)
+//			}
+//			lockedAcc.Unlock()
+//			done <- struct{}{}
+//		}()
+//
+//		select {
+//		case <-time.After(100 * time.Millisecond):
+//		case <-done:
+//			t.Fatal("expected account to be locked")
+//		}
+//		return func() {
+//			select {
+//			case <-time.After(100 * time.Millisecond):
+//				t.Fatal("expected account to be unlocked")
+//			case <-done:
+//			}
+//		}
+//	}
+//
+//	// helper to update balance
+//	updateBalance := func(account LockedServiceAccount, balance types.Currency) {
+//		t.Helper()
+//		if err := am.UpdateServiceAccountBalance(context.Background(), account, balance); err != nil {
+//			t.Fatal(err)
+//		}
+//	}
+//
+//	am.RegisterServiceAccount(account2) // register
+//
+//	// Lock the account and make sure it is locked and can be unlocked
+//	lockedAcc, err := am.LockAccount(account1, host.PublicKey)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	wait := assertLocked(account1)
+//	updateBalance(lockedAcc, types.Siacoins(1))
+//	lockedAcc.Unlock()
+//	wait()
+//
+//	// Same thing with the batched functions
+//	lockedAccs := am.lockServiceAccounts([]HostAccount{
+//		{
+//			// known account
+//			AccountKey: account2,
+//			HostKey:    host.PublicKey,
+//		},
+//		{
+//			// unknown account
+//			AccountKey: proto.Account(frand.Entropy256()),
+//			HostKey:    types.PublicKey(frand.Entropy256()),
+//		},
+//	})
+//	if len(lockedAccs) != 1 {
+//		t.Fatal("expected 1 locked account")
+//	}
+//	lockedAcc2 := lockedAccs[0]
+//	wait = assertLocked(account2)
+//	updateBalance(lockedAcc2, types.Siacoins(2))
+//	lockedAcc2.Unlock()
+//	wait()
+//
+//	// Assert balances of accounts
+//	assertBalance := func(account proto.Account, expected types.Currency) {
+//		t.Helper()
+//		lockedAcc, err := am.LockAccount(account, host.PublicKey)
+//		if err != nil {
+//			t.Fatal(err)
+//		}
+//		defer lockedAcc.Unlock()
+//
+//		balance, err := am.ServiceAccountBalance(context.Background(), lockedAcc)
+//		if err != nil {
+//			t.Fatal(err)
+//		} else if !balance.Equals(expected) {
+//			t.Fatalf("expected balance %v, got %v", expected, balance)
+//		}
+//	}
+//	assertBalance(account1, types.Siacoins(1))
+//	assertBalance(account2, types.Siacoins(2))
+//}

--- a/accounts/serviceaccounts_test.go
+++ b/accounts/serviceaccounts_test.go
@@ -2,145 +2,143 @@ package accounts
 
 import (
 	"context"
+	"errors"
+	"testing"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/indexd/hosts"
 )
+
+func (s *mockStore) serviceAccount(hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
+	accs, ok := s.serviceAccounts[account]
+	if !ok {
+		accs = make(map[types.PublicKey]types.Currency)
+		s.serviceAccounts[account] = accs
+	}
+	return accs[hostKey], nil
+}
+
+// DebitServiceAccount withdraws from a service account.
+func (s *mockStore) DebitServiceAccount(ctx context.Context, hostKey types.PublicKey, account proto.Account, amount types.Currency) error {
+	balance, err := s.serviceAccount(hostKey, account)
+	if err != nil {
+		return err
+	}
+	if balance.Cmp(amount) < 0 {
+		balance = types.ZeroCurrency
+	} else {
+		balance = balance.Sub(amount)
+	}
+	s.serviceAccounts[account][hostKey] = balance
+	return nil
+}
 
 // UpdateServiceAccountBalance updates the balance of a service account.
 func (s *mockStore) UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error {
-	accs, ok := s.serviceAccounts[account]
-	if !ok {
-		s.serviceAccounts[account] = make(map[types.PublicKey]types.Currency)
-		accs = s.serviceAccounts[account]
+	_, err := s.serviceAccount(hostKey, account)
+	if err != nil {
+		return err
 	}
-	accs[hostKey] = balance
+	s.serviceAccounts[account][hostKey] = balance
 	return nil
 }
 
 // ServiceAccountBalance returns the balance of a service account.
 func (s *mockStore) ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
-	accs, ok := s.serviceAccounts[account]
-	if !ok {
-		return types.ZeroCurrency, nil
-	}
-	return accs[hostKey], nil
+	return s.serviceAccount(hostKey, account)
 }
 
-//func TestServiceAccounts(t *testing.T) {
-//	s := newMockStore()
-//
-//	// add host
-//	host := hosts.Host{
-//		PublicKey: types.GeneratePrivateKey().PublicKey(),
-//		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "foo"}},
-//		Usability: goodUsability,
-//	}
-//	s.hosts[host.PublicKey] = host
-//
-//	// add accounts
-//	account1 := proto.Account(types.GeneratePrivateKey().PublicKey())
-//	account2 := proto.Account(types.GeneratePrivateKey().PublicKey())
-//	s.accounts[types.PublicKey(account1)] = struct{}{}
-//	s.accounts[types.PublicKey(account2)] = struct{}{}
-//
-//	f := &mockFunder{}
-//	am := NewManager(s, f)
-//	defer am.Close()
-//
-//	// try to fetch the service account before registering it
-//	_, err := am.LockAccount(account1, host.PublicKey)
-//	if !errors.Is(err, ErrNotFound) {
-//		t.Fatal(err)
-//	}
-//
-//	am.RegisterServiceAccount(account1) // register
-//
-//	// helper to assert the account is locked
-//	assertLocked := func(account proto.Account) func() {
-//		t.Helper()
-//		done := make(chan struct{})
-//		go func() {
-//			lockedAcc, err := am.LockAccount(account, host.PublicKey)
-//			if err != nil {
-//				t.Error(err)
-//			}
-//			lockedAcc.Unlock()
-//			done <- struct{}{}
-//		}()
-//
-//		select {
-//		case <-time.After(100 * time.Millisecond):
-//		case <-done:
-//			t.Fatal("expected account to be locked")
-//		}
-//		return func() {
-//			select {
-//			case <-time.After(100 * time.Millisecond):
-//				t.Fatal("expected account to be unlocked")
-//			case <-done:
-//			}
-//		}
-//	}
-//
-//	// helper to update balance
-//	updateBalance := func(account LockedServiceAccount, balance types.Currency) {
-//		t.Helper()
-//		if err := am.UpdateServiceAccountBalance(context.Background(), account, balance); err != nil {
-//			t.Fatal(err)
-//		}
-//	}
-//
-//	am.RegisterServiceAccount(account2) // register
-//
-//	// Lock the account and make sure it is locked and can be unlocked
-//	lockedAcc, err := am.LockAccount(account1, host.PublicKey)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	wait := assertLocked(account1)
-//	updateBalance(lockedAcc, types.Siacoins(1))
-//	lockedAcc.Unlock()
-//	wait()
-//
-//	// Same thing with the batched functions
-//	lockedAccs := am.lockServiceAccounts([]HostAccount{
-//		{
-//			// known account
-//			AccountKey: account2,
-//			HostKey:    host.PublicKey,
-//		},
-//		{
-//			// unknown account
-//			AccountKey: proto.Account(frand.Entropy256()),
-//			HostKey:    types.PublicKey(frand.Entropy256()),
-//		},
-//	})
-//	if len(lockedAccs) != 1 {
-//		t.Fatal("expected 1 locked account")
-//	}
-//	lockedAcc2 := lockedAccs[0]
-//	wait = assertLocked(account2)
-//	updateBalance(lockedAcc2, types.Siacoins(2))
-//	lockedAcc2.Unlock()
-//	wait()
-//
-//	// Assert balances of accounts
-//	assertBalance := func(account proto.Account, expected types.Currency) {
-//		t.Helper()
-//		lockedAcc, err := am.LockAccount(account, host.PublicKey)
-//		if err != nil {
-//			t.Fatal(err)
-//		}
-//		defer lockedAcc.Unlock()
-//
-//		balance, err := am.ServiceAccountBalance(context.Background(), lockedAcc)
-//		if err != nil {
-//			t.Fatal(err)
-//		} else if !balance.Equals(expected) {
-//			t.Fatalf("expected balance %v, got %v", expected, balance)
-//		}
-//	}
-//	assertBalance(account1, types.Siacoins(1))
-//	assertBalance(account2, types.Siacoins(2))
-//}
+func TestServiceAccounts(t *testing.T) {
+	s := newMockStore()
+
+	// add host
+	host := hosts.Host{
+		PublicKey: types.GeneratePrivateKey().PublicKey(),
+		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "foo"}},
+		Usability: goodUsability,
+	}
+	s.hosts[host.PublicKey] = host
+
+	// add accounts
+	account1 := proto.Account(types.GeneratePrivateKey().PublicKey())
+	account2 := proto.Account(types.GeneratePrivateKey().PublicKey())
+	s.accounts[types.PublicKey(account1)] = struct{}{}
+	s.accounts[types.PublicKey(account2)] = struct{}{}
+
+	f := &mockFunder{}
+	am := NewManager(s, f)
+	defer am.Close()
+
+	// helper to assert balance
+	assertBalance := func(account proto.Account, expected types.Currency) {
+		t.Helper()
+		if balance, err := am.store.ServiceAccountBalance(context.Background(), host.PublicKey, account); err != nil {
+			t.Fatal(err)
+		} else if !balance.Equals(expected) {
+			t.Fatalf("expected balance %v, got %v", expected, balance)
+		}
+	}
+
+	// try to user account before registering it
+	err := am.ResetAccountBalance(context.Background(), host.PublicKey, account1)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal("expected ErrNotFound")
+	}
+	_, err = am.ServiceAccountBalance(context.Background(), host.PublicKey, account1)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal("expected ErrNotFound")
+	}
+	err = am.DebitServiceAccount(context.Background(), host.PublicKey, account1, types.Siacoins(1))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal("expected ErrNotFound")
+	}
+
+	// batch updating should ignore the account
+	err = am.updateServiceAccounts(context.Background(), []HostAccount{
+		{AccountKey: account1, HostKey: host.PublicKey},
+		{AccountKey: account2, HostKey: host.PublicKey},
+	}, types.Siacoins(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBalance(account1, types.ZeroCurrency)
+	assertBalance(account2, types.ZeroCurrency)
+
+	// register account, it's now possible to update the balance of account 1
+	am.RegisterServiceAccount(account1)
+	err = am.updateServiceAccounts(context.Background(), []HostAccount{
+		{AccountKey: account1, HostKey: host.PublicKey},
+		{AccountKey: account2, HostKey: host.PublicKey},
+	}, types.Siacoins(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBalance(account1, types.Siacoins(1))
+	assertBalance(account2, types.ZeroCurrency)
+
+	// other methods should also work now
+	err = am.DebitServiceAccount(context.Background(), host.PublicKey, account1, types.Siacoins(1).Div64(2))
+	if err != nil {
+		t.Fatal(err)
+	} else if balance, err := am.ServiceAccountBalance(context.Background(), host.PublicKey, account1); err != nil {
+		t.Fatal(err)
+	} else if !balance.Equals(types.Siacoins(1).Div64(2)) {
+		t.Fatalf("expected balance %v, got %v", types.Siacoins(1).Div64(2), balance)
+	}
+	assertBalance(account1, types.Siacoins(1).Div64(2))
+	assertBalance(account2, types.ZeroCurrency)
+
+	err = am.ResetAccountBalance(context.Background(), host.PublicKey, account1)
+	if err != nil {
+		t.Fatal(err)
+	} else if balance, err := am.ServiceAccountBalance(context.Background(), host.PublicKey, account1); err != nil {
+		t.Fatal(err)
+	} else if !balance.Equals(types.ZeroCurrency) {
+		t.Fatalf("expected balance %v, got %v", types.ZeroCurrency, balance)
+	}
+	assertBalance(account1, types.ZeroCurrency)
+	assertBalance(account2, types.ZeroCurrency)
+}

--- a/accounts/serviceaccounts_test.go
+++ b/accounts/serviceaccounts_test.go
@@ -1,0 +1,153 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/indexd/hosts"
+	"lukechampine.com/frand"
+)
+
+// UpdateServiceAccountBalance updates the balance of a service account.
+func (s *mockStore) UpdateServiceAccountBalance(ctx context.Context, account LockedServiceAccount, balance types.Currency) error {
+	accs, ok := s.serviceAccounts[account.Account]
+	if !ok {
+		s.serviceAccounts[account.Account] = make(map[types.PublicKey]types.Currency)
+		accs = s.serviceAccounts[account.Account]
+	}
+	accs[account.HostKey] = balance
+	return nil
+}
+
+// ServiceAccountBalance returns the balance of a service account.
+func (s *mockStore) ServiceAccountBalance(ctx context.Context, account LockedServiceAccount) (types.Currency, error) {
+	accs, ok := s.serviceAccounts[account.Account]
+	if !ok {
+		return types.ZeroCurrency, nil
+	}
+	return accs[account.HostKey], nil
+}
+
+func TestServiceAccounts(t *testing.T) {
+	s := newMockStore()
+
+	// add host
+	host := hosts.Host{
+		PublicKey: types.GeneratePrivateKey().PublicKey(),
+		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "foo"}},
+		Usability: goodUsability,
+	}
+	s.hosts[host.PublicKey] = host
+
+	// add accounts
+	account1 := proto.Account(types.GeneratePrivateKey().PublicKey())
+	account2 := proto.Account(types.GeneratePrivateKey().PublicKey())
+	s.accounts[types.PublicKey(account1)] = struct{}{}
+	s.accounts[types.PublicKey(account2)] = struct{}{}
+
+	f := &mockFunder{}
+	am := NewManager(s, f)
+	defer am.Close()
+
+	// try to fetch the service account before registering it
+	_, err := am.LockAccount(account1, host.PublicKey)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal(err)
+	}
+
+	am.RegisterServiceAccount(account1) // register
+
+	// helper to assert the account is locked
+	assertLocked := func(account proto.Account) func() {
+		t.Helper()
+		done := make(chan struct{})
+		go func() {
+			lockedAcc, err := am.LockAccount(account, host.PublicKey)
+			if err != nil {
+				t.Error(err)
+			}
+			lockedAcc.Unlock()
+			done <- struct{}{}
+		}()
+
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-done:
+			t.Fatal("expected account to be locked")
+		}
+		return func() {
+			select {
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("expected account to be unlocked")
+			case <-done:
+			}
+		}
+	}
+
+	// helper to update balance
+	updateBalance := func(account LockedServiceAccount, balance types.Currency) {
+		t.Helper()
+		if err := am.UpdateServiceAccountBalance(context.Background(), account, balance); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	am.RegisterServiceAccount(account2) // register
+
+	// Lock the account and make sure it is locked and can be unlocked
+	lockedAcc, err := am.LockAccount(account1, host.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wait := assertLocked(account1)
+	updateBalance(lockedAcc, types.Siacoins(1))
+	lockedAcc.Unlock()
+	wait()
+
+	// Same thing with the batched functions
+	lockedAccs := am.lockServiceAccounts([]HostAccount{
+		{
+			// known account
+			AccountKey: account2,
+			HostKey:    host.PublicKey,
+		},
+		{
+			// unknown account
+			AccountKey: proto.Account(frand.Entropy256()),
+			HostKey:    types.PublicKey(frand.Entropy256()),
+		},
+	})
+	if len(lockedAccs) != 1 {
+		t.Fatal("expected 1 locked account")
+	}
+	lockedAcc2 := lockedAccs[0]
+	wait = assertLocked(account2)
+	updateBalance(lockedAcc2, types.Siacoins(2))
+	lockedAcc2.Unlock()
+	wait()
+
+	// Assert balances of accounts
+	assertBalance := func(account proto.Account, expected types.Currency) {
+		t.Helper()
+		lockedAcc, err := am.LockAccount(account, host.PublicKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lockedAcc.Unlock()
+
+		balance, err := am.ServiceAccountBalance(context.Background(), lockedAcc)
+		if err != nil {
+			t.Fatal(err)
+		} else if !balance.Equals(expected) {
+			t.Fatalf("expected balance %v, got %v", expected, balance)
+		}
+	}
+	assertBalance(account1, types.Siacoins(1))
+	assertBalance(account2, types.Siacoins(2))
+}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -106,7 +106,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer hm.Close()
 
-	funder := accounts.NewFunder(cm, wm, types.Siacoins(1))
+	funder := accounts.NewFunder(cm, wm)
 	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
 	defer am.Close()
 

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -55,7 +55,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		t.Fatalf("failed to create host manager: %v", err)
 	}
 
-	funder := accounts.NewFunder(c.cm, wm, types.Siacoins(1))
+	funder := accounts.NewFunder(c.cm, wm)
 	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
 
 	contractor := contracts.NewContractor(c.cm, wm, walletKey)

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -189,13 +189,23 @@ DO UPDATE SET
 	})
 }
 
+// UpdateServiceAccountBalance updates the balance of a service account.
+func (s *Store) UpdateServiceAccountBalance(ctx context.Context, account proto.Account, balance types.Currency) error {
+	return errors.New("not implemented")
+}
+
+// ServiceAccountBalance returns the balance of a service account.
+func (s *Store) ServiceAccountBalance(ctx context.Context, account proto.Account) (types.Currency, error) {
+	return types.Currency{}, errors.New("not implemented")
+}
+
 func (s *Store) newHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, limit int) ([]accounts.HostAccount, error) {
 	accs := make([]accounts.HostAccount, 0, limit)
 
 	rows, err := tx.Query(ctx, `
-SELECT a.public_key 
-FROM accounts a LEFT JOIN account_hosts ah ON a.id = ah.account_id AND ah.host_id = $1 
-WHERE ah.account_id IS NULL 
+SELECT a.public_key
+FROM accounts a LEFT JOIN account_hosts ah ON a.id = ah.account_id AND ah.host_id = $1
+WHERE ah.account_id IS NULL
 LIMIT $2;`, hostID, limit)
 	if err != nil {
 		return nil, err
@@ -221,10 +231,10 @@ func (s *Store) existingHostAccountsForFunding(ctx context.Context, tx *txn, hk 
 
 	rows, err := tx.Query(ctx, `
 SELECT public_key, consecutive_failed_funds, next_fund
-FROM account_hosts ha 
-INNER JOIN accounts a ON a.id = ha.account_id 
-WHERE ha.host_id = $1 AND ha.next_fund <= NOW() 
-ORDER BY next_fund ASC 
+FROM account_hosts ha
+INNER JOIN accounts a ON a.id = ha.account_id
+WHERE ha.host_id = $1 AND ha.next_fund <= NOW()
+ORDER BY next_fund ASC
 LIMIT $2`, hostID, limit)
 	if err != nil {
 		return nil, err

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -190,12 +190,12 @@ DO UPDATE SET
 }
 
 // UpdateServiceAccountBalance updates the balance of a service account.
-func (s *Store) UpdateServiceAccountBalance(ctx context.Context, account accounts.LockedServiceAccount, balance types.Currency) error {
+func (s *Store) UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error {
 	return errors.New("not implemented")
 }
 
 // ServiceAccountBalance returns the balance of a service account.
-func (s *Store) ServiceAccountBalance(ctx context.Context, account accounts.LockedServiceAccount) (types.Currency, error) {
+func (s *Store) ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
 	return types.Currency{}, errors.New("not implemented")
 }
 

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -189,6 +189,13 @@ DO UPDATE SET
 	})
 }
 
+// DebitServiceAccount withdraws from a service account. The balance of the
+// account can't underflow, instead it will be set to 0 if the amount withdrawn
+// exceeds the stored balance.
+func (s *Store) DebitServiceAccount(ctx context.Context, hostKey types.PublicKey, account proto.Account, amount types.Currency) error {
+	return errors.New("not implemented")
+}
+
 // UpdateServiceAccountBalance updates the balance of a service account.
 func (s *Store) UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error {
 	return errors.New("not implemented")

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -190,12 +190,12 @@ DO UPDATE SET
 }
 
 // UpdateServiceAccountBalance updates the balance of a service account.
-func (s *Store) UpdateServiceAccountBalance(ctx context.Context, account proto.Account, balance types.Currency) error {
+func (s *Store) UpdateServiceAccountBalance(ctx context.Context, account accounts.LockedServiceAccount, balance types.Currency) error {
 	return errors.New("not implemented")
 }
 
 // ServiceAccountBalance returns the balance of a service account.
-func (s *Store) ServiceAccountBalance(ctx context.Context, account proto.Account) (types.Currency, error) {
+func (s *Store) ServiceAccountBalance(ctx context.Context, account accounts.LockedServiceAccount) (types.Currency, error) {
 	return types.Currency{}, errors.New("not implemented")
 }
 

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -42,6 +42,13 @@ CREATE TABLE account_hosts (
 );
 CREATE INDEX account_hosts_host_id_next_fund_idx ON account_hosts (host_id, next_fund);
 
+CREATE TABLE service_accounts (
+    account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    host_id INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+    balance NUMERIC(50,0) NOT NULL DEFAULT 0 CHECK (balance >= 0),
+    CONSTRAINT service_accounts_pk PRIMARY KEY (account_id, host_id)
+);
+
 CREATE TABLE hosts_blocklist (
     public_key BYTEA PRIMARY KEY CHECK (LENGTH(public_key) = 32),
     added TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
This PR implements service accounts. Service accounts are regular accounts for internal use which have their balances tracked.

There is a bit of a race between funding an account and withdrawing from it but we accept that race since we should at most be off by 1 withdrawal. Meaning that an account might have the balance 1SC when it actually has slightly less. 
The idea is that when we run into an insufficient balance error on an RPC, we reset our local balance to 0 which pauses integrity checks until we manage to fund the account again.

That means a host will only fail the integrity check once for an insufficient balance per time we fund the account.Given that they have 5 tries before a sector is considered lost, this should work nicely. It also allows us to get rid of the locking I initially had in this PR.