### PR TITLE
Check for missing recovery phrase

### DIFF
--- a/cmd/indexd/main.go
+++ b/cmd/indexd/main.go
@@ -266,6 +266,9 @@ func main() {
 		if cfg.AdminAPI.Password == "" {
 			os.Stderr.WriteString(fmt.Sprintf("missing admin password - needs to be set either via config file or '%s' env var\n", indexdAdminPasswordEnvVar))
 			os.Exit(1)
+		} else if cfg.RecoveryPhrase == "" {
+			os.Stderr.WriteString("missing recovery phrase - needs to be set via config file\n")
+			os.Exit(1)
 		}
 
 		var seed [32]byte


### PR DESCRIPTION
Makes the error message more consistent with a missing admin password. If you run the binary with only an admin password you get `failed to load wallet seed: wrong number of words in seed phrase` which is not terribly helpful.