### PR TITLE
Add MigrateSector method to database

### DIFF
--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -386,3 +386,20 @@ func (s *Store) UnhealthySlab(ctx context.Context, maxRepairAttempt time.Time) (
 	})
 	return slabID, err
 }
+
+// MigrateSector updates a sector that was just migrated in the database to be
+// linked to the new host identified by 'hostKey'. This will reset the contract
+// ID since a freshly migrated sector isn't pinned yet. To pin a sector
+// 'PinSectors' is used. If the host is not found, e.g. due to being deleted in
+// the meantime, this operation is a no-op.
+func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey types.PublicKey) error {
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE sectors
+			SET host_id = host.id, contract_sectors_map_id = NULL
+			FROM ( SELECT id, public_key FROM hosts ) AS host
+			WHERE sector_root = $1 AND host.public_key = $2 AND host.id IS NOT NULL
+		`, sqlHash256(root), sqlPublicKey(hostKey))
+		return err
+	})
+}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -392,14 +392,17 @@ func (s *Store) UnhealthySlab(ctx context.Context, maxRepairAttempt time.Time) (
 // ID since a freshly migrated sector isn't pinned yet. To pin a sector
 // 'PinSectors' is used. If the host is not found, e.g. due to being deleted in
 // the meantime, this operation is a no-op.
-func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey types.PublicKey) error {
-	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, `
+func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey types.PublicKey) (bool, error) {
+	var migrated bool
+	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		resp, err := tx.Exec(ctx, `
 			UPDATE sectors
-			SET host_id = host.id, contract_sectors_map_id = NULL
-			FROM ( SELECT id, public_key FROM hosts ) AS host
-			WHERE sector_root = $1 AND host.public_key = $2 AND host.id IS NOT NULL
+			SET host_id = hosts.id, contract_sectors_map_id = NULL
+			FROM hosts
+			WHERE sector_root = $1 AND hosts.public_key = $2
 		`, sqlHash256(root), sqlPublicKey(hostKey))
+		migrated = resp.RowsAffected() > 0
 		return err
 	})
+	return migrated, err
 }

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -22,6 +22,94 @@ import (
 	"lukechampine.com/frand"
 )
 
+func TestMigrateSector(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// add account
+	account := proto.Account{1}
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		t.Fatal("failed to add account:", err)
+	}
+
+	// add 2 hosts
+	hk1 := types.PublicKey{1}
+	hk2 := types.PublicKey{2}
+	for _, hk := range []types.PublicKey{hk1, hk2} {
+		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// add contract for first host
+	fcid1 := types.FileContractID{1}
+	if err := store.AddFormedContract(context.Background(), fcid1, hk1, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		t.Fatal(err)
+	}
+
+	// pin a slab to add 2 sectors which are both stored on the first host
+	pinTime := time.Now().Round(time.Microsecond)
+	root1 := types.Hash256{1}
+	root2 := types.Hash256{2}
+	_, err := store.PinSlab(context.Background(), account, pinTime, slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     10,
+		Sectors: []slabs.SectorPinParams{
+			{
+				Root:    root1,
+				HostKey: hk1,
+			},
+			{
+				Root:    root2,
+				HostKey: hk1,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// pin sectors to contract
+	if err := store.PinSectors(context.Background(), fcid1, []types.Hash256{root1, root2}); err != nil {
+		t.Fatal(err)
+	}
+
+	// helper to assert sector state
+	assertSector := func(root types.Hash256, hostKey types.PublicKey, contractID types.FileContractID) {
+		t.Helper()
+
+		// TODO: check sector
+	}
+
+	migrate := func(root types.Hash256, hostKey types.PublicKey) {
+		t.Helper()
+		if err := store.MigrateSector(context.Background(), root, hostKey); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// assert intial state
+	assertSector(root1, hk1, fcid1)
+	assertSector(root2, hk1, fcid1)
+
+	// TODO: migrate sector 1 to host 2
+	migrate(root1, hk2)
+	assertSector(root1, hk2, types.FileContractID{})
+	assertSector(root2, hk1, fcid1)
+
+	// TODO: migrate sector 2 to unknown host, this should be a no-op
+	migrate(root1, types.PublicKey{10})
+	assertSector(root1, hk2, types.FileContractID{})
+	assertSector(root2, hk2, fcid1)
+
+	// migrate sector 2 to host 2
+	migrate(root1, hk2)
+	assertSector(root1, hk2, types.FileContractID{})
+	assertSector(root2, hk2, types.FileContractID{})
+}
+
 func TestRecordIntegrityCheck(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -98,10 +98,12 @@ func TestMigrateSector(t *testing.T) {
 		}
 	}
 
-	migrate := func(root types.Hash256, hostKey types.PublicKey) {
+	migrate := func(root types.Hash256, hostKey types.PublicKey, expectedMigrated bool) {
 		t.Helper()
-		if err := store.MigrateSector(context.Background(), root, hostKey); err != nil {
+		if migrated, err := store.MigrateSector(context.Background(), root, hostKey); err != nil {
 			t.Fatal(err)
+		} else if migrated != expectedMigrated {
+			t.Fatalf("expected migrated %v, got %v", expectedMigrated, migrated)
 		}
 	}
 
@@ -110,17 +112,17 @@ func TestMigrateSector(t *testing.T) {
 	assertSector(root2, hk1, fcid1)
 
 	// migrate sector 1 to host 2
-	migrate(root1, hk2)
+	migrate(root1, hk2, true)
 	assertSector(root1, hk2, types.FileContractID{})
 	assertSector(root2, hk1, fcid1)
 
 	// migrate sector 2 to unknown host, this should be a no-op
-	migrate(root2, types.PublicKey{10})
+	migrate(root2, types.PublicKey{10}, false)
 	assertSector(root1, hk2, types.FileContractID{})
 	assertSector(root2, hk1, fcid1)
 
 	// migrate sector 2 to host 2
-	migrate(root2, hk2)
+	migrate(root2, hk2, true)
 	assertSector(root1, hk2, types.FileContractID{})
 	assertSector(root2, hk2, types.FileContractID{})
 }
@@ -1709,7 +1711,7 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	}
 }
 
-// BenchmarkMarkSectorsLost benchmarks MarkSectorsLost in various batch sizes.
+// BenchmarkMigrateSector benchmarks MigrateSector.
 //
 // CPU    |	 Count  |     Time/op    |    Throughput
 // M2 Pro |   2508  |   0.437476 ms  |   9587.50 MB/s
@@ -1783,18 +1785,14 @@ func BenchmarkMigrateSector(b *testing.B) {
 		}
 	}
 
-	b.Run("1", func(b *testing.B) {
-		b.SetBytes(proto.SectorSize)
-		b.ResetTimer()
-
-		for b.Loop() {
-			// migrate random sector to random host
-			root := roots[frand.Intn(len(roots))]
-			hostKey := hks[frand.Intn(len(hks))]
-			err := store.MigrateSector(context.Background(), root, hostKey)
-			if err != nil {
-				b.Fatal(err)
-			}
+	b.SetBytes(proto.SectorSize)
+	for b.Loop() {
+		// migrate random sector to random host
+		root := roots[frand.Intn(len(roots))]
+		hostKey := hks[frand.Intn(len(hks))]
+		_, err := store.MigrateSector(context.Background(), root, hostKey)
+		if err != nil {
+			b.Fatal(err)
 		}
-	})
+	}
 }

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -77,10 +77,25 @@ func TestMigrateSector(t *testing.T) {
 	}
 
 	// helper to assert sector state
-	assertSector := func(root types.Hash256, hostKey types.PublicKey, contractID types.FileContractID) {
+	assertSector := func(root types.Hash256, expectedHostKey types.PublicKey, expectedContractID types.FileContractID) {
 		t.Helper()
 
-		// TODO: check sector
+		var hostKey types.PublicKey
+		var contractID types.FileContractID
+		err := store.pool.QueryRow(context.Background(), `
+			SELECT hosts.public_key, contract_sectors_map.contract_id
+			FROM sectors
+			INNER JOIN hosts ON sectors.host_id = hosts.id
+			LEFT JOIN contract_sectors_map ON sectors.contract_sectors_map_id = contract_sectors_map.id
+			WHERE sector_root = $1
+		`, sqlHash256(root)).Scan(asNullable((*sqlPublicKey)(&hostKey)), asNullable((*sqlHash256)(&contractID)))
+		if err != nil {
+			t.Fatal(err)
+		} else if hostKey != expectedHostKey {
+			t.Fatalf("expected host key %v, got %v", expectedHostKey, hostKey)
+		} else if contractID != expectedContractID {
+			t.Fatalf("expected contract ID %v, got %v", expectedContractID, contractID)
+		}
 	}
 
 	migrate := func(root types.Hash256, hostKey types.PublicKey) {
@@ -90,22 +105,22 @@ func TestMigrateSector(t *testing.T) {
 		}
 	}
 
-	// assert intial state
+	// assert initial state
 	assertSector(root1, hk1, fcid1)
 	assertSector(root2, hk1, fcid1)
 
-	// TODO: migrate sector 1 to host 2
+	// migrate sector 1 to host 2
 	migrate(root1, hk2)
 	assertSector(root1, hk2, types.FileContractID{})
 	assertSector(root2, hk1, fcid1)
 
-	// TODO: migrate sector 2 to unknown host, this should be a no-op
-	migrate(root1, types.PublicKey{10})
+	// migrate sector 2 to unknown host, this should be a no-op
+	migrate(root2, types.PublicKey{10})
 	assertSector(root1, hk2, types.FileContractID{})
-	assertSector(root2, hk2, fcid1)
+	assertSector(root2, hk1, fcid1)
 
 	// migrate sector 2 to host 2
-	migrate(root1, hk2)
+	migrate(root2, hk2)
 	assertSector(root1, hk2, types.FileContractID{})
 	assertSector(root2, hk2, types.FileContractID{})
 }

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1708,3 +1708,93 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkMarkSectorsLost benchmarks MarkSectorsLost in various batch sizes.
+//
+// CPU    |	 Count  |     Time/op    |    Throughput
+// M2 Pro |   2508  |   0.437476 ms  |   9587.50 MB/s
+func BenchmarkMigrateSector(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	// create account, host and contract
+	account := proto.Account{1}
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal("failed to add account:", err)
+	}
+
+	// add 100 hosts and contracts
+	var hks []types.PublicKey
+	for range 100 {
+		hk := types.PublicKey(frand.Entropy256())
+		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
+		}); err != nil {
+			b.Fatal(err)
+		}
+		if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+			b.Fatal(err)
+		}
+		hks = append(hks, hk)
+	}
+
+	// prepare base db
+	const (
+		dbBaseSize = 1 << 40 // 1TiB of sectors
+		nSectors   = dbBaseSize / proto.SectorSize
+	)
+
+	// insert sectors in batches
+	hostIdx := 0
+	var roots []types.Hash256
+	rootsByContract := make(map[types.FileContractID][]types.Hash256)
+	for remainingSectors := nSectors; remainingSectors > 0; {
+		batchSize := min(remainingSectors, 10000)
+		remainingSectors -= batchSize
+		var sectors []slabs.SectorPinParams
+		for range batchSize {
+			hk := hks[hostIdx]
+			root := frand.Entropy256()
+			sectors = append(sectors, slabs.SectorPinParams{
+				Root:    root,
+				HostKey: hks[hostIdx],
+			})
+			rootsByContract[types.FileContractID(hk)] = append(rootsByContract[types.FileContractID(hk)], root)
+			roots = append(roots, root)
+			hostIdx = (hostIdx + 1) % len(hks)
+		}
+
+		// pin slab
+		_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
+			MinShards:     1,
+			EncryptionKey: frand.Entropy256(),
+			Sectors:       sectors,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// pin all sectors to contracts
+	for contractID, roots := range rootsByContract {
+		err := store.PinSectors(context.Background(), contractID, roots)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.Run("1", func(b *testing.B) {
+		b.SetBytes(proto.SectorSize)
+		b.ResetTimer()
+
+		for b.Loop() {
+			// migrate random sector to random host
+			root := roots[frand.Intn(len(roots))]
+			hostKey := hks[frand.Intn(len(hks))]
+			err := store.MigrateSector(context.Background(), root, hostKey)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Used for marking a sector as migrated after uploading it to a new host.