### PR TITLE
Implement service account database methods

### DIFF
--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -193,17 +193,55 @@ DO UPDATE SET
 // account can't underflow, instead it will be set to 0 if the amount withdrawn
 // exceeds the stored balance.
 func (s *Store) DebitServiceAccount(ctx context.Context, hostKey types.PublicKey, account proto.Account, amount types.Currency) error {
-	return errors.New("not implemented")
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		resp, err := tx.Exec(ctx, `
+			UPDATE service_accounts
+			SET balance = GREATEST(balance - $1, 0)
+			WHERE account_id = (SELECT id FROM accounts WHERE public_key = $2)
+			AND host_id = (SELECT id FROM hosts WHERE public_key = $3)
+		`, sqlCurrency(amount), sqlPublicKey(account), sqlPublicKey(hostKey))
+		if err != nil {
+			return err
+		} else if resp.RowsAffected() == 0 {
+			return accounts.ErrNotFound
+		}
+		return nil
+	})
 }
 
 // UpdateServiceAccountBalance updates the balance of a service account.
 func (s *Store) UpdateServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account, balance types.Currency) error {
-	return errors.New("not implemented")
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO service_accounts (account_id, host_id, balance)
+			VALUES (
+				(SELECT id FROM accounts WHERE public_key = $1),
+				(SELECT id FROM hosts WHERE public_key = $2),
+				$3
+			)
+			ON CONFLICT (account_id, host_id) DO UPDATE SET balance = EXCLUDED.balance
+		`, sqlPublicKey(account), sqlPublicKey(hostKey), sqlCurrency(balance))
+		return err
+	})
 }
 
 // ServiceAccountBalance returns the balance of a service account.
 func (s *Store) ServiceAccountBalance(ctx context.Context, hostKey types.PublicKey, account proto.Account) (types.Currency, error) {
-	return types.Currency{}, errors.New("not implemented")
+	var balance types.Currency
+	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		err := tx.QueryRow(ctx, `
+			SELECT balance
+			FROM service_accounts
+			INNER JOIN accounts ON accounts.id = service_accounts.account_id
+			INNER JOIN hosts ON hosts.id = service_accounts.host_id
+			WHERE accounts.public_key = $1 AND hosts.public_key = $2
+		`, sqlPublicKey(account), sqlPublicKey(hostKey)).Scan((*sqlCurrency)(&balance))
+		if errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrNotFound
+		}
+		return err
+	})
+	return balance, err
 }
 
 func (s *Store) newHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, limit int) ([]accounts.HostAccount, error) {

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap"
@@ -536,4 +539,142 @@ func BenchmarkUpdateHostAccounts(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestServiceAccounts(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// setup
+	account := types.GeneratePrivateKey().PublicKey()
+	err := store.AddAccount(context.Background(), account)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hk := types.GeneratePrivateKey().PublicKey()
+	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add account
+	err = store.AddAccount(context.Background(), hk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// account not found
+	_, err = store.ServiceAccountBalance(context.Background(), hk, proto.Account(account))
+	if !errors.Is(err, accounts.ErrNotFound) {
+		t.Fatal(err)
+	}
+	err = store.DebitServiceAccount(context.Background(), hk, proto.Account(account), types.Siacoins(1))
+	if !errors.Is(err, accounts.ErrNotFound) {
+		t.Fatal(err)
+	}
+
+	// helper to assert balance
+	assertBalance := func(expected types.Currency) {
+		t.Helper()
+		balance, err := store.ServiceAccountBalance(context.Background(), hk, proto.Account(account))
+		if err != nil {
+			t.Fatal(err)
+		} else if !balance.Equals(expected) {
+			t.Fatal("unexpected balance", balance)
+		}
+	}
+
+	// set account balance
+	expectedBalance := types.Siacoins(1)
+	err = store.UpdateServiceAccountBalance(context.Background(), hk, proto.Account(account), expectedBalance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// fetch balance
+	assertBalance(expectedBalance)
+
+	// withdraw from it
+	withdrawal := types.Siacoins(1).Div64(10)         // 0.1SC
+	expectedBalance = expectedBalance.Sub(withdrawal) // 0.9SC
+	if err := store.DebitServiceAccount(context.Background(), hk, proto.Account(account), withdrawal); err != nil {
+		t.Fatal(err)
+	}
+	assertBalance(expectedBalance)
+
+	// withdraw more than the balance
+	if err := store.DebitServiceAccount(context.Background(), hk, proto.Account(account), types.Siacoins(100)); err != nil {
+		t.Fatal(err)
+	}
+	assertBalance(types.ZeroCurrency)
+}
+
+// BenchmarkServiceAccounts benchmarks the service account related methods
+func BenchmarkServiceAccounts(b *testing.B) {
+	// define parameters
+	const (
+		numAccounts = 10000
+		numHosts    = 1000
+	)
+
+	// prepare database
+	store := initPostgres(b, zaptest.NewLogger(b).Named("postgres"))
+	for range numAccounts {
+		_, err := store.pool.Exec(context.Background(), `INSERT INTO accounts (public_key) VALUES ($1);`, sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	account := proto.Account(types.GeneratePrivateKey().PublicKey())
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal(err)
+	}
+
+	var hosts []types.PublicKey
+	for range numHosts {
+		hk := types.GeneratePrivateKey().PublicKey()
+		hosts = append(hosts, hk)
+		_, err := store.pool.Exec(context.Background(), `INSERT INTO hosts (public_key, last_announcement) VALUES ($1, NOW());`, sqlPublicKey(hk))
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		// assume that the account is funded with every host
+		err = store.UpdateServiceAccountBalance(context.Background(), hk, account, types.Siacoins(1))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.Run("UpdateServiceAccountBalance", func(b *testing.B) {
+		for b.Loop() {
+			hk := hosts[frand.Intn(numHosts)]
+			err := store.UpdateServiceAccountBalance(context.Background(), hk, account, types.NewCurrency64(frand.Uint64n(math.MaxUint64)))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("DebitServiceAccount", func(b *testing.B) {
+		for b.Loop() {
+			hk := hosts[frand.Intn(numHosts)]
+			err := store.DebitServiceAccount(context.Background(), hk, account, types.NewCurrency64(1))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("ServiceAccountBalance", func(b *testing.B) {
+		for b.Loop() {
+			hk := hosts[frand.Intn(numHosts)]
+			_, err := store.ServiceAccountBalance(context.Background(), hk, account)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Apple M2 Pro
BenchmarkServiceAccounts
BenchmarkServiceAccounts/UpdateServiceAccountBalance
BenchmarkServiceAccounts/UpdateServiceAccountBalance-12         	    2770	    428645 ns/op
BenchmarkServiceAccounts/DebitServiceAccount
BenchmarkServiceAccounts/DebitServiceAccount-12                 	    2708	    430238 ns/op
BenchmarkServiceAccounts/ServiceAccountBalance
BenchmarkServiceAccounts/ServiceAccountBalance-12               	    1212	   1021690 ns/op
PASS
```