### PR TITLE
Persist revisions

### DIFF
--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -37,18 +37,18 @@ type storeMock struct {
 	hosts       map[types.PublicKey]hosts.Host
 }
 
-func (s *storeMock) AddFormedContract(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, proofHeight, expirationHeight uint64, contractPrice, allowance, minerFee, totalCollateral types.Currency) error {
+func (s *storeMock) AddFormedContract(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, revision types.V2FileContract, contractPrice, allowance, minerFee types.Currency) error {
 	s.contracts = append(s.contracts, Contract{
 		ID:      contractID,
 		HostKey: hostKey,
 
 		Formation:        time.Now(),
-		ProofHeight:      proofHeight,
-		ExpirationHeight: expirationHeight,
+		ProofHeight:      revision.ProofHeight,
+		ExpirationHeight: revision.ExpirationHeight,
 		State:            ContractStatePending,
 
 		RemainingAllowance: allowance,
-		TotalCollateral:    totalCollateral,
+		TotalCollateral:    revision.TotalCollateral,
 
 		ContractPrice:    contractPrice,
 		InitialAllowance: allowance,
@@ -59,11 +59,11 @@ func (s *storeMock) AddFormedContract(ctx context.Context, contractID types.File
 	return nil
 }
 
-func (s *storeMock) AddRenewedContract(ctx context.Context, params AddRenewedContractParams) error {
+func (s *storeMock) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, revision types.V2FileContract, contractPrice, minerFee, usedCollateral types.Currency) error {
 	var source *Contract
 	for i := range s.contracts {
-		if s.contracts[i].ID == params.RenewedFrom {
-			s.contracts[i].RenewedTo = params.RenewedTo
+		if s.contracts[i].ID == renewedFrom {
+			s.contracts[i].RenewedTo = renewedTo
 			source = &s.contracts[i]
 			break
 		}
@@ -72,7 +72,7 @@ func (s *storeMock) AddRenewedContract(ctx context.Context, params AddRenewedCon
 		return ErrNotFound
 	}
 	s.contracts = append(s.contracts, Contract{
-		ID:      params.RenewedTo,
+		ID:      renewedTo,
 		HostKey: source.HostKey,
 
 		Capacity:    source.Size,
@@ -80,17 +80,17 @@ func (s *storeMock) AddRenewedContract(ctx context.Context, params AddRenewedCon
 		RenewedFrom: source.ID,
 
 		Formation:        time.Now(),
-		ProofHeight:      params.ProofHeight,
-		ExpirationHeight: params.ExpirationHeight,
+		ProofHeight:      revision.ProofHeight,
+		ExpirationHeight: revision.ExpirationHeight,
 		State:            ContractStatePending,
 
-		RemainingAllowance: params.Allowance,
-		UsedCollateral:     params.UsedCollateral,
-		TotalCollateral:    params.TotalCollateral,
+		RemainingAllowance: revision.RenterOutput.Value,
+		UsedCollateral:     usedCollateral,
+		TotalCollateral:    revision.TotalCollateral,
 
-		ContractPrice:    params.ContractPrice,
-		InitialAllowance: params.Allowance,
-		MinerFee:         params.MinerFee,
+		ContractPrice:    contractPrice,
+		InitialAllowance: revision.RenterOutput.Value,
+		MinerFee:         minerFee,
 
 		Good: true,
 	})

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -50,22 +50,6 @@ func WithRevisable(revisable bool) ContractQueryOpt {
 }
 
 type (
-	// AddRenewedContractParams contains the parameters for adding a renewed
-	// contract to the store
-	AddRenewedContractParams struct {
-		RenewedFrom      types.FileContractID
-		RenewedTo        types.FileContractID
-		ProofHeight      uint64
-		ExpirationHeight uint64
-		ContractPrice    types.Currency
-		Allowance        types.Currency
-		MinerFee         types.Currency
-		UsedCollateral   types.Currency
-		TotalCollateral  types.Currency
-	}
-)
-
-type (
 	// ContractState describes the current state of the contract on the network
 	// - pending: the contract has not yet been seen on-chain
 	// - active: the contract was mined on-chain

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -80,29 +80,31 @@ type (
 
 	// Contract is a contract formed with a host
 	Contract struct {
-		ID      types.FileContractID `json:"id"`
-		HostKey types.PublicKey      `json:"hostKey"`
+		// static fields
+		ID          types.FileContractID `json:"id"`
+		HostKey     types.PublicKey      `json:"hostKey"`
+		Formation   time.Time            `json:"formation"`
+		RenewedFrom types.FileContractID `json:"renewedFrom"`
 
-		Formation        time.Time            `json:"formation"`
-		ProofHeight      uint64               `json:"proofHeight"`      // start of the contract's proof window
-		ExpirationHeight uint64               `json:"expirationHeight"` // end of the contract's proof window
-		RenewedFrom      types.FileContractID `json:"renewedFrom"`
-		RenewedTo        types.FileContractID `json:"renewedTo"`
-		State            ContractState        `json:"state"`
+		// state fields
+		LastPrune            time.Time `json:"lastPrune"`
+		LastBroadcastAttempt time.Time `json:"lastBroadcastAttempt"`
 
-		Capacity           uint64           `json:"capacity"`           // already paid for capacity (always >=Size)
-		RemainingAllowance types.Currency   `json:"remainingAllowance"` // remaining renter allowance
-		RevisionNumber     uint64           `json:"revisionNumber"`     // current revision number
-		Size               uint64           `json:"size"`               // current size of the contract
-		Spending           ContractSpending `json:"spending"`
-		TotalCollateral    types.Currency   `json:"totalCollateral"` // total amount of collateral locked in contract
-		UsedCollateral     types.Currency   `json:"usedCollateral"`  // used collateral
+		// revision fields
+		RevisionNumber     uint64         `json:"revisionNumber"`     // current revision number
+		ProofHeight        uint64         `json:"proofHeight"`        // start of the contract's proof window
+		ExpirationHeight   uint64         `json:"expirationHeight"`   // end of the contract's proof window
+		Capacity           uint64         `json:"capacity"`           // already paid for capacity (always >=Size)
+		Size               uint64         `json:"size"`               // current size of the contract
+		InitialAllowance   types.Currency `json:"initialAllowance"`   // initial renter allowance locked in contract
+		RemainingAllowance types.Currency `json:"remainingAllowance"` // remaining renter allowance
+		TotalCollateral    types.Currency `json:"totalCollateral"`    // total amount of collateral locked in contract
 
-		ContractPrice    types.Currency `json:"contractPrice"`    // price of the contract creation as charged by the host
-		InitialAllowance types.Currency `json:"initialAllowance"` // initial renter allowance locked in contract
-		MinerFee         types.Currency `json:"minerFee"`         // miner fee spent on formation txn
-
-		LastPrune time.Time `json:"lastPrune"` // last time the contract was pruned
+		// updated on refresh/renewal
+		RenewedTo      types.FileContractID `json:"renewedTo"`
+		UsedCollateral types.Currency       `json:"usedCollateral"`
+		ContractPrice  types.Currency       `json:"contractPrice"` // price of the contract creation as charged by the host
+		MinerFee       types.Currency       `json:"minerFee"`      // miner fee spent on formation txn
 
 		// Good determines whether a contract is good or bad. A contract that
 		// is not good, will have its data migrated to a new contract.
@@ -110,9 +112,9 @@ type (
 		// A contract can be bad for multiple reasons such as the host being
 		// considered bad or failing to renew when being too close to its
 		// ProofHeight. This field is set by the contract maintenance code.
-		Good bool `json:"good"`
-
-		LastBroadcastAttempt time.Time `json:"lastBroadcastAttempt"`
+		Good     bool             `json:"good"`
+		State    ContractState    `json:"state"`
+		Spending ContractSpending `json:"spending"`
 	}
 
 	// ContractSettings contains various settings used by the manager for

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -86,11 +86,11 @@ type (
 		Formation   time.Time            `json:"formation"`
 		RenewedFrom types.FileContractID `json:"renewedFrom"`
 
-		// state fields
+		// event tracking fields
 		LastPrune            time.Time `json:"lastPrune"`
 		LastBroadcastAttempt time.Time `json:"lastBroadcastAttempt"`
 
-		// revision fields
+		// revision fields, updated on refresh/renewal
 		RevisionNumber     uint64         `json:"revisionNumber"`     // current revision number
 		ProofHeight        uint64         `json:"proofHeight"`        // start of the contract's proof window
 		ExpirationHeight   uint64         `json:"expirationHeight"`   // end of the contract's proof window
@@ -106,6 +106,8 @@ type (
 		ContractPrice  types.Currency       `json:"contractPrice"` // price of the contract creation as charged by the host
 		MinerFee       types.Currency       `json:"minerFee"`      // miner fee spent on formation txn
 
+		// state fields, reset on refresh/renewal
+		//
 		// Good determines whether a contract is good or bad. A contract that
 		// is not good, will have its data migrated to a new contract.
 		//

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -259,7 +259,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		contract := res.Contract
 		minerFee := res.FormationSet.Transactions[len(res.FormationSet.Transactions)-1].MinerFee
 
-		err = cm.store.AddFormedContract(ctx, contract.ID, host.PublicKey, contract.Revision.ProofHeight, contract.Revision.ExpirationHeight, host.Settings.Prices.ContractPrice, allowance, minerFee, contract.Revision.TotalCollateral)
+		err = cm.store.AddFormedContract(ctx, host.PublicKey, contract.ID, contract.Revision, host.Settings.Prices.ContractPrice, allowance, minerFee)
 		if err != nil {
 			formationLog.Error("failed to add formed contract", zap.Error(err))
 			continue

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -340,7 +340,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	formContract := func(hostKey types.PublicKey, good bool) {
 		t.Helper()
 
-		err := store.AddFormedContract(context.Background(), hostKey, types.FileContractID(hostKey), newTestContract(hostKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
+		err := store.AddFormedContract(context.Background(), hostKey, types.FileContractID(hostKey), newTestRevision(hostKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -487,7 +487,7 @@ func TestInitialContractFunding(t *testing.T) {
 	}
 }
 
-func newTestContract(hk types.PublicKey) types.V2FileContract {
+func newTestRevision(hk types.PublicKey) types.V2FileContract {
 	return types.V2FileContract{
 		HostPublicKey:    hk,
 		Capacity:         200,

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -339,7 +339,8 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	formContract := func(hostKey types.PublicKey, good bool) {
 		t.Helper()
-		err := store.AddFormedContract(context.Background(), types.FileContractID(hostKey), hostKey, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4))
+
+		err := store.AddFormedContract(context.Background(), hostKey, types.FileContractID(hostKey), newTestContract(hostKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -483,5 +484,18 @@ func TestInitialContractFunding(t *testing.T) {
 		t.Fatalf("expected allowance %v, got %v", minAllowance, allowance)
 	} else if !collateral.Equals(maxCollateral) {
 		t.Fatalf("expected collateral %v, got %v", maxCollateral, collateral)
+	}
+}
+
+func newTestContract(hk types.PublicKey) types.V2FileContract {
+	return types.V2FileContract{
+		HostPublicKey:    hk,
+		Capacity:         200,
+		Filesize:         100,
+		FileMerkleRoot:   types.Hash256{1},
+		ProofHeight:      400,
+		ExpirationHeight: 800,
+		RevisionNumber:   1,
+		TotalCollateral:  types.Siacoins(100),
 	}
 }

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -65,8 +65,8 @@ type (
 	// Store is the minimal interface of Store functionality the ContractManager
 	// requires.
 	Store interface {
-		AddFormedContract(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, proofHeight, expirationHeight uint64, contractPrice, allowance, minerFee, totalCollateral types.Currency) error
-		AddRenewedContract(ctx context.Context, params AddRenewedContractParams) error
+		AddFormedContract(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, revision types.V2FileContract, contractPrice, allowance, minerFee types.Currency) error
+		AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, revision types.V2FileContract, contractPrice, minerFee, usedCollateral types.Currency) error
 		ContractElement(ctx context.Context, contractID types.FileContractID) (types.V2FileContractElement, error)
 		ContractElementsForBroadcast(ctx context.Context, maxBlocksSinceExpiry uint64) ([]types.V2FileContractElement, error)
 		Contracts(ctx context.Context, offset, limit int, queryOpts ...ContractQueryOpt) ([]Contract, error)

--- a/contracts/manager_test.go
+++ b/contracts/manager_test.go
@@ -25,7 +25,7 @@ func TestBlockBadHosts(t *testing.T) {
 
 	// form a contract with each host except the unused one
 	for _, host := range []hosts.Host{goodHost, badHost} {
-		err := store.AddFormedContract(context.Background(), host.PublicKey, types.FileContractID(host.PublicKey), newTestContract(host.PublicKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
+		err := store.AddFormedContract(context.Background(), host.PublicKey, types.FileContractID(host.PublicKey), newTestRevision(host.PublicKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/contracts/manager_test.go
+++ b/contracts/manager_test.go
@@ -25,7 +25,7 @@ func TestBlockBadHosts(t *testing.T) {
 
 	// form a contract with each host except the unused one
 	for _, host := range []hosts.Host{goodHost, badHost} {
-		err := store.AddFormedContract(context.Background(), types.FileContractID(host.PublicKey), host.PublicKey, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4))
+		err := store.AddFormedContract(context.Background(), host.PublicKey, types.FileContractID(host.PublicKey), newTestContract(host.PublicKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -136,17 +136,7 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 	renewed := res.Contract
 	minerFee := res.RenewalSet.Transactions[len(res.RenewalSet.Transactions)-1].MinerFee
 
-	if err := cm.store.AddRenewedContract(ctx, AddRenewedContractParams{
-		RenewedFrom:      contract.ID,
-		RenewedTo:        renewed.ID,
-		ProofHeight:      renewed.Revision.ProofHeight,
-		ExpirationHeight: renewed.Revision.ExpirationHeight,
-		ContractPrice:    host.Settings.Prices.ContractPrice,
-		Allowance:        renewed.Revision.RenterOutput.Value,
-		MinerFee:         minerFee,
-		UsedCollateral:   res.Contract.Revision.MissedHostValue,
-		TotalCollateral:  renewed.Revision.TotalCollateral,
-	}); err != nil {
+	if err := cm.store.AddRenewedContract(ctx, contract.ID, renewed.ID, renewed.Revision, host.Settings.Prices.ContractPrice, minerFee, renewed.Revision.MissedHostValue); err != nil {
 		return fmt.Errorf("failed to store renewed contract: %w", err)
 	}
 

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -81,11 +81,11 @@ func TestPerformContractRefreshes(t *testing.T) {
 
 	formContract := func(contractID types.FileContractID, hostKey types.PublicKey, good, oof, ooc bool) {
 		t.Helper()
-		contract := newTestContract(hostKey)
-		contract.ProofHeight = proofHeight
-		contract.ExpirationHeight = expirationHeight
-		contract.TotalCollateral = totalCollateral
-		err := store.AddFormedContract(context.Background(), hostKey, contractID, contract, types.Siacoins(1), initialAllowance, types.Siacoins(3))
+		revision := newTestRevision(hostKey)
+		revision.ProofHeight = proofHeight
+		revision.ExpirationHeight = expirationHeight
+		revision.TotalCollateral = totalCollateral
+		err := store.AddFormedContract(context.Background(), hostKey, contractID, revision, types.Siacoins(1), initialAllowance, types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -81,7 +81,11 @@ func TestPerformContractRefreshes(t *testing.T) {
 
 	formContract := func(contractID types.FileContractID, hostKey types.PublicKey, good, oof, ooc bool) {
 		t.Helper()
-		err := store.AddFormedContract(context.Background(), contractID, hostKey, proofHeight, expirationHeight, types.Siacoins(1), initialAllowance, types.Siacoins(3), totalCollateral)
+		contract := newTestContract(hostKey)
+		contract.ProofHeight = proofHeight
+		contract.ExpirationHeight = expirationHeight
+		contract.TotalCollateral = totalCollateral
+		err := store.AddFormedContract(context.Background(), hostKey, contractID, contract, types.Siacoins(1), initialAllowance, types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -113,17 +113,7 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 	renewed := res.Contract
 	minerFee := res.RenewalSet.Transactions[len(res.RenewalSet.Transactions)-1].MinerFee
 
-	if err := cm.store.AddRenewedContract(ctx, AddRenewedContractParams{
-		RenewedFrom:      contract.ID,
-		RenewedTo:        renewed.ID,
-		ProofHeight:      renewed.Revision.ProofHeight,
-		ExpirationHeight: renewed.Revision.ExpirationHeight,
-		ContractPrice:    host.Settings.Prices.ContractPrice,
-		Allowance:        renewed.Revision.RenterOutput.Value,
-		MinerFee:         minerFee,
-		UsedCollateral:   types.ZeroCurrency,
-		TotalCollateral:  renewed.Revision.TotalCollateral,
-	}); err != nil {
+	if err := cm.store.AddRenewedContract(ctx, contract.ID, renewed.ID, renewed.Revision, host.Settings.Prices.ContractPrice, minerFee, types.ZeroCurrency); err != nil {
 		return fmt.Errorf("failed to store renewed contract: %w", err)
 	}
 

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -68,10 +68,10 @@ func TestPerformContractRenewals(t *testing.T) {
 	blockHeight := cmMock.state.Index.Height
 	formContract := func(contractID types.FileContractID, hostKey types.PublicKey, good bool) {
 		t.Helper()
-		contract := newTestContract(hostKey)
-		contract.ProofHeight = blockHeight + renewWindow + 1
-		contract.ExpirationHeight = 9999
-		err := store.AddFormedContract(context.Background(), hostKey, contractID, contract, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
+		revision := newTestRevision(hostKey)
+		revision.ProofHeight = blockHeight + renewWindow + 1
+		revision.ExpirationHeight = 9999
+		err := store.AddFormedContract(context.Background(), hostKey, contractID, revision, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -190,7 +190,7 @@ func TestSyncRevisionState(t *testing.T) {
 	hostKey := types.PublicKey(contractID)
 	hc := dialer.HostClient(hostKey)
 	store.hosts = map[types.PublicKey]hosts.Host{hostKey: {PublicKey: hostKey}}
-	err := store.AddFormedContract(context.Background(), hostKey, contractID, newTestContract(hostKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
+	err := store.AddFormedContract(context.Background(), hostKey, contractID, newTestRevision(hostKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -68,7 +68,10 @@ func TestPerformContractRenewals(t *testing.T) {
 	blockHeight := cmMock.state.Index.Height
 	formContract := func(contractID types.FileContractID, hostKey types.PublicKey, good bool) {
 		t.Helper()
-		err := store.AddFormedContract(context.Background(), contractID, hostKey, blockHeight+renewWindow+1, 9999, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4))
+		contract := newTestContract(hostKey)
+		contract.ProofHeight = blockHeight + renewWindow + 1
+		contract.ExpirationHeight = 9999
+		err := store.AddFormedContract(context.Background(), hostKey, contractID, contract, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -184,11 +187,10 @@ func TestSyncRevisionState(t *testing.T) {
 
 	// add a host and contract
 	contractID := types.FileContractID{1}
-	hc := dialer.HostClient(types.PublicKey(contractID))
-	store.hosts = map[types.PublicKey]hosts.Host{
-		types.PublicKey(contractID): {PublicKey: types.PublicKey(contractID)},
-	}
-	err := store.AddFormedContract(context.Background(), contractID, types.PublicKey(contractID), 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4))
+	hostKey := types.PublicKey(contractID)
+	hc := dialer.HostClient(hostKey)
+	store.hosts = map[types.PublicKey]hosts.Host{hostKey: {PublicKey: hostKey}}
+	err := store.AddFormedContract(context.Background(), hostKey, contractID, newTestContract(hostKey), types.Siacoins(1), types.Siacoins(2), types.Siacoins(3))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -11,7 +11,6 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
-	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
@@ -214,13 +213,9 @@ func TestHostAccountsForFunding(t *testing.T) {
 		return
 	}
 
-	// add a host
-	hk1 := types.PublicKey{1}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk1, nil, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	// add two host
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	// assert there are no accounts to fund
 	accounts, err := store.HostAccountsForFunding(context.Background(), hk1, 10)
@@ -276,14 +271,6 @@ func TestHostAccountsForFunding(t *testing.T) {
 		t.Fatal("expected no accounts")
 	}
 
-	// add another host
-	hk2 := types.PublicKey{2}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk2, nil, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
-
 	// add another account
 	ak2 := types.PublicKey{2, 2}
 	if err := store.AddAccount(context.Background(), ak2); err != nil {
@@ -329,15 +316,8 @@ func TestHostAccountsForFunding(t *testing.T) {
 func TestUpdateHostAccounts(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// add a host
-	hk := types.GeneratePrivateKey().PublicKey()
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, nil, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// add an account
+	// add a host and an account
+	hk := store.addTestHost(t)
 	ak := types.GeneratePrivateKey().PublicKey()
 	if err := store.AddAccount(context.Background(), ak); err != nil {
 		t.Fatal(err)

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -317,7 +317,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accounts) != 1 {
-		t.Fatal("expected one accounts")
+		t.Fatal("expected one accounts", len(accounts))
 	}
 
 	// assert the updates inserted all accounts

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -317,7 +317,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accounts) != 1 {
-		t.Fatal("expected one accounts", len(accounts))
+		t.Fatal("expected one accounts")
 	}
 
 	// assert the updates inserted all accounts

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AddFormedContract adds a freshly formed contract to the database.
-func (s *Store) AddFormedContract(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, contract types.V2FileContract, contractPrice, allowance, minerFee types.Currency) error {
+func (s *Store) AddFormedContract(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, revision types.V2FileContract, contractPrice, allowance, minerFee types.Currency) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		var hostID int64
 		if err := tx.QueryRow(ctx, `SELECT id FROM hosts WHERE public_key = $1`, sqlPublicKey(hostKey)).Scan(&hostID); errors.Is(err, sql.ErrNoRows) {
@@ -22,7 +22,7 @@ func (s *Store) AddFormedContract(ctx context.Context, hostKey types.PublicKey, 
 			return fmt.Errorf("failed to fetch host: %w", err)
 		}
 		resp, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, remaining_allowance, miner_fee, total_collateral, raw_revision) VALUES ($1, $2, $3, $4, $5, $6, $6, $7, $8, $9)`,
-			hostID, sqlHash256(contractID), contract.ProofHeight, contract.ExpirationHeight, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(contract.TotalCollateral), sqlFileContract(contract))
+			hostID, sqlHash256(contractID), revision.ProofHeight, revision.ExpirationHeight, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(revision.TotalCollateral), sqlFileContract(revision))
 		if err != nil {
 			return fmt.Errorf("failed to add formed contract to database: %w", err)
 		} else if resp.RowsAffected() != 1 {

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -21,8 +21,8 @@ func (s *Store) AddFormedContract(ctx context.Context, hostKey types.PublicKey, 
 		} else if err != nil {
 			return fmt.Errorf("failed to fetch host: %w", err)
 		}
-		resp, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, remaining_allowance, miner_fee, total_collateral, raw_revision) VALUES ($1, $2, $3, $4, $5, $6, $6, $7, $8, $9)`,
-			hostID, sqlHash256(contractID), revision.ProofHeight, revision.ExpirationHeight, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(revision.TotalCollateral), sqlFileContract(revision))
+		resp, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, capacity, size, revision_number, contract_price, initial_allowance, remaining_allowance, miner_fee, total_collateral, raw_revision) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $9, $10, $11, $12)`,
+			hostID, sqlHash256(contractID), revision.ProofHeight, revision.ExpirationHeight, revision.Capacity, revision.Filesize, revision.RevisionNumber, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(revision.TotalCollateral), sqlFileContract(revision))
 		if err != nil {
 			return fmt.Errorf("failed to add formed contract to database: %w", err)
 		} else if resp.RowsAffected() != 1 {
@@ -44,17 +44,20 @@ func (s *Store) AddFormedContract(ctx context.Context, hostKey types.PublicKey, 
 func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, revision types.V2FileContract, contractPrice, minerFee, usedCollateral types.Currency) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		_, err := tx.Exec(ctx, `
-INSERT INTO contracts(host_id, contract_id, proof_height, expiration_height, renewed_from, capacity, size, contract_price, initial_allowance, remaining_allowance, miner_fee, used_collateral, total_collateral, raw_revision)
-(SELECT host_id, $1, $2, $3, contract_id, CASE WHEN $2 = proof_height THEN capacity ELSE size END, size, $4, $5, $5, $6, $7, $8, $9 FROM contracts WHERE contract_id = $10)`,
+INSERT INTO contracts(host_id, contract_id, renewed_from, raw_revision, revision_number, proof_height, expiration_height, capacity, size, initial_allowance, remaining_allowance, total_collateral, used_collateral, contract_price, miner_fee)
+(SELECT host_id, $1, contract_id, $2, $3, $4, $5, $6, $7, $8, $8, $9, $10, $11, $12 FROM contracts WHERE contract_id = $13)`,
 			sqlHash256(renewedTo),
+			sqlFileContract(revision),
+			revision.RevisionNumber,
 			revision.ProofHeight,
 			revision.ExpirationHeight,
-			sqlCurrency(contractPrice),
-			sqlCurrency(revision.RenterOutput.Value),
-			sqlCurrency(minerFee),
-			sqlCurrency(usedCollateral),
+			revision.Capacity,
+			revision.Filesize,
+			sqlCurrency(revision.RenterOutput.Value), // initial & remaining allowance
 			sqlCurrency(revision.TotalCollateral),
-			sqlFileContract(revision),
+			sqlCurrency(usedCollateral),
+			sqlCurrency(contractPrice),
+			sqlCurrency(minerFee),
 			sqlHash256(renewedFrom),
 		)
 		if err != nil {

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AddFormedContract adds a freshly formed contract to the database.
-func (s *Store) AddFormedContract(ctx context.Context, contractID types.FileContractID, hostKey types.PublicKey, proofHeight, expirationHeight uint64, contractPrice, allowance, minerFee, totalCollateral types.Currency) error {
+func (s *Store) AddFormedContract(ctx context.Context, hostKey types.PublicKey, contractID types.FileContractID, contract types.V2FileContract, contractPrice, allowance, minerFee types.Currency) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		var hostID int64
 		if err := tx.QueryRow(ctx, `SELECT id FROM hosts WHERE public_key = $1`, sqlPublicKey(hostKey)).Scan(&hostID); errors.Is(err, sql.ErrNoRows) {
@@ -21,8 +21,8 @@ func (s *Store) AddFormedContract(ctx context.Context, contractID types.FileCont
 		} else if err != nil {
 			return fmt.Errorf("failed to fetch host: %w", err)
 		}
-		resp, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, remaining_allowance, miner_fee, total_collateral) VALUES ($1, $2, $3, $4, $5, $6, $6, $7, $8)`,
-			hostID, sqlHash256(contractID), proofHeight, expirationHeight, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(totalCollateral))
+		resp, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, remaining_allowance, miner_fee, total_collateral, raw_revision) VALUES ($1, $2, $3, $4, $5, $6, $6, $7, $8, $9)`,
+			hostID, sqlHash256(contractID), contract.ProofHeight, contract.ExpirationHeight, sqlCurrency(contractPrice), sqlCurrency(allowance), sqlCurrency(minerFee), sqlCurrency(contract.TotalCollateral), sqlFileContract(contract))
 		if err != nil {
 			return fmt.Errorf("failed to add formed contract to database: %w", err)
 		} else if resp.RowsAffected() != 1 {
@@ -41,37 +41,38 @@ func (s *Store) AddFormedContract(ctx context.Context, contractID types.FileCont
 // AddRenewedContract adds a renewed contract to the database. It will update
 // the renewed contract and point it to the renewal, as well as update the
 // contract id in the contract sectors map.
-func (s *Store) AddRenewedContract(ctx context.Context, params contracts.AddRenewedContractParams) error {
+func (s *Store) AddRenewedContract(ctx context.Context, renewedFrom, renewedTo types.FileContractID, revision types.V2FileContract, contractPrice, minerFee, usedCollateral types.Currency) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		_, err := tx.Exec(ctx, `
-INSERT INTO contracts(host_id, contract_id, proof_height, expiration_height, renewed_from, capacity, size, contract_price, initial_allowance, remaining_allowance, miner_fee, used_collateral, total_collateral)
-(SELECT host_id, $1, $2, $3, contract_id, CASE WHEN $2 = proof_height THEN capacity ELSE size END, size, $4, $5, $5, $6, $7, $8 FROM contracts WHERE contract_id = $9)`,
-			sqlHash256(params.RenewedTo),
-			params.ProofHeight,
-			params.ExpirationHeight,
-			sqlCurrency(params.ContractPrice),
-			sqlCurrency(params.Allowance),
-			sqlCurrency(params.MinerFee),
-			sqlCurrency(params.UsedCollateral),
-			sqlCurrency(params.TotalCollateral),
-			sqlHash256(params.RenewedFrom),
+INSERT INTO contracts(host_id, contract_id, proof_height, expiration_height, renewed_from, capacity, size, contract_price, initial_allowance, remaining_allowance, miner_fee, used_collateral, total_collateral, raw_revision)
+(SELECT host_id, $1, $2, $3, contract_id, CASE WHEN $2 = proof_height THEN capacity ELSE size END, size, $4, $5, $5, $6, $7, $8, $9 FROM contracts WHERE contract_id = $10)`,
+			sqlHash256(renewedTo),
+			revision.ProofHeight,
+			revision.ExpirationHeight,
+			sqlCurrency(contractPrice),
+			sqlCurrency(revision.RenterOutput.Value),
+			sqlCurrency(minerFee),
+			sqlCurrency(usedCollateral),
+			sqlCurrency(revision.TotalCollateral),
+			sqlFileContract(revision),
+			sqlHash256(renewedFrom),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to add renewal to database: %w", err)
 		}
 
-		res, err := tx.Exec(ctx, `UPDATE contracts SET renewed_to = $1 WHERE contract_id = $2`, sqlHash256(params.RenewedTo), sqlHash256(params.RenewedFrom))
+		res, err := tx.Exec(ctx, `UPDATE contracts SET renewed_to = $1 WHERE contract_id = $2`, sqlHash256(renewedTo), sqlHash256(renewedFrom))
 		if err != nil {
 			return fmt.Errorf("failed to update renewed contract: %w", err)
 		} else if res.RowsAffected() != 1 {
 			return fmt.Errorf("expected 1 row to be affected, got %d", res.RowsAffected())
 		}
 
-		res, err = tx.Exec(ctx, `UPDATE contract_sectors_map SET contract_id = $1 WHERE contract_id = $2`, sqlHash256(params.RenewedTo), sqlHash256(params.RenewedFrom))
+		res, err = tx.Exec(ctx, `UPDATE contract_sectors_map SET contract_id = $1 WHERE contract_id = $2`, sqlHash256(renewedTo), sqlHash256(renewedFrom))
 		if err != nil {
 			return fmt.Errorf("failed to update contract sectors map: %w", err)
 		} else if res.RowsAffected() != 1 {
-			return fmt.Errorf("failed to update contract sectors map, no entry found for contract %v", sqlHash256(params.RenewedFrom))
+			return fmt.Errorf("failed to update contract sectors map, no entry found for contract %v", sqlHash256(renewedFrom))
 		}
 		return nil
 	})

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -33,16 +33,9 @@ func TestContracts(t *testing.T) {
 	}
 
 	// add three contracts
-	fcid1 := types.FileContractID{1}
-	fcid2 := types.FileContractID{2}
-	fcid3 := types.FileContractID{3}
-	if err := errors.Join(
-		store.AddFormedContract(context.Background(), hk, fcid1, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk, fcid2, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk, fcid3, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-	); err != nil {
-		t.Fatal(err)
-	}
+	fcid1 := store.addTestContract(t, hk, types.FileContractID{1})
+	fcid2 := store.addTestContract(t, hk, types.FileContractID{2})
+	fcid3 := store.addTestContract(t, hk, types.FileContractID{3})
 
 	// mark the second one resolved so it's considered inactive
 	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
@@ -122,11 +115,10 @@ func TestContractElement(t *testing.T) {
 	}
 
 	// add a contract and an element
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	} else if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+	fcid := store.addTestContract(t, hk)
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.UpdateContractElements(types.V2FileContractElement{
-			ID: types.FileContractID(hk),
+			ID: fcid,
 			StateElement: types.StateElement{
 				LeafIndex:   1,
 				MerkleProof: []types.Hash256{{1}},
@@ -141,7 +133,7 @@ func TestContractElement(t *testing.T) {
 	}
 
 	// assert contract element is found
-	_, err = store.ContractElement(context.Background(), types.FileContractID(hk))
+	_, err = store.ContractElement(context.Background(), fcid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,14 +220,8 @@ func TestContractsForBroadcasting(t *testing.T) {
 	}
 
 	// add two contracts
-	fcid1 := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, fcid1, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
-	fcid2 := types.FileContractID{2}
-	if err := store.AddFormedContract(context.Background(), hk, fcid2, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
+	fcid1 := store.addTestContract(t, hk, types.FileContractID{1})
+	fcid2 := store.addTestContract(t, hk, types.FileContractID{2})
 
 	// tweak timestamp to assert order next
 	now := time.Now()
@@ -531,14 +517,8 @@ func TestPrunableContractRoots(t *testing.T) {
 	}
 
 	// add a contract for each host
-	fcid1 := types.FileContractID{1}
-	fcid2 := types.FileContractID{2}
-	if err := errors.Join(
-		store.AddFormedContract(context.Background(), hk1, fcid1, newTestRevision(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk2, fcid2, newTestRevision(hk2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-	); err != nil {
-		t.Fatal(err)
-	}
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID{1})
+	fcid2 := store.addTestContract(t, hk2, types.FileContractID{2})
 
 	// prepare roots
 	roots := []types.Hash256{
@@ -953,11 +933,7 @@ func TestRejectContracts(t *testing.T) {
 	// form 3 contracts
 	now := time.Now()
 	for i := range 3 {
-		contractID := types.FileContractID{byte(i + 1)}
-		err = store.AddFormedContract(context.Background(), hk, contractID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-		if err != nil {
-			t.Fatal("failed to add formed contract", err)
-		}
+		contractID := store.addTestContract(t, hk, types.FileContractID{byte(i + 1)})
 		switch i {
 		case 0:
 			updateStateAndFormation(contractID, contracts.ContractStatePending, now) // recently formed
@@ -1050,9 +1026,7 @@ func TestUpdateContractElement(t *testing.T) {
 	assertKnownContract(false)
 
 	// add a contract
-	if err := store.AddFormedContract(context.Background(), hk, fce.ID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
+	store.addTestContract(t, hk, fce.ID)
 	assertKnownContract(true)
 
 	updateElement := func() {
@@ -1125,12 +1099,8 @@ func TestUpdateContractState(t *testing.T) {
 		}
 	}
 
-	// add a contract
-	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
-
 	// run tests
+	store.addTestContract(t, hk, contractID)
 	assertState(contracts.ContractStatePending) // fresh contract state
 	updateState(contracts.ContractStateActive)  // set to active
 	assertState(contracts.ContractStateActive)  // assert active
@@ -1254,13 +1224,8 @@ func TestMarkBroadcastAttempt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// add a contract
-	fcid := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
-
 	// assert broadcast attempt is defaulted
+	fcid := store.addTestContract(t, hk)
 	contract, err := store.Contract(context.Background(), fcid)
 	if err != nil {
 		t.Fatal(err)
@@ -1295,13 +1260,8 @@ func TestSyncContract(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// add a contract
-	contractID := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
-
 	// helper to sync and assert contract
+	contractID := store.addTestContract(t, hk, types.FileContractID{1})
 	assertContract := func(params contracts.ContractSyncParams) {
 		t.Helper()
 		if err := store.SyncContract(context.Background(), contractID, params); err != nil {
@@ -1576,6 +1536,24 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 			}
 		})
 	}
+}
+
+func (s *Store) addTestContract(t *testing.T, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
+	var fcid types.FileContractID
+	switch len(fcids) {
+	case 0:
+		fcid = types.FileContractID(hk)
+	case 1:
+		fcid = fcids[0]
+	default:
+		panic("developer error")
+	}
+
+	err := s.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fcid
 }
 
 func newTestRevision(hk types.PublicKey) types.V2FileContract {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -721,22 +722,23 @@ func TestFormRenewContract(t *testing.T) {
 
 	// add a host
 	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// helper to assert contract in db
+	// define helper to assert contract in db
 	assertContract := func(id types.FileContractID, expected contracts.Contract) {
 		t.Helper()
+
 		contract, err := store.Contract(context.Background(), id)
 		if err != nil {
 			t.Fatal("failed to fetch contract", err)
 		} else if contract.Formation.Before(start) || contract.Formation.After(time.Now().Round(time.Microsecond)) {
 			t.Fatalf("expected formation time to be after start time but not in the future")
 		}
+
 		contract.Formation = time.Time{}
 		contract.LastBroadcastAttempt = time.Time{}
 		if !reflect.DeepEqual(contract, expected) {
@@ -744,63 +746,62 @@ func TestFormRenewContract(t *testing.T) {
 		}
 	}
 
-	// form contract
-	expectedFormed := contracts.Contract{
-		ID:               types.FileContractID{1, 2, 3},
-		HostKey:          hk,
-		ProofHeight:      100,
-		ExpirationHeight: 200,
-		State:            contracts.ContractStatePending,
-
-		ContractPrice:      types.Siacoins(1),
-		InitialAllowance:   types.Siacoins(2),
-		RemainingAllowance: types.Siacoins(2),
-		MinerFee:           types.Siacoins(3),
-		TotalCollateral:    types.Siacoins(4),
-
-		Good: true,
-	}
-	revision := newTestRevision(hk)
-	revision.ProofHeight = expectedFormed.ProofHeight
-	revision.ExpirationHeight = expectedFormed.ExpirationHeight
-	revision.TotalCollateral = expectedFormed.TotalCollateral
-	err = store.AddFormedContract(context.Background(), hk, expectedFormed.ID, revision, expectedFormed.ContractPrice, expectedFormed.InitialAllowance, expectedFormed.MinerFee)
-	if err != nil {
-		t.Fatal("failed to add formed contract", err)
-	}
-	assertContract(expectedFormed.ID, expectedFormed)
-
-	// assert `contract_sectors_map` entry was created when forming a contract
-	var mapID int64
-	err = store.pool.QueryRow(context.Background(), `SELECT id FROM contract_sectors_map WHERE contract_id = $1`, sqlHash256(expectedFormed.ID)).Scan(&mapID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// simulate using the contract and marking it not good
-	modifyContract := func(contractID types.FileContractID) {
-		err = store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
-			resp, err := tx.Exec(context.Background(), `
-					UPDATE contracts
-					SET state = 1, capacity = 2000, size = 1000, good = FALSE, append_sector_spending = 1, free_sector_spending = 2, fund_account_spending = 3, sector_roots_spending = 4
-					WHERE contract_id = $1
-					`, sqlHash256(contractID))
+	// define helper to simulate contract usage
+	simulateUsage := func(contractID types.FileContractID) {
+		t.Helper()
+		if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
+			resp, err := tx.Exec(context.Background(), `UPDATE contracts SET state = 1, good = FALSE, append_sector_spending = 1, free_sector_spending = 2, fund_account_spending = 3, sector_roots_spending = 4 WHERE contract_id = $1`, sqlHash256(contractID))
 			if err != nil {
 				return err
 			} else if resp.RowsAffected() != 1 {
 				t.Fatalf("expected 1 row to be affected, got %d", resp.RowsAffected())
 			}
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	modifyContract(expectedFormed.ID)
 
+	// form contract
+	formation := newTestRevision(hk)
+	formation.RenterOutput.Value = types.NewCurrency64(math.MaxUint64) // initial allowance
+
+	expectedFormed := contracts.Contract{
+		ID:      types.FileContractID{1},
+		HostKey: hk,
+		State:   contracts.ContractStatePending,
+
+		// revision fields
+		RevisionNumber:     formation.RevisionNumber,
+		ProofHeight:        formation.ProofHeight,
+		ExpirationHeight:   formation.ExpirationHeight,
+		Capacity:           formation.Capacity,
+		Size:               formation.Filesize,
+		InitialAllowance:   formation.RenterOutput.Value,
+		RemainingAllowance: formation.RenterOutput.Value,
+		TotalCollateral:    formation.TotalCollateral,
+
+		ContractPrice: types.Siacoins(1),
+		MinerFee:      types.Siacoins(2),
+
+		Good: true,
+	}
+	if err := store.AddFormedContract(context.Background(), hk, expectedFormed.ID, formation, expectedFormed.ContractPrice, expectedFormed.InitialAllowance, expectedFormed.MinerFee); err != nil {
+		t.Fatal("failed to add formed contract", err)
+	}
+
+	// assert the contract matches the expectations
+	assertContract(expectedFormed.ID, expectedFormed)
+
+	// assert the contract sector mapping exists
+	var mapID int64
+	if err := store.pool.QueryRow(context.Background(), `SELECT id FROM contract_sectors_map WHERE contract_id = $1`, sqlHash256(expectedFormed.ID)).Scan(&mapID); err != nil {
+		t.Fatal(err)
+	}
+
+	// simulate usage, assert the contract is active, bad and has spending
+	simulateUsage(expectedFormed.ID)
 	expectedFormed.State = contracts.ContractStateActive
-	expectedFormed.Capacity = 2000
-	expectedFormed.Size = 1000
 	expectedFormed.Good = false
 	expectedFormed.Spending = contracts.ContractSpending{
 		AppendSector: types.NewCurrency64(1),
@@ -810,34 +811,37 @@ func TestFormRenewContract(t *testing.T) {
 	}
 	assertContract(expectedFormed.ID, expectedFormed)
 
-	// refresh the contract
+	// prepare a refresh of the contract, we want to assert spending gets reset,
+	// refreshed contracts are good and the renewed from is set
+	refresh := formation
+	refresh.RenterOutput.Value = types.NewCurrency64(math.MaxUint64) // new initial allowance
+
 	expectedRefreshed := contracts.Contract{
-		ID:                 types.FileContractID{4, 5, 6},
-		Capacity:           expectedFormed.Capacity,         // same capacity after refresh
-		Size:               expectedFormed.Size,             // same size after refresh
-		HostKey:            expectedFormed.HostKey,          // same host
-		ProofHeight:        expectedFormed.ProofHeight,      // same proof height for refresh
-		ExpirationHeight:   expectedFormed.ExpirationHeight, // same expiration height for refresh
-		State:              contracts.ContractStatePending,  // refresh resets state
-		ContractPrice:      types.Siacoins(2),               // new contract price
-		InitialAllowance:   types.Siacoins(3),               // new initial allowance
-		RemainingAllowance: types.Siacoins(3),               // matches initial allowance
-		MinerFee:           types.Siacoins(4),               // new miner fee
-		Good:               true,                            // refreshed contract is good
-		RenewedFrom:        expectedFormed.ID,               // refreshed from formed contract
-		Spending:           contracts.ContractSpending{},    // spending is reset
-		UsedCollateral:     types.Siacoins(4),
-		TotalCollateral:    types.Siacoins(5),
+		ID:          types.FileContractID{2},
+		HostKey:     expectedFormed.HostKey, // same host
+		RenewedFrom: expectedFormed.ID,      // refreshed from formed contract
+
+		// revision fields
+		RevisionNumber:     refresh.RevisionNumber,
+		ProofHeight:        refresh.ProofHeight,
+		ExpirationHeight:   refresh.ExpirationHeight,
+		Capacity:           refresh.Capacity,
+		Size:               refresh.Filesize,
+		InitialAllowance:   refresh.RenterOutput.Value,
+		RemainingAllowance: refresh.RenterOutput.Value,
+		TotalCollateral:    refresh.TotalCollateral,
+
+		UsedCollateral: refresh.TotalCollateral.Div64(2), // updated used collateral
+		ContractPrice:  types.Siacoins(2),                // new contract price
+		MinerFee:       types.Siacoins(4),                // new miner fee
+
+		State: contracts.ContractStatePending, // refresh resets state
+		Good:  true,                           // refreshed contract is good
+
+		Spending: contracts.ContractSpending{}, // spending is reset
 	}
 
-	renewed := newTestRevision(hk)
-	renewed.ProofHeight = expectedRefreshed.ProofHeight
-	renewed.ExpirationHeight = expectedRefreshed.ExpirationHeight
-	renewed.TotalCollateral = expectedRefreshed.TotalCollateral
-	renewed.RenterOutput.Value = expectedRefreshed.InitialAllowance
-
-	err = store.AddRenewedContract(context.Background(), expectedRefreshed.RenewedFrom, expectedRefreshed.ID, renewed, expectedRefreshed.ContractPrice, expectedRefreshed.MinerFee, expectedRefreshed.UsedCollateral)
-	if err != nil {
+	if err := store.AddRenewedContract(context.Background(), expectedRefreshed.RenewedFrom, expectedRefreshed.ID, refresh, expectedRefreshed.ContractPrice, expectedRefreshed.MinerFee, expectedRefreshed.UsedCollateral); err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}
 	expectedFormed.RenewedTo = expectedRefreshed.ID
@@ -845,10 +849,8 @@ func TestFormRenewContract(t *testing.T) {
 	assertContract(expectedRefreshed.ID, expectedRefreshed)
 
 	// modify the refreshed contract
-	modifyContract(expectedRefreshed.ID)
+	simulateUsage(expectedRefreshed.ID)
 	expectedRefreshed.State = contracts.ContractStateActive
-	expectedRefreshed.Capacity = 2000
-	expectedRefreshed.Size = 1000
 	expectedRefreshed.Good = false
 	expectedRefreshed.Spending = contracts.ContractSpending{
 		AppendSector: types.NewCurrency64(1),
@@ -859,34 +861,39 @@ func TestFormRenewContract(t *testing.T) {
 	assertContract(expectedRefreshed.ID, expectedRefreshed)
 
 	// renew the refreshed contract
+	renewal := refresh
+	renewal.RenterOutput.Value = types.Siacoins(6) // new initial allowance
+	renewal.Capacity = renewal.Filesize            // capacity shrinks to size upon renewal
+	renewal.ProofHeight *= 2                       // higher proof height for renew
+	renewal.ExpirationHeight *= 2                  // higher expiration height for renew
+
 	expectedRenewed := contracts.Contract{
-		ID:                 types.FileContractID{7, 8, 9},
-		Capacity:           expectedRefreshed.Size,                 // capacity shrinks to size upon renewal
-		Size:               expectedRefreshed.Size,                 // same size after renewal
-		HostKey:            expectedRefreshed.HostKey,              // same host
-		ProofHeight:        expectedRefreshed.ProofHeight * 2,      // higher proof height for renew
-		ExpirationHeight:   expectedRefreshed.ExpirationHeight * 2, // higher expiration height for renew
-		State:              contracts.ContractStatePending,         // renewal resets state
-		ContractPrice:      types.Siacoins(5),                      // new contract price
-		InitialAllowance:   types.Siacoins(6),                      // new initial allowance
-		RemainingAllowance: types.Siacoins(6),                      // matches initial allowance
-		MinerFee:           types.Siacoins(7),                      // new miner fee
-		Good:               true,                                   // renewed contract is good
-		RenewedFrom:        expectedRefreshed.ID,                   // renewed from refreshed contract
-		Spending:           contracts.ContractSpending{},           // spending is reset
-		UsedCollateral:     types.Siacoins(4),
-		TotalCollateral:    types.Siacoins(5),
+		ID:          types.FileContractID{7, 8, 9},
+		HostKey:     expectedRefreshed.HostKey, // same host
+		RenewedFrom: expectedRefreshed.ID,      // renewed from refreshed contract
+
+		// revision fields
+		RevisionNumber:     renewal.RevisionNumber,
+		ProofHeight:        renewal.ProofHeight,
+		ExpirationHeight:   renewal.ExpirationHeight,
+		Capacity:           renewal.Capacity,
+		Size:               renewal.Filesize,
+		InitialAllowance:   renewal.RenterOutput.Value,
+		RemainingAllowance: renewal.RenterOutput.Value,
+		TotalCollateral:    renewal.TotalCollateral,
+
+		UsedCollateral: renewal.TotalCollateral.Div64(4), // updated used collateral
+		ContractPrice:  types.Siacoins(5),                // new contract price
+		MinerFee:       types.Siacoins(7),                // new miner fee
+
+		State: contracts.ContractStatePending, // renewal resets state
+		Good:  true,                           // renewed contract is good
+
+		Spending: contracts.ContractSpending{}, // spending is reset
 	}
 
-	renewed = newTestRevision(hk)
-	renewed.ProofHeight = expectedRenewed.ProofHeight
-	renewed.ExpirationHeight = expectedRenewed.ExpirationHeight
-	renewed.TotalCollateral = expectedRenewed.TotalCollateral
-	renewed.RenterOutput.Value = expectedRenewed.InitialAllowance
-
-	err = store.AddRenewedContract(context.Background(), expectedRenewed.RenewedFrom, expectedRenewed.ID, renewed, expectedRenewed.ContractPrice, expectedRenewed.MinerFee, expectedRenewed.UsedCollateral)
-	if err != nil {
-		t.Fatal("failed to add refreshed contract", err)
+	if err := store.AddRenewedContract(context.Background(), expectedRenewed.RenewedFrom, expectedRenewed.ID, renewal, expectedRenewed.ContractPrice, expectedRenewed.MinerFee, expectedRenewed.UsedCollateral); err != nil {
+		t.Fatal("failed to add renewed contract", err)
 	}
 	expectedRefreshed.RenewedTo = expectedRenewed.ID
 	assertContract(expectedFormed.ID, expectedFormed)
@@ -1364,11 +1371,13 @@ func BenchmarkContracts(b *testing.B) {
 
 			hostContractIDs := make([]types.FileContractID, numContractsPerHost)
 			for i := range numContractsPerHost {
+				revision := newTestRevision(hk)
 				frand.Read(hostContractIDs[i][:])
 				size := frand.Uint64n(1e9)
-				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, last_prune, raw_revision) VALUES ($1, $2, 0, 0, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, E'\\x');`,
+				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, last_prune) VALUES ($1, $2, $3, 0, 0, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`,
 					hostID,
 					sqlHash256(hostContractIDs[i][:]),
+					sqlFileContract(revision),
 					sqlCurrency(types.ZeroCurrency),
 					sqlCurrency(types.ZeroCurrency),
 					sqlCurrency(types.ZeroCurrency),
@@ -1575,7 +1584,7 @@ func newTestRevision(hk types.PublicKey) types.V2FileContract {
 		Capacity:         200,
 		Filesize:         100,
 		FileMerkleRoot:   types.Hash256{1},
-		ProofHeight:      400,
+		ProofHeight:      600,
 		ExpirationHeight: 800,
 		RevisionNumber:   1,
 		TotalCollateral:  types.Siacoins(100),

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -11,8 +11,6 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/subscriber"
@@ -24,15 +22,8 @@ import (
 func TestContracts(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// add a host
-	hk := types.PublicKey{1}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// add three contracts
+	// add a host with three contracts
+	hk := store.addTestHost(t)
 	fcid1 := store.addTestContract(t, hk, types.FileContractID{1})
 	fcid2 := store.addTestContract(t, hk, types.FileContractID{2})
 	fcid3 := store.addTestContract(t, hk, types.FileContractID{3})
@@ -100,16 +91,10 @@ func TestContractElement(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// assert contract element is not found
-	_, err = store.ContractElement(context.Background(), types.FileContractID(hk))
+	_, err := store.ContractElement(context.Background(), types.FileContractID(hk))
 	if !errors.Is(err, contracts.ErrNotFound) {
 		t.Fatal(err)
 	}
@@ -143,13 +128,7 @@ func TestContractElementsForBroadcast(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// add a contract
 	fcid := types.FileContractID{1}
@@ -170,7 +149,7 @@ func TestContractElementsForBroadcast(t *testing.T) {
 	}
 
 	// set height to 10 blocks after expiration
-	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: revision.ExpirationHeight + 10})
 	})
 	if err != nil {
@@ -211,15 +190,8 @@ func TestContractElementsForBroadcast(t *testing.T) {
 func TestContractsForBroadcasting(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// add a host
-	hk := types.PublicKey{1}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// add two contracts
+	// add a host with two contracts
+	hk := store.addTestHost(t)
 	fcid1 := store.addTestContract(t, hk, types.FileContractID{1})
 	fcid2 := store.addTestContract(t, hk, types.FileContractID{2})
 
@@ -280,34 +252,29 @@ func TestContractsForBroadcasting(t *testing.T) {
 func TestContractsForFunding(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	var fcidCnt uint8
-	addContract := func(hk types.PublicKey, remaininAllowance types.Currency) types.FileContractID {
+	updateAllowance := func(contractID types.FileContractID, allowance types.Currency) {
 		t.Helper()
-		fcidCnt++
-		fcid := types.FileContractID{byte(fcidCnt)}
-		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, remaininAllowance, types.ZeroCurrency); err != nil {
+		_, err := store.pool.Exec(context.Background(), `UPDATE contracts SET initial_allowance = $1, remaining_allowance = $1 WHERE contract_id = $2`, sqlCurrency(allowance), sqlHash256(contractID))
+		if err != nil {
 			t.Fatal(err)
 		}
-		return fcid
 	}
 
 	// add two hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return errors.Join(
-			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
-			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
-		)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	// add four contracts for h1
-	fcid1 := addContract(hk1, types.Siacoins(1))
-	fcid2 := addContract(hk1, types.Siacoins(3))
-	fcid3 := addContract(hk1, types.Siacoins(2))
-	_ = addContract(hk1, types.ZeroCurrency)
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID{1})
+	fcid2 := store.addTestContract(t, hk1, types.FileContractID{2})
+	fcid3 := store.addTestContract(t, hk1, types.FileContractID{3})
+	fcid4 := store.addTestContract(t, hk1, types.FileContractID{4})
+
+	// update their allowance
+	updateAllowance(fcid1, types.Siacoins(1))
+	updateAllowance(fcid2, types.Siacoins(3))
+	updateAllowance(fcid3, types.Siacoins(2))
+	updateAllowance(fcid4, types.ZeroCurrency)
 
 	// assert only 3 contracts are returned for h1, in order, the fourth has no
 	// remaining allowance and h2 doesn't have contracts yet
@@ -346,8 +313,9 @@ func TestContractsForFunding(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// add a contract for h2
-	fcid5 := addContract(hk2, types.Siacoins(1))
+	// add a contract for h2 with allowance
+	fcid5 := store.addTestContract(t, hk2, types.FileContractID{5})
+	updateAllowance(fcid5, types.Siacoins(1))
 
 	// assert we have only one contract for h1 now, and one on h2
 	if fcids, err := store.ContractsForFunding(context.Background(), hk1, 10); err != nil {
@@ -379,16 +347,8 @@ func TestContractsForPinning(t *testing.T) {
 	}
 
 	// add two hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return errors.Join(
-			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
-			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
-		)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	// add contracts for h1
 	const maxContractSize = 499
@@ -442,16 +402,8 @@ func TestContractsForPruning(t *testing.T) {
 	}
 
 	// add two hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return errors.Join(
-			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
-			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
-		)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	now := time.Now()
 	oneDayAgo := now.Add(-24 * time.Hour)
@@ -501,16 +453,8 @@ func TestPrunableContractRoots(t *testing.T) {
 	}
 
 	// add two hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return errors.Join(
-			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
-			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
-		)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	// add a contract for each host
 	fcid1 := store.addTestContract(t, hk1, types.FileContractID{1})
@@ -593,13 +537,7 @@ func TestPruneExpiredContractElements(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	addContract := func(expirationHeight uint64) types.FileContractID {
 		t.Helper()
@@ -611,12 +549,11 @@ func TestPruneExpiredContractElements(t *testing.T) {
 		if err := store.AddFormedContract(context.Background(), hk, contractID, revision, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
-		err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 			return tx.UpdateContractElements(types.V2FileContractElement{
 				ID: contractID,
 			})
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatal(err)
 		}
 		return contractID
@@ -646,10 +583,9 @@ func TestPruneExpiredContractElements(t *testing.T) {
 
 	// set height to block 12
 	bh := uint64(12)
-	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: bh})
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -677,7 +613,7 @@ func TestPruneExpiredContractElements(t *testing.T) {
 	assertContracts([]types.FileContractID{})
 
 	// assert only the elements got pruned but the contracts remain
-	err = store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
+	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 		var count int
 		err := tx.QueryRow(ctx, "SELECT COUNT(*) FROM contracts").Scan(&count)
 		if err != nil {
@@ -686,8 +622,7 @@ func TestPruneExpiredContractElements(t *testing.T) {
 			t.Fatalf("expected 3 contracts, got %d", count)
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -697,12 +632,7 @@ func TestFormRenewContract(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// define helper to assert contract in db
 	assertContract := func(id types.FileContractID, expected contracts.Contract) {
@@ -889,13 +819,7 @@ func TestRejectContracts(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// helper to assert contract state
 	assertContractState := func(id types.FileContractID, state contracts.ContractState) {
@@ -949,8 +873,7 @@ func TestRejectContracts(t *testing.T) {
 	assertContractState(activeID, contracts.ContractStateActive)
 
 	// reject pending contracts older than 30 minutes
-	err = store.RejectPendingContracts(context.Background(), now.Add(-30*time.Minute))
-	if err != nil {
+	if err := store.RejectPendingContracts(context.Background(), now.Add(-30*time.Minute)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -964,13 +887,7 @@ func TestUpdateContractElement(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	fce := types.V2FileContractElement{
 		ID: types.FileContractID{1, 2, 3},
@@ -1009,11 +926,10 @@ func TestUpdateContractElement(t *testing.T) {
 	assertKnownContract := func(known bool) {
 		t.Helper()
 		var storedKnown bool
-		err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) (err error) {
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) (err error) {
 			storedKnown, err = tx.IsKnownContract(fce.ID)
 			return err
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatal(err)
 		} else if storedKnown != known {
 			t.Fatalf("expected known=%v, got %v", known, storedKnown)
@@ -1064,13 +980,7 @@ func TestUpdateContractState(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// create a contract
 	contractID := types.FileContractID{1, 2, 3}
@@ -1105,15 +1015,8 @@ func TestUpdateContractState(t *testing.T) {
 func TestMarkPruned(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// add a host
-	hk := types.PublicKey{1}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// add a contract
+	// add a host with one contract
+	hk := store.addTestHost(t)
 	fcid := store.addTestContract(t, hk)
 
 	// assert contract is not marked as pruned
@@ -1147,9 +1050,11 @@ func TestMarkUnrenewableContractsBad(t *testing.T) {
 
 	const proofHeight = 100
 
+	// add a hosts
+	hk := store.addTestHost(t)
+
 	// prepare 2 contracts, one for testing and another one that remains good
 	// for the duration of the test to serve as a canary
-	hk := types.PublicKey{1, 1, 1}
 	fcid := types.FileContractID{1}
 	goodFCID := types.FileContractID{2}
 
@@ -1172,14 +1077,6 @@ func TestMarkUnrenewableContractsBad(t *testing.T) {
 		} else if !contract.Good {
 			t.Fatal("canary should be good")
 		}
-	}
-
-	// add a host and the contracts
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	revision1 := newTestRevision(hk)
@@ -1210,12 +1107,7 @@ func TestMarkBroadcastAttempt(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// assert broadcast attempt is defaulted
 	fcid := store.addTestContract(t, hk)
@@ -1245,13 +1137,7 @@ func TestSyncContract(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host
-	hk := types.PublicKey{1, 1, 1}
-	err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// helper to sync and assert contract
 	contractID := store.addTestContract(t, hk, types.FileContractID{1})
@@ -1454,13 +1340,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	// add hosts and contracts
 	var hks []types.PublicKey
 	for range nHosts {
-		hk := types.PublicKey(frand.Entropy256())
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			b.Fatal(err)
-		}
+		hk := store.addTestHost(b)
 		store.addTestContract(b, hk)
 		hks = append(hks, hk)
 	}

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -36,9 +36,9 @@ func TestContracts(t *testing.T) {
 	fcid2 := types.FileContractID{2}
 	fcid3 := types.FileContractID{3}
 	if err := errors.Join(
-		store.AddFormedContract(context.Background(), hk, fcid1, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk, fcid2, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk, fcid3, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid1, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid2, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid3, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestContractElement(t *testing.T) {
 	}
 
 	// add a contract and an element
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	} else if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.UpdateContractElements(types.V2FileContractElement{
@@ -160,8 +160,8 @@ func TestContractElementsForBroadcast(t *testing.T) {
 
 	// add a contract
 	fcid := types.FileContractID{1}
-	contract := newTestContract(hk)
-	if err := store.AddFormedContract(context.Background(), hk, fcid, contract, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	revision := newTestRevision(hk)
+	if err := store.AddFormedContract(context.Background(), hk, fcid, revision, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -178,7 +178,7 @@ func TestContractElementsForBroadcast(t *testing.T) {
 
 	// set height to 10 blocks after expiration
 	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: contract.ExpirationHeight + 10})
+		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: revision.ExpirationHeight + 10})
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -190,7 +190,7 @@ func TestContractElementsForBroadcast(t *testing.T) {
 	fce := types.V2FileContractElement{
 		ID:             fcid,
 		StateElement:   types.StateElement{LeafIndex: 1, MerkleProof: []types.Hash256{{1}}},
-		V2FileContract: contract,
+		V2FileContract: revision,
 	}
 
 	// add contract element, 1 contract to broadcast
@@ -228,11 +228,11 @@ func TestContractsForBroadcasting(t *testing.T) {
 
 	// add two contracts
 	fcid1 := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, fcid1, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid1, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 	fcid2 := types.FileContractID{2}
-	if err := store.AddFormedContract(context.Background(), hk, fcid2, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid2, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -298,7 +298,7 @@ func TestContractsForFunding(t *testing.T) {
 		t.Helper()
 		fcidCnt++
 		fcid := types.FileContractID{byte(fcidCnt)}
-		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, remaininAllowance, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, remaininAllowance, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		return fcid
@@ -383,7 +383,7 @@ func TestContractsForPinning(t *testing.T) {
 
 	addContract := func(hk types.PublicKey, fcid types.FileContractID, allowance types.Currency, size, capacity uint64, state contracts.ContractState, good bool) {
 		t.Helper()
-		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		query := `UPDATE contracts SET size = $1, capacity = $2, state = $3, good = $4 WHERE contract_id = $5`
@@ -448,7 +448,7 @@ func TestContractsForPruning(t *testing.T) {
 
 	addContract := func(hk types.PublicKey, fcid types.FileContractID, allowance types.Currency, size uint64, state contracts.ContractState, good bool, lastPrune time.Time) {
 		t.Helper()
-		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		query := `UPDATE contracts SET state = $1, good = $2, size = $3, capacity = $4, last_prune = $5 WHERE contract_id = $6`
@@ -533,8 +533,8 @@ func TestPrunableContractRoots(t *testing.T) {
 	fcid1 := types.FileContractID{1}
 	fcid2 := types.FileContractID{2}
 	if err := errors.Join(
-		store.AddFormedContract(context.Background(), hk1, fcid1, newTestContract(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk2, fcid2, newTestContract(hk2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk1, fcid1, newTestRevision(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk2, fcid2, newTestRevision(hk2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -629,9 +629,9 @@ func TestPruneExpiredContractElements(t *testing.T) {
 		var contractID types.FileContractID
 		frand.Read(contractID[:])
 
-		contract := newTestContract(hk)
-		contract.ExpirationHeight = expirationHeight
-		if err := store.AddFormedContract(context.Background(), hk, contractID, contract, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		revision := newTestRevision(hk)
+		revision.ExpirationHeight = expirationHeight
+		if err := store.AddFormedContract(context.Background(), hk, contractID, revision, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
@@ -760,11 +760,11 @@ func TestFormRenewContract(t *testing.T) {
 
 		Good: true,
 	}
-	contract := newTestContract(hk)
-	contract.ProofHeight = expectedFormed.ProofHeight
-	contract.ExpirationHeight = expectedFormed.ExpirationHeight
-	contract.TotalCollateral = expectedFormed.TotalCollateral
-	err = store.AddFormedContract(context.Background(), hk, expectedFormed.ID, contract, expectedFormed.ContractPrice, expectedFormed.InitialAllowance, expectedFormed.MinerFee)
+	revision := newTestRevision(hk)
+	revision.ProofHeight = expectedFormed.ProofHeight
+	revision.ExpirationHeight = expectedFormed.ExpirationHeight
+	revision.TotalCollateral = expectedFormed.TotalCollateral
+	err = store.AddFormedContract(context.Background(), hk, expectedFormed.ID, revision, expectedFormed.ContractPrice, expectedFormed.InitialAllowance, expectedFormed.MinerFee)
 	if err != nil {
 		t.Fatal("failed to add formed contract", err)
 	}
@@ -830,7 +830,7 @@ func TestFormRenewContract(t *testing.T) {
 		TotalCollateral:    types.Siacoins(5),
 	}
 
-	renewed := newTestContract(hk)
+	renewed := newTestRevision(hk)
 	renewed.ProofHeight = expectedRefreshed.ProofHeight
 	renewed.ExpirationHeight = expectedRefreshed.ExpirationHeight
 	renewed.TotalCollateral = expectedRefreshed.TotalCollateral
@@ -878,7 +878,7 @@ func TestFormRenewContract(t *testing.T) {
 		TotalCollateral:    types.Siacoins(5),
 	}
 
-	renewed = newTestContract(hk)
+	renewed = newTestRevision(hk)
 	renewed.ProofHeight = expectedRenewed.ProofHeight
 	renewed.ExpirationHeight = expectedRenewed.ExpirationHeight
 	renewed.TotalCollateral = expectedRenewed.TotalCollateral
@@ -947,7 +947,7 @@ func TestRejectContracts(t *testing.T) {
 	now := time.Now()
 	for i := range 3 {
 		contractID := types.FileContractID{byte(i + 1)}
-		err = store.AddFormedContract(context.Background(), hk, contractID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+		err = store.AddFormedContract(context.Background(), hk, contractID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 		if err != nil {
 			t.Fatal("failed to add formed contract", err)
 		}
@@ -1043,7 +1043,7 @@ func TestUpdateContractElement(t *testing.T) {
 	assertKnownContract(false)
 
 	// add a contract
-	if err := store.AddFormedContract(context.Background(), hk, fce.ID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fce.ID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 	assertKnownContract(true)
@@ -1119,7 +1119,7 @@ func TestUpdateContractState(t *testing.T) {
 	}
 
 	// add a contract
-	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1142,7 +1142,7 @@ func TestMarkPruned(t *testing.T) {
 
 	// add a contract
 	fcid := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1212,16 +1212,17 @@ func TestMarkUnrenewableContractsBad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contract1 := newTestContract(hk)
-	contract1.ProofHeight = proofHeight
-	contract1.ExpirationHeight = 9999
-	contract2 := newTestContract(hk)
-	contract2.ProofHeight = 8888
-	contract2.ExpirationHeight = 9999
+	revision1 := newTestRevision(hk)
+	revision1.ProofHeight = proofHeight
+	revision1.ExpirationHeight = 9999
+
+	revision2 := newTestRevision(hk)
+	revision2.ProofHeight = 8888
+	revision2.ExpirationHeight = 9999
 
 	if err := errors.Join(
-		store.AddFormedContract(context.Background(), hk, fcid, contract1, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), hk, goodFCID, contract2, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid, revision1, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, goodFCID, revision2, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -1248,7 +1249,7 @@ func TestMarkBroadcastAttempt(t *testing.T) {
 
 	// add a contract
 	fcid := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1289,7 +1290,7 @@ func TestSyncContract(t *testing.T) {
 
 	// add a contract
 	contractID := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1498,7 +1499,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 		}); err != nil {
 			b.Fatal(err)
 		}
-		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			b.Fatal(err)
 		}
 		hks = append(hks, hk)
@@ -1568,7 +1569,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	}
 }
 
-func newTestContract(hk types.PublicKey) types.V2FileContract {
+func newTestRevision(hk types.PublicKey) types.V2FileContract {
 	return types.V2FileContract{
 		HostPublicKey:    hk,
 		Capacity:         200,

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -370,11 +370,9 @@ func TestContractsForPinning(t *testing.T) {
 
 	addContract := func(hk types.PublicKey, fcid types.FileContractID, allowance types.Currency, size, capacity uint64, state contracts.ContractState, good bool) {
 		t.Helper()
-		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
-			t.Fatal(err)
-		}
-		query := `UPDATE contracts SET size = $1, capacity = $2, state = $3, good = $4 WHERE contract_id = $5`
-		_, err := store.pool.Exec(context.Background(), query, size, capacity, sqlContractState(state), good, sqlHash256(fcid))
+		store.addTestContract(t, hk, fcid)
+		query := `UPDATE contracts SET size = $1, capacity = $2, state = $3, good = $4, initial_allowance = $5, remaining_allowance = $5 WHERE contract_id = $6`
+		_, err := store.pool.Exec(context.Background(), query, size, capacity, sqlContractState(state), good, sqlCurrency(allowance), sqlHash256(fcid))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -435,11 +433,9 @@ func TestContractsForPruning(t *testing.T) {
 
 	addContract := func(hk types.PublicKey, fcid types.FileContractID, allowance types.Currency, size uint64, state contracts.ContractState, good bool, lastPrune time.Time) {
 		t.Helper()
-		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
-			t.Fatal(err)
-		}
-		query := `UPDATE contracts SET state = $1, good = $2, size = $3, capacity = $4, last_prune = $5 WHERE contract_id = $6`
-		_, err := store.pool.Exec(context.Background(), query, sqlContractState(state), good, size, size, lastPrune, sqlHash256(fcid))
+		store.addTestContract(t, hk, fcid)
+		query := `UPDATE contracts SET state = $1, good = $2, size = $3, capacity = $4, last_prune = $5, initial_allowance = $6, remaining_allowance = $6 WHERE contract_id = $7`
+		_, err := store.pool.Exec(context.Background(), query, sqlContractState(state), good, size, size, lastPrune, sqlCurrency(allowance), sqlHash256(fcid))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1118,10 +1114,7 @@ func TestMarkPruned(t *testing.T) {
 	}
 
 	// add a contract
-	fcid := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
+	fcid := store.addTestContract(t, hk)
 
 	// assert contract is not marked as pruned
 	if contract, err := store.Contract(context.Background(), fcid); err != nil {
@@ -1468,9 +1461,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 		}); err != nil {
 			b.Fatal(err)
 		}
-		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-			b.Fatal(err)
-		}
+		store.addTestContract(b, hk)
 		hks = append(hks, hk)
 	}
 
@@ -1538,7 +1529,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	}
 }
 
-func (s *Store) addTestContract(t *testing.T, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
+func (s *Store) addTestContract(t interface{ Fatal(args ...any) }, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
 	var fcid types.FileContractID
 	switch len(fcids) {
 	case 0:

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1529,7 +1529,9 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	}
 }
 
-func (s *Store) addTestContract(t interface{ Fatal(args ...any) }, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
+func (s *Store) addTestContract(t testingCommon, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
+	t.Helper()
+
 	var fcid types.FileContractID
 	switch len(fcids) {
 	case 0:

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -36,9 +36,9 @@ func TestContracts(t *testing.T) {
 	fcid2 := types.FileContractID{2}
 	fcid3 := types.FileContractID{3}
 	if err := errors.Join(
-		store.AddFormedContract(context.Background(), fcid1, hk, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), fcid2, hk, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
-		store.AddFormedContract(context.Background(), fcid3, hk, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid1, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid2, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, fcid3, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestContractElement(t *testing.T) {
 	}
 
 	// add a contract and an element
-	if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	} else if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.UpdateContractElements(types.V2FileContractElement{
@@ -159,18 +159,9 @@ func TestContractElementsForBroadcast(t *testing.T) {
 	}
 
 	// add a contract
-	fce := types.V2FileContractElement{
-		ID: types.FileContractID{1, 2, 3},
-		StateElement: types.StateElement{
-			LeafIndex:   1,
-			MerkleProof: []types.Hash256{{1}},
-		},
-		V2FileContract: types.V2FileContract{
-			ExpirationHeight: 100,
-			HostPublicKey:    hk,
-		},
-	}
-	if err := store.AddFormedContract(context.Background(), fce.ID, hk, 50, fce.V2FileContract.ExpirationHeight, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)); err != nil {
+	fcid := types.FileContractID{1}
+	contract := newTestContract(hk)
+	if err := store.AddFormedContract(context.Background(), hk, fcid, contract, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -187,7 +178,7 @@ func TestContractElementsForBroadcast(t *testing.T) {
 
 	// set height to 10 blocks after expiration
 	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: fce.V2FileContract.ExpirationHeight + 10})
+		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: contract.ExpirationHeight + 10})
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -195,6 +186,12 @@ func TestContractElementsForBroadcast(t *testing.T) {
 
 	// no contracts to broadcast since we haven't added the element yet
 	assertContractsToBroadcast(1, 0)
+
+	fce := types.V2FileContractElement{
+		ID:             fcid,
+		StateElement:   types.StateElement{LeafIndex: 1, MerkleProof: []types.Hash256{{1}}},
+		V2FileContract: contract,
+	}
 
 	// add contract element, 1 contract to broadcast
 	err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
@@ -231,11 +228,11 @@ func TestContractsForBroadcasting(t *testing.T) {
 
 	// add two contracts
 	fcid1 := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), fcid1, hk, 100, 200, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid1, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 	fcid2 := types.FileContractID{2}
-	if err := store.AddFormedContract(context.Background(), fcid2, hk, 100, 200, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid2, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -280,10 +277,7 @@ func TestContractsForBroadcasting(t *testing.T) {
 	}
 
 	// renew the contract
-	if err := store.AddRenewedContract(context.Background(), contracts.AddRenewedContractParams{
-		RenewedFrom: res[0],
-		RenewedTo:   types.FileContractID{9, 9, 9},
-	}); err != nil {
+	if err := store.AddRenewedContract(context.Background(), res[0], types.FileContractID{9, 9, 9}, types.V2FileContract{}, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -304,7 +298,7 @@ func TestContractsForFunding(t *testing.T) {
 		t.Helper()
 		fcidCnt++
 		fcid := types.FileContractID{byte(fcidCnt)}
-		if err := store.AddFormedContract(context.Background(), fcid, hk, 100, 200, types.ZeroCurrency, remaininAllowance, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, remaininAllowance, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		return fcid
@@ -389,7 +383,7 @@ func TestContractsForPinning(t *testing.T) {
 
 	addContract := func(hk types.PublicKey, fcid types.FileContractID, allowance types.Currency, size, capacity uint64, state contracts.ContractState, good bool) {
 		t.Helper()
-		if err := store.AddFormedContract(context.Background(), fcid, hk, 100, 200, types.ZeroCurrency, allowance, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		query := `UPDATE contracts SET size = $1, capacity = $2, state = $3, good = $4 WHERE contract_id = $5`
@@ -454,7 +448,7 @@ func TestContractsForPruning(t *testing.T) {
 
 	addContract := func(hk types.PublicKey, fcid types.FileContractID, allowance types.Currency, size uint64, state contracts.ContractState, good bool, lastPrune time.Time) {
 		t.Helper()
-		if err := store.AddFormedContract(context.Background(), fcid, hk, 100, 200, types.ZeroCurrency, allowance, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, allowance, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		query := `UPDATE contracts SET state = $1, good = $2, size = $3, capacity = $4, last_prune = $5 WHERE contract_id = $6`
@@ -539,8 +533,8 @@ func TestPrunableContractRoots(t *testing.T) {
 	fcid1 := types.FileContractID{1}
 	fcid2 := types.FileContractID{2}
 	if err := errors.Join(
-		store.AddFormedContract(context.Background(), fcid1, hk1, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)),
-		store.AddFormedContract(context.Background(), fcid2, hk2, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)),
+		store.AddFormedContract(context.Background(), hk1, fcid1, newTestContract(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk2, fcid2, newTestContract(hk2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -634,7 +628,10 @@ func TestPruneExpiredContractElements(t *testing.T) {
 		t.Helper()
 		var contractID types.FileContractID
 		frand.Read(contractID[:])
-		if err := store.AddFormedContract(context.Background(), contractID, hk, 50, expirationHeight, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)); err != nil {
+
+		contract := newTestContract(hk)
+		contract.ExpirationHeight = expirationHeight
+		if err := store.AddFormedContract(context.Background(), hk, contractID, contract, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			t.Fatal(err)
 		}
 		err = store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
@@ -763,7 +760,11 @@ func TestFormRenewContract(t *testing.T) {
 
 		Good: true,
 	}
-	err = store.AddFormedContract(context.Background(), expectedFormed.ID, expectedFormed.HostKey, expectedFormed.ProofHeight, expectedFormed.ExpirationHeight, expectedFormed.ContractPrice, expectedFormed.InitialAllowance, expectedFormed.MinerFee, expectedFormed.TotalCollateral)
+	contract := newTestContract(hk)
+	contract.ProofHeight = expectedFormed.ProofHeight
+	contract.ExpirationHeight = expectedFormed.ExpirationHeight
+	contract.TotalCollateral = expectedFormed.TotalCollateral
+	err = store.AddFormedContract(context.Background(), hk, expectedFormed.ID, contract, expectedFormed.ContractPrice, expectedFormed.InitialAllowance, expectedFormed.MinerFee)
 	if err != nil {
 		t.Fatal("failed to add formed contract", err)
 	}
@@ -828,17 +829,14 @@ func TestFormRenewContract(t *testing.T) {
 		UsedCollateral:     types.Siacoins(4),
 		TotalCollateral:    types.Siacoins(5),
 	}
-	err = store.AddRenewedContract(context.Background(), contracts.AddRenewedContractParams{
-		RenewedFrom:      expectedRefreshed.RenewedFrom,
-		RenewedTo:        expectedRefreshed.ID,
-		ProofHeight:      expectedRefreshed.ProofHeight,
-		ExpirationHeight: expectedRefreshed.ExpirationHeight,
-		ContractPrice:    expectedRefreshed.ContractPrice,
-		Allowance:        expectedRefreshed.InitialAllowance,
-		MinerFee:         expectedRefreshed.MinerFee,
-		UsedCollateral:   expectedRefreshed.UsedCollateral,
-		TotalCollateral:  expectedRefreshed.TotalCollateral,
-	})
+
+	renewed := newTestContract(hk)
+	renewed.ProofHeight = expectedRefreshed.ProofHeight
+	renewed.ExpirationHeight = expectedRefreshed.ExpirationHeight
+	renewed.TotalCollateral = expectedRefreshed.TotalCollateral
+	renewed.RenterOutput.Value = expectedRefreshed.InitialAllowance
+
+	err = store.AddRenewedContract(context.Background(), expectedRefreshed.RenewedFrom, expectedRefreshed.ID, renewed, expectedRefreshed.ContractPrice, expectedRefreshed.MinerFee, expectedRefreshed.UsedCollateral)
 	if err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}
@@ -879,17 +877,14 @@ func TestFormRenewContract(t *testing.T) {
 		UsedCollateral:     types.Siacoins(4),
 		TotalCollateral:    types.Siacoins(5),
 	}
-	err = store.AddRenewedContract(context.Background(), contracts.AddRenewedContractParams{
-		RenewedFrom:      expectedRenewed.RenewedFrom,
-		RenewedTo:        expectedRenewed.ID,
-		ProofHeight:      expectedRenewed.ProofHeight,
-		ExpirationHeight: expectedRenewed.ExpirationHeight,
-		ContractPrice:    expectedRenewed.ContractPrice,
-		Allowance:        expectedRenewed.InitialAllowance,
-		MinerFee:         expectedRenewed.MinerFee,
-		UsedCollateral:   expectedRenewed.UsedCollateral,
-		TotalCollateral:  expectedRenewed.TotalCollateral,
-	})
+
+	renewed = newTestContract(hk)
+	renewed.ProofHeight = expectedRenewed.ProofHeight
+	renewed.ExpirationHeight = expectedRenewed.ExpirationHeight
+	renewed.TotalCollateral = expectedRenewed.TotalCollateral
+	renewed.RenterOutput.Value = expectedRenewed.InitialAllowance
+
+	err = store.AddRenewedContract(context.Background(), expectedRenewed.RenewedFrom, expectedRenewed.ID, renewed, expectedRenewed.ContractPrice, expectedRenewed.MinerFee, expectedRenewed.UsedCollateral)
 	if err != nil {
 		t.Fatal("failed to add refreshed contract", err)
 	}
@@ -952,7 +947,7 @@ func TestRejectContracts(t *testing.T) {
 	now := time.Now()
 	for i := range 3 {
 		contractID := types.FileContractID{byte(i + 1)}
-		err = store.AddFormedContract(context.Background(), contractID, hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4))
+		err = store.AddFormedContract(context.Background(), hk, contractID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 		if err != nil {
 			t.Fatal("failed to add formed contract", err)
 		}
@@ -1048,7 +1043,7 @@ func TestUpdateContractElement(t *testing.T) {
 	assertKnownContract(false)
 
 	// add a contract
-	if err := store.AddFormedContract(context.Background(), fce.ID, hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fce.ID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 	assertKnownContract(true)
@@ -1124,7 +1119,7 @@ func TestUpdateContractState(t *testing.T) {
 	}
 
 	// add a contract
-	if err := store.AddFormedContract(context.Background(), contractID, hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1147,7 +1142,7 @@ func TestMarkPruned(t *testing.T) {
 
 	// add a contract
 	fcid := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), fcid, hk, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1216,9 +1211,18 @@ func TestMarkUnrenewableContractsBad(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), fcid, hk, proofHeight, 9999, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)); err != nil {
-		t.Fatal(err)
-	} else if err := store.AddFormedContract(context.Background(), goodFCID, hk, 8888, 9999, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(4)); err != nil {
+
+	contract1 := newTestContract(hk)
+	contract1.ProofHeight = proofHeight
+	contract1.ExpirationHeight = 9999
+	contract2 := newTestContract(hk)
+	contract2.ProofHeight = 8888
+	contract2.ExpirationHeight = 9999
+
+	if err := errors.Join(
+		store.AddFormedContract(context.Background(), hk, fcid, contract1, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+		store.AddFormedContract(context.Background(), hk, goodFCID, contract2, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency),
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1244,7 +1248,7 @@ func TestMarkBroadcastAttempt(t *testing.T) {
 
 	// add a contract
 	fcid := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), fcid, hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, fcid, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1285,7 +1289,7 @@ func TestSyncContract(t *testing.T) {
 
 	// add a contract
 	contractID := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), contractID, hk, 50, 100, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(10000)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, contractID, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1361,7 +1365,7 @@ func BenchmarkContracts(b *testing.B) {
 			for i := range numContractsPerHost {
 				frand.Read(hostContractIDs[i][:])
 				size := frand.Uint64n(1e9)
-				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, last_prune) VALUES ($1, $2, 0, 0, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13);`,
+				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, last_prune, raw_revision) VALUES ($1, $2, 0, 0, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, E'\\x');`,
 					hostID,
 					sqlHash256(hostContractIDs[i][:]),
 					sqlCurrency(types.ZeroCurrency),
@@ -1494,7 +1498,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 		}); err != nil {
 			b.Fatal(err)
 		}
-		if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			b.Fatal(err)
 		}
 		hks = append(hks, hk)
@@ -1561,5 +1565,18 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+func newTestContract(hk types.PublicKey) types.V2FileContract {
+	return types.V2FileContract{
+		HostPublicKey:    hk,
+		Capacity:         200,
+		Filesize:         100,
+		FileMerkleRoot:   types.Hash256{1},
+		ProofHeight:      400,
+		ExpirationHeight: 800,
+		RevisionNumber:   1,
+		TotalCollateral:  types.Siacoins(100),
 	}
 }

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1409,7 +1409,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	}
 }
 
-func (s *Store) addTestContract(t testingCommon, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
+func (s *Store) addTestContract(t testing.TB, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
 	t.Helper()
 
 	var fcid types.FileContractID

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -396,7 +396,7 @@ func TestHosts(t *testing.T) {
 
 		// form contract
 		if contract {
-			err := db.AddFormedContract(context.Background(), hk, types.FileContractID{i}, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+			err := db.AddFormedContract(context.Background(), hk, types.FileContractID{i}, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -750,7 +750,7 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// add contract to h2
-	err = db.AddFormedContract(context.Background(), h2, types.FileContractID{1}, newTestContract(h2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+	err = db.AddFormedContract(context.Background(), h2, types.FileContractID{1}, newTestRevision(h2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1139,7 +1139,7 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	}
 }
 
-func (s *Store) addTestHost(t testingCommon, hks ...types.PublicKey) types.PublicKey {
+func (s *Store) addTestHost(t testing.TB, hks ...types.PublicKey) types.PublicKey {
 	t.Helper()
 
 	var hk types.PublicKey

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -98,13 +98,8 @@ func TestHost(t *testing.T) {
 		t.Fatal("expected [hosts.ErrNotFound], got", err)
 	}
 
-	// add a host
-	ha1 := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha1}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	// add the host
+	db.addTestHost(t, hk)
 
 	// update the host
 	networks := []net.IPNet{{IP: net.IPv4(1, 2, 3, 4), Mask: net.CIDRMask(32, 32)}}
@@ -179,11 +174,7 @@ func TestHostChecks(t *testing.T) {
 	}
 
 	// add a host
-	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, nil, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	db.addTestHost(t, hk)
 
 	// assert unscanned host is unusable
 	if h, err := db.Host(context.Background(), hk); err != nil {
@@ -364,13 +355,7 @@ func TestHosts(t *testing.T) {
 	addHost := func(i byte, usable, blocked bool, contract bool) types.PublicKey {
 		t.Helper()
 		hk := types.PublicKey{i}
-
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			t.Fatal(err)
-		}
+		db.addTestHost(t, hk)
 
 		// "scan" host - first scan fails
 		settings := newSettings(hk)
@@ -514,16 +499,8 @@ func TestHostsForScanning(t *testing.T) {
 	db := initPostgres(t, log.Named("postgres"))
 
 	// add two hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return errors.Join(
-			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
-			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
-		)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk1 := db.addTestHost(t)
+	hk2 := db.addTestHost(t)
 
 	// assert both hosts are returned
 	hosts, err := db.HostsForScanning(context.Background())
@@ -601,11 +578,7 @@ func TestHostsRecentUptime(t *testing.T) {
 	}
 
 	// add a host
-	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, nil, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk = db.addTestHost(t)
 
 	// assert default uptime
 	if uptime() != .894 {
@@ -659,21 +632,9 @@ func TestPruneHosts(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	db := initPostgres(t, log.Named("postgres"))
 
-	// create helper to add a host
-	addHost := func() types.PublicKey {
-		t.Helper()
-		hk := types.GeneratePrivateKey().PublicKey()
-		if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-		}); err != nil {
-			t.Fatal(err)
-		}
-		return hk
-	}
-
 	// add two hosts
-	addHost()
-	addHost()
+	db.addTestHost(t)
+	db.addTestHost(t)
 
 	// assert both get pruned when no params are given
 	n, err := db.PruneHosts(context.Background(), time.Time{}, 0)
@@ -684,8 +645,8 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// re-add the hosts
-	h1 := addHost()
-	h2 := addHost()
+	h1 := db.addTestHost(t)
+	h2 := db.addTestHost(t)
 
 	// assert none get pruned when we require at least one failed scan
 	n, err = db.PruneHosts(context.Background(), time.Now().Add(time.Second), 1)
@@ -726,8 +687,8 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// re-add both hosts, simulate both a successful and failed scan
-	h1 = addHost()
-	h2 = addHost()
+	h1 = db.addTestHost(t)
+	h2 = db.addTestHost(t)
 	err = errors.Join(
 		db.UpdateHost(context.Background(), h1, testNetworks, proto4.HostSettings{}, true, time.Now()),
 		db.UpdateHost(context.Background(), h1, testNetworks, proto4.HostSettings{}, false, time.Now()),
@@ -786,11 +747,7 @@ func TestUpdateHost(t *testing.T) {
 	}
 
 	// add a host
-	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	db.addTestHost(t, hk)
 
 	// assert host settings are not inserted if the scan failed
 	hs := newTestHostSettings(hk)
@@ -1022,16 +979,8 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	db := initPostgres(t, log.Named("postgres"))
 
 	// add two hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	if err := db.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return errors.Join(
-			tx.AddHostAnnouncement(hk1, chain.V2HostAnnouncement{}, time.Now()),
-			tx.AddHostAnnouncement(hk2, chain.V2HostAnnouncement{}, time.Now()),
-		)
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk1 := db.addTestHost(t)
+	hk2 := db.addTestHost(t)
 
 	// add account
 	acc := proto4.Account{1}
@@ -1144,13 +1093,7 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 
 	// add hosts
 	for range nHosts {
-		hk := types.PublicKey(frand.Entropy256())
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			b.Fatal(err)
-		}
+		hk := store.addTestHost(b)
 
 		// add sectors
 		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
@@ -1194,4 +1137,26 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 			}
 		})
 	}
+}
+
+func (s *Store) addTestHost(t testingCommon, hks ...types.PublicKey) types.PublicKey {
+	t.Helper()
+
+	var hk types.PublicKey
+	switch len(hks) {
+	case 0:
+		hk = types.GeneratePrivateKey().PublicKey() // generate a random host key
+	case 1:
+		hk = hks[0]
+	default:
+		panic("developer error")
+	}
+
+	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
+	if err := s.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return hk
 }

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -396,10 +396,7 @@ func TestHosts(t *testing.T) {
 
 		// form contract
 		if contract {
-			err := db.AddFormedContract(context.Background(), hk, types.FileContractID{i}, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-			if err != nil {
-				t.Fatal(err)
-			}
+			db.addTestContract(t, hk)
 		}
 		return hk
 	}
@@ -750,10 +747,7 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// add contract to h2
-	err = db.AddFormedContract(context.Background(), h2, types.FileContractID{1}, newTestRevision(h2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-	if err != nil {
-		t.Fatal(err)
-	}
+	db.addTestContract(t, h2)
 
 	// assert only h1 got pruned if we set the cutoff in the future
 	n, err = db.PruneHosts(context.Background(), time.Now().Add(time.Second), 1)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -396,7 +396,10 @@ func TestHosts(t *testing.T) {
 
 		// form contract
 		if contract {
-			db.AddFormedContract(context.Background(), types.FileContractID{i}, hk, 100, 1000, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+			err := db.AddFormedContract(context.Background(), hk, types.FileContractID{i}, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 		return hk
 	}
@@ -747,7 +750,7 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// add contract to h2
-	err = db.AddFormedContract(context.Background(), types.FileContractID{1}, h2, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+	err = db.AddFormedContract(context.Background(), h2, types.FileContractID{1}, newTestContract(h2), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -180,7 +180,10 @@ CREATE TABLE contracts (
   append_sector_spending DECIMAL(50, 0) NOT NULL DEFAULT 0,
   free_sector_spending DECIMAL(50, 0) NOT NULL DEFAULT 0,
   fund_account_spending DECIMAL(50, 0) NOT NULL DEFAULT 0,
-  sector_roots_spending DECIMAL(50, 0) NOT NULL DEFAULT 0
+  sector_roots_spending DECIMAL(50, 0) NOT NULL DEFAULT 0,
+
+  -- raw contract revision data
+  raw_revision BYTEA NOT NULL
 );
 CREATE INDEX contracts_state_formation_idx ON contracts(state, formation); -- for rejecting expired contracts
 CREATE INDEX contracts_state_good_idx ON contracts(state) WHERE state <= 1 AND good; -- for filtering contracts

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -45,10 +45,7 @@ func TestMigrateSector(t *testing.T) {
 	}
 
 	// add contract for first host
-	fcid1 := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk1, fcid1, newTestRevision(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
+	fcid := store.addTestContract(t, hk1)
 
 	// pin a slab to add 2 sectors which are both stored on the first host
 	pinTime := time.Now().Round(time.Microsecond)
@@ -73,7 +70,7 @@ func TestMigrateSector(t *testing.T) {
 	}
 
 	// pin sectors to contract
-	if err := store.PinSectors(context.Background(), fcid1, []types.Hash256{root1, root2}); err != nil {
+	if err := store.PinSectors(context.Background(), fcid, []types.Hash256{root1, root2}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -109,18 +106,18 @@ func TestMigrateSector(t *testing.T) {
 	}
 
 	// assert initial state
-	assertSector(root1, hk1, fcid1)
-	assertSector(root2, hk1, fcid1)
+	assertSector(root1, hk1, fcid)
+	assertSector(root2, hk1, fcid)
 
 	// migrate sector 1 to host 2
 	migrate(root1, hk2, true)
 	assertSector(root1, hk2, types.FileContractID{})
-	assertSector(root2, hk1, fcid1)
+	assertSector(root2, hk1, fcid)
 
 	// migrate sector 2 to unknown host, this should be a no-op
 	migrate(root2, types.PublicKey{10}, false)
 	assertSector(root1, hk2, types.FileContractID{})
-	assertSector(root2, hk1, fcid1)
+	assertSector(root2, hk1, fcid)
 
 	// migrate sector 2 to host 2
 	migrate(root2, hk2, true)
@@ -641,12 +638,8 @@ func TestPinSectors(t *testing.T) {
 	}
 
 	// create 2 contracts
-	contractID1, contractID2 := types.FileContractID{1}, types.FileContractID{2}
-	if err := store.AddFormedContract(context.Background(), hk, contractID1, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	} else if err := store.AddFormedContract(context.Background(), hk, contractID2, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
+	contractID1 := store.addTestContract(t, hk, types.FileContractID{1})
+	contractID2 := store.addTestContract(t, hk, types.FileContractID{2})
 
 	// create 4 sectors
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
@@ -757,10 +750,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	// add contract
-	err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-	if err != nil {
-		t.Fatal(err)
-	}
+	store.addTestContract(t, hk)
 
 	// pin a slab to add a few sectors to the database
 	root1 := frand.Entropy256()
@@ -874,9 +864,7 @@ func TestUnpinnedSectors(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		t.Fatal(err)
-	}
+	store.addTestContract(t, hk)
 
 	// create 4 sectors
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
@@ -1063,9 +1051,7 @@ func BenchmarkUnpinnedSectors(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		b.Fatal(err)
-	}
+	store.addTestContract(b, hk)
 
 	// prepare base db
 	const (
@@ -1225,9 +1211,7 @@ func BenchmarkPinSectors(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		b.Fatal(err)
-	}
+	store.addTestContract(b, hk)
 
 	// prepare base db
 	const (
@@ -1329,15 +1313,11 @@ func BenchmarkUnhealthySlab(b *testing.B) {
 		hks = append(hks, hk)
 	}
 
-	// add 1 good and 1 bad contract
-	err := store.AddFormedContract(context.Background(), hks[0], types.FileContractID(hks[0]), newTestRevision(hks[0]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-	if err != nil {
-		b.Fatal(err)
-	}
-	err = store.AddFormedContract(context.Background(), hks[1], types.FileContractID(hks[1]), newTestRevision(hks[1]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-	if err != nil {
-		b.Fatal(err)
-	}
+	// add 2 contracts
+	store.addTestContract(b, hks[0])
+	store.addTestContract(b, hks[1])
+
+	// mark the second contract as bad
 	res, err := store.pool.Exec(context.Background(), "UPDATE contracts SET good = FALSE WHERE id = 2") // id 2 is bad
 	if err != nil {
 		b.Fatal(err)
@@ -1436,9 +1416,7 @@ func BenchmarkUnpinSlab(b *testing.B) {
 	}
 
 	// add contract
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		b.Fatal(err)
-	}
+	store.addTestContract(b, hk)
 
 	// prepare base db
 	const (
@@ -1669,10 +1647,7 @@ func TestMarkSectorsLost(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
-		if err != nil {
-			t.Fatal(err)
-		}
+		store.addTestContract(t, hk)
 	}
 
 	// pin a slab that adds 2 sectors to each host
@@ -1781,9 +1756,7 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-		b.Fatal(err)
-	}
+	store.addTestContract(b, hk)
 
 	// prepare base db
 	const (
@@ -1907,9 +1880,7 @@ func BenchmarkMigrateSector(b *testing.B) {
 		}); err != nil {
 			b.Fatal(err)
 		}
-		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
-			b.Fatal(err)
-		}
+		store.addTestContract(b, hk)
 		hks = append(hks, hk)
 	}
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -46,7 +46,7 @@ func TestMigrateSector(t *testing.T) {
 
 	// add contract for first host
 	fcid1 := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), hk1, fcid1, newTestContract(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk1, fcid1, newTestRevision(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -642,9 +642,9 @@ func TestPinSectors(t *testing.T) {
 
 	// create 2 contracts
 	contractID1, contractID2 := types.FileContractID{1}, types.FileContractID{2}
-	if err := store.AddFormedContract(context.Background(), hk, contractID1, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, contractID1, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
-	} else if err := store.AddFormedContract(context.Background(), hk, contractID2, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	} else if err := store.AddFormedContract(context.Background(), hk, contractID2, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -757,7 +757,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	// add contract
-	err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+	err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -874,7 +874,7 @@ func TestUnpinnedSectors(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1063,7 +1063,7 @@ func BenchmarkUnpinnedSectors(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1225,7 +1225,7 @@ func BenchmarkPinSectors(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1330,11 +1330,11 @@ func BenchmarkUnhealthySlab(b *testing.B) {
 	}
 
 	// add 1 good and 1 bad contract
-	err := store.AddFormedContract(context.Background(), hks[0], types.FileContractID(hks[0]), newTestContract(hks[0]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+	err := store.AddFormedContract(context.Background(), hks[0], types.FileContractID(hks[0]), newTestRevision(hks[0]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		b.Fatal(err)
 	}
-	err = store.AddFormedContract(context.Background(), hks[1], types.FileContractID(hks[1]), newTestContract(hks[1]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+	err = store.AddFormedContract(context.Background(), hks[1], types.FileContractID(hks[1]), newTestRevision(hks[1]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1436,7 +1436,7 @@ func BenchmarkUnpinSlab(b *testing.B) {
 	}
 
 	// add contract
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1669,7 +1669,7 @@ func TestMarkSectorsLost(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
+		err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1781,7 +1781,7 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1907,7 +1907,7 @@ func BenchmarkMigrateSector(b *testing.B) {
 		}); err != nil {
 			b.Fatal(err)
 		}
-		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			b.Fatal(err)
 		}
 		hks = append(hks, hk)

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -12,12 +12,9 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
-	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/slabs"
-	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
@@ -32,17 +29,9 @@ func TestMigrateSector(t *testing.T) {
 		t.Fatal("failed to add account:", err)
 	}
 
-	// add 2 hosts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	for _, hk := range []types.PublicKey{hk1, hk2} {
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			t.Fatal(err)
-		}
-	}
+	// add two hosts
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	// add contract for first host
 	fcid := store.addTestContract(t, hk1)
@@ -135,13 +124,7 @@ func TestRecordIntegrityCheck(t *testing.T) {
 	}
 
 	// add host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// pin a slab to add 2 sectors
 	pinTime := time.Now().Round(time.Microsecond)
@@ -239,13 +222,7 @@ func TestSectorsForIntegrityCheck(t *testing.T) {
 	}
 
 	// add host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// pin a slab to add a few sectors to the database
 	root1 := frand.Entropy256()
@@ -338,21 +315,9 @@ func TestPinSlabs(t *testing.T) {
 		t.Fatal("failed to add account:", err)
 	}
 
-	// add hosts
-	addHost := func(i byte) types.PublicKey {
-		t.Helper()
-		hk := types.PublicKey{i}
-
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			t.Fatal(err)
-		}
-		return hk
-	}
-	hk1 := addHost(1)
-	hk2 := addHost(2)
+	// add two hosts
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 
 	// helper to create slabs
 	newSlab := func(i byte) (slabs.SlabID, slabs.SlabPinParams) {
@@ -509,13 +474,7 @@ func TestUnpinSlab(t *testing.T) {
 	}
 
 	// add host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 
 	// precreate 3 slabs, 2 sectors each
 	var params []slabs.SlabPinParams
@@ -624,17 +583,11 @@ func TestUnpinSlab(t *testing.T) {
 func TestPinSectors(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// create account and host
+	// create host and account
+	hk := store.addTestHost(t)
 	account := proto.Account{1}
 	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		t.Fatal("failed to add account:", err)
-	}
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
 	}
 
 	// create 2 contracts
@@ -740,16 +693,8 @@ func TestUnhealthySlabs(t *testing.T) {
 		t.Fatal("failed to add account:", err)
 	}
 
-	// add host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// add contract
+	// add host with a contract
+	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
 	// pin a slab to add a few sectors to the database
@@ -852,18 +797,12 @@ func TestUnhealthySlabs(t *testing.T) {
 func TestUnpinnedSectors(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// create account, host and contract
+	// create host with account and contract
 	account := proto.Account{1}
 	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		t.Fatal("failed to add account:", err)
 	}
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		t.Fatal(err)
-	}
+	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
 	// create 4 sectors
@@ -949,14 +888,7 @@ func BenchmarkSlabs(b *testing.B) {
 	// 30 hosts to simulate default redundancy
 	var hks []types.PublicKey
 	for i := byte(0); i < 30; i++ {
-		hk := types.PublicKey{i}
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			b.Fatal(err)
-		}
-		hks = append(hks, hk)
+		hks = append(hks, store.addTestHost(b, types.PublicKey{i}))
 	}
 
 	// helper to create slabs
@@ -1044,13 +976,7 @@ func BenchmarkUnpinnedSectors(b *testing.B) {
 	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		b.Fatal("failed to add account:", err)
 	}
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
+	hk := store.addTestHost(b)
 	store.addTestContract(b, hk)
 
 	// prepare base db
@@ -1136,13 +1062,7 @@ func BenchmarkSectorsForIntegrityCheck(b *testing.B) {
 	}
 
 	// add a host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
+	hk := store.addTestHost(b)
 
 	// prepare base db
 	const (
@@ -1204,13 +1124,7 @@ func BenchmarkPinSectors(b *testing.B) {
 	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		b.Fatal("failed to add account:", err)
 	}
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
+	hk := store.addTestHost(b)
 	store.addTestContract(b, hk)
 
 	// prepare base db
@@ -1303,14 +1217,7 @@ func BenchmarkUnhealthySlab(b *testing.B) {
 	// 30 hosts to simulate default redundancy
 	var hks []types.PublicKey
 	for i := byte(0); i < 30; i++ {
-		hk := types.PublicKey{i}
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			b.Fatal(err)
-		}
-		hks = append(hks, hk)
+		hks = append(hks, store.addTestHost(b, types.PublicKey{i}))
 	}
 
 	// add 2 contracts
@@ -1406,16 +1313,8 @@ func BenchmarkUnpinSlab(b *testing.B) {
 		b.Fatal("failed to add account:", err)
 	}
 
-	// add host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
-
-	// add contract
+	// add host with one contract
+	hk := store.addTestHost(b)
 	store.addTestContract(b, hk)
 
 	// prepare base db
@@ -1474,13 +1373,7 @@ func BenchmarkRecordIntegrityChecks(b *testing.B) {
 	}
 
 	// add a host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
+	hk := store.addTestHost(b)
 
 	// prepare base db
 	const (
@@ -1544,13 +1437,7 @@ func BenchmarkFailingSectors(b *testing.B) {
 	}
 
 	// add a host
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
+	hk := store.addTestHost(b)
 
 	// prepare base db
 	const (
@@ -1637,18 +1524,13 @@ func TestMarkSectorsLost(t *testing.T) {
 		t.Fatal("failed to add account:", err)
 	}
 
-	// add hosts and contracts
-	hk1 := types.PublicKey{1}
-	hk2 := types.PublicKey{2}
-	for _, hk := range []types.PublicKey{hk1, hk2} {
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			t.Fatal(err)
-		}
-		store.addTestContract(t, hk)
-	}
+	// add two hosts
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+
+	// add a contract for each host
+	store.addTestContract(t, hk1)
+	store.addTestContract(t, hk2)
 
 	// pin a slab that adds 2 sectors to each host
 	root1 := frand.Entropy256()
@@ -1749,13 +1631,7 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		b.Fatal("failed to add account:", err)
 	}
-	hk := types.PublicKey{1}
-	ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-	}); err != nil {
-		b.Fatal(err)
-	}
+	hk := store.addTestHost(b)
 	store.addTestContract(b, hk)
 
 	// prepare base db
@@ -1873,13 +1749,7 @@ func BenchmarkMigrateSector(b *testing.B) {
 	// add 100 hosts and contracts
 	var hks []types.PublicKey
 	for range 100 {
-		hk := types.PublicKey(frand.Entropy256())
-		ha := chain.NetAddress{Protocol: quic.Protocol, Address: "[::]:4848"}
-		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-			return tx.AddHostAnnouncement(hk, chain.V2HostAnnouncement{ha}, time.Now())
-		}); err != nil {
-			b.Fatal(err)
-		}
+		hk := store.addTestHost(b)
 		store.addTestContract(b, hk)
 		hks = append(hks, hk)
 	}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -46,7 +46,7 @@ func TestMigrateSector(t *testing.T) {
 
 	// add contract for first host
 	fcid1 := types.FileContractID{1}
-	if err := store.AddFormedContract(context.Background(), fcid1, hk1, 0, 0, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk1, fcid1, newTestContract(hk1), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -642,9 +642,9 @@ func TestPinSectors(t *testing.T) {
 
 	// create 2 contracts
 	contractID1, contractID2 := types.FileContractID{1}, types.FileContractID{2}
-	if err := store.AddFormedContract(context.Background(), contractID1, hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, contractID1, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
-	} else if err := store.AddFormedContract(context.Background(), contractID2, hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	} else if err := store.AddFormedContract(context.Background(), hk, contractID2, newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -757,7 +757,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	}
 
 	// add contract
-	err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(3))
+	err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -874,7 +874,7 @@ func TestUnpinnedSectors(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1063,7 +1063,7 @@ func BenchmarkUnpinnedSectors(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1225,7 +1225,7 @@ func BenchmarkPinSectors(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1330,11 +1330,11 @@ func BenchmarkUnhealthySlab(b *testing.B) {
 	}
 
 	// add 1 good and 1 bad contract
-	err := store.AddFormedContract(context.Background(), types.FileContractID(hks[0]), hks[0], 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(3))
+	err := store.AddFormedContract(context.Background(), hks[0], types.FileContractID(hks[0]), newTestContract(hks[0]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		b.Fatal(err)
 	}
-	err = store.AddFormedContract(context.Background(), types.FileContractID(hks[1]), hks[1], 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(3))
+	err = store.AddFormedContract(context.Background(), hks[1], types.FileContractID(hks[1]), newTestContract(hks[1]), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1436,7 +1436,7 @@ func BenchmarkUnpinSlab(b *testing.B) {
 	}
 
 	// add contract
-	if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1669,7 +1669,7 @@ func TestMarkSectorsLost(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(2), types.Siacoins(3), types.Siacoins(3))
+		err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1781,7 +1781,7 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	}); err != nil {
 		b.Fatal(err)
 	}
-	if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+	if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1907,7 +1907,7 @@ func BenchmarkMigrateSector(b *testing.B) {
 		}); err != nil {
 			b.Fatal(err)
 		}
-		if err := store.AddFormedContract(context.Background(), types.FileContractID(hk), hk, 100, 200, types.Siacoins(1), types.Siacoins(1), types.Siacoins(1), types.Siacoins(1)); err != nil {
+		if err := store.AddFormedContract(context.Background(), hk, types.FileContractID(hk), newTestContract(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency); err != nil {
 			b.Fatal(err)
 		}
 		hks = append(hks, hk)

--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -28,6 +28,11 @@ type (
 		pool *pgxpool.Pool
 		log  *zap.Logger
 	}
+
+	testingCommon interface {
+		Helper()
+		Fatal(args ...any)
+	}
 )
 
 // String returns a connection string for the given ConnectionInfo.

--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -28,11 +28,6 @@ type (
 		pool *pgxpool.Pool
 		log  *zap.Logger
 	}
-
-	testingCommon interface {
-		Helper()
-		Fatal(args ...any)
-	}
 )
 
 // String returns a connection string for the given ConnectionInfo.


### PR DESCRIPTION
This PR persists the revision on the contract. Having local revisions will allow us to optimistically try and revise those and only fetch the latest revision from the host if we run into invalid signature errors trying to revise the contract.