### PR TITLE
Refactor `Contractor` into `Dialer` and `Contractor` for easier testing and nice interfaces

### DIFF
--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -110,7 +110,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
 	defer am.Close()
 
-	cf := contracts.NewContractor(cm, wm, walletKey)
+	cf := contracts.NewSiamuxDialer(cm, wm, walletKey)
 	contracts, err := contracts.NewManager(walletKey.PublicKey(), am, cm, cf, hm, store, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -110,8 +110,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
 	defer am.Close()
 
-	cf := contracts.NewSiamuxDialer(cm, wm, walletKey)
-	contracts, err := contracts.NewManager(walletKey.PublicKey(), am, cm, cf, hm, store, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, cm, hm, store, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)
 	}

--- a/contracts/broadcast.go
+++ b/contracts/broadcast.go
@@ -56,7 +56,13 @@ func (cm *ContractManager) broadcastContractRevision(ctx context.Context, contra
 	}
 
 	// fetch the latest revision
-	resp, err := cm.contractor.LatestRevision(ctx, host.PublicKey, host.SiamuxAddr(), contractID)
+	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	if err != nil {
+		return fmt.Errorf("failed to create contractor: %w", err)
+	}
+	defer contractor.Close()
+
+	resp, err := contractor.LatestRevision(ctx, contractID)
 	if err != nil {
 		log.Warn("failed to fetch latest revision", zap.Error(err))
 		return nil

--- a/contracts/broadcast.go
+++ b/contracts/broadcast.go
@@ -56,13 +56,13 @@ func (cm *ContractManager) broadcastContractRevision(ctx context.Context, contra
 	}
 
 	// fetch the latest revision
-	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
-		return fmt.Errorf("failed to create contractor: %w", err)
+		return fmt.Errorf("failed to dial host: %w", err)
 	}
-	defer contractor.Close()
+	defer hc.Close()
 
-	resp, err := contractor.LatestRevision(ctx, contractID)
+	resp, err := hc.LatestRevision(ctx, contractID)
 	if err != nil {
 		log.Warn("failed to fetch latest revision", zap.Error(err))
 		return nil

--- a/contracts/broadcast.go
+++ b/contracts/broadcast.go
@@ -56,7 +56,7 @@ func (cm *ContractManager) broadcastContractRevision(ctx context.Context, contra
 	}
 
 	// fetch the latest revision
-	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		return fmt.Errorf("failed to create contractor: %w", err)
 	}

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -76,9 +76,9 @@ func TestBroadcastContractRevisions(t *testing.T) {
 
 	// mock a latest revision
 	rev := types.V2FileContract{RevisionNumber: 1}
-	contractor := newContractorMock()
-	dialer.contractor[hk] = contractor
-	contractor.latestRevisions[types.FileContractID{4}] = proto.RPCLatestRevisionResponse{Contract: rev}
+	hc := newHostClientMock()
+	dialer.clients[hk] = hc
+	hc.latestRevisions[types.FileContractID{4}] = proto.RPCLatestRevisionResponse{Contract: rev}
 
 	// assert revision was broadcasted and contract was marked as such
 	if err := contracts.performBroadcastContractRevisions(context.Background(), zap.NewNop()); err != nil {

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -26,7 +26,6 @@ func TestBroadcastContractRevisions(t *testing.T) {
 
 	// add host
 	hk := types.PublicKey{1}
-	contractor := dialer.Contractor(hk)
 	store.hosts = map[types.PublicKey]hosts.Host{
 		hk: {
 			PublicKey: hk,
@@ -77,6 +76,8 @@ func TestBroadcastContractRevisions(t *testing.T) {
 
 	// mock a latest revision
 	rev := types.V2FileContract{RevisionNumber: 1}
+	contractor := newContractorMock()
+	dialer.contractor[hk] = contractor
 	contractor.latestRevisions[types.FileContractID{4}] = proto.RPCLatestRevisionResponse{Contract: rev}
 
 	// assert revision was broadcasted and contract was marked as such

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -16,12 +16,13 @@ import (
 
 func TestBroadcastContractRevisions(t *testing.T) {
 	cmMock := newChainManagerMock()
-	contractor := newContractorMock()
+	dialer := newDialerMock()
+	contractor := dialer.contractor
 	syncerMock := &syncerMock{}
 	walletMock := &walletMock{}
 	store := &storeMock{}
 
-	contracts := newContractManager(types.PublicKey{}, nil, cmMock, contractor, nil, store, syncerMock, walletMock)
+	contracts := newContractManager(types.PublicKey{}, nil, cmMock, dialer, nil, store, syncerMock, walletMock)
 	contracts.revisionBroadcastInterval = time.Minute
 
 	// add host

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -17,7 +17,6 @@ import (
 func TestBroadcastContractRevisions(t *testing.T) {
 	cmMock := newChainManagerMock()
 	dialer := newDialerMock()
-	contractor := dialer.contractor
 	syncerMock := &syncerMock{}
 	walletMock := &walletMock{}
 	store := &storeMock{}
@@ -27,6 +26,7 @@ func TestBroadcastContractRevisions(t *testing.T) {
 
 	// add host
 	hk := types.PublicKey{1}
+	contractor := dialer.Contractor(hk)
 	store.hosts = map[types.PublicKey]hosts.Host{
 		hk: {
 			PublicKey: hk,

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -7,7 +7,6 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/indexd/hosts"
@@ -51,27 +50,27 @@ func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int
 	s.w.SignV2Inputs(txn, toSign)
 }
 
-// Dialer is an interface for dialing a host.
-type Dialer interface {
+// dialer is an interface for dialing a host.
+type dialer interface {
 	NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error)
 }
 
 type contractor struct {
-	cm      *chain.Manager
+	cm      ChainManager
 	client  rhp.TransportClient
 	hostKey types.PublicKey
 	signer  *formContractSigner
 }
 
 type siamuxDialer struct {
-	cm     *chain.Manager
+	cm     ChainManager
 	ownKey types.PrivateKey
 	w      rhp.Wallet
 }
 
-// NewSiamuxDialer creates a new Dialer that uses the SiaMux protocol to dial a
+// newSiamuxDialer creates a new Dialer that uses the SiaMux protocol to dial a
 // host.
-func NewSiamuxDialer(cm *chain.Manager, w rhp.Wallet, ownKey types.PrivateKey) Dialer {
+func newSiamuxDialer(cm ChainManager, w rhp.Wallet, ownKey types.PrivateKey) dialer {
 	return &siamuxDialer{
 		cm:     cm,
 		ownKey: ownKey,

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -51,6 +51,7 @@ func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int
 	s.w.SignV2Inputs(txn, toSign)
 }
 
+// Dialer is an interface for dialing a host.
 type Dialer interface {
 	NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error)
 }
@@ -68,6 +69,8 @@ type siamuxDialer struct {
 	w      rhp.Wallet
 }
 
+// NewSiamuxDialer creates a new Dialer that uses the SiaMux protocol to dial a
+// host.
 func NewSiamuxDialer(cm *chain.Manager, w rhp.Wallet, ownKey types.PrivateKey) Dialer {
 	return &siamuxDialer{
 		cm:     cm,
@@ -236,12 +239,11 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 
 		allowance, collateral := initialContractFunding(host.Settings.Prices, host.Settings.MaxCollateral, period)
 		formationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
 		contractor, err := cm.dialer.NewContractor(formationCtx, host.PublicKey, host.SiamuxAddr())
 		if err != nil {
+			cancel()
 			return fmt.Errorf("failed to create contractor: %w", err)
 		}
-		defer contractor.Close()
 		res, err := contractor.FormContract(formationCtx, host.Settings, proto.RPCFormContractParams{
 			RenterPublicKey: cm.renterKey,
 			RenterAddress:   cm.w.Address(),
@@ -250,6 +252,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			ProofHeight:     cm.cm.TipState().Index.Height + period,
 		})
 		cancel()
+		_ = contractor.Close()
 		if err != nil {
 			hostLog.Error("failed to form contract", zap.Error(err))
 			continue

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -52,10 +52,10 @@ func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int
 
 // dialer is an interface for dialing a host.
 type dialer interface {
-	Dial(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error)
+	Dial(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
 }
 
-type contractor struct {
+type hostClient struct {
 	cm      ChainManager
 	client  rhp.TransportClient
 	hostKey types.PublicKey
@@ -78,16 +78,16 @@ func newSiamuxDialer(cm ChainManager, w rhp.Wallet, ownKey types.PrivateKey) dia
 	}
 }
 
-// Dial creates a production Contractor that forms, refreshes and renews contracts by
-// dialing up hosts using the SiaMux protocol.
-func (d *siamuxDialer) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
+// Dial creates a production HostClient that forms, refreshes and renews
+// contracts by dialing up hosts using the SiaMux protocol.
+func (d *siamuxDialer) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 	client, err := siamux.Dial(ctx, addr, hostKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial host: %w", err)
 	}
-	return &contractor{
+	return &hostClient{
 		client:  client,
 		cm:      d.cm,
 		hostKey: hostKey,
@@ -98,11 +98,11 @@ func (d *siamuxDialer) Dial(ctx context.Context, hostKey types.PublicKey, addr s
 	}, nil
 }
 
-func (c *contractor) Close() error {
+func (c *hostClient) Close() error {
 	return c.client.Close()
 }
 
-func (c *contractor) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+func (c *hostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
 	res, err := rhp.RPCFormContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, c.hostKey, settings.WalletAddress, params)
 	if err != nil {
 		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to form contract: %w", err)
@@ -111,7 +111,7 @@ func (c *contractor) FormContract(ctx context.Context, settings proto.HostSettin
 	return res, nil
 }
 
-func (c *contractor) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+func (c *hostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
 	return rhp.RPCLatestRevision(ctx, c.client, contractID)
 }
 
@@ -238,12 +238,12 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 
 		allowance, collateral := initialContractFunding(host.Settings.Prices, host.Settings.MaxCollateral, period)
 		formationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		contractor, err := cm.dialer.Dial(formationCtx, host.PublicKey, host.SiamuxAddr())
+		hc, err := cm.dialer.Dial(formationCtx, host.PublicKey, host.SiamuxAddr())
 		if err != nil {
 			cancel()
-			return fmt.Errorf("failed to create contractor: %w", err)
+			return fmt.Errorf("failed to dial host: %w", err)
 		}
-		res, err := contractor.FormContract(formationCtx, host.Settings, proto.RPCFormContractParams{
+		res, err := hc.FormContract(formationCtx, host.Settings, proto.RPCFormContractParams{
 			RenterPublicKey: cm.renterKey,
 			RenterAddress:   cm.w.Address(),
 			Allowance:       allowance,
@@ -251,7 +251,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			ProofHeight:     cm.cm.TipState().Index.Height + period,
 		})
 		cancel()
-		_ = contractor.Close()
+		_ = hc.Close()
 		if err != nil {
 			hostLog.Error("failed to form contract", zap.Error(err))
 			continue

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -51,34 +51,58 @@ func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int
 	s.w.SignV2Inputs(txn, toSign)
 }
 
+type Dialer interface {
+	NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error)
+}
+
 type contractor struct {
+	cm      *chain.Manager
+	client  rhp.TransportClient
+	hostKey types.PublicKey
+	signer  *formContractSigner
+}
+
+type siamuxDialer struct {
 	cm     *chain.Manager
-	signer *formContractSigner
+	ownKey types.PrivateKey
+	w      rhp.Wallet
+}
+
+func NewSiamuxDialer(cm *chain.Manager, w rhp.Wallet, ownKey types.PrivateKey) Dialer {
+	return &siamuxDialer{
+		cm:     cm,
+		ownKey: ownKey,
+		w:      w,
+	}
 }
 
 // NewContractor creates a production Contractor that forms, refreshes and renews contracts by
 // dialing up hosts using the SiaMux protocol and fetching fresh settings right
 // before the RPC call.
-func NewContractor(cm *chain.Manager, w rhp.Wallet, renterKey types.PrivateKey) Contractor {
-	return &contractor{
-		cm: cm,
-		signer: &formContractSigner{
-			renterKey: renterKey,
-			w:         w,
-		},
+func (d *siamuxDialer) NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
+	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+	client, err := siamux.Dial(ctx, addr, hostKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial host: %w", err)
 	}
+	return &contractor{
+		client:  client,
+		cm:      d.cm,
+		hostKey: hostKey,
+		signer: &formContractSigner{
+			renterKey: d.ownKey,
+			w:         d.w,
+		},
+	}, nil
 }
 
-func (c *contractor) FormContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
-	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-	defer cancel()
-	t, err := siamux.Dial(dialCtx, addr, hk)
-	if err != nil {
-		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to dial host: %w", err)
-	}
-	defer t.Close()
+func (c *contractor) Close() error {
+	return c.client.Close()
+}
 
-	res, err := rhp.RPCFormContract(ctx, t, c.cm, c.signer, c.cm.TipState(), settings.Prices, hk, settings.WalletAddress, params)
+func (c *contractor) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+	res, err := rhp.RPCFormContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, c.hostKey, settings.WalletAddress, params)
 	if err != nil {
 		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to form contract: %w", err)
 	}
@@ -86,15 +110,8 @@ func (c *contractor) FormContract(ctx context.Context, hk types.PublicKey, addr 
 	return res, nil
 }
 
-func (cf *contractor) LatestRevision(ctx context.Context, hk types.PublicKey, addr string, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
-	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-	defer cancel()
-	t, err := siamux.Dial(dialCtx, addr, hk)
-	if err != nil {
-		return proto.RPCLatestRevisionResponse{}, fmt.Errorf("failed to dial host: %w", err)
-	}
-	defer t.Close()
-	return rhp.RPCLatestRevision(ctx, t, contractID)
+func (c *contractor) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+	return rhp.RPCLatestRevision(ctx, c.client, contractID)
 }
 
 // performContractFormation makes sure that we have at least 'wanted' good
@@ -217,11 +234,16 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		if !isGood(host, hostLog) {
 			continue // ignore bad host
 		}
-		hostAddr := host.SiamuxAddr()
 
 		allowance, collateral := initialContractFunding(host.Settings.Prices, host.Settings.MaxCollateral, period)
 		formationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		res, err := cm.contractor.FormContract(formationCtx, host.PublicKey, hostAddr, host.Settings, proto.RPCFormContractParams{
+		defer cancel()
+		contractor, err := cm.dialer.NewContractor(formationCtx, host.PublicKey, host.SiamuxAddr())
+		if err != nil {
+			return fmt.Errorf("failed to create contractor: %w", err)
+		}
+		defer contractor.Close()
+		res, err := contractor.FormContract(formationCtx, host.Settings, proto.RPCFormContractParams{
 			RenterPublicKey: cm.renterKey,
 			RenterAddress:   cm.w.Address(),
 			Allowance:       allowance,

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -52,7 +52,7 @@ func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int
 
 // dialer is an interface for dialing a host.
 type dialer interface {
-	NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error)
+	Dial(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error)
 }
 
 type contractor struct {
@@ -78,9 +78,9 @@ func newSiamuxDialer(cm ChainManager, w rhp.Wallet, ownKey types.PrivateKey) dia
 	}
 }
 
-// NewContractor creates a production Contractor that forms, refreshes and renews contracts by
+// Dial creates a production Contractor that forms, refreshes and renews contracts by
 // dialing up hosts using the SiaMux protocol.
-func (d *siamuxDialer) NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
+func (d *siamuxDialer) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 	client, err := siamux.Dial(ctx, addr, hostKey)
@@ -238,7 +238,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 
 		allowance, collateral := initialContractFunding(host.Settings.Prices, host.Settings.MaxCollateral, period)
 		formationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		contractor, err := cm.dialer.NewContractor(formationCtx, host.PublicKey, host.SiamuxAddr())
+		contractor, err := cm.dialer.Dial(formationCtx, host.PublicKey, host.SiamuxAddr())
 		if err != nil {
 			cancel()
 			return fmt.Errorf("failed to create contractor: %w", err)

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -77,8 +77,7 @@ func NewSiamuxDialer(cm *chain.Manager, w rhp.Wallet, ownKey types.PrivateKey) D
 }
 
 // NewContractor creates a production Contractor that forms, refreshes and renews contracts by
-// dialing up hosts using the SiaMux protocol and fetching fresh settings right
-// before the RPC call.
+// dialing up hosts using the SiaMux protocol.
 func (d *siamuxDialer) NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"slices"
-	"strings"
 	"testing"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -35,10 +34,22 @@ var (
 )
 
 type formContractCall struct {
-	hk       types.PublicKey
-	addr     string
 	settings proto.HostSettings
 	params   proto.RPCFormContractParams
+}
+
+type dialerMock struct {
+	contractor *contractorMock
+}
+
+func newDialerMock() *dialerMock {
+	return &dialerMock{
+		contractor: newContractorMock(),
+	}
+}
+
+func (d *dialerMock) NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
+	return d.contractor, nil
 }
 
 type contractorMock struct {
@@ -54,18 +65,16 @@ func newContractorMock() *contractorMock {
 	}
 }
 
-func (c *contractorMock) Calls() []formContractCall {
-	calls := slices.Clone(c.formCalls)
-	slices.SortFunc(calls, func(a, b formContractCall) int {
-		return strings.Compare(a.hk.String(), b.hk.String())
-	})
-	return calls
+func (c *contractorMock) Close() error {
+	return nil
 }
 
-func (c *contractorMock) FormContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+func (c *contractorMock) Calls() []formContractCall {
+	return slices.Clone(c.formCalls)
+}
+
+func (c *contractorMock) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
 	c.formCalls = append(c.formCalls, formContractCall{
-		hk:       hk,
-		addr:     addr,
 		settings: settings,
 		params:   params,
 	})
@@ -88,7 +97,7 @@ func (c *contractorMock) FormContract(ctx context.Context, hk types.PublicKey, a
 	}, nil
 }
 
-func (c *contractorMock) LatestRevision(ctx context.Context, hk types.PublicKey, addr string, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+func (c *contractorMock) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
 	resp, ok := c.latestRevisions[contractID]
 	if !ok {
 		return proto.RPCLatestRevisionResponse{}, fmt.Errorf("contract %v not found", contractID)
@@ -211,21 +220,18 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 		good3.PublicKey: good3,
 	}
 
-	contractor := newContractorMock()
+	dialer := newDialerMock()
+	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, contractor, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
 
 	// disable randomizing hosts to make test deterministic
 	contracts.shuffle = func(int, func(i, j int)) {}
 
 	assertFormation := func(h hosts.Host, call formContractCall) {
 		t.Helper()
-		if call.hk != h.PublicKey {
-			t.Fatalf("expected host key %v, got %v", h.PublicKey, call.hk)
-		} else if call.addr != h.SiamuxAddr() {
-			t.Fatalf("expected address %v, got %v", h.SiamuxAddr(), call.addr)
-		} else if call.settings != goodSettings {
+		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
 		// assert params
@@ -376,21 +382,18 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 		good5.PublicKey: good5,
 	}
 
-	cf := &contractorMock{}
+	dialer := newDialerMock()
+	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, cf, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
 
 	// disable randomizing hosts to make test deterministic
 	contracts.shuffle = func(int, func(i, j int)) {}
 
 	assertFormation := func(h hosts.Host, call formContractCall) {
 		t.Helper()
-		if call.hk != h.PublicKey {
-			t.Fatalf("expected host key %v, got %v", h.PublicKey, call.hk)
-		} else if call.addr != h.SiamuxAddr() {
-			t.Fatalf("expected address %v, got %v", h.SiamuxAddr(), call.addr)
-		} else if call.settings != goodSettings {
+		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
 		// assert params
@@ -415,7 +418,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	// assert that we attempted to form contracts with the right hosts,
 	// settings and params
-	calls := cf.Calls()
+	calls := contractor.Calls()
 	if len(calls) != wanted-1 {
 		t.Fatalf("expected %v calls, got %v", wanted-1, len(calls))
 	}

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -39,51 +39,51 @@ type formContractCall struct {
 }
 
 type dialerMock struct {
-	contractor map[types.PublicKey]*contractorMock
+	clients map[types.PublicKey]*hostClientMock
 }
 
 func newDialerMock() *dialerMock {
 	return &dialerMock{
-		contractor: make(map[types.PublicKey]*contractorMock),
+		clients: make(map[types.PublicKey]*hostClientMock),
 	}
 }
 
-func (d *dialerMock) Contractor(hostKey types.PublicKey) *contractorMock {
-	if _, ok := d.contractor[hostKey]; !ok {
-		d.contractor[hostKey] = newContractorMock()
+func (d *dialerMock) HostClient(hostKey types.PublicKey) *hostClientMock {
+	if _, ok := d.clients[hostKey]; !ok {
+		d.clients[hostKey] = newHostClientMock()
 	}
-	return d.contractor[hostKey]
+	return d.clients[hostKey]
 }
 
-func (d *dialerMock) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
-	if _, ok := d.contractor[hostKey]; !ok {
-		d.contractor[hostKey] = newContractorMock()
+func (d *dialerMock) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	if _, ok := d.clients[hostKey]; !ok {
+		d.clients[hostKey] = newHostClientMock()
 	}
-	return d.contractor[hostKey], nil
+	return d.clients[hostKey], nil
 }
 
-type contractorMock struct {
+type hostClientMock struct {
 	formCalls       []formContractCall
 	refreshCalls    []refreshContractCall
 	renewCalls      []renewContractCall
 	latestRevisions map[types.FileContractID]proto.RPCLatestRevisionResponse
 }
 
-func newContractorMock() *contractorMock {
-	return &contractorMock{
+func newHostClientMock() *hostClientMock {
+	return &hostClientMock{
 		latestRevisions: map[types.FileContractID]proto.RPCLatestRevisionResponse{},
 	}
 }
 
-func (c *contractorMock) Close() error {
+func (c *hostClientMock) Close() error {
 	return nil
 }
 
-func (c *contractorMock) Calls() []formContractCall {
+func (c *hostClientMock) Calls() []formContractCall {
 	return slices.Clone(c.formCalls)
 }
 
-func (c *contractorMock) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+func (c *hostClientMock) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
 	c.formCalls = append(c.formCalls, formContractCall{
 		settings: settings,
 		params:   params,
@@ -107,7 +107,7 @@ func (c *contractorMock) FormContract(ctx context.Context, settings proto.HostSe
 	}, nil
 }
 
-func (c *contractorMock) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+func (c *hostClientMock) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
 	resp, ok := c.latestRevisions[contractID]
 	if !ok {
 		return proto.RPCLatestRevisionResponse{}, fmt.Errorf("contract %v not found", contractID)
@@ -240,7 +240,7 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 
 	assertFormation := func(h hosts.Host) {
 		t.Helper()
-		call := dialer.Contractor(h.PublicKey).Calls()[0]
+		call := dialer.HostClient(h.PublicKey).Calls()[0]
 		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
@@ -267,7 +267,7 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 	// assert that we attempted to form contracts with the right hosts,
 	// settings and params
 	var nCalls int
-	for _, calls := range dialer.contractor {
+	for _, calls := range dialer.clients {
 		nCalls += len(calls.formCalls)
 	}
 	if nCalls != wanted {
@@ -405,7 +405,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	assertFormation := func(h hosts.Host) {
 		t.Helper()
-		call := dialer.Contractor(h.PublicKey).Calls()[0]
+		call := dialer.HostClient(h.PublicKey).Calls()[0]
 		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
@@ -432,7 +432,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	// assert that we attempted to form contracts with the right hosts,
 	// settings and params
 	var nCalls int
-	for _, calls := range dialer.contractor {
+	for _, calls := range dialer.clients {
 		nCalls += len(calls.formCalls)
 	}
 	if nCalls != wanted-1 {

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -55,7 +55,7 @@ func (d *dialerMock) Contractor(hostKey types.PublicKey) *contractorMock {
 	return d.contractor[hostKey]
 }
 
-func (d *dialerMock) NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
+func (d *dialerMock) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
 	if _, ok := d.contractor[hostKey]; !ok {
 		d.contractor[hostKey] = newContractorMock()
 	}

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -49,6 +49,9 @@ func newDialerMock() *dialerMock {
 }
 
 func (d *dialerMock) Contractor(hostKey types.PublicKey) *contractorMock {
+	if _, ok := d.contractor[hostKey]; !ok {
+		d.contractor[hostKey] = newContractorMock()
+	}
 	return d.contractor[hostKey]
 }
 

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -39,17 +39,24 @@ type formContractCall struct {
 }
 
 type dialerMock struct {
-	contractor *contractorMock
+	contractor map[types.PublicKey]*contractorMock
 }
 
 func newDialerMock() *dialerMock {
 	return &dialerMock{
-		contractor: newContractorMock(),
+		contractor: make(map[types.PublicKey]*contractorMock),
 	}
 }
 
+func (d *dialerMock) Contractor(hostKey types.PublicKey) *contractorMock {
+	return d.contractor[hostKey]
+}
+
 func (d *dialerMock) NewContractor(ctx context.Context, hostKey types.PublicKey, addr string) (Contractor, error) {
-	return d.contractor, nil
+	if _, ok := d.contractor[hostKey]; !ok {
+		d.contractor[hostKey] = newContractorMock()
+	}
+	return d.contractor[hostKey], nil
 }
 
 type contractorMock struct {
@@ -221,7 +228,6 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 	}
 
 	dialer := newDialerMock()
-	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
@@ -229,8 +235,9 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 	// disable randomizing hosts to make test deterministic
 	contracts.shuffle = func(int, func(i, j int)) {}
 
-	assertFormation := func(h hosts.Host, call formContractCall) {
+	assertFormation := func(h hosts.Host) {
 		t.Helper()
+		call := dialer.Contractor(h.PublicKey).Calls()[0]
 		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
@@ -256,13 +263,16 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 
 	// assert that we attempted to form contracts with the right hosts,
 	// settings and params
-	calls := contractor.Calls()
-	if len(calls) != wanted {
-		t.Fatalf("expected %v calls, got %v", wanted, len(calls))
+	var nCalls int
+	for _, calls := range dialer.contractor {
+		nCalls += len(calls.formCalls)
 	}
-	assertFormation(good1, calls[0])
-	assertFormation(good2, calls[1])
-	assertFormation(good3, calls[2])
+	if nCalls != wanted {
+		t.Fatalf("expected %v calls, got %v", wanted, nCalls)
+	}
+	assertFormation(good1)
+	assertFormation(good2)
+	assertFormation(good3)
 
 	// assert formations made it into the store
 	if len(store.contracts) != wanted {
@@ -383,7 +393,6 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	}
 
 	dialer := newDialerMock()
-	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
@@ -391,8 +400,9 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	// disable randomizing hosts to make test deterministic
 	contracts.shuffle = func(int, func(i, j int)) {}
 
-	assertFormation := func(h hosts.Host, call formContractCall) {
+	assertFormation := func(h hosts.Host) {
 		t.Helper()
+		call := dialer.Contractor(h.PublicKey).Calls()[0]
 		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		}
@@ -418,13 +428,16 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	// assert that we attempted to form contracts with the right hosts,
 	// settings and params
-	calls := contractor.Calls()
-	if len(calls) != wanted-1 {
-		t.Fatalf("expected %v calls, got %v", wanted-1, len(calls))
+	var nCalls int
+	for _, calls := range dialer.contractor {
+		nCalls += len(calls.formCalls)
 	}
-	assertFormation(good3, calls[0])
-	assertFormation(good4, calls[1])
-	assertFormation(good5, calls[2])
+	if nCalls != wanted-1 {
+		t.Fatalf("expected %v calls, got %v", wanted-1, nCalls)
+	}
+	assertFormation(good3)
+	assertFormation(good4)
+	assertFormation(good5)
 
 	// the store should now contain the right number of total contracts which is
 	// the 3 we started with plus the 3 we formed

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -48,10 +49,11 @@ type (
 	// Contractor defines the dependencies required to form, renew and refresh
 	// contracts.
 	Contractor interface {
-		FormContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
-		LatestRevision(ctx context.Context, hk types.PublicKey, addr string, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error)
-		RefreshContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
-		RenewContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error)
+		io.Closer
+		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
+		LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error)
+		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
+		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error)
 	}
 
 	// HostManager defines the minimal interface of HostManager functionality
@@ -132,9 +134,9 @@ type (
 		w     Wallet
 		store Store
 
-		contractor Contractor
-		scanner    HostManager
-		renterKey  types.PublicKey
+		dialer    Dialer
+		scanner   HostManager
+		renterKey types.PublicKey
 
 		triggerFundingChan chan struct{}
 
@@ -160,8 +162,8 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, contractor Contractor, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	cm := newContractManager(renterKey, accountManager, chainManager, contractor, scanner, store, syncer, wallet, opts...)
+func NewManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, dialer Dialer, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	cm := newContractManager(renterKey, accountManager, chainManager, dialer, scanner, store, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {
@@ -174,15 +176,15 @@ func NewManager(renterKey types.PublicKey, accountManager AccountManager, chainM
 	return cm, nil
 }
 
-func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, contractor Contractor, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
+func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, dialer Dialer, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
 	cm := &ContractManager{
 		am: accountManager,
 		cm: chainManager,
 		s:  syncer,
 		w:  wallet,
 
-		contractor: contractor,
-		renterKey:  renterKey,
+		dialer:    dialer,
+		renterKey: renterKey,
 
 		scanner: scanner,
 		store:   store,
@@ -464,7 +466,13 @@ func (cm *ContractManager) syncContract(ctx context.Context, contract Contract, 
 	revisionCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	resp, err := cm.contractor.LatestRevision(revisionCtx, contract.HostKey, host.SiamuxAddr(), contract.ID)
+	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	if err != nil {
+		contractLog.Warn("failed to create contractor", zap.Error(err))
+		return err
+	}
+	defer contractor.Close()
+	resp, err := contractor.LatestRevision(revisionCtx, contract.ID)
 	if err != nil {
 		contractLog.Warn("failed to fetch latest revision", zap.Error(err))
 		return nil

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -46,9 +46,9 @@ type (
 		V2TransactionSet(basis types.ChainIndex, txn types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error)
 	}
 
-	// Contractor defines the dependencies required to form, renew and refresh
+	// HostClient defines the dependencies required to form, renew and refresh
 	// contracts.
-	Contractor interface {
+	HostClient interface {
 		io.Closer
 		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
 		LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error)
@@ -467,13 +467,13 @@ func (cm *ContractManager) syncContract(ctx context.Context, contract Contract, 
 	revisionCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
-		contractLog.Warn("failed to create contractor", zap.Error(err))
+		contractLog.Warn("failed to dial host", zap.Error(err))
 		return err
 	}
-	defer contractor.Close()
-	resp, err := contractor.LatestRevision(revisionCtx, contract.ID)
+	defer hc.Close()
+	resp, err := hc.LatestRevision(revisionCtx, contract.ID)
 	if err != nil {
 		contractLog.Warn("failed to fetch latest revision", zap.Error(err))
 		return nil

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -134,7 +134,7 @@ type (
 		w     Wallet
 		store Store
 
-		dialer    Dialer
+		dialer    dialer
 		scanner   HostManager
 		renterKey types.PublicKey
 
@@ -162,8 +162,9 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, dialer Dialer, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	cm := newContractManager(renterKey, accountManager, chainManager, dialer, scanner, store, syncer, wallet, opts...)
+func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	dialer := newSiamuxDialer(chainManager, wallet, renterKey)
+	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, dialer, scanner, store, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {
@@ -176,7 +177,7 @@ func NewManager(renterKey types.PublicKey, accountManager AccountManager, chainM
 	return cm, nil
 }
 
-func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, dialer Dialer, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
+func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, dialer dialer, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
 	cm := &ContractManager{
 		am: accountManager,
 		cm: chainManager,

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -467,7 +467,7 @@ func (cm *ContractManager) syncContract(ctx context.Context, contract Contract, 
 	revisionCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		contractLog.Warn("failed to create contractor", zap.Error(err))
 		return err

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (c *contractor) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+func (c *hostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, params.ContractID)
 	if err != nil {
 		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -118,13 +118,13 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 		return nil
 	}
 
-	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
-		contractLog.Debug("failed to dial contractor", zap.Error(err))
+		contractLog.Debug("failed to dial host", zap.Error(err))
 		return nil
 	}
-	defer contractor.Close()
-	res, err := contractor.RefreshContract(ctx, host.Settings, proto.RPCRefreshContractParams{
+	defer hc.Close()
+	res, err := hc.RefreshContract(ctx, host.Settings, proto.RPCRefreshContractParams{
 		Allowance:  additionalAllowance,
 		Collateral: additionalCollateral,
 		ContractID: contract.ID,

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -8,20 +8,11 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.uber.org/zap"
 )
 
-func (cf *contractor) RefreshContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
-	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-	defer cancel()
-	t, err := siamux.Dial(dialCtx, addr, hk)
-	if err != nil {
-		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to dial host: %w", err)
-	}
-	defer t.Close()
-
-	rev, err := rhp.RPCLatestRevision(ctx, t, params.ContractID)
+func (c *contractor) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, params.ContractID)
 	if err != nil {
 		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
 	} else if rev.Renewed {
@@ -30,7 +21,7 @@ func (cf *contractor) RefreshContract(ctx context.Context, hk types.PublicKey, a
 		return rhp.RPCRefreshContractResult{}, fmt.Errorf("contract not revisable")
 	}
 
-	res, err := rhp.RPCRefreshContract(ctx, t, cf.cm, cf.signer, cf.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRefreshContractParams{
+	res, err := rhp.RPCRefreshContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRefreshContractParams{
 		Allowance:  rev.Contract.RenterOutput.Value,
 		Collateral: rev.Contract.MissedHostValue,
 	})
@@ -127,7 +118,13 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 		return nil
 	}
 
-	res, err := cm.contractor.RefreshContract(ctx, contract.HostKey, host.SiamuxAddr(), host.Settings, proto.RPCRefreshContractParams{
+	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	if err != nil {
+		contractLog.Debug("failed to dial contractor", zap.Error(err))
+		return nil
+	}
+	defer contractor.Close()
+	res, err := contractor.RefreshContract(ctx, host.Settings, proto.RPCRefreshContractParams{
 		Allowance:  additionalAllowance,
 		Collateral: additionalCollateral,
 		ContractID: contract.ID,

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -118,7 +118,7 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 		return nil
 	}
 
-	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		contractLog.Debug("failed to dial contractor", zap.Error(err))
 		return nil

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -17,7 +17,7 @@ type refreshContractCall struct {
 	params   proto.RPCRefreshContractParams
 }
 
-func (c *contractorMock) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+func (c *hostClientMock) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
 	c.refreshCalls = append(c.refreshCalls, refreshContractCall{
 		settings: settings,
 		params:   params,
@@ -162,15 +162,15 @@ func TestPerformContractRefreshes(t *testing.T) {
 
 	if err := contracts.performContractRefreshes(context.Background(), zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(dialer.Contractor(good.PublicKey).refreshCalls) != 4 {
-		t.Fatalf("expected 4 refresh calls, got %v", len(dialer.Contractor(good.PublicKey).refreshCalls))
-	} else if len(dialer.Contractor(bad.PublicKey).refreshCalls) != 0 {
+	} else if len(dialer.HostClient(good.PublicKey).refreshCalls) != 4 {
+		t.Fatalf("expected 4 refresh calls, got %v", len(dialer.HostClient(good.PublicKey).refreshCalls))
+	} else if len(dialer.HostClient(bad.PublicKey).refreshCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
-	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, dialer.Contractor(good.PublicKey).refreshCalls[0])
-	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{3}, dialer.Contractor(good.PublicKey).refreshCalls[1])
-	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{4}, dialer.Contractor(good.PublicKey).refreshCalls[2])
-	assertRefresh(good, types.Siacoins(1), types.Siacoins(1), types.FileContractID{6}, dialer.Contractor(good.PublicKey).refreshCalls[3])
+	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, dialer.HostClient(good.PublicKey).refreshCalls[0])
+	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{3}, dialer.HostClient(good.PublicKey).refreshCalls[1])
+	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{4}, dialer.HostClient(good.PublicKey).refreshCalls[2])
+	assertRefresh(good, types.Siacoins(1), types.Siacoins(1), types.FileContractID{6}, dialer.HostClient(good.PublicKey).refreshCalls[3])
 
 	// assert refreshes made it into the store leading to 8 existing + 4 refreshed
 	// contracts in the store

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -163,7 +163,7 @@ func TestPerformContractRefreshes(t *testing.T) {
 	if err := contracts.performContractRefreshes(context.Background(), zap.NewNop()); err != nil {
 		t.Fatal(err)
 	} else if len(dialer.Contractor(good.PublicKey).refreshCalls) != 4 {
-		t.Fatalf("expected 2 refresh calls, got %v", len(dialer.Contractor(good.PublicKey).refreshCalls))
+		t.Fatalf("expected 4 refresh calls, got %v", len(dialer.Contractor(good.PublicKey).refreshCalls))
 	} else if len(dialer.Contractor(bad.PublicKey).refreshCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -13,16 +13,12 @@ import (
 )
 
 type refreshContractCall struct {
-	hk       types.PublicKey
-	addr     string
 	settings proto.HostSettings
 	params   proto.RPCRefreshContractParams
 }
 
-func (c *contractorMock) RefreshContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+func (c *contractorMock) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
 	c.refreshCalls = append(c.refreshCalls, refreshContractCall{
-		hk:       hk,
-		addr:     addr,
 		settings: settings,
 		params:   params,
 	})
@@ -146,18 +142,15 @@ func TestPerformContractRefreshes(t *testing.T) {
 		bad.PublicKey:  bad,
 	}
 
-	contractor := newContractorMock()
+	dialer := newDialerMock()
+	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, contractor, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
 
 	assertRefresh := func(h hosts.Host, allowance, collateral types.Currency, refreshedFrom types.FileContractID, call refreshContractCall) {
 		t.Helper()
-		if call.hk != h.PublicKey {
-			t.Fatalf("expected host key %v, got %v", h.PublicKey, call.hk)
-		} else if call.addr != h.SiamuxAddr() {
-			t.Fatalf("expected address %v, got %v", h.SiamuxAddr(), call.addr)
-		} else if call.settings != goodSettings {
+		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		} else if call.params.ContractID != refreshedFrom {
 			t.Fatalf("expected refreshedFrom %v, got %v", refreshedFrom, call.params.ContractID)

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -164,7 +164,7 @@ func TestPerformContractRefreshes(t *testing.T) {
 		t.Fatal(err)
 	} else if len(dialer.Contractor(good.PublicKey).refreshCalls) != 4 {
 		t.Fatalf("expected 2 refresh calls, got %v", len(dialer.Contractor(good.PublicKey).refreshCalls))
-	} else if dialer.Contractor(bad.PublicKey) != nil {
+	} else if len(dialer.Contractor(bad.PublicKey).refreshCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
 	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, dialer.Contractor(good.PublicKey).refreshCalls[0])

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -143,7 +143,6 @@ func TestPerformContractRefreshes(t *testing.T) {
 	}
 
 	dialer := newDialerMock()
-	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
@@ -163,13 +162,15 @@ func TestPerformContractRefreshes(t *testing.T) {
 
 	if err := contracts.performContractRefreshes(context.Background(), zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(contractor.refreshCalls) != 4 {
-		t.Fatalf("expected 4 refreshes, got %v", len(contractor.refreshCalls))
+	} else if len(dialer.Contractor(good.PublicKey).refreshCalls) != 4 {
+		t.Fatalf("expected 2 refresh calls, got %v", len(dialer.Contractor(good.PublicKey).refreshCalls))
+	} else if dialer.Contractor(bad.PublicKey) != nil {
+		t.Fatal("expected bad host to not be dialed")
 	}
-	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, contractor.refreshCalls[0])
-	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{3}, contractor.refreshCalls[1])
-	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{4}, contractor.refreshCalls[2])
-	assertRefresh(good, types.Siacoins(1), types.Siacoins(1), types.FileContractID{6}, contractor.refreshCalls[3])
+	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{2}, dialer.Contractor(good.PublicKey).refreshCalls[0])
+	assertRefresh(good, types.Siacoins(110), types.Siacoins(110), types.FileContractID{3}, dialer.Contractor(good.PublicKey).refreshCalls[1])
+	assertRefresh(good, types.Siacoins(110), types.ZeroCurrency, types.FileContractID{4}, dialer.Contractor(good.PublicKey).refreshCalls[2])
+	assertRefresh(good, types.Siacoins(1), types.Siacoins(1), types.FileContractID{6}, dialer.Contractor(good.PublicKey).refreshCalls[3])
 
 	// assert refreshes made it into the store leading to 8 existing + 4 refreshed
 	// contracts in the store

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -8,20 +8,11 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.uber.org/zap"
 )
 
-func (cf *contractor) RenewContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
-	dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-	defer cancel()
-	t, err := siamux.Dial(dialCtx, addr, hk)
-	if err != nil {
-		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to dial host: %w", err)
-	}
-	defer t.Close()
-
-	rev, err := rhp.RPCLatestRevision(ctx, t, contractID)
+func (c *contractor) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
 		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
 	} else if rev.Renewed {
@@ -35,7 +26,7 @@ func (cf *contractor) RenewContract(ctx context.Context, hk types.PublicKey, add
 	// 1. Contracts drain over time if they contain more funds than needed
 	// 2. Renewals are very "cheap" since no party needs to lock away
 	//    additional funds. Only the fees need to be paid.
-	res, err := rhp.RPCRenewContract(ctx, t, cf.cm, cf.signer, cf.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRenewContractParams{
+	res, err := rhp.RPCRenewContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRenewContractParams{
 		ContractID:  contractID,
 		Allowance:   rev.Contract.RenterOutput.Value,
 		Collateral:  rev.Contract.MissedHostValue,
@@ -108,7 +99,13 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 		return nil
 	}
 
-	res, err := cm.contractor.RenewContract(ctx, contract.HostKey, host.SiamuxAddr(), host.Settings, contract.ID, proofHeight)
+	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	if err != nil {
+		contractLog.Debug("failed to create contractor", zap.Error(err))
+		return nil
+	}
+	defer contractor.Close()
+	res, err := contractor.RenewContract(ctx, host.Settings, contract.ID, proofHeight)
 	if err != nil {
 		contractLog.Debug("failed to renew", zap.Error(err))
 		return nil

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (c *contractor) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+func (c *hostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
 		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -99,13 +99,13 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 		return nil
 	}
 
-	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
-		contractLog.Debug("failed to create contractor", zap.Error(err))
+		contractLog.Debug("failed to dial host", zap.Error(err))
 		return nil
 	}
-	defer contractor.Close()
-	res, err := contractor.RenewContract(ctx, host.Settings, contract.ID, proofHeight)
+	defer hc.Close()
+	res, err := hc.RenewContract(ctx, host.Settings, contract.ID, proofHeight)
 	if err != nil {
 		contractLog.Debug("failed to renew", zap.Error(err))
 		return nil

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -99,7 +99,7 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 		return nil
 	}
 
-	contractor, err := cm.dialer.NewContractor(ctx, host.PublicKey, host.SiamuxAddr())
+	contractor, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		contractLog.Debug("failed to create contractor", zap.Error(err))
 		return nil

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -18,7 +18,7 @@ type renewContractCall struct {
 	proofHeight uint64
 }
 
-func (c *contractorMock) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+func (c *hostClientMock) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
 	c.renewCalls = append(c.renewCalls, renewContractCall{
 		settings:    settings,
 		contractID:  contractID,
@@ -120,9 +120,9 @@ func TestPerformContractRenewals(t *testing.T) {
 	// perform renewals when no contract is ready for it
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 0 {
+	} else if len(dialer.HostClient(good.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected good host to not be dialed")
-	} else if len(dialer.Contractor(bad.PublicKey).renewCalls) != 0 {
+	} else if len(dialer.HostClient(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
 
@@ -131,12 +131,12 @@ func TestPerformContractRenewals(t *testing.T) {
 
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 1 {
-		t.Fatalf("expected one renewal, got %v", len(dialer.Contractor(good.PublicKey).renewCalls))
-	} else if len(dialer.Contractor(bad.PublicKey).renewCalls) != 0 {
+	} else if len(dialer.HostClient(good.PublicKey).renewCalls) != 1 {
+		t.Fatalf("expected one renewal, got %v", len(dialer.HostClient(good.PublicKey).renewCalls))
+	} else if len(dialer.HostClient(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
-	assertRenewal(good, types.FileContractID{1}, blockHeight+period+renewWindow, dialer.Contractor(good.PublicKey).renewCalls[0])
+	assertRenewal(good, types.FileContractID{1}, blockHeight+period+renewWindow, dialer.HostClient(good.PublicKey).renewCalls[0])
 
 	// assert renewal made it into the store
 	if len(store.contracts) != 4 {
@@ -168,9 +168,9 @@ func TestPerformContractRenewals(t *testing.T) {
 	// assert consecutive calls don't keep renewing the same contract
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 1 {
-		t.Fatalf("expected one renewal, got %v", len(dialer.Contractor(good.PublicKey).renewCalls))
-	} else if len(dialer.Contractor(bad.PublicKey).renewCalls) != 0 {
+	} else if len(dialer.HostClient(good.PublicKey).renewCalls) != 1 {
+		t.Fatalf("expected one renewal, got %v", len(dialer.HostClient(good.PublicKey).renewCalls))
+	} else if len(dialer.HostClient(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
 }
@@ -184,7 +184,7 @@ func TestSyncRevisionState(t *testing.T) {
 
 	// add a host and contract
 	contractID := types.FileContractID{1}
-	contractor := dialer.Contractor(types.PublicKey(contractID))
+	hc := dialer.HostClient(types.PublicKey(contractID))
 	store.hosts = map[types.PublicKey]hosts.Host{
 		types.PublicKey(contractID): {PublicKey: types.PublicKey(contractID)},
 	}
@@ -197,8 +197,8 @@ func TestSyncRevisionState(t *testing.T) {
 	assertContract := func(revisionParams, expectedParams ContractSyncParams) {
 		t.Helper()
 
-		// update latest revision in mocked contractor
-		contractor.latestRevisions[contractID] = proto.RPCLatestRevisionResponse{
+		// update latest revision in mocked client
+		hc.latestRevisions[contractID] = proto.RPCLatestRevisionResponse{
 			Contract: types.V2FileContract{
 				Capacity: revisionParams.Capacity,
 				RenterOutput: types.SiacoinOutput{

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -13,17 +13,13 @@ import (
 )
 
 type renewContractCall struct {
-	hk          types.PublicKey
-	addr        string
 	settings    proto.HostSettings
 	contractID  types.FileContractID
 	proofHeight uint64
 }
 
-func (c *contractorMock) RenewContract(ctx context.Context, hk types.PublicKey, addr string, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+func (c *contractorMock) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
 	c.renewCalls = append(c.renewCalls, renewContractCall{
-		hk:          hk,
-		addr:        addr,
 		settings:    settings,
 		contractID:  contractID,
 		proofHeight: proofHeight,
@@ -105,18 +101,15 @@ func TestPerformContractRenewals(t *testing.T) {
 		bad.PublicKey:  bad,
 	}
 
-	contractor := newContractorMock()
+	dialer := newDialerMock()
+	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, contractor, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
 
 	assertRenewal := func(h hosts.Host, renewedFrom types.FileContractID, proofHeight uint64, call renewContractCall) {
 		t.Helper()
-		if call.hk != h.PublicKey {
-			t.Fatalf("expected host key %v, got %v", h.PublicKey, call.hk)
-		} else if call.addr != h.SiamuxAddr() {
-			t.Fatalf("expected address %v, got %v", h.SiamuxAddr(), call.addr)
-		} else if call.settings != goodSettings {
+		if call.settings != goodSettings {
 			t.Fatalf("expected settings %v+, got %v+", goodSettings, call.settings)
 		} else if call.contractID != renewedFrom {
 			t.Fatalf("expected renewedFrom %v, got %v", renewedFrom, call.contractID)
@@ -180,9 +173,10 @@ func TestPerformContractRenewals(t *testing.T) {
 func TestSyncRevisionState(t *testing.T) {
 	amMock := &accountsManagerMock{}
 	store := &storeMock{}
-	contractor := newContractorMock()
+	dialer := newDialerMock()
+	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
-	contracts := newContractManager(renterKey, amMock, nil, contractor, nil, store, nil, nil)
+	contracts := newContractManager(renterKey, amMock, nil, dialer, nil, store, nil, nil)
 
 	// add a host and contract
 	contractID := types.FileContractID{1}

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -120,9 +120,9 @@ func TestPerformContractRenewals(t *testing.T) {
 	// perform renewals when no contract is ready for it
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if dialer.Contractor(good.PublicKey) != nil {
+	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected good host to not be dialed")
-	} else if dialer.Contractor(bad.PublicKey) != nil {
+	} else if len(dialer.Contractor(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
 
@@ -133,7 +133,7 @@ func TestPerformContractRenewals(t *testing.T) {
 		t.Fatal(err)
 	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 1 {
 		t.Fatalf("expected one renewal, got %v", len(dialer.Contractor(good.PublicKey).renewCalls))
-	} else if dialer.Contractor(bad.PublicKey) != nil {
+	} else if len(dialer.Contractor(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
 	assertRenewal(good, types.FileContractID{1}, blockHeight+period+renewWindow, dialer.Contractor(good.PublicKey).renewCalls[0])
@@ -170,7 +170,7 @@ func TestPerformContractRenewals(t *testing.T) {
 		t.Fatal(err)
 	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 1 {
 		t.Fatalf("expected one renewal, got %v", len(dialer.Contractor(good.PublicKey).renewCalls))
-	} else if dialer.Contractor(bad.PublicKey) != nil {
+	} else if len(dialer.Contractor(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
 }

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -102,7 +102,6 @@ func TestPerformContractRenewals(t *testing.T) {
 	}
 
 	dialer := newDialerMock()
-	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
@@ -121,8 +120,10 @@ func TestPerformContractRenewals(t *testing.T) {
 	// perform renewals when no contract is ready for it
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(contractor.renewCalls) != 0 {
-		t.Fatalf("expected no renewals, got %v", contractor.renewCalls)
+	} else if dialer.Contractor(good.PublicKey) != nil {
+		t.Fatal("expected good host to not be dialed")
+	} else if dialer.Contractor(bad.PublicKey) != nil {
+		t.Fatal("expected bad host to not be dialed")
 	}
 
 	cmMock.state.Index.Height++
@@ -130,10 +131,12 @@ func TestPerformContractRenewals(t *testing.T) {
 
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(contractor.renewCalls) != 1 {
-		t.Fatalf("expected one renewal, got %v", len(contractor.renewCalls))
+	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 1 {
+		t.Fatalf("expected one renewal, got %v", len(dialer.Contractor(good.PublicKey).renewCalls))
+	} else if dialer.Contractor(bad.PublicKey) != nil {
+		t.Fatal("expected bad host to not be dialed")
 	}
-	assertRenewal(good, types.FileContractID{1}, blockHeight+period+renewWindow, contractor.renewCalls[0])
+	assertRenewal(good, types.FileContractID{1}, blockHeight+period+renewWindow, dialer.Contractor(good.PublicKey).renewCalls[0])
 
 	// assert renewal made it into the store
 	if len(store.contracts) != 4 {
@@ -165,8 +168,10 @@ func TestPerformContractRenewals(t *testing.T) {
 	// assert consecutive calls don't keep renewing the same contract
 	if err := contracts.performContractRenewals(context.Background(), period, renewWindow, zap.NewNop()); err != nil {
 		t.Fatal(err)
-	} else if len(contractor.renewCalls) > 1 {
-		t.Fatalf("expected no new renewals, got %v", len(contractor.renewCalls))
+	} else if len(dialer.Contractor(good.PublicKey).renewCalls) != 1 {
+		t.Fatalf("expected one renewal, got %v", len(dialer.Contractor(good.PublicKey).renewCalls))
+	} else if dialer.Contractor(bad.PublicKey) != nil {
+		t.Fatal("expected bad host to not be dialed")
 	}
 }
 
@@ -174,12 +179,12 @@ func TestSyncRevisionState(t *testing.T) {
 	amMock := &accountsManagerMock{}
 	store := &storeMock{}
 	dialer := newDialerMock()
-	contractor := dialer.contractor
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	contracts := newContractManager(renterKey, amMock, nil, dialer, nil, store, nil, nil)
 
 	// add a host and contract
 	contractID := types.FileContractID{1}
+	contractor := dialer.Contractor(types.PublicKey(contractID))
 	store.hosts = map[types.PublicKey]hosts.Host{
 		types.PublicKey(contractID): {PublicKey: types.PublicKey(contractID)},
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -58,8 +58,8 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 	funder := accounts.NewFunder(c.cm, wm)
 	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
 
-	contractor := contracts.NewContractor(c.cm, wm, walletKey)
-	contracts, err := contracts.NewManager(walletKey.PublicKey(), am, c.cm, contractor, nil, store, s, wm, contracts.WithLogger(log.Named("contracts")))
+	dialer := contracts.NewSiamuxDialer(c.cm, wm, walletKey)
+	contracts, err := contracts.NewManager(walletKey.PublicKey(), am, c.cm, dialer, nil, store, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -58,8 +58,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 	funder := accounts.NewFunder(c.cm, wm)
 	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
 
-	dialer := contracts.NewSiamuxDialer(c.cm, wm, walletKey)
-	contracts, err := contracts.NewManager(walletKey.PublicKey(), am, c.cm, dialer, nil, store, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, c.cm, nil, store, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}


### PR DESCRIPTION
This is a small refactor which was triggered by https://github.com/SiaFoundation/indexd/pull/153/files#diff-52dce9968f7373dadf41cf819e65996c2a5cd28408843f8779cd04bf704d8b93R51

Pulling out dialing of methods like `AppendSectors` definitely makes sense to get better testability but passing a transport client limits it again since we can't easily mock that in testing.

So this PR isolates only the dialing of the connection into a `Dialer` while simultaneously making `Contractor` a very thin wrapper around the RHP4 client. Reducing the amount of code we need to mock to only RPC code.