### PR TITLE
Migrations: Contracts for repair

### DIFF
--- a/hosts/host.go
+++ b/hosts/host.go
@@ -109,6 +109,11 @@ type (
 	}
 )
 
+// IsGood returns true if the host is considered good for storing data.
+func (h *Host) IsGood() bool {
+	return h.Usability.Usable() && !h.Blocked && len(h.Networks) > 0
+}
+
 // GoodUsability is the usability struct indicating that all checks passed.
 var GoodUsability = Usability{
 	Uptime:              true,

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -1,0 +1,52 @@
+package slabs
+
+import (
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
+)
+
+// contractsForRepair filters the sectors of a slab and returns the sectors that
+// require migration together with the contracts to use for them.
+func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contracts.Contract, period uint64) ([]Sector, []contracts.Contract) {
+	goodHostsMap := make(map[types.PublicKey]hosts.Host)
+	for _, host := range goodHosts {
+		if host.Usability.Usable() && !host.Blocked {
+			goodHostsMap[host.PublicKey] = host
+		}
+	}
+
+	// prepare a map of good-for-upload goodContractMap
+	goodContractMap := make(map[types.FileContractID]contracts.Contract)
+	for _, contract := range goodContracts {
+		host, ok := goodHostsMap[contract.HostKey]
+		if !ok {
+			continue
+		} else if !contract.GoodForUpload(host.Settings.Prices, host.Settings.MaxCollateral, period) {
+			continue
+		}
+		goodContractMap[contract.ID] = contract
+	}
+
+	var toMigrate []Sector
+	for _, sector := range slab.Sectors {
+		// determine whether the sector needs to be migrated. That's the case if
+		// one of the following is true:
+		// - the sector was marked lost (contract ID and host key are nil)
+		// - the sector is stored on a bad contract
+		isLost := sector.ContractID == nil && sector.HostKey == nil
+		goodContract := sector.ContractID != nil && goodContractMap[*sector.ContractID] != contracts.Contract{}
+		if isLost || !goodContract {
+			toMigrate = append(toMigrate, sector)
+			continue
+		}
+		delete(goodContractMap, *sector.ContractID)
+	}
+
+	var remainingContracts []contracts.Contract
+	for _, contract := range goodContractMap {
+		// TODO: filter by used CIDRs
+		remainingContracts = append(remainingContracts, contract)
+	}
+	return toMigrate, remainingContracts
+}

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -6,9 +6,9 @@ import (
 	"go.sia.tech/indexd/hosts"
 )
 
-// contractsForRepair filters the sectors of a slab and returns the sectors that
+// contractsForRepair filters the sectors of a slab and returns the indices of the sectors that
 // require migration together with the contracts to use for them.
-func contractsForRepair(slab Slab, availableHosts []hosts.Host, availableContracts []contracts.Contract, period uint64) ([]Sector, []contracts.Contract) {
+func contractsForRepair(slab Slab, availableHosts []hosts.Host, availableContracts []contracts.Contract, period uint64) ([]int, []contracts.Contract) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range availableHosts {
@@ -38,12 +38,12 @@ func contractsForRepair(slab Slab, availableHosts []hosts.Host, availableContrac
 	// one of the following is true:
 	// - the sector was marked lost (contract ID and host key are nil)
 	// - the sector is stored on a bad contract
-	var toMigrate []Sector
-	for _, sector := range slab.Sectors {
+	var toMigrate []int
+	for i, sector := range slab.Sectors {
 		isLost := sector.ContractID == nil && sector.HostKey == nil
 		goodContract := sector.ContractID != nil && goodContractMap[*sector.ContractID] != contracts.Contract{}
 		if isLost || !goodContract {
-			toMigrate = append(toMigrate, sector)
+			toMigrate = append(toMigrate, i)
 			continue
 		}
 

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -9,6 +9,7 @@ import (
 // contractsForRepair filters the sectors of a slab and returns the sectors that
 // require migration together with the contracts to use for them.
 func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contracts.Contract, period uint64) ([]Sector, []contracts.Contract) {
+	// prepare a map of good hosts
 	goodHostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range goodHosts {
 		if host.Usability.Usable() && !host.Blocked && len(host.Networks) > 0 {
@@ -16,9 +17,8 @@ func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contr
 		}
 	}
 
-	// prepare a map of good-for-upload goodContractMap
+	// prepare a map of good contracts
 	goodContractMap := make(map[types.FileContractID]contracts.Contract)
-	usedCIDRs := make(map[string]struct{})
 	for _, contract := range goodContracts {
 		host, ok := goodHostsMap[contract.HostKey]
 		if !ok {
@@ -27,24 +27,33 @@ func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contr
 			continue
 		}
 		goodContractMap[contract.ID] = contract
-		for _, network := range host.Networks {
-			usedCIDRs[network.String()] = struct{}{}
-		}
 	}
 
+	// remember the CIDRs of the hosts that good sectors are stored on. We don't
+	// care if two good sectors are stored on the same CIDR but we don't want to
+	// migrate bad sectors to the same CIDR.
+	usedCIDRs := make(map[string]struct{})
+
+	// determine whether the sector needs to be migrated. That's the case if
+	// one of the following is true:
+	// - the sector was marked lost (contract ID and host key are nil)
+	// - the sector is stored on a bad contract
 	var toMigrate []Sector
 	for _, sector := range slab.Sectors {
-		// determine whether the sector needs to be migrated. That's the case if
-		// one of the following is true:
-		// - the sector was marked lost (contract ID and host key are nil)
-		// - the sector is stored on a bad contract
 		isLost := sector.ContractID == nil && sector.HostKey == nil
 		goodContract := sector.ContractID != nil && goodContractMap[*sector.ContractID] != contracts.Contract{}
 		if isLost || !goodContract {
 			toMigrate = append(toMigrate, sector)
 			continue
 		}
+
+		// remove contract from the map since we don't want to use it again
 		delete(goodContractMap, *sector.ContractID)
+
+		// add the CIDRs of the host to the map
+		for _, network := range goodHostsMap[*sector.HostKey].Networks {
+			usedCIDRs[network.String()] = struct{}{}
+		}
 	}
 
 	// return all contracts that are good, not in use and are not stored on hosts

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -12,7 +12,7 @@ func contractsForRepair(slab Slab, availableHosts []hosts.Host, availableContrac
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range availableHosts {
-		if host.Usability.Usable() && !host.Blocked && len(host.Networks) > 0 {
+		if host.IsGood() {
 			hostsMap[host.PublicKey] = host
 		}
 	}
@@ -21,12 +21,9 @@ func contractsForRepair(slab Slab, availableHosts []hosts.Host, availableContrac
 	goodContractMap := make(map[types.FileContractID]contracts.Contract)
 	for _, contract := range availableContracts {
 		host, ok := hostsMap[contract.HostKey]
-		if !ok {
-			continue
-		} else if !contract.GoodForUpload(host.Settings.Prices, host.Settings.MaxCollateral, period) {
-			continue
+		if ok && contract.GoodForUpload(host.Settings.Prices, host.Settings.MaxCollateral, period) {
+			goodContractMap[contract.ID] = contract
 		}
-		goodContractMap[contract.ID] = contract
 	}
 
 	// remember the CIDRs of the hosts that good sectors are stored on. We don't

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -8,19 +8,19 @@ import (
 
 // contractsForRepair filters the sectors of a slab and returns the sectors that
 // require migration together with the contracts to use for them.
-func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contracts.Contract, period uint64) ([]Sector, []contracts.Contract) {
+func contractsForRepair(slab Slab, availableHosts []hosts.Host, availableContracts []contracts.Contract, period uint64) ([]Sector, []contracts.Contract) {
 	// prepare a map of good hosts
-	goodHostsMap := make(map[types.PublicKey]hosts.Host)
-	for _, host := range goodHosts {
+	hostsMap := make(map[types.PublicKey]hosts.Host)
+	for _, host := range availableHosts {
 		if host.Usability.Usable() && !host.Blocked && len(host.Networks) > 0 {
-			goodHostsMap[host.PublicKey] = host
+			hostsMap[host.PublicKey] = host
 		}
 	}
 
 	// prepare a map of good contracts
 	goodContractMap := make(map[types.FileContractID]contracts.Contract)
-	for _, contract := range goodContracts {
-		host, ok := goodHostsMap[contract.HostKey]
+	for _, contract := range availableContracts {
+		host, ok := hostsMap[contract.HostKey]
 		if !ok {
 			continue
 		} else if !contract.GoodForUpload(host.Settings.Prices, host.Settings.MaxCollateral, period) {
@@ -51,7 +51,7 @@ func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contr
 		delete(goodContractMap, *sector.ContractID)
 
 		// add the CIDRs of the host to the map
-		for _, network := range goodHostsMap[*sector.HostKey].Networks {
+		for _, network := range hostsMap[*sector.HostKey].Networks {
 			usedCIDRs[network.String()] = struct{}{}
 		}
 	}
@@ -60,7 +60,7 @@ func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contr
 	var remainingContracts []contracts.Contract
 LOOP:
 	for _, contract := range goodContractMap {
-		for _, network := range goodHostsMap[contract.HostKey].Networks {
+		for _, network := range hostsMap[contract.HostKey].Networks {
 			if _, ok := usedCIDRs[network.String()]; ok {
 				continue LOOP
 			}

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -11,13 +11,14 @@ import (
 func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contracts.Contract, period uint64) ([]Sector, []contracts.Contract) {
 	goodHostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range goodHosts {
-		if host.Usability.Usable() && !host.Blocked {
+		if host.Usability.Usable() && !host.Blocked && len(host.Networks) > 0 {
 			goodHostsMap[host.PublicKey] = host
 		}
 	}
 
 	// prepare a map of good-for-upload goodContractMap
 	goodContractMap := make(map[types.FileContractID]contracts.Contract)
+	usedCIDRs := make(map[string]struct{})
 	for _, contract := range goodContracts {
 		host, ok := goodHostsMap[contract.HostKey]
 		if !ok {
@@ -26,6 +27,9 @@ func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contr
 			continue
 		}
 		goodContractMap[contract.ID] = contract
+		for _, network := range host.Networks {
+			usedCIDRs[network.String()] = struct{}{}
+		}
 	}
 
 	var toMigrate []Sector
@@ -43,9 +47,15 @@ func contractsForRepair(slab Slab, goodHosts []hosts.Host, goodContracts []contr
 		delete(goodContractMap, *sector.ContractID)
 	}
 
+	// return all contracts that are good, not in use and are not stored on hosts
 	var remainingContracts []contracts.Contract
+LOOP:
 	for _, contract := range goodContractMap {
-		// TODO: filter by used CIDRs
+		for _, network := range goodHostsMap[contract.HostKey].Networks {
+			if _, ok := usedCIDRs[network.String()]; ok {
+				continue LOOP
+			}
+		}
 		remainingContracts = append(remainingContracts, contract)
 	}
 	return toMigrate, remainingContracts

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -108,8 +108,8 @@ func TestContractsForRepair(t *testing.T) {
 			t.Fatalf("expected %d contracts to use, got %d: %v", len(expectedContracts), len(toUse), toUse)
 		}
 		for i := range toRepair {
-			if toRepair[i].Root != (types.Hash256{byte(expectedRoots[i])}) {
-				t.Fatalf("expected root %d to repair, got %s", expectedRoots[i], toRepair[i].Root)
+			if toRepair[i] != expectedRoots[i] {
+				t.Fatalf("expected root %d to repair, got %d", expectedRoots[i], toRepair[i])
 			}
 		}
 		expectedContractsMap := make(map[types.FileContractID]struct{})
@@ -125,13 +125,13 @@ func TestContractsForRepair(t *testing.T) {
 
 	// with no contracts or hosts, all sectors require migration but no
 	// contracts are available
-	assertResult(nil, nil, []int{1, 2, 3, 4}, []int{})
+	assertResult(nil, nil, []int{0, 1, 2, 3}, []int{})
 
 	// calling contractsForRepair with just the hosts and contracts the slab is stored on should
 	// return the missing sectors and no contracts
 	allHosts := []hosts.Host{goodHost, redundantCIDRHost}
 	allContracts := []contracts.Contract{goodContract, badContract, redundantCIDRContract}
-	assertResult(allHosts, allContracts, []int{2, 3}, []int{})
+	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
 
 	// prepare a bunch of hosts and contracts which can't be used for repairs
 	badHost2 := newHost(3, false, false, true)
@@ -150,7 +150,7 @@ func TestContractsForRepair(t *testing.T) {
 	// add the bad hosts+contracts and try again - expect same result
 	allHosts = append(allHosts, badHost2, hostWithoutNetworks, blockedHost, redundantCIDRHost2)
 	allContracts = append(allContracts, cBadHost2, cHostWithoutNetworks, cBlockedHost, cRedundantCIDRHost2)
-	assertResult(allHosts, allContracts, []int{2, 3}, []int{})
+	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
 
 	// prepare 2 good hosts
 	goodHost2 := newHost(7, true, false, true)
@@ -162,5 +162,5 @@ func TestContractsForRepair(t *testing.T) {
 	// should use them
 	allHosts = append(allHosts, goodHost2, goodHost3)
 	allContracts = append(allContracts, cGoodHost2, cGoodHost3)
-	assertResult(allHosts, allContracts, []int{2, 3}, []int{8, 9})
+	assertResult(allHosts, allContracts, []int{1, 2}, []int{8, 9})
 }

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -34,42 +34,133 @@ func TestContractsForRepair(t *testing.T) {
 			h.Usability = hosts.GoodUsability
 		}
 		if networks {
-			h.Networks = []net.IPNet{{}}
+			h.Networks = []net.IPNet{{IP: net.IP{1, 1, 1, i}, Mask: net.CIDRMask(24, 32)}}
 		}
 		return h
 	}
 
-	newContract := func(i byte, goodForUpload bool) contracts.Contract {
-		c := contracts.Contract{}
-		if !goodForUpload {
-			c.Good = false
-		} else if c.GoodForUpload(goodSettings.Prices, goodSettings.MaxCollateral, 100) != goodForUpload {
+	newContract := func(i byte, hk types.PublicKey, goodForUpload bool) contracts.Contract {
+		c := contracts.Contract{
+			ID:                 types.FileContractID{i},
+			HostKey:            hk,
+			Good:               goodForUpload,
+			RemainingAllowance: types.MaxCurrency,
+			TotalCollateral:    types.MaxCurrency,
+		}
+		if isGood := c.GoodForUpload(goodSettings.Prices, goodSettings.MaxCollateral, 100); isGood != goodForUpload {
 			// sanity check
-			t.Fatalf("contract %d: expected goodForUpload %v, got %v", i, goodForUpload, c.GoodForUpload(goodSettings.Prices, goodSettings.MaxCollateral, 100))
+			t.Fatalf("contract %d: expected goodForUpload %v, got %v", i, goodForUpload, isGood)
 		}
 		return c
 	}
 
 	// good host with good contract
-	gh1 := newHost(1, true, false, true)
-	gc1 := newContract(1, true)
+	goodHost := newHost(1, true, false, true)
+	goodContract := newContract(1, goodHost.PublicKey, true)
 
+	// good host with bad contract
+	badContract := newContract(2, goodHost.PublicKey, false)
+
+	// good host with redundant CIDR
+	redundantCIDRHost := newHost(2, true, false, true)
+	redundantCIDRHost.Networks = goodHost.Networks
+	redundantCIDRContract := newContract(3, redundantCIDRHost.PublicKey, true)
+
+	// prepare a slab that has one good sector and multiple bad sectors for
+	// various reasons
 	slab := Slab{
 		Sectors: []Sector{
-			// good sector
+			// good sector -> don't migrate
 			{
-				Root:       types.Hash256{},
-				ContractID: &gc1.ID,
-				HostKey:    &gh1.PublicKey,
+				Root:       types.Hash256{1},
+				ContractID: &goodContract.ID,
+				HostKey:    &goodContract.HostKey,
+			},
+			// lost sector -> migrate
+			{
+				Root:       types.Hash256{2},
+				ContractID: nil,
+				HostKey:    nil,
+			},
+			// bad contract -> migrate
+			{
+				Root:       types.Hash256{3},
+				ContractID: &badContract.ID,
+				HostKey:    &badContract.HostKey,
+			},
+			// good contract with host on redundant CIDR -> don't migrate
+			{
+				Root:       types.Hash256{4},
+				ContractID: &redundantCIDRContract.ID,
+				HostKey:    &redundantCIDRContract.HostKey,
 			},
 		},
 	}
 	_ = slab
 
-	// TODO: lost sector
-	// TODO: bad contract sector
-	// TODO: contract with redundant CIDR
-	// TODO: good contract
-	// TODO: bad contract
-	// TODO: good contract, bad host
+	// helper to assert result of contractsForRepair
+	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots, expectedContracts []int) {
+		t.Helper()
+		toRepair, toUse := contractsForRepair(slab, availableHosts, availableContracts, 100)
+		if len(toRepair) != len(expectedRoots) {
+			t.Fatalf("expected %d roots to repair, got %d: %v", len(expectedRoots), len(toRepair), toRepair)
+		} else if len(toUse) != len(expectedContracts) {
+			t.Fatalf("expected %d contracts to use, got %d: %v", len(expectedContracts), len(toUse), toUse)
+		}
+		for i := range toRepair {
+			if toRepair[i].Root != (types.Hash256{byte(expectedRoots[i])}) {
+				t.Fatalf("expected root %d to repair, got %s", expectedRoots[i], toRepair[i].Root)
+			}
+		}
+		expectedContractsMap := make(map[types.FileContractID]struct{})
+		for i := range expectedContracts {
+			expectedContractsMap[types.FileContractID{byte(expectedContracts[i])}] = struct{}{}
+		}
+		for i := range toUse {
+			if _, ok := expectedContractsMap[toUse[i].ID]; !ok {
+				t.Fatalf("contract %v is unexpected", toUse[i].ID)
+			}
+		}
+	}
+
+	// with no contracts or hosts, all sectors require migration but no
+	// contracts are available
+	assertResult(nil, nil, []int{1, 2, 3, 4}, []int{})
+
+	// calling contractsForRepair with just the hosts and contracts the slab is stored on should
+	// return the missing sectors and no contracts
+	allHosts := []hosts.Host{goodHost, redundantCIDRHost}
+	allContracts := []contracts.Contract{goodContract, badContract, redundantCIDRContract}
+	assertResult(allHosts, allContracts, []int{2, 3}, []int{})
+
+	// prepare a bunch of hosts and contracts which can't be used for repairs
+	badHost2 := newHost(3, false, false, true)
+	cBadHost2 := newContract(4, badHost2.PublicKey, true)
+
+	hostWithoutNetworks := newHost(4, true, false, false)
+	cHostWithoutNetworks := newContract(5, hostWithoutNetworks.PublicKey, true)
+
+	blockedHost := newHost(5, true, true, false)
+	cBlockedHost := newContract(6, blockedHost.PublicKey, true)
+
+	redundantCIDRHost2 := newHost(6, true, false, true)
+	redundantCIDRHost2.Networks = goodHost.Networks
+	cRedundantCIDRHost2 := newContract(7, redundantCIDRHost2.PublicKey, true)
+
+	// add the bad hosts+contracts and try again - expect same result
+	allHosts = append(allHosts, badHost2, hostWithoutNetworks, blockedHost, redundantCIDRHost2)
+	allContracts = append(allContracts, cBadHost2, cHostWithoutNetworks, cBlockedHost, cRedundantCIDRHost2)
+	assertResult(allHosts, allContracts, []int{2, 3}, []int{})
+
+	// prepare 2 good hosts
+	goodHost2 := newHost(7, true, false, true)
+	cGoodHost2 := newContract(8, goodHost2.PublicKey, true)
+
+	goodHost3 := newHost(8, true, false, true)
+	cGoodHost3 := newContract(9, goodHost3.PublicKey, true)
+
+	// should use them
+	allHosts = append(allHosts, goodHost2, goodHost3)
+	allContracts = append(allContracts, cGoodHost2, cGoodHost3)
+	assertResult(allHosts, allContracts, []int{2, 3}, []int{8, 9})
 }

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -1,0 +1,75 @@
+package slabs
+
+import (
+	"math"
+	"net"
+	"testing"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
+)
+
+var goodSettings = proto.HostSettings{
+	AcceptingContracts: true,
+	RemainingStorage:   math.MaxUint32,
+	Prices: proto.HostPrices{
+		ContractPrice: types.Siacoins(1),
+		Collateral:    types.NewCurrency64(1),
+		StoragePrice:  types.NewCurrency64(1),
+	},
+	MaxContractDuration: 90 * 144,
+	MaxCollateral:       types.Siacoins(1000),
+}
+
+func TestContractsForRepair(t *testing.T) {
+	newHost := func(i byte, usable, blocked, networks bool) hosts.Host {
+		h := hosts.Host{
+			Blocked:   blocked,
+			PublicKey: types.PublicKey{i},
+			Settings:  goodSettings,
+		}
+		if usable {
+			h.Usability = hosts.GoodUsability
+		}
+		if networks {
+			h.Networks = []net.IPNet{{}}
+		}
+		return h
+	}
+
+	newContract := func(i byte, goodForUpload bool) contracts.Contract {
+		c := contracts.Contract{}
+		if !goodForUpload {
+			c.Good = false
+		} else if c.GoodForUpload(goodSettings.Prices, goodSettings.MaxCollateral, 100) != goodForUpload {
+			// sanity check
+			t.Fatalf("contract %d: expected goodForUpload %v, got %v", i, goodForUpload, c.GoodForUpload(goodSettings.Prices, goodSettings.MaxCollateral, 100))
+		}
+		return c
+	}
+
+	// good host with good contract
+	gh1 := newHost(1, true, false, true)
+	gc1 := newContract(1, true)
+
+	slab := Slab{
+		Sectors: []Sector{
+			// good sector
+			{
+				Root:       types.Hash256{},
+				ContractID: &gc1.ID,
+				HostKey:    &gh1.PublicKey,
+			},
+		},
+	}
+	_ = slab
+
+	// TODO: lost sector
+	// TODO: bad contract sector
+	// TODO: contract with redundant CIDR
+	// TODO: good contract
+	// TODO: bad contract
+	// TODO: good contract, bad host
+}


### PR DESCRIPTION
This PR adds a helper to get all sectors from a slab that require migration as well as the contracts that can be used for it.