### PR TITLE
Ensure database exists

### DIFF
--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -72,7 +72,7 @@ func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*Store, e
 		pool.Close()
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
-	log.Sugar().Infof("successfully connected to database %q on %s:%d", ci.Database, ci.Host, ci.Port)
+	log.Info("connected", zap.String("database", ci.Database), zap.String("host", ci.Host), zap.Int("port", ci.Port))
 
 	store := &Store{
 		pool: pool,

--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -61,10 +61,19 @@ func (s *Store) Close() error {
 // determines the lifecycle of necessary migrations. If the context is cancelled,
 // the running migration will be interupted and an error returned.
 func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*Store, error) {
+	if err := ensureDatabase(ctx, ci); err != nil {
+		return nil, fmt.Errorf("failed to ensure database exists: %w", err)
+	}
+
 	pool, err := pgxpool.New(ctx, ci.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect: %w", err)
+		return nil, fmt.Errorf("failed to create pool: %w", err)
+	} else if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
+	log.Sugar().Infof("successfully connected to database %q on %s:%d", ci.Database, ci.Host, ci.Port)
+
 	store := &Store{
 		pool: pool,
 		log:  log,
@@ -73,4 +82,33 @@ func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*Store, e
 		return nil, fmt.Errorf("failed to initialize store: %w", err)
 	}
 	return store, nil
+}
+
+func ensureDatabase(ctx context.Context, ci ConnectionInfo) error {
+	// return early if we're connecting to the default database
+	if ci.Database == "postgres" {
+		return nil
+	}
+	db := ci.Database
+	ci.Database = "postgres"
+
+	// connect to the postgres database
+	pool, err := pgxpool.New(ctx, ci.String())
+	if err != nil {
+		return fmt.Errorf("failed to connect to postgres database: %w", err)
+	}
+	defer pool.Close()
+
+	// check if the database exists
+	var exists bool
+	if err = pool.QueryRow(ctx, "SELECT EXISTS(SELECT FROM pg_database WHERE datname = $1)", db).Scan(&exists); err != nil {
+		return fmt.Errorf("failed to check if database exists: %w", err)
+	} else if exists {
+		return nil
+	}
+
+	// create the database if it does not exist
+	query := "CREATE DATABASE " + pgx.Identifier{db}.Sanitize()
+	_, err = pool.Exec(ctx, query)
+	return err
 }

--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -62,7 +62,7 @@ func (s *Store) Close() error {
 // the running migration will be interupted and an error returned.
 func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*Store, error) {
 	if err := ensureDatabase(ctx, ci); err != nil {
-		return nil, fmt.Errorf("failed to ensure database exists: %w", err)
+		return nil, fmt.Errorf("failed to ensure database %q exists: %w", ci.Database, err)
 	}
 
 	pool, err := pgxpool.New(ctx, ci.String())

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -2,23 +2,41 @@ package postgres
 
 import (
 	"context"
+	"encoding/hex"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
 )
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
 
-func initPostgres(t testing.TB, log *zap.Logger) *Store {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+func TestEnsureDatabase(t *testing.T) {
+	// generate random database name
+	rBytes := frand.Entropy128()
+	ci := connectionInfoFromEnv()
+	ci.Database = hex.EncodeToString(rBytes[:])
 
-	ci := ConnectionInfo{
+	// ensure the database exists
+	if err := ensureDatabase(context.Background(), ci); err != nil {
+		t.Fatalf("failed to ensure database: %v", err)
+	}
+
+	// cleanup - drop the database
+	store := initPostgres(t, zap.NewNop())
+	if _, err := store.pool.Exec(context.Background(), `DROP DATABASE `+pgx.Identifier{ci.Database}.Sanitize()); err != nil {
+		t.Fatalf("failed to drop database: %v", err)
+	}
+}
+
+func connectionInfoFromEnv() ConnectionInfo {
+	return ConnectionInfo{
 		Host:     "localhost",
 		Port:     5432,
 		User:     os.Getenv("POSTGRES_USER"),
@@ -26,7 +44,13 @@ func initPostgres(t testing.TB, log *zap.Logger) *Store {
 		Database: os.Getenv("POSTGRES_DB"),
 		SSLMode:  "disable",
 	}
-	db, err := Connect(ctx, ci, log)
+}
+
+func initPostgres(t testing.TB, log *zap.Logger) *Store {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	db, err := Connect(ctx, connectionInfoFromEnv(), log)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR avoids an unnecessary error at startup when starting the daemon using a database that doesn't exist yet.

```
daemon startup failed: failed to connect to postgres database: failed to initialize store: failed to initialize database: failed to begin transaction: failed to connect to `user=postgres database=indexd`: [::1]:5432 (localhost): server error: FATAL: database "indexd" does not exist (SQLSTATE 3D000)
```