### PR TITLE
Add store.PrunableContractRoots

### DIFF
--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -383,21 +383,19 @@ WHERE contract_id = $6
 // PrunableContractRoots diffs the given roots with the roots in the database
 // and returns the roots that can be pruned.
 func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, roots []types.Hash256) ([]types.Hash256, error) {
-	copied := append([]types.Hash256(nil), roots...)
-
 	var sqlRoots []sqlHash256
-	for _, root := range copied {
+	for _, root := range roots {
 		sqlRoots = append(sqlRoots, sqlHash256(root))
 	}
+	_ = hostKey
 
-	var prunable []types.Hash256
+	prunable := make([]types.Hash256, 0, len(roots))
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
 			SELECT s.sector_root
 			FROM sectors s
 			INNER JOIN contract_sectors_map csm ON s.contract_sectors_map_id = csm.id
-			INNER JOIN hosts h ON s.host_id = h.id
-			WHERE csm.contract_id = $1 AND h.public_key = $2 AND s.sector_root = ANY($3)`, sqlHash256(contractID), sqlPublicKey(hostKey), sqlRoots)
+			WHERE csm.contract_id = $1 AND s.sector_root = ANY($2)`, sqlHash256(contractID), sqlRoots)
 		if err != nil {
 			return fmt.Errorf("failed to fetch prunable contract roots: %w", err)
 		}
@@ -415,8 +413,7 @@ func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicK
 			return fmt.Errorf("failed to iterate over rows: %w", err)
 		}
 
-		prunable = copied[:0]
-		for _, root := range copied {
+		for _, root := range roots {
 			if _, ok := lookup[sqlHash256(root)]; !ok {
 				prunable = append(prunable, root)
 			}

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -380,6 +380,52 @@ WHERE contract_id = $6
 	})
 }
 
+// PrunableContractRoots returns the indices of the roots that are not present
+// in the database, and thus can be pruned.
+func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, roots []types.Hash256) ([]uint64, error) {
+	var sqlRoots []sqlHash256
+	for _, root := range roots {
+		sqlRoots = append(sqlRoots, sqlHash256(root))
+	}
+
+	var indices []uint64
+	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT s.sector_root
+			FROM sectors s
+			INNER JOIN contract_sectors_map csm ON s.contract_sectors_map_id = csm.id
+			INNER JOIN hosts h ON s.host_id = h.id
+			WHERE csm.contract_id = $1 AND h.public_key = $2 AND s.sector_root = ANY($3)`, sqlHash256(contractID), sqlPublicKey(hostKey), sqlRoots)
+		if err != nil {
+			return fmt.Errorf("failed to fetch prunable contract roots: %w", err)
+		}
+		defer rows.Close()
+
+		lookup := make(map[sqlHash256]struct{})
+		for rows.Next() {
+			var root sqlHash256
+			if err := rows.Scan(&root); err != nil {
+				return fmt.Errorf("failed to scan root: %w", err)
+			}
+			lookup[root] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to iterate over rows: %w", err)
+		}
+
+		for idx, root := range roots {
+			if _, ok := lookup[sqlHash256(root)]; !ok {
+				indices = append(indices, uint64(idx))
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return indices, nil
+}
+
 func (tx *updateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {
 	for _, fce := range fces {
 		_, err := tx.tx.Exec(tx.ctx, `

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -380,15 +380,17 @@ WHERE contract_id = $6
 	})
 }
 
-// PrunableContractRoots returns the indices of the roots that are not present
-// in the database, and thus can be pruned.
-func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, roots []types.Hash256) ([]uint64, error) {
+// PrunableContractRoots diffs the given roots with the roots in the database
+// and returns the roots that can be pruned.
+func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, roots []types.Hash256) ([]types.Hash256, error) {
+	copied := append([]types.Hash256(nil), roots...)
+
 	var sqlRoots []sqlHash256
-	for _, root := range roots {
+	for _, root := range copied {
 		sqlRoots = append(sqlRoots, sqlHash256(root))
 	}
 
-	var indices []uint64
+	var prunable []types.Hash256
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
 			SELECT s.sector_root
@@ -413,9 +415,10 @@ func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicK
 			return fmt.Errorf("failed to iterate over rows: %w", err)
 		}
 
-		for idx, root := range roots {
+		prunable = copied[:0]
+		for _, root := range copied {
 			if _, ok := lookup[sqlHash256(root)]; !ok {
-				indices = append(indices, uint64(idx))
+				prunable = append(prunable, root)
 			}
 		}
 		return nil
@@ -423,7 +426,7 @@ func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicK
 		return nil, err
 	}
 
-	return indices, nil
+	return prunable, nil
 }
 
 func (tx *updateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -382,12 +382,11 @@ WHERE contract_id = $6
 
 // PrunableContractRoots diffs the given roots with the roots in the database
 // and returns the roots that can be pruned.
-func (s *Store) PrunableContractRoots(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, roots []types.Hash256) ([]types.Hash256, error) {
+func (s *Store) PrunableContractRoots(ctx context.Context, contractID types.FileContractID, roots []types.Hash256) ([]types.Hash256, error) {
 	var sqlRoots []sqlHash256
 	for _, root := range roots {
 		sqlRoots = append(sqlRoots, sqlHash256(root))
 	}
-	_ = hostKey
 
 	prunable := make([]types.Hash256, 0, len(roots))
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -443,6 +446,111 @@ func TestContractsForPinning(t *testing.T) {
 		t.Fatalf("expected 1 contract, got %d", len(contractIDs))
 	} else if contractIDs[0] != (types.FileContractID{8}) {
 		t.Fatalf("expected contract %v, got %v", types.FileContractID{8}, contractIDs[0])
+	}
+}
+
+func TestPrunableContractRoots(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// add account
+	account := proto.Account{1}
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		t.Fatal("failed to add account:", err)
+	}
+
+	// add two hosts
+	hk1 := types.PublicKey{1}
+	hk2 := types.PublicKey{2}
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return errors.Join(
+			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
+			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add a contract for each host
+	fcid1 := types.FileContractID{1}
+	fcid2 := types.FileContractID{2}
+	if err := errors.Join(
+		store.AddFormedContract(context.Background(), fcid1, hk1, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)),
+		store.AddFormedContract(context.Background(), fcid2, hk2, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// prepare roots
+	roots := []types.Hash256{
+		frand.Entropy256(),
+		frand.Entropy256(),
+		frand.Entropy256(),
+		frand.Entropy256(),
+	}
+
+	// pin two slabs to add sectors
+	_, err := store.PinSlab(context.Background(), account, time.Now(), slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     11,
+		Sectors: []slabs.SectorPinParams{
+			{Root: roots[0], HostKey: hk1},
+			{Root: roots[2], HostKey: hk2},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	slabID, err := store.PinSlab(context.Background(), account, time.Now(), slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     11,
+		Sectors: []slabs.SectorPinParams{
+			{Root: roots[1], HostKey: hk1},
+			{Root: roots[3], HostKey: hk2},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// pin sectors for h1
+	if sectors, err := store.UnpinnedSectors(context.Background(), hk1, 10); err != nil {
+		t.Fatal(err)
+	} else if err := store.PinSectors(context.Background(), fcid1, sectors); err != nil {
+		t.Fatal(err)
+	}
+
+	// pin sectors for h2
+	if sectors, err := store.UnpinnedSectors(context.Background(), hk2, 10); err != nil {
+		t.Fatal(err)
+	} else if err := store.PinSectors(context.Background(), fcid2, sectors); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert no prunable roots for either contract
+	if indices, err := store.PrunableContractRoots(context.Background(), hk1, fcid1, roots[:2]); err != nil {
+		t.Fatal(err)
+	} else if len(indices) != 0 {
+		t.Fatalf("unexpected prunable indices, %+v", indices)
+	} else if indices, err := store.PrunableContractRoots(context.Background(), hk2, fcid2, roots[2:]); err != nil {
+		t.Fatal(err)
+	} else if len(indices) != 0 {
+		t.Fatalf("unexpected prunable indices, %+v", indices)
+	}
+
+	// unpin the second slab to remove sectors for both hosts
+	if err := store.UnpinSlab(context.Background(), account, slabID); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert prunable roots for both contracts
+	if indices, err := store.PrunableContractRoots(context.Background(), hk1, fcid1, roots[:2]); err != nil {
+		t.Fatal(err)
+	} else if len(indices) != 1 || indices[0] != 1 {
+		t.Fatalf("unexpected prunable indices, %+v", indices)
+	} else if indices, err := store.PrunableContractRoots(context.Background(), hk2, fcid2, roots[2:]); err != nil {
+		t.Fatal(err)
+	} else if len(indices) != 1 || indices[0] != 1 {
+		t.Fatalf("unexpected prunable indices, %+v", indices)
 	}
 }
 
@@ -1437,5 +1545,101 @@ func BenchmarkContractsForPinning(b *testing.B) {
 		} else if len(ids) == 0 {
 			b.Fatal("no contracts found for pinning")
 		}
+	}
+}
+
+func BenchmarkPrunableContractRoots(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	// benchmark parameters
+	const (
+		oneTB    = 1 << 40 // 1TiB of sectors
+		nHosts   = 100
+		nSectors = oneTB / proto.SectorSize
+	)
+
+	// add account
+	account := proto.Account{1}
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal("failed to add account:", err)
+	}
+
+	// add hosts and contracts
+	var hks []types.PublicKey
+	for range nHosts {
+		hk := types.PublicKey(frand.Entropy256())
+		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
+		}); err != nil {
+			b.Fatal(err)
+		}
+		if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+			b.Fatal(err)
+		}
+		hks = append(hks, hk)
+	}
+
+	// insert sectors in batches
+	hostIdx := 0
+	rootsByContract := make(map[types.FileContractID][]types.Hash256)
+	for remainingSectors := nSectors; remainingSectors > 0; {
+		batchSize := min(remainingSectors, 10000)
+		remainingSectors -= batchSize
+		var sectors []slabs.SectorPinParams
+		for range batchSize {
+			hk := hks[hostIdx]
+			root := frand.Entropy256()
+			sectors = append(sectors, slabs.SectorPinParams{
+				Root:    root,
+				HostKey: hks[hostIdx],
+			})
+			rootsByContract[types.FileContractID(hk)] = append(rootsByContract[types.FileContractID(hk)], root)
+			hostIdx = (hostIdx + 1) % len(hks)
+		}
+
+		// pin slab
+		if _, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
+			MinShards:     1,
+			EncryptionKey: frand.Entropy256(),
+			Sectors:       sectors,
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// pin all sectors to contracts
+	for contractID, roots := range rootsByContract {
+		err := store.PinSectors(context.Background(), contractID, roots)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// extend roots to 1TB worth of sectors and random shuffle
+	for contractID, roots := range rootsByContract {
+		for range nSectors - len(roots) {
+			rootsByContract[contractID] = append(rootsByContract[contractID], frand.Entropy256())
+		}
+		frand.Shuffle(len(rootsByContract[contractID]), func(i, j int) {
+			rootsByContract[contractID][i], rootsByContract[contractID][j] = rootsByContract[contractID][j], rootsByContract[contractID][i]
+		})
+	}
+
+	// run benchmarks with various batch sizes
+	for _, batchSize := range []int64{1000, 5000, 10000, nSectors} {
+		b.Run(fmt.Sprintf("prunable_roots_batch_%d", batchSize), func(b *testing.B) {
+			b.ResetTimer()
+			b.SetBytes(batchSize * proto.SectorSize)
+			for b.Loop() {
+				hk := hks[frand.Intn(len(hks))]
+				indices, err := store.PrunableContractRoots(context.Background(), hk, types.FileContractID(hk), rootsByContract[types.FileContractID(hk)][:batchSize])
+				if err != nil {
+					b.Fatal(err)
+				} else if len(indices) == 0 || len(indices) == int(batchSize) {
+					b.Fatal("unexpected number of indices", len(indices)) // assert it's not empty or all
+				}
+			}
+		})
 	}
 }

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -543,14 +543,14 @@ func TestPrunableContractRoots(t *testing.T) {
 	}
 
 	// assert prunable roots for both contracts
-	if indices, err := store.PrunableContractRoots(context.Background(), hk1, fcid1, roots[:2]); err != nil {
+	if prunable, err := store.PrunableContractRoots(context.Background(), hk1, fcid1, roots[:2]); err != nil {
 		t.Fatal(err)
-	} else if len(indices) != 1 || indices[0] != 1 {
-		t.Fatalf("unexpected prunable indices, %+v", indices)
-	} else if indices, err := store.PrunableContractRoots(context.Background(), hk2, fcid2, roots[2:]); err != nil {
+	} else if len(prunable) != 1 || prunable[0] != roots[1] {
+		t.Fatalf("unexpected prunable roots, %+v", prunable)
+	} else if prunable, err := store.PrunableContractRoots(context.Background(), hk2, fcid2, roots[2:]); err != nil {
 		t.Fatal(err)
-	} else if len(indices) != 1 || indices[0] != 1 {
-		t.Fatalf("unexpected prunable indices, %+v", indices)
+	} else if len(prunable) != 1 || prunable[0] != roots[3] {
+		t.Fatalf("unexpected prunable roots, %+v", prunable)
 	}
 }
 
@@ -1633,11 +1633,12 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 			b.SetBytes(batchSize * proto.SectorSize)
 			for b.Loop() {
 				hk := hks[frand.Intn(len(hks))]
-				indices, err := store.PrunableContractRoots(context.Background(), hk, types.FileContractID(hk), rootsByContract[types.FileContractID(hk)][:batchSize])
+				fcid := types.FileContractID(hk)
+				prunable, err := store.PrunableContractRoots(context.Background(), hk, fcid, rootsByContract[fcid][:batchSize])
 				if err != nil {
 					b.Fatal(err)
-				} else if len(indices) == 0 || len(indices) == int(batchSize) {
-					b.Fatal("unexpected number of indices", len(indices)) // assert it's not empty or all
+				} else if len(prunable) == 0 || len(prunable) == int(batchSize) {
+					b.Fatal("unexpected number of prunable roots", len(prunable)) // assert it's not empty or all
 				}
 			}
 		})

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -527,11 +527,11 @@ func TestPrunableContractRoots(t *testing.T) {
 	}
 
 	// assert no prunable roots for either contract
-	if indices, err := store.PrunableContractRoots(context.Background(), hk1, fcid1, roots[:2]); err != nil {
+	if indices, err := store.PrunableContractRoots(context.Background(), fcid1, roots[:2]); err != nil {
 		t.Fatal(err)
 	} else if len(indices) != 0 {
 		t.Fatalf("unexpected prunable indices, %+v", indices)
-	} else if indices, err := store.PrunableContractRoots(context.Background(), hk2, fcid2, roots[2:]); err != nil {
+	} else if indices, err := store.PrunableContractRoots(context.Background(), fcid2, roots[2:]); err != nil {
 		t.Fatal(err)
 	} else if len(indices) != 0 {
 		t.Fatalf("unexpected prunable indices, %+v", indices)
@@ -543,11 +543,11 @@ func TestPrunableContractRoots(t *testing.T) {
 	}
 
 	// assert prunable roots for both contracts
-	if prunable, err := store.PrunableContractRoots(context.Background(), hk1, fcid1, roots[:2]); err != nil {
+	if prunable, err := store.PrunableContractRoots(context.Background(), fcid1, roots[:2]); err != nil {
 		t.Fatal(err)
 	} else if len(prunable) != 1 || prunable[0] != roots[1] {
 		t.Fatalf("unexpected prunable roots, %+v", prunable)
-	} else if prunable, err := store.PrunableContractRoots(context.Background(), hk2, fcid2, roots[2:]); err != nil {
+	} else if prunable, err := store.PrunableContractRoots(context.Background(), fcid2, roots[2:]); err != nil {
 		t.Fatal(err)
 	} else if len(prunable) != 1 || prunable[0] != roots[3] {
 		t.Fatalf("unexpected prunable roots, %+v", prunable)
@@ -1632,9 +1632,8 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 			b.ResetTimer()
 			b.SetBytes(batchSize * proto.SectorSize)
 			for b.Loop() {
-				hk := hks[frand.Intn(len(hks))]
-				fcid := types.FileContractID(hk)
-				prunable, err := store.PrunableContractRoots(context.Background(), hk, fcid, rootsByContract[fcid][:batchSize])
+				fcid := types.FileContractID(hks[frand.Intn(len(hks))])
+				prunable, err := store.PrunableContractRoots(context.Background(), fcid, rootsByContract[fcid][:batchSize])
 				if err != nil {
 					b.Fatal(err)
 				} else if len(prunable) == 0 || len(prunable) == int(batchSize) {

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -246,6 +246,9 @@ CREATE INDEX sectors_contract_sectors_map_id_uploaded_at_idx ON sectors(contract
 -- speed up lookup of unpinned sectors
 CREATE INDEX sectors_host_id_uploaded_at_idx ON sectors(host_id, uploaded_at ASC) WHERE contract_sectors_map_id IS NULL;
 
+-- speed up prunable roots check
+CREATE INDEX sectors_host_id_sector_root_contract_sectors_map_id_idx ON sectors(host_id, sector_root, contract_sectors_map_id);
+
 -- foreign key constraint keys
 CREATE INDEX sectors_host_id_idx ON sectors(host_id);
 -- CREATE INDEX sectors_contract_sectors_map_id_idx ON sectors(contract_sectors_map_id); -- covered by sectors_contract_sectors_map_id_uploaded_at_idx
@@ -269,3 +272,4 @@ CREATE INDEX slab_sectors_sector_id_idx ON slab_sectors(sector_id);
 
 -- speed up fetching sectors for slab ordered by their position within the slab
 CREATE UNIQUE INDEX slab_sectors_slab_id_slab_index_idx ON slab_sectors(slab_id, slab_index ASC);
+

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -247,7 +247,7 @@ CREATE INDEX sectors_contract_sectors_map_id_uploaded_at_idx ON sectors(contract
 CREATE INDEX sectors_host_id_uploaded_at_idx ON sectors(host_id, uploaded_at ASC) WHERE contract_sectors_map_id IS NULL;
 
 -- speed up prunable roots check
-CREATE INDEX sectors_host_id_sector_root_contract_sectors_map_id_idx ON sectors(host_id, sector_root, contract_sectors_map_id);
+CREATE INDEX sectors_sector_root_contract_sectors_map_id_idx ON sectors(sector_root, contract_sectors_map_id);
 
 -- foreign key constraint keys
 CREATE INDEX sectors_host_id_idx ON sectors(host_id);

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -247,7 +247,7 @@ CREATE INDEX sectors_contract_sectors_map_id_uploaded_at_idx ON sectors(contract
 CREATE INDEX sectors_host_id_uploaded_at_idx ON sectors(host_id, uploaded_at ASC) WHERE contract_sectors_map_id IS NULL;
 
 -- speed up prunable roots check
-CREATE INDEX sectors_sector_root_contract_sectors_map_id_idx ON sectors(sector_root, contract_sectors_map_id);
+CREATE INDEX sectors_contract_sectors_map_id_sector_root_idx ON sectors(contract_sectors_map_id, sector_root);
 
 -- foreign key constraint keys
 CREATE INDEX sectors_host_id_idx ON sectors(host_id);


### PR DESCRIPTION
This PR adds `PrunableContractRoots` which returns the indices of the roots that are not in the database and thus can be pruned from the contract. Passing the contract and host key is not strictly necessary (because of the unique on `sector_root`) but it speeds up the query slightly.

```
goos: darwin
goarch: arm64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Apple M1 Max
BenchmarkPrunableContractRoots
BenchmarkPrunableContractRoots/prunable_roots_batch_1000                  429           2686550 ns/op        1561223.23 MB/s   413295 B/op       3122 allocs/op
BenchmarkPrunableContractRoots/prunable_roots_batch_5000                  193           6739835 ns/op        3111577.43 MB/s  2384964 B/op      15339 allocs/op
BenchmarkPrunableContractRoots/prunable_roots_batch_10000                 100          12012812 ns/op        3491525.52 MB/s  4916550 B/op      30584 allocs/op
BenchmarkPrunableContractRoots/prunable_roots_batch_262144                  6         202999146 ns/op        5416336.23 MB/s 137257990 B/op    799709 allocs/op
```

edit: new benchmark without join on hosts:

```
goos: darwin
goarch: arm64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Apple M1 Max
BenchmarkPrunableContractRoots
BenchmarkPrunableContractRoots/prunable_roots_batch_1000                  100           2380502 ns/op        1761940.91 MB/s
BenchmarkPrunableContractRoots/prunable_roots_batch_5000                  100           6083192 ns/op        3447452.96 MB/s
BenchmarkPrunableContractRoots/prunable_roots_batch_10000                 100           9759810 ns/op        4297526.10 MB/s
BenchmarkPrunableContractRoots/prunable_roots_batch_262144                100         191616244 ns/op        5738091.95 MB/s
```