### PR TITLE
Add store.HostsForPinning

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -648,15 +648,21 @@ func (s *Store) HostsForPinning(ctx context.Context) ([]types.PublicKey, error) 
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-			SELECT h.public_key 
+			SELECT h.public_key
 			FROM hosts h
-			INNER JOIN contracts c ON h.id = c.host_id
-			LEFT JOIN hosts_blocklist hb ON h.public_key = hb.public_key
-			WHERE c.state <= $1 AND hb.public_key IS NULL AND EXISTS (
-				SELECT 1 
-				FROM sectors 
-				WHERE sectors.host_id = h.id AND contract_sectors_map_id IS NULL
-			)`, contracts.ContractStateActive)
+			WHERE
+				EXISTS (
+					SELECT 1
+					FROM sectors
+					WHERE sectors.host_id = h.id AND contract_sectors_map_id IS NULL
+				) AND
+				EXISTS (
+					SELECT 1
+					FROM contracts
+					WHERE contracts.host_id = h.id AND contracts.state <= $1 AND contracts.good = TRUE
+				) AND
+				NOT EXISTS (SELECT 1 FROM hosts_blocklist hb WHERE hb.public_key = h.public_key)
+				 `, contracts.ContractStateActive)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts for pinning: %w", err)
 		}

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -641,3 +641,37 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context, maxLastCheck time.T
 	}
 	return hosts, nil
 }
+
+// HostsForPinning returns a list of hosts that have unpinned sectors as well as
+// active contracts to pin them to. Hosts that are blocked are excluded.
+func (s *Store) HostsForPinning(ctx context.Context) ([]types.PublicKey, error) {
+	var hosts []types.PublicKey
+	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT h.public_key 
+			FROM hosts h
+			INNER JOIN contracts c ON h.id = c.host_id
+			LEFT JOIN hosts_blocklist hb ON h.public_key = hb.public_key
+			WHERE c.state <= $1 AND hb.public_key IS NULL AND EXISTS (
+				SELECT 1 
+				FROM sectors 
+				WHERE sectors.host_id = h.id AND contract_sectors_map_id IS NULL
+			)`, contracts.ContractStateActive)
+		if err != nil {
+			return fmt.Errorf("failed to query hosts for pinning: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var hk sqlPublicKey
+			if err := rows.Scan(&hk); err != nil {
+				return err
+			}
+			hosts = append(hosts, types.PublicKey(hk))
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	return hosts, nil
+}

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1019,6 +1019,101 @@ func newTestHostSettings(pk types.PublicKey) proto4.HostSettings {
 	}
 }
 
+func TestHostsForPinning(t *testing.T) {
+	// create database
+	log := zaptest.NewLogger(t)
+	db := initPostgres(t, log.Named("postgres"))
+
+	// add two hosts
+	hk1 := types.PublicKey{1}
+	hk2 := types.PublicKey{2}
+	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return errors.Join(
+			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
+			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
+		)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add account
+	acc := proto4.Account{1}
+	if err := db.AddAccount(context.Background(), types.PublicKey(acc)); err != nil {
+		t.Fatal(err)
+	}
+
+	// pin a slab with sector on both hosts
+	r1 := frand.Entropy256()
+	if _, err := db.PinSlab(context.Background(), acc, time.Now(), slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     1,
+		Sectors: []slabs.SectorPinParams{
+			{
+				Root:    r1,
+				HostKey: hk1,
+			},
+			{
+				Root:    frand.Entropy256(),
+				HostKey: hk2,
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert no hosts are returned, they don't have active contracts
+	hks, err := db.HostsForPinning(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hks) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(hks))
+	}
+
+	// add contract for both hosts
+	fcid1 := types.FileContractID{1}
+	if err := db.AddFormedContract(context.Background(), fcid1, hk1, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		t.Fatal(err)
+	} else if err := db.AddFormedContract(context.Background(), types.FileContractID{2}, hk2, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert both hosts are returned now
+	hks, err = db.HostsForPinning(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hks) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(hks))
+	}
+
+	// pin sectors for h1
+	if err := db.PinSectors(context.Background(), types.FileContractID{1}, []types.Hash256{r1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert only h2 is returned
+	hks, err = db.HostsForPinning(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hks) != 1 {
+		t.Fatalf("expected one host, got %d", len(hks))
+	} else if hks[0] != hk2 {
+		t.Fatalf("expected host %v, got %v", hk2, hks[0])
+	}
+
+	// block host 2
+	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk2}, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert no hosts are returned
+	hks, err = db.HostsForPinning(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hks) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(hks))
+	}
+}
+
 func TestHostsForIntegrityChecks(t *testing.T) {
 	// create database
 	log := zaptest.NewLogger(t)
@@ -1126,6 +1221,105 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatal(err)
 	} else if len(hosts) != 0 {
 		t.Fatalf("expected 0 hosts, got %d", len(hosts))
+	}
+}
+
+// BenchmarkHostsForPinning benchmarks HostsForPinning.
+func BenchmarkHostsForPinning(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	// add account
+	account := proto4.Account{1}
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal("failed to add account:", err)
+	}
+
+	const (
+		dbBaseSize = 1 << 40 // 1TiB of sectors
+
+		nHosts            = 1000
+		nContractsPerHost = 100
+		nSectorsPerHost   = dbBaseSize / proto4.SectorSize / nHosts
+	)
+
+	// prepare database
+	hostToContractID := make(map[types.PublicKey]types.FileContractID, nHosts)
+	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
+		for range nHosts {
+			// add host
+			hk := types.PublicKey(frand.Entropy256())
+			var hostID int64
+			err := tx.QueryRow(ctx, `INSERT INTO hosts (public_key, last_announcement) VALUES ($1, NOW()) RETURNING id;`, sqlPublicKey(hk)).Scan(&hostID)
+			if err != nil {
+				return err
+			}
+
+			// add contracts
+			var fcid types.FileContractID
+			for range nContractsPerHost {
+				frand.Read(fcid[:])
+				size := frand.Uint64n(1e9)
+				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity) VALUES ($1, $2, 0, 0, $3, $4, $5, $6, $7, $8, $9, $10, $11);`,
+					hostID,
+					sqlHash256(fcid[:]),
+					sqlCurrency(types.ZeroCurrency),
+					sqlCurrency(types.ZeroCurrency),
+					sqlCurrency(types.ZeroCurrency),
+					sqlCurrency(types.ZeroCurrency),
+					sqlCurrency(types.NewCurrency64(frand.Uint64n(5))), // random remaining allowance
+					sqlContractState(uint8(frand.Uint64n(5))),          // random contract state (40% active)
+					frand.Uint64n(2) == 0,                              // random good state (50% good)
+					size,                                               // random size
+					size+frand.Uint64n(1e3),                            // random capacity
+				); err != nil {
+					return err
+				}
+			}
+			hostToContractID[hk] = fcid
+		}
+		return nil
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	// add sectors
+	for hk, fcid := range hostToContractID {
+		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
+			batchSize := min(remainingSectors, 10000)
+			remainingSectors -= batchSize
+			var sectors []slabs.SectorPinParams
+			var roots []types.Hash256
+			for range batchSize {
+				root := frand.Entropy256()
+				sectors = append(sectors, slabs.SectorPinParams{
+					Root:    root,
+					HostKey: hk,
+				})
+				roots = append(roots, root)
+			}
+			if _, err := store.PinSlab(context.Background(), account, time.Now().Add(time.Hour), slabs.SlabPinParams{
+				MinShards:     1,
+				EncryptionKey: frand.Entropy256(),
+				Sectors:       sectors,
+			}); err != nil {
+				b.Fatal(err)
+			}
+
+			// pin 10% of the sectors
+			frand.Shuffle(len(roots), func(i, j int) { roots[i], roots[j] = roots[j], roots[i] })
+			if err := store.PinSectors(context.Background(), fcid, roots[:len(roots)/10]); err != nil {
+				b.Fatal(err, fcid)
+			}
+		}
+	}
+
+	for b.Loop() {
+		batch, err := store.HostsForPinning(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		} else if len(batch) == 0 {
+			b.Fatal("expected hosts, got none")
+		}
 	}
 }
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1239,6 +1239,7 @@ func BenchmarkHostsForPinning(b *testing.B) {
 
 		nHosts            = 1000
 		nContractsPerHost = 100
+		nBlocklistHosts   = 1000
 		nSectorsPerHost   = dbBaseSize / proto4.SectorSize / nHosts
 	)
 
@@ -1277,6 +1278,15 @@ func BenchmarkHostsForPinning(b *testing.B) {
 			}
 			hostToContractID[hk] = fcid
 		}
+
+		// we LEFT JOIN the blocklist so we populate it with random entries
+		for range nBlocklistHosts {
+			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key, reason) VALUES ($1, 'none') ON CONFLICT (public_key) DO NOTHING", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}); err != nil {
 		b.Fatal(err)
@@ -1317,8 +1327,8 @@ func BenchmarkHostsForPinning(b *testing.B) {
 		batch, err := store.HostsForPinning(context.Background())
 		if err != nil {
 			b.Fatal(err)
-		} else if len(batch) == 0 {
-			b.Fatal("expected hosts, got none")
+		} else if len(batch) != len(batch) {
+			b.Fatal("unexpected number of hosts", len(batch))
 		}
 	}
 }

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1327,7 +1327,7 @@ func BenchmarkHostsForPinning(b *testing.B) {
 		batch, err := store.HostsForPinning(context.Background())
 		if err != nil {
 			b.Fatal(err)
-		} else if len(batch) != len(batch) {
+		} else if len(batch) != nHosts {
 			b.Fatal("unexpected number of hosts", len(batch))
 		}
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -261,7 +261,7 @@ CREATE INDEX sectors_next_integrity_check_idx ON sectors(next_integrity_check AS
 CREATE INDEX sectors_host_id_next_integrity_check_idx ON sectors(host_id, next_integrity_check ASC);
 
 -- speed up hosts for pinning query
-CREATE INDEX sectors_host_id_null_contract_map_idx ON sectors(host_id, contract_sectors_map_id) WHERE contract_sectors_map_id IS NULL;
+CREATE INDEX sectors_host_id_null_contract_map_idx ON sectors(host_id) WHERE contract_sectors_map_id IS NULL;
 
 -- speed up querying sectors of a host by root
 CREATE INDEX sectors_host_id_sector_root_idx ON sectors(host_id, sector_root);

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -260,6 +260,9 @@ CREATE INDEX sectors_host_id_idx ON sectors(host_id);
 CREATE INDEX sectors_next_integrity_check_idx ON sectors(next_integrity_check ASC);
 CREATE INDEX sectors_host_id_next_integrity_check_idx ON sectors(host_id, next_integrity_check ASC);
 
+-- speed up hosts for pinning query
+CREATE INDEX sectors_host_id_null_contract_map_idx ON sectors(host_id, contract_sectors_map_id) WHERE contract_sectors_map_id IS NULL;
+
 -- speed up querying sectors of a host by root
 CREATE INDEX sectors_host_id_sector_root_idx ON sectors(host_id, sector_root);
 

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -33,7 +33,8 @@ func initPostgres(t testing.TB, log *zap.Logger) *Store {
 	t.Cleanup(func() {
 		if _, err := db.pool.Exec(context.Background(), `DROP SCHEMA public CASCADE;CREATE SCHEMA public;`); err != nil {
 			panic(err)
-		} else if err := db.Close(); err != nil {
+		}
+		if err := db.Close(); err != nil {
 			panic(err)
 		}
 	})

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -33,8 +33,7 @@ func initPostgres(t testing.TB, log *zap.Logger) *Store {
 	t.Cleanup(func() {
 		if _, err := db.pool.Exec(context.Background(), `DROP SCHEMA public CASCADE;CREATE SCHEMA public;`); err != nil {
 			panic(err)
-		}
-		if err := db.Close(); err != nil {
+		} else if err := db.Close(); err != nil {
 			panic(err)
 		}
 	})


### PR DESCRIPTION
This PR implements `HostsForPinning`, it's fast so I don't think it warrants an extra field on hosts that would allow us to `limit` the query.

```
Apple M1 Max
BenchmarkHostsForPinning-10          200          5.4 ms/op
```