### PR TITLE
Add HostsForIntegrityCheck implementation

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -599,7 +599,7 @@ func scanHost(s scanner) (dbHost, error) {
 
 // HostsForIntegrityChecks returns a list of hosts that have sectors
 // requiring integrity checks.
-func (s *Store) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey, error) {
+func (s *Store) HostsForIntegrityChecks(ctx context.Context, limit int) ([]types.PublicKey, error) {
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
@@ -611,7 +611,8 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey,
 				WHERE sectors.host_id = hosts.id
 					AND sectors.next_integrity_check <= NOW()
 			)
-		`)
+			LIMIT $1
+		`, limit)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts for scanning: %w", err)
 		}

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -600,5 +600,33 @@ func scanHost(s scanner) (dbHost, error) {
 // HostsForIntegrityChecks returns a list of hosts that have sectors
 // requiring integrity checks.
 func (s *Store) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey, error) {
-	panic("implement")
+	var hosts []types.PublicKey
+	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT public_key
+			FROM hosts
+			WHERE EXISTS (
+				SELECT 1
+				FROM sectors
+				WHERE sectors.host_id = hosts.id
+					AND sectors.next_integrity_check <= NOW()
+			)
+		`)
+		if err != nil {
+			return fmt.Errorf("failed to query hosts for scanning: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var hk sqlPublicKey
+			if err := rows.Scan(&hk); err != nil {
+				return err
+			}
+			hosts = append(hosts, types.PublicKey(hk))
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	return hosts, nil
 }

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -599,22 +599,29 @@ func scanHost(s scanner) (dbHost, error) {
 
 // HostsForIntegrityChecks returns a list of hosts that have sectors
 // requiring integrity checks.
-func (s *Store) HostsForIntegrityChecks(ctx context.Context, limit int) ([]types.PublicKey, error) {
+func (s *Store) HostsForIntegrityChecks(ctx context.Context, maxLastCheck time.Time, limit int) ([]types.PublicKey, error) {
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-			SELECT hosts.public_key
-			FROM hosts
-			LEFT JOIN hosts_blocklist hb ON hosts.public_key = hb.public_key
-			WHERE EXISTS (
-				SELECT 1
-				FROM sectors
-				WHERE sectors.host_id = hosts.id
-					AND sectors.next_integrity_check <= NOW()
-			)
-			AND hb.public_key IS NULL
-			LIMIT $1
-		`, limit)
+			UPDATE hosts
+			SET last_integrity_check = NOW()
+			FROM (
+				SELECT h.id
+				FROM hosts h
+				LEFT JOIN hosts_blocklist hb ON h.public_key = hb.public_key
+				WHERE EXISTS (
+					SELECT 1
+					FROM sectors
+					WHERE sectors.host_id = h.id
+						AND sectors.next_integrity_check <= NOW()
+				)
+				AND hb.public_key IS NULL
+				AND h.last_integrity_check <= $1
+				LIMIT $2
+			) as to_check
+			WHERE hosts.id = to_check.id
+			RETURNING hosts.public_key
+		`, maxLastCheck, limit)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts for integrity checks: %w", err)
 		}

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -603,9 +603,7 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context, maxLastCheck time.T
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-			UPDATE hosts
-			SET last_integrity_check = NOW()
-			FROM (
+			WITH to_check AS (
 				SELECT h.id
 				FROM hosts h
 				LEFT JOIN hosts_blocklist hb ON h.public_key = hb.public_key
@@ -618,7 +616,10 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context, maxLastCheck time.T
 				AND hb.public_key IS NULL
 				AND h.last_integrity_check <= $1
 				LIMIT $2
-			) as to_check
+			)
+			UPDATE hosts
+			SET last_integrity_check = NOW()
+			FROM to_check
 			WHERE hosts.id = to_check.id
 			RETURNING hosts.public_key
 		`, maxLastCheck, limit)

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -599,7 +599,7 @@ func scanHost(s scanner) (dbHost, error) {
 
 // HostsForIntegrityChecks returns a list of hosts that have sectors
 // requiring integrity checks.
-func (s *Store) HostsForIntegrityChecks(ctx context.Context, limit int) ([]types.PublicKey, error) {
+func (s *Store) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey, error) {
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
@@ -612,7 +612,7 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context, limit int) ([]types
 					AND sectors.next_integrity_check <= NOW()
 			)
 			LIMIT $1
-		`, limit)
+		`)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts for scanning: %w", err)
 		}

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -614,7 +614,7 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey,
 			LIMIT $1
 		`)
 		if err != nil {
-			return fmt.Errorf("failed to query hosts for scanning: %w", err)
+			return fmt.Errorf("failed to query hosts for integrity checks: %w", err)
 		}
 		defer rows.Close()
 

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -599,20 +599,22 @@ func scanHost(s scanner) (dbHost, error) {
 
 // HostsForIntegrityChecks returns a list of hosts that have sectors
 // requiring integrity checks.
-func (s *Store) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey, error) {
+func (s *Store) HostsForIntegrityChecks(ctx context.Context, limit int) ([]types.PublicKey, error) {
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-			SELECT public_key
+			SELECT hosts.public_key
 			FROM hosts
+			LEFT JOIN hosts_blocklist hb ON hosts.public_key = hb.public_key
 			WHERE EXISTS (
 				SELECT 1
 				FROM sectors
 				WHERE sectors.host_id = hosts.id
 					AND sectors.next_integrity_check <= NOW()
 			)
+			AND hb.public_key IS NULL
 			LIMIT $1
-		`)
+		`, limit)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts for integrity checks: %w", err)
 		}

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
@@ -17,6 +18,7 @@ import (
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -1015,5 +1017,82 @@ func newTestHostSettings(pk types.PublicKey) proto4.HostSettings {
 			ValidUntil:    time.Now().Add(24 * time.Hour).Round(time.Microsecond),
 			TipHeight:     1,
 		},
+	}
+}
+
+func TestHostsForIntegrityChecks(t *testing.T) {
+	// create database
+	log := zaptest.NewLogger(t)
+	db := initPostgres(t, log.Named("postgres"))
+
+	// add two hosts
+	hk1 := types.PublicKey{1}
+	hk2 := types.PublicKey{2}
+	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return errors.Join(
+			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
+			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add account
+	acc := proto.Account{1}
+	if err := db.AddAccount(context.Background(), types.PublicKey(acc)); err != nil {
+		t.Fatal(err)
+	}
+
+	// helper to pin sector with a given checkTime
+	pinSector := func(hk types.PublicKey, root types.Hash256, nextCheck time.Time) {
+		t.Helper()
+		_, err := db.PinSlab(context.Background(), acc, nextCheck, slabs.SlabPinParams{
+			EncryptionKey: [32]byte{},
+			MinShards:     1,
+			Sectors: []slabs.SectorPinParams{
+				{
+					Root:    root,
+					HostKey: hk,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// pin 2 sectors for each host, one with a check time in the past and one in
+	// the future
+	root1 := types.Hash256{1}
+	root2 := types.Hash256{2}
+	root3 := types.Hash256{3}
+	root4 := types.Hash256{4}
+	pinSector(hk1, root1, time.Now().Add(-time.Hour))
+	pinSector(hk2, root2, time.Now().Add(-time.Hour))
+	pinSector(hk1, root3, time.Now().Add(time.Hour))
+	pinSector(hk2, root4, time.Now().Add(time.Hour))
+
+	hosts, err := db.HostsForIntegrityChecks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(hosts))
+	} else if hosts[0] != hk1 || hosts[1] != hk2 {
+		t.Fatalf("expected hosts %v, got %v", []types.PublicKey{hk1, hk2}, hosts)
+	}
+
+	// unpinning the sector on host 2 which is up for a check should cause host
+	// 2 to not be returned anymore
+	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root2}); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts, err = db.HostsForIntegrityChecks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	} else if hosts[0] != hk1 {
+		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
 	}
 }

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1071,7 +1071,9 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	pinSector(hk1, root3, time.Now().Add(time.Hour))
 	pinSector(hk2, root4, time.Now().Add(time.Hour))
 
-	hosts, err := db.HostsForIntegrityChecks(context.Background(), 10)
+	futureTime := time.Now().Add(time.Hour)
+
+	hosts, err := db.HostsForIntegrityChecks(context.Background(), futureTime, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 2 {
@@ -1081,7 +1083,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	}
 
 	// apply limit
-	hosts, err = db.HostsForIntegrityChecks(context.Background(), 1)
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), futureTime, 1)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 1 {
@@ -1090,13 +1092,21 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
 	}
 
+	// using a maxLastCheck time in the past should cause no hosts to be returned
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), time.Now().Add(-time.Hour), 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(hosts))
+	}
+
 	// unpinning the sector on host 2 which is up for a check should cause host
 	// 2 to not be returned anymore
 	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root2}); err != nil {
 		t.Fatal(err)
 	}
 
-	hosts, err = db.HostsForIntegrityChecks(context.Background(), 10)
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), futureTime, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 1 {
@@ -1109,7 +1119,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk1}, ""); err != nil {
 		t.Fatal(err)
 	}
-	hosts, err = db.HostsForIntegrityChecks(context.Background(), 10)
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), futureTime, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 0 {
@@ -1171,10 +1181,11 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	}
 
 	// run benchmark for various batch sizes
+	futureTime := time.Now().Add(time.Hour)
 	for _, batchSize := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
 			for b.Loop() {
-				batch, err := store.HostsForIntegrityChecks(context.Background(), batchSize)
+				batch, err := store.HostsForIntegrityChecks(context.Background(), futureTime, batchSize)
 				if err != nil {
 					b.Fatal(err)
 				} else if len(batch) == 0 {

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1072,7 +1072,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	pinSector(hk1, root3, time.Now().Add(time.Hour))
 	pinSector(hk2, root4, time.Now().Add(time.Hour))
 
-	hosts, err := db.HostsForIntegrityChecks(context.Background())
+	hosts, err := db.HostsForIntegrityChecks(context.Background(), 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 2 {
@@ -1081,13 +1081,23 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatalf("expected hosts %v, got %v", []types.PublicKey{hk1, hk2}, hosts)
 	}
 
+	// apply limit
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	} else if hosts[0] != hk1 {
+		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
+	}
+
 	// unpinning the sector on host 2 which is up for a check should cause host
 	// 2 to not be returned anymore
 	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root2}); err != nil {
 		t.Fatal(err)
 	}
 
-	hosts, err = db.HostsForIntegrityChecks(context.Background())
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 1 {
@@ -1153,11 +1163,11 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	// run benchmark for various batch sizes
 	for _, batchSize := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
-			b.SetBytes(int64(batchSize) * proto.SectorSize)
+			b.ReportMetric(float64(batchSize), "hosts")
 			b.ResetTimer()
 
 			for b.Loop() {
-				batch, err := store.HostsForIntegrityChecks(context.Background())
+				batch, err := store.HostsForIntegrityChecks(context.Background(), batchSize)
 				if err != nil {
 					b.Fatal(err)
 				} else if len(batch) == 0 {

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1096,3 +1096,74 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
 	}
 }
+
+// BenchmarkHostsForIntegrityCheck benchmarks HostsForIntegrityCheck.
+func BenchmarkHostsForIntegrityCheck(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+	account := proto.Account{1}
+
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal("failed to add account:", err)
+	}
+
+	const (
+		nHosts          = 10000
+		dbBaseSize      = 1 << 40 // 1TiB of sectors
+		nSectorsPerHost = dbBaseSize / proto.SectorSize / nHosts
+	)
+
+	// add hosts
+	for range nHosts {
+		hk := types.PublicKey(frand.Entropy256())
+		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
+		}); err != nil {
+			b.Fatal(err)
+		}
+
+		// add sectors
+		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
+			batchSize := min(remainingSectors, 10000)
+			remainingSectors -= batchSize
+			var sectors []slabs.SectorPinParams
+			for range batchSize {
+				root := frand.Entropy256()
+				sectors = append(sectors, slabs.SectorPinParams{
+					Root:    root,
+					HostKey: hk,
+				})
+			}
+			if _, err := store.PinSlab(context.Background(), account, time.Now().Add(time.Hour), slabs.SlabPinParams{
+				MinShards:     1,
+				EncryptionKey: frand.Entropy256(),
+				Sectors:       sectors,
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	// 10% of the sectors have a next check time in the past
+	_, err := store.pool.Exec(context.Background(), `UPDATE sectors SET next_integrity_check = NOW() - INTERVAL '1 hour' WHERE id % 10 = 0`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// run benchmark for various batch sizes
+	for _, batchSize := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
+			b.SetBytes(int64(batchSize) * proto.SectorSize)
+			b.ResetTimer()
+
+			for b.Loop() {
+				batch, err := store.HostsForIntegrityChecks(context.Background())
+				if err != nil {
+					b.Fatal(err)
+				} else if len(batch) == 0 {
+					b.Fatal("expected hosts, got none")
+				}
+			}
+		})
+	}
+}

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1072,6 +1072,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	pinSector(hk2, root4, time.Now().Add(time.Hour))
 
 	futureTime := time.Now().Add(time.Hour)
+	firstCallTime := time.Now().Round(time.Microsecond)
 
 	hosts, err := db.HostsForIntegrityChecks(context.Background(), futureTime, 10)
 	if err != nil {
@@ -1093,7 +1094,8 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	}
 
 	// using a maxLastCheck time in the past should cause no hosts to be returned
-	hosts, err = db.HostsForIntegrityChecks(context.Background(), time.Now().Add(-time.Hour), 10)
+	time.Sleep(time.Microsecond)
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), firstCallTime, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 0 {

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1163,9 +1163,6 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	// run benchmark for various batch sizes
 	for _, batchSize := range []int{100, 1000, 10000} {
 		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
-			b.ReportMetric(float64(batchSize), "hosts")
-			b.ResetTimer()
-
 			for b.Loop() {
 				batch, err := store.HostsForIntegrityChecks(context.Background(), batchSize)
 				if err != nil {

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1182,7 +1182,7 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 
 	// run benchmark for various batch sizes
 	futureTime := time.Now().Add(time.Hour)
-	for _, batchSize := range []int{100, 1000, 10000} {
+	for _, batchSize := range []int{50, 100, 200} {
 		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
 			for b.Loop() {
 				batch, err := store.HostsForIntegrityChecks(context.Background(), futureTime, batchSize)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
@@ -1038,7 +1037,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	}
 
 	// add account
-	acc := proto.Account{1}
+	acc := proto4.Account{1}
 	if err := db.AddAccount(context.Background(), types.PublicKey(acc)); err != nil {
 		t.Fatal(err)
 	}
@@ -1110,7 +1109,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 // BenchmarkHostsForIntegrityCheck benchmarks HostsForIntegrityCheck.
 func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	store := initPostgres(b, zap.NewNop())
-	account := proto.Account{1}
+	account := proto4.Account{1}
 
 	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		b.Fatal("failed to add account:", err)
@@ -1119,7 +1118,7 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	const (
 		nHosts          = 10000
 		dbBaseSize      = 1 << 40 // 1TiB of sectors
-		nSectorsPerHost = dbBaseSize / proto.SectorSize / nHosts
+		nSectorsPerHost = dbBaseSize / proto4.SectorSize / nHosts
 	)
 
 	// add hosts

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1071,7 +1071,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	pinSector(hk1, root3, time.Now().Add(time.Hour))
 	pinSector(hk2, root4, time.Now().Add(time.Hour))
 
-	hosts, err := db.HostsForIntegrityChecks(context.Background(), 10)
+	hosts, err := db.HostsForIntegrityChecks(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 2 {
@@ -1080,23 +1080,13 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatalf("expected hosts %v, got %v", []types.PublicKey{hk1, hk2}, hosts)
 	}
 
-	// apply limit
-	hosts, err = db.HostsForIntegrityChecks(context.Background(), 1)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(hosts) != 1 {
-		t.Fatalf("expected 1 host, got %d", len(hosts))
-	} else if hosts[0] != hk1 {
-		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
-	}
-
 	// unpinning the sector on host 2 which is up for a check should cause host
 	// 2 to not be returned anymore
 	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root2}); err != nil {
 		t.Fatal(err)
 	}
 
-	hosts, err = db.HostsForIntegrityChecks(context.Background(), 10)
+	hosts, err = db.HostsForIntegrityChecks(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 1 {
@@ -1160,16 +1150,12 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	}
 
 	// run benchmark for various batch sizes
-	for _, batchSize := range []int{100, 1000, 10000} {
-		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
-			for b.Loop() {
-				batch, err := store.HostsForIntegrityChecks(context.Background(), batchSize)
-				if err != nil {
-					b.Fatal(err)
-				} else if len(batch) == 0 {
-					b.Fatal("expected hosts, got none")
-				}
-			}
-		})
+	for b.Loop() {
+		batch, err := store.HostsForIntegrityChecks(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		} else if len(batch) == 0 {
+			b.Fatal("expected hosts, got none")
+		}
 	}
 }

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1071,7 +1071,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	pinSector(hk1, root3, time.Now().Add(time.Hour))
 	pinSector(hk2, root4, time.Now().Add(time.Hour))
 
-	hosts, err := db.HostsForIntegrityChecks(context.Background())
+	hosts, err := db.HostsForIntegrityChecks(context.Background(), 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 2 {
@@ -1080,19 +1080,40 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatalf("expected hosts %v, got %v", []types.PublicKey{hk1, hk2}, hosts)
 	}
 
-	// unpinning the sector on host 2 which is up for a check should cause host
-	// 2 to not be returned anymore
-	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root2}); err != nil {
-		t.Fatal(err)
-	}
-
-	hosts, err = db.HostsForIntegrityChecks(context.Background())
+	// apply limit
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), 1)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 1 {
 		t.Fatalf("expected 1 host, got %d", len(hosts))
 	} else if hosts[0] != hk1 {
 		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
+	}
+
+	// unpinning the sector on host 2 which is up for a check should cause host
+	// 2 to not be returned anymore
+	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root2}); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	} else if hosts[0] != hk1 {
+		t.Fatalf("expected host %v, got %v", hk1, hosts[0])
+	}
+
+	// block host 1 so that it's also not returned anymore
+	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk1}, ""); err != nil {
+		t.Fatal(err)
+	}
+	hosts, err = db.HostsForIntegrityChecks(context.Background(), 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(hosts))
 	}
 }
 
@@ -1150,12 +1171,16 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	}
 
 	// run benchmark for various batch sizes
-	for b.Loop() {
-		batch, err := store.HostsForIntegrityChecks(context.Background())
-		if err != nil {
-			b.Fatal(err)
-		} else if len(batch) == 0 {
-			b.Fatal("expected hosts, got none")
-		}
+	for _, batchSize := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprint(batchSize), func(b *testing.B) {
+			for b.Loop() {
+				batch, err := store.HostsForIntegrityChecks(context.Background(), batchSize)
+				if err != nil {
+					b.Fatal(err)
+				} else if len(batch) == 0 {
+					b.Fatal("expected hosts, got none")
+				}
+			}
+		})
 	}
 }

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -155,9 +155,9 @@ CREATE TABLE contracts (
   -- revision broadcast related columns
   last_broadcast_attempt TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 
-  -- contract pruning 
+  -- contract pruning
   last_prune TIMESTAMP WITH TIME ZONE,
-  
+
   -- metrics for visualization (not ACID)
   capacity BIGINT NOT NULL DEFAULT 0 CHECK(capacity >= size),
   size BIGINT NOT NULL DEFAULT 0 CHECK(size >= 0),
@@ -272,4 +272,3 @@ CREATE INDEX slab_sectors_sector_id_idx ON slab_sectors(sector_id);
 
 -- speed up fetching sectors for slab ordered by their position within the slab
 CREATE UNIQUE INDEX slab_sectors_slab_id_slab_index_idx ON slab_sectors(slab_id, slab_index ASC);
-

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -8,6 +8,7 @@ CREATE TABLE hosts (
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
     consecutive_failed_scans INTEGER NOT NULL DEFAULT 0,
     recent_uptime DOUBLE PRECISION NOT NULL DEFAULT 0.894 CHECK (recent_uptime > 0 AND recent_uptime < 1),
+    last_integrity_check TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     last_failed_scan TIMESTAMP WITH TIME ZONE,
     last_successful_scan TIMESTAMP WITH TIME ZONE,
     last_announcement TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -31,7 +32,9 @@ CREATE TABLE hosts (
     settings_tip_height BIGINT NOT NULL DEFAULT 0,
     settings_valid_until TIMESTAMP WITH TIME ZONE
 );
-CREATE INDEX idx_hosts_next_scan_idx ON hosts(next_scan);
+CREATE INDEX hosts_next_scan_idx ON hosts(next_scan);
+
+CREATE INDEX hosts_last_integrity_check_idx ON hosts(last_integrity_check ASC);
 
 CREATE TABLE account_hosts (
     account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -189,6 +189,12 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 				return
 			}
 
+			// ignore hosts that are not usable
+			if !host.IsGood() {
+				logger.With(zap.Stringer("hostKey", hostKey)).Debug("skipping host since it's not usable")
+				return
+			}
+
 			// create verifier
 			verifier, err := newSectorVerifier(ctx, host.SiamuxAddr(), host.PublicKey, host.Settings.Prices)
 			if err != nil {

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 	"time"
 
@@ -160,56 +159,60 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 	logger := m.log.Named("integrity")
 	logger.Debug("starting integrity checks", zap.Time("start", start))
 
-	usedHosts, err := m.store.HostsForIntegrityChecks(ctx, math.MaxInt)
-	if err != nil {
-		return fmt.Errorf("failed to fetch hosts to block: %w", err)
-	}
-
-	sem := make(chan struct{}, 50)
-	var wg sync.WaitGroup
-	for _, host := range usedHosts {
-		select {
-		case <-m.tg.Done():
-			return nil
-		default:
+	for {
+		usedHosts, err := m.store.HostsForIntegrityChecks(ctx, 100)
+		if err != nil {
+			return fmt.Errorf("failed to fetch hosts to block: %w", err)
+		} else if len(usedHosts) == 0 {
+			break
 		}
 
-		sem <- struct{}{}
-		wg.Add(1)
-		go func(hostKey types.PublicKey) {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
-
-			// fetch good price table
-			host, err := m.hm.ScanHost(ctx, hostKey)
-			if err != nil {
-				logger.With(zap.Stringer("hostKey", hostKey)).Error("failed to scan host", zap.Error(err))
-				return
+		sem := make(chan struct{}, 50)
+		var wg sync.WaitGroup
+		for _, host := range usedHosts {
+			select {
+			case <-m.tg.Done():
+				return nil
+			default:
 			}
 
-			// ignore hosts that are not usable
-			if !host.IsGood() {
-				logger.With(zap.Stringer("hostKey", hostKey)).Debug("skipping host since it's not usable")
-				return
-			}
+			sem <- struct{}{}
+			wg.Add(1)
+			go func(hostKey types.PublicKey) {
+				defer func() {
+					<-sem
+					wg.Done()
+				}()
 
-			// create verifier
-			verifier, err := newSectorVerifier(ctx, host.SiamuxAddr(), host.PublicKey, host.Settings.Prices)
-			if err != nil {
-				// NOTE: If we can't dial the host we don't mark sectors as lost.
-				// Instead we leave it up to the scan code to determine whether the host
-				// is offline.
-				logger.With(zap.Stringer("hostKey", host.PublicKey)).Warn("failed to create sector verifier", zap.Error(err))
-				return
-			}
-			defer verifier.Close()
+				// fetch good price table
+				host, err := m.hm.ScanHost(ctx, hostKey)
+				if err != nil {
+					logger.With(zap.Stringer("hostKey", hostKey)).Error("failed to scan host", zap.Error(err))
+					return
+				}
 
-			m.performIntegrityChecksForHost(ctx, verifier, logger)
-		}(host)
+				// ignore hosts that are not usable
+				if !host.IsGood() {
+					logger.With(zap.Stringer("hostKey", hostKey)).Debug("skipping host since it's not usable")
+					return
+				}
+
+				// create verifier
+				verifier, err := newSectorVerifier(ctx, host.SiamuxAddr(), host.PublicKey, host.Settings.Prices)
+				if err != nil {
+					// NOTE: If we can't dial the host we don't mark sectors as lost.
+					// Instead we leave it up to the scan code to determine whether the host
+					// is offline.
+					logger.With(zap.Stringer("hostKey", host.PublicKey)).Warn("failed to create sector verifier", zap.Error(err))
+					return
+				}
+				defer verifier.Close()
+
+				m.performIntegrityChecksForHost(ctx, verifier, logger)
+			}(host)
+		}
+		wg.Wait()
 	}
-	wg.Wait()
 
 	logger.Debug("finished integrity checks", zap.Duration("elapsed", time.Since(start)))
 	return nil

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -59,7 +60,7 @@ type (
 		AddAccount(ctx context.Context, ak types.PublicKey) error
 		FailingSectors(ctx context.Context, hostKey types.PublicKey, minChecks, limit int) ([]types.Hash256, error)
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
-		HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey, error)
+		HostsForIntegrityChecks(ctx context.Context, limit int) ([]types.PublicKey, error)
 		MarkFailingSectorsLost(ctx context.Context, hostKey types.PublicKey, maxFailedIntegrityChecks uint) error
 		MarkSectorsLost(ctx context.Context, hostKey types.PublicKey, roots []types.Hash256) error
 		PinSlab(ctx context.Context, account proto.Account, nextIntegrityCheck time.Time, slab SlabPinParams) (SlabID, error)
@@ -159,7 +160,7 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 	logger := m.log.Named("integrity")
 	logger.Debug("starting integrity checks", zap.Time("start", start))
 
-	usedHosts, err := m.store.HostsForIntegrityChecks(ctx)
+	usedHosts, err := m.store.HostsForIntegrityChecks(ctx, math.MaxInt)
 	if err != nil {
 		return fmt.Errorf("failed to fetch hosts to block: %w", err)
 	}

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -46,7 +46,7 @@ func (s *mockStore) Hosts(ctx context.Context, offset, limit int, queryOpts ...h
 	panic("not implemented")
 }
 
-func (s *mockStore) HostsForIntegrityChecks(ctx context.Context) ([]types.PublicKey, error) {
+func (s *mockStore) HostsForIntegrityChecks(ctx context.Context, limit int) ([]types.PublicKey, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Apple M2 Pro
BenchmarkHostsForIntegrityCheck
BenchmarkHostsForIntegrityCheck/100
BenchmarkHostsForIntegrityCheck/100-12         	    2062	    491420 ns/op
BenchmarkHostsForIntegrityCheck/1000
BenchmarkHostsForIntegrityCheck/1000-12        	     915	   1244286 ns/op
BenchmarkHostsForIntegrityCheck/10000
BenchmarkHostsForIntegrityCheck/10000-12       	     136	   8736631 ns/op
```