### PR TITLE
Make sure failed scans don't affect the networks associated with a host

### DIFF
--- a/hosts/host.go
+++ b/hosts/host.go
@@ -14,6 +14,10 @@ var (
 	// ErrNotFound is returned by database operations that fail due to a host
 	// not being found.
 	ErrNotFound = errors.New("host not found")
+
+	// ErrNoNetworks is returned when a host has no networks even though it
+	// should.
+	ErrNoNetworks = errors.New("host has no networks")
 )
 
 // DefaultHostsQueryOpts re the default options applied when querying hosts. By

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -358,6 +358,9 @@ func (s *Store) PruneHosts(ctx context.Context, minLastSuccessfulScan time.Time,
 
 // UpdateHost updates a host in the database, the given parameters are the result of scanning the host.
 func (s *Store) UpdateHost(ctx context.Context, hk types.PublicKey, networks []net.IPNet, hs proto4.HostSettings, scanSucceeded bool, nextScan time.Time) error {
+	if len(networks) == 0 && scanSucceeded {
+		return hosts.ErrNoNetworks
+	}
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		if !scanSucceeded {
 			if res, err := tx.Exec(ctx, `
@@ -462,15 +465,17 @@ WHERE hosts.id = computed.id RETURNING hosts.id`,
 			return errors.New("failed to return host id after successful update") // sanity check
 		}
 
-		_, err = tx.Exec(ctx, `DELETE FROM host_resolved_cidrs WHERE host_id = $1`, hostID)
-		if err != nil {
-			return err
-		}
-
-		for _, cidr := range networks {
-			_, err = tx.Exec(ctx, `INSERT INTO host_resolved_cidrs (host_id, cidr) VALUES ($1, $2)`, hostID, cidr.String())
+		if scanSucceeded {
+			_, err = tx.Exec(ctx, `DELETE FROM host_resolved_cidrs WHERE host_id = $1`, hostID)
 			if err != nil {
-				return fmt.Errorf("failed to insert host resolved CIDR: %w", err)
+				return err
+			}
+
+			for _, cidr := range networks {
+				_, err = tx.Exec(ctx, `INSERT INTO host_resolved_cidrs (host_id, cidr) VALUES ($1, $2)`, hostID, cidr.String())
+				if err != nil {
+					return fmt.Errorf("failed to insert host resolved CIDR: %w", err)
+				}
 			}
 		}
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -23,6 +23,8 @@ import (
 	"lukechampine.com/frand"
 )
 
+var testNetworks = []net.IPNet{{IP: net.IPv4(1, 2, 3, 4), Mask: net.CIDRMask(32, 32)}}
+
 func TestAddHostAnnouncement(t *testing.T) {
 	// create database
 	log := zaptest.NewLogger(t)
@@ -190,7 +192,7 @@ func TestHostChecks(t *testing.T) {
 	}
 
 	// update host with settings that fail all checks
-	err := db.UpdateHost(context.Background(), hk, nil, proto4.HostSettings{
+	err := db.UpdateHost(context.Background(), hk, testNetworks, proto4.HostSettings{
 		Release:             "test",
 		ProtocolVersion:     [3]uint8{0, 0, 0},
 		AcceptingContracts:  false,
@@ -242,58 +244,58 @@ func TestHostChecks(t *testing.T) {
 
 	// adjust max duration so we pass the check
 	hs.MaxContractDuration = settingPeriod
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("MaxContractDuration")
 
 	// adjust max collateral so we pass the check
 	hs.MaxCollateral = hs.Prices.Collateral.Mul64(oneTB).Mul64(settingPeriod)
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("MaxCollateral")
 
 	// adjust protocol to pass the check
 	hs.ProtocolVersion = [3]uint8{1, 0, 0}
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("ProtocolVersion")
 
 	// adjust price validity so we pass the check
 	hs.Prices.ValidUntil = time.Now().Add(time.Second * 3601)
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("PriceValidity")
 
 	// adjust accepting contracts so we pass the check
 	hs.AcceptingContracts = true
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("AcceptingContracts")
 
 	// adjust contract price so we pass the check
 	hs.Prices.ContractPrice = oneSC.Sub(oneH)
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("ContractPrice")
 
 	// adjust collateral so we pass the check
 	hs.Prices.Collateral = hs.Prices.StoragePrice.Mul64(2)
 	hs.MaxCollateral = hs.Prices.Collateral.Mul64(oneTB).Mul64(settingPeriod)
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("Collateral")
 
 	// adjust storage price so we pass the check
 	hs.Prices.StoragePrice = settingMaxStoragePrice
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("StoragePrice")
 
 	// adjust egress price so we pass the check
 	hs.Prices.EgressPrice = settingMaxEgressPrice
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("EgressPrice")
 
 	// adjust ingress price so we pass the check
 	hs.Prices.IngressPrice = settingMaxIngressPrice
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("IngressPrice")
 
 	// adjust free sector price so we pass the check
 	hs.Prices.FreeSectorPrice = oneSC.Div64(oneTB)
-	_ = db.UpdateHost(context.Background(), hk, nil, hs, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("FreeSectorPrice")
 
 	// assert host is usable
@@ -532,7 +534,7 @@ func TestHostsForScanning(t *testing.T) {
 
 	// simulate scanning h1 successfully
 	nextScan := time.Now().Round(time.Microsecond).Add(time.Minute)
-	err = db.UpdateHost(context.Background(), hk1, nil, proto4.HostSettings{}, true, nextScan)
+	err = db.UpdateHost(context.Background(), hk1, testNetworks, proto4.HostSettings{}, true, nextScan)
 	if err != nil {
 		t.Fatal("unexpected", err)
 	}
@@ -548,7 +550,7 @@ func TestHostsForScanning(t *testing.T) {
 	}
 
 	// simulate scanning h2 successfully
-	err = db.UpdateHost(context.Background(), hk2, nil, proto4.HostSettings{}, true, nextScan)
+	err = db.UpdateHost(context.Background(), hk2, testNetworks, proto4.HostSettings{}, true, nextScan)
 	if err != nil {
 		t.Fatal("unexpected", err)
 	}
@@ -574,14 +576,14 @@ func TestHostsRecentUptime(t *testing.T) {
 		if up {
 			for range n {
 				_, err1 := db.pool.Exec(context.Background(), `UPDATE hosts SET last_failed_scan = '0001-01-01 00:00:00+00'::timestamptz, last_successful_scan = NOW() - INTERVAL '24 hours'`)
-				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, nil, newTestHostSettings(hk), true, time.Time{})); err != nil {
+				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, testNetworks, newTestHostSettings(hk), true, time.Time{})); err != nil {
 					t.Fatal(err)
 				}
 			}
 		} else {
 			for range n {
 				_, err1 := db.pool.Exec(context.Background(), `UPDATE hosts SET last_successful_scan = '0001-01-01 00:00:00+00'::timestamptz, last_failed_scan = NOW() - INTERVAL '24 hours'`)
-				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, nil, proto4.HostSettings{}, false, time.Time{})); err != nil {
+				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, testNetworks, proto4.HostSettings{}, false, time.Time{})); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -726,10 +728,10 @@ func TestPruneHosts(t *testing.T) {
 	h1 = addHost()
 	h2 = addHost()
 	err = errors.Join(
-		db.UpdateHost(context.Background(), h1, nil, proto4.HostSettings{}, true, time.Now()),
-		db.UpdateHost(context.Background(), h1, nil, proto4.HostSettings{}, false, time.Now()),
-		db.UpdateHost(context.Background(), h2, nil, proto4.HostSettings{}, true, time.Now()),
-		db.UpdateHost(context.Background(), h2, nil, proto4.HostSettings{}, false, time.Now()),
+		db.UpdateHost(context.Background(), h1, testNetworks, proto4.HostSettings{}, true, time.Now()),
+		db.UpdateHost(context.Background(), h1, testNetworks, proto4.HostSettings{}, false, time.Now()),
+		db.UpdateHost(context.Background(), h2, testNetworks, proto4.HostSettings{}, true, time.Now()),
+		db.UpdateHost(context.Background(), h2, testNetworks, proto4.HostSettings{}, false, time.Now()),
 	)
 	if err != nil {
 		t.Fatal("unexpected", err)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -855,6 +855,24 @@ func TestUpdateHost(t *testing.T) {
 	} else if h.Networks[0].String() != networks[0].String() {
 		t.Fatal("unexpected network", h.Networks)
 	}
+
+	// assert successful scan needs networks
+	err = db.UpdateHost(context.Background(), hk, nil, hs, true, nextScan)
+	if !errors.Is(err, hosts.ErrNoNetworks) {
+		t.Fatalf("expected hosts.ErrNoNetworks, got %v", err)
+	}
+
+	// assert updating with a failed scan doesn't affect the host's networks
+	err = db.UpdateHost(context.Background(), hk, []net.IPNet{{IP: net.IPv4(9, 9, 9, 9)}}, hs, false, nextScan)
+	if err != nil {
+		t.Fatal(err)
+	} else if h, err := db.Host(context.Background(), hk); err != nil {
+		t.Fatal(err)
+	} else if len(h.Networks) != 1 {
+		t.Fatal("unexpected networks", h.Networks)
+	} else if h.Networks[0].String() != networks[0].String() {
+		t.Fatal("unexpected network", h.Networks)
+	}
 }
 
 // BenchmarkHosts is a set of benchmarks that verify the performance of the host


### PR DESCRIPTION
Considering that we use the networks for checks during migration, it would be unfortunate to wipe them upon the first failed scan.