### PR TITLE
Update host checks and settings.

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -89,13 +89,13 @@ WITH globals AS (
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
-	has_settings AND settings_valid_until >= (NOW() + INTERVAL '1 hour'),
+	has_settings AND settings_valid_until >= (NOW() + INTERVAL '15 minutes'),
 	has_settings AND settings_accepting_contracts,
 	has_settings AND settings_contract_price <= globals.one_sc,
-	has_settings AND settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price,
-	has_settings AND settings_storage_price <= globals.hosts_max_storage_price,
-	has_settings AND settings_ingress_price <= globals.hosts_max_ingress_price,
-	has_settings AND settings_egress_price <= globals.hosts_max_egress_price,
+	has_settings AND (globals.hosts_min_collateral = 0 OR (settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price)),
+	has_settings AND (globals.hosts_max_storage_price = 0 OR settings_storage_price <= globals.hosts_max_storage_price),
+	has_settings AND (globals.hosts_max_ingress_price = 0 OR settings_ingress_price <= globals.hosts_max_ingress_price),
+	has_settings AND (globals.hosts_max_egress_price = 0 OR settings_egress_price <= globals.hosts_max_egress_price),
 	has_settings AND settings_free_sector_price <= globals.one_sc / globals.one_tb
 FROM hosts CROSS JOIN globals;`, sqlPublicKey(hk)))
 		if errors.Is(err, sql.ErrNoRows) {
@@ -163,13 +163,13 @@ WITH globals AS (
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
-	has_settings AND settings_valid_until >= (NOW() + INTERVAL '1 hour'),
+	has_settings AND settings_valid_until >= (NOW() + INTERVAL '15 minutes'),
 	has_settings AND settings_accepting_contracts,
 	has_settings AND settings_contract_price <= globals.one_sc,
-	has_settings AND settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price,
-	has_settings AND settings_storage_price <= globals.hosts_max_storage_price,
-	has_settings AND settings_ingress_price <= globals.hosts_max_ingress_price,
-	has_settings AND settings_egress_price <= globals.hosts_max_egress_price,
+	has_settings AND (globals.hosts_min_collateral = 0 OR (settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price)),
+	has_settings AND (globals.hosts_max_storage_price = 0 OR settings_storage_price <= globals.hosts_max_storage_price),
+	has_settings AND (globals.hosts_max_ingress_price = 0 OR settings_ingress_price <= globals.hosts_max_ingress_price),
+	has_settings AND (globals.hosts_max_egress_price = 0 OR settings_egress_price <= globals.hosts_max_egress_price),
 	has_settings AND settings_free_sector_price <= globals.one_sc / globals.one_tb
 FROM hosts CROSS JOIN globals
 WHERE
@@ -180,14 +180,13 @@ WHERE
 		settings_max_contract_duration >= globals.contracts_period AND
 		settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period AND
 		settings_version >= globals.host_min_version AND
-		settings_valid_until >= (NOW() + INTERVAL '1 hour') AND
+		settings_valid_until >= (NOW() + INTERVAL '15 minutes') AND
 		settings_accepting_contracts AND
 		settings_contract_price <= globals.one_sc AND
-		settings_collateral >= globals.hosts_min_collateral AND
-		settings_collateral >= 2 * settings_storage_price AND
-		settings_storage_price <= globals.hosts_max_storage_price AND
-		settings_ingress_price <= globals.hosts_max_ingress_price AND
-		settings_egress_price <= globals.hosts_max_egress_price AND
+		(globals.hosts_min_collateral = 0 OR (settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price)) AND
+		(globals.hosts_max_storage_price = 0 OR settings_storage_price <= globals.hosts_max_storage_price) AND
+		(globals.hosts_max_ingress_price = 0 OR settings_ingress_price <= globals.hosts_max_ingress_price) AND
+		(globals.hosts_max_egress_price = 0 OR settings_egress_price <= globals.hosts_max_egress_price) AND
 		settings_free_sector_price <= globals.one_sc / globals.one_tb
 		)
 	))

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -575,7 +575,7 @@ func TestHosts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// veriy hosts are unusable
+	// verify hosts are unusable
 	allHosts, err = db.Hosts(context.Background(), 0, 10)
 	if err != nil {
 		t.Fatal(err)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -108,7 +108,7 @@ func TestHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// assert host is found and address, networks and settings are populated
+	// assert host is found and address, networks and settings are populated and usability is good
 	if h, err := db.Host(context.Background(), hk); err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(h.Settings, hs) {
@@ -119,6 +119,26 @@ func TestHost(t *testing.T) {
 		t.Fatal("unexpected networks", h.Networks)
 	} else if h.LostSectors != 0 {
 		t.Fatal("expected lost sectors to be 0, got", h.LostSectors)
+	} else if !h.Usability.Collateral || !h.Usability.StoragePrice || !h.Usability.EgressPrice || !h.Usability.IngressPrice {
+		t.Fatal("expected host settings to be usable")
+	}
+
+	// update usability settings
+	oneH := types.NewCurrency64(1)
+	if err := db.UpdateUsabilitySettings(context.Background(), hosts.UsabilitySettings{
+		MaxEgressPrice:  hs.Prices.EgressPrice.Sub(oneH),
+		MaxIngressPrice: hs.Prices.IngressPrice.Sub(oneH),
+		MaxStoragePrice: hs.Prices.StoragePrice.Sub(oneH),
+		MinCollateral:   hs.Prices.Collateral.Add(oneH),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert the host's usability is updated
+	if h, err := db.Host(context.Background(), hk); err != nil {
+		t.Fatal(err)
+	} else if h.Usability.Collateral || h.Usability.StoragePrice || h.Usability.EgressPrice || h.Usability.IngressPrice {
+		t.Fatal("expected host settings to be unusable")
 	}
 
 	// pin a sector and mark it as lost
@@ -234,7 +254,7 @@ func TestHostChecks(t *testing.T) {
 			EgressPrice:     settingMaxEgressPrice.Add(oneH),
 			Collateral:      settingMinCollataral.Sub(oneH),
 			FreeSectorPrice: oneSC.Div64(oneTB).Add(oneH),
-			ValidUntil:      time.Now().Add(59 * time.Minute).Round(time.Microsecond),
+			ValidUntil:      time.Now().Add(14 * time.Minute).Add(59 * time.Second).Round(time.Microsecond),
 			TipHeight:       frand.Uint64n(1e3),
 		},
 	}, true, time.Now())
@@ -284,7 +304,7 @@ func TestHostChecks(t *testing.T) {
 	assertCheckOK("ProtocolVersion")
 
 	// adjust price validity so we pass the check
-	hs.Prices.ValidUntil = time.Now().Add(time.Second * 3601)
+	hs.Prices.ValidUntil = time.Now().Add(time.Second * (60*15 + 1))
 	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("PriceValidity")
 
@@ -337,16 +357,8 @@ func TestHosts(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	db := initPostgres(t, log.Named("postgres"))
 
-	// update global settings to make hosts pass all checks
-	if err := db.UpdateUsabilitySettings(context.Background(), hosts.UsabilitySettings{
-		MaxEgressPrice:     types.MaxCurrency,
-		MaxIngressPrice:    types.MaxCurrency,
-		MaxStoragePrice:    types.MaxCurrency,
-		MinCollateral:      types.ZeroCurrency,
-		MinProtocolVersion: [3]uint8{1, 0, 0},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	// update maintenance settings, we can leave usability settings at their
+	// default 0 values because they'll be ignored
 	if err := db.UpdateMaintenanceSettings(context.Background(), contracts.MaintenanceSettings{
 		Period:          2,
 		RenewWindow:     1,
@@ -525,6 +537,59 @@ func TestHosts(t *testing.T) {
 	assertHosts([]types.PublicKey{hk1}, 0, 1, hosts.WithBlocked(false))
 	assertHosts([]types.PublicKey{hk2}, 1, 1, hosts.WithBlocked(false))
 	assertHosts([]types.PublicKey{hk2}, 1, 1, hosts.WithActiveContracts(true))
+
+	// update usability settings in a way all hosts pass
+	defaults := newTestHostSettings(types.PublicKey{})
+	if err := db.UpdateUsabilitySettings(context.Background(), hosts.UsabilitySettings{
+		MaxEgressPrice:  defaults.Prices.EgressPrice,
+		MaxIngressPrice: defaults.Prices.IngressPrice,
+		MaxStoragePrice: defaults.Prices.StoragePrice,
+		MinCollateral:   defaults.Prices.Collateral,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// veriy hosts are still unusable
+	allHosts, err := db.Hosts(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(allHosts) != 4 {
+		t.Fatalf("expected 4 hosts, got %v", len(allHosts))
+	}
+	for _, h := range allHosts {
+		if !h.Usability.EgressPrice ||
+			!h.Usability.IngressPrice ||
+			!h.Usability.StoragePrice ||
+			!h.Usability.Collateral {
+			t.Fatalf("expected host %v to be usable, got %+v", h.PublicKey, h.Usability)
+		}
+	}
+
+	// update usability settings to make hosts unusable
+	if err := db.UpdateUsabilitySettings(context.Background(), hosts.UsabilitySettings{
+		MaxEgressPrice:  defaults.Prices.EgressPrice.Sub(types.NewCurrency64(1)),
+		MaxIngressPrice: defaults.Prices.IngressPrice.Sub(types.NewCurrency64(1)),
+		MaxStoragePrice: defaults.Prices.StoragePrice.Sub(types.NewCurrency64(1)),
+		MinCollateral:   defaults.Prices.Collateral.Add(types.NewCurrency64(1)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// veriy hosts are unusable
+	allHosts, err = db.Hosts(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(allHosts) != 4 {
+		t.Fatalf("expected 4 hosts, got %v", len(allHosts))
+	}
+	for _, h := range allHosts {
+		if h.Usability.EgressPrice ||
+			h.Usability.IngressPrice ||
+			h.Usability.StoragePrice ||
+			h.Usability.Collateral {
+			t.Fatalf("expected host %v to be usable, got %+v", h.PublicKey, h.Usability)
+		}
+	}
 }
 
 func TestHostsForScanning(t *testing.T) {
@@ -991,7 +1056,7 @@ func newTestHostSettings(pk types.PublicKey) proto4.HostSettings {
 		ProtocolVersion:     [3]uint8{1, 0, 0},
 		AcceptingContracts:  true,
 		WalletAddress:       types.StandardAddress(pk),
-		MaxCollateral:       types.Siacoins(10000),
+		MaxCollateral:       types.NewCurrency64(1e6).Mul64(1e12).Mul64(144 * 7 * 6), // collateral * 1TB * period
 		MaxContractDuration: 1000,
 		RemainingStorage:    100 * proto4.SectorSize,
 		TotalStorage:        100 * proto4.SectorSize,
@@ -1000,7 +1065,7 @@ func newTestHostSettings(pk types.PublicKey) proto4.HostSettings {
 			StoragePrice:  types.NewCurrency64(100),   // 100 H / byte / block
 			IngressPrice:  types.NewCurrency64(100),   // 100 H / byte
 			EgressPrice:   types.NewCurrency64(100),   // 100 H / byte
-			Collateral:    types.NewCurrency64(200),
+			Collateral:    types.NewCurrency64(1e6),
 			ValidUntil:    time.Now().Add(24 * time.Hour).Round(time.Microsecond),
 			TipHeight:     1,
 			Signature:     types.Signature{1, 2, 3},

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -129,7 +129,7 @@ CREATE TABLE global_settings (
     scanned_block_id BYTEA NOT NULL DEFAULT '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea CHECK (LENGTH(scanned_block_id) = 32),
 
     -- contract manager settings
-    contracts_maintenance_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    contracts_maintenance_enabled BOOLEAN NOT NULL DEFAULT TRUE,
     contracts_wanted INTEGER NOT NULL DEFAULT 50 CHECK(contracts_wanted > 0), -- number of contracts to maintain
     contracts_renew_window INTEGER NOT NULL DEFAULT 144 * 7 * 2 CHECK(contracts_renew_window > 0), -- 2 weeks
     contracts_period INTEGER NOT NULL DEFAULT 144 * 7 * 6 CHECK(contracts_period > contracts_renew_window), -- 6 weeks

--- a/persist/postgres/settings_test.go
+++ b/persist/postgres/settings_test.go
@@ -15,7 +15,7 @@ func TestContractSettings(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	expectedSettings := contracts.MaintenanceSettings{
-		Enabled:         false,
+		Enabled:         true,
 		Period:          6048,
 		RenewWindow:     2016,
 		WantedContracts: 50,
@@ -30,7 +30,7 @@ func TestContractSettings(t *testing.T) {
 	}
 
 	// update and check again
-	expectedSettings.Enabled = true
+	expectedSettings.Enabled = false
 	expectedSettings.Period *= 2
 	expectedSettings.RenewWindow *= 2
 	expectedSettings.WantedContracts *= 2


### PR DESCRIPTION
This PR changes 3 things:

It updates the `settings_valid_until` check and requires a minimum of 15 minutes instead of an hour. Most hosts set the validity to 30 minutes, so an hour definitely doesn't make sense unless we update the host code. Because it's a minimum value, I opted to go with 15 minutes as an absolute minimum. The hosts should really commit to prices for at least an hour though, and even more, in my opinion.

It allows disabling price checks on hosts by ignoring the check if the value in the database is 0. This allows the user to set the setting at 0 and essentially disable the check all together. An alternative would've been default settings but I think we should support disabling them all together anyway. This way we can keep the defaults at 0 for now.

I enabled contract maintenance by default. I think it's just annoying to disable it by default and have everyone manually update it before the indexer starts forming contracts. I understand why we didn't do this though and I'm fine with disabling it by default. Just a suggestion I had after running `indexd` for the first time locally.

Related https://github.com/SiaFoundation/indexd/issues/189