### PR TITLE
Move host client to its own package

### DIFF
--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -23,15 +23,34 @@ type (
 		ReplenishAccounts(context.Context, types.FileContractID, []proto.Account, types.Currency) (rhp.RPCReplenishAccountsResult, int, error)
 	}
 
+	// Dialer defines an interface for dialing the host and returning a host client. This client can be used to
+	// interact with the host using the RHP methods. The client is expected to be closed when no longer needed.
+	Dialer interface {
+		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
+	}
+
 	// Funder dials a host and replenish a set of ephemeral accounts.
 	Funder struct {
-		dialer client.Dialer[HostClient]
+		dialer Dialer
 	}
 )
 
+type wrapper struct {
+	d *client.SiamuxDialer
+}
+
+// DialHost dials the host and returns a HostClient.
+func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := w.d.DialHost(ctx, hostKey, addr)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
 // NewFunder creates a new Funder.
-func NewFunder(dialer client.Dialer[HostClient]) *Funder {
-	return &Funder{dialer: dialer}
+func NewFunder(dialer *client.SiamuxDialer) *Funder {
+	return &Funder{dialer: &wrapper{d: dialer}}
 }
 
 // FundAccounts tops up the provided accounts to the target balance using the

--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -35,12 +35,12 @@ type (
 	}
 )
 
-type wrapper struct {
-	d rhp.Dialer
+type dialer struct {
+	d *rhp.SiamuxDialer
 }
 
-func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
-	client, err := w.d.DialHost(ctx, hostKey, addr)
+func (d *dialer) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := d.d.DialHost(ctx, hostKey, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -48,8 +48,8 @@ func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr st
 }
 
 // NewFunder creates a new Funder.
-func NewFunder(dialer rhp.Dialer) *Funder {
-	return &Funder{dialer: &wrapper{d: dialer}}
+func NewFunder(d *rhp.SiamuxDialer) *Funder {
+	return &Funder{dialer: &dialer{d: d}}
 }
 
 // FundAccounts tops up the provided accounts to the target balance using the

--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -4,98 +4,52 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
+	"io"
 
-	"go.sia.tech/core/consensus"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
+	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/rhp"
 	"go.uber.org/zap"
 )
 
-const dialTimeout = 10 * time.Second
-
 type (
-	// ChainManager is the minimal interface of ChainManager functionality the
-	// Funder requires.
-	ChainManager interface {
-		TipState() consensus.State
+	// Dialer defines an interface to dial a host and get a client.
+	// host.
+	Dialer interface {
+		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
 	}
 
 	// HostClient defines the interface for the funder to interact with the
 	// host.
 	HostClient interface {
-		Dial(context.Context, string, types.PublicKey) (rhp.TransportClient, error)
-		RPCLatestRevision(context.Context, rhp.TransportClient, types.FileContractID) (proto.RPCLatestRevisionResponse, error)
-		RPCReplenishAccounts(context.Context, rhp.TransportClient, types.FileContractID, []proto.Account, types.Currency) (rhp.RPCReplenishAccountsResult, int, error)
+		io.Closer
+		LatestRevision(context.Context, types.FileContractID) (proto.RPCLatestRevisionResponse, error)
+		ReplenishAccounts(context.Context, types.FileContractID, []proto.Account, types.Currency) (rhp4.RPCReplenishAccountsResult, int, error)
 	}
 
 	// Funder dials a host and replenish a set of ephemeral accounts.
 	Funder struct {
-		client HostClient
+		dialer Dialer
 	}
 )
 
-var (
-	errContractInsufficientFunds = errors.New("contract has insufficient funds")
-	errContractNotRevisable      = errors.New("contract is not revisable")
-	errContractOutOfFunds        = errors.New("contract is out of funds")
-	errContractRenewed           = errors.New("contract got renewed")
-)
-
-type hostClient struct {
-	cm     ChainManager
-	signer rhp.ContractSigner
+type wrapper struct {
+	d rhp.Dialer
 }
 
-func (c *hostClient) Dial(ctx context.Context, addr string, peerKey types.PublicKey) (rhp.TransportClient, error) {
-	return siamux.Dial(ctx, addr, peerKey)
-}
-
-func (c *hostClient) RPCLatestRevision(ctx context.Context, t rhp.TransportClient, fcid types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
-	return rhp.RPCLatestRevision(ctx, t, fcid)
-}
-
-// RPCReplenishAccounts replenishes the accounts in the contract to the target value.
-func (c *hostClient) RPCReplenishAccounts(ctx context.Context, t rhp.TransportClient, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp.RPCReplenishAccountsResult, int, error) {
-	revision, err := c.RPCLatestRevision(ctx, t, contractID)
+func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := w.d.DialHost(ctx, hostKey, addr)
 	if err != nil {
-		return rhp.RPCReplenishAccountsResult{}, 0, fmt.Errorf("failed to fetch latest revision: %w", err)
-	} else if !revision.Revisable {
-		return rhp.RPCReplenishAccountsResult{}, 0, errContractNotRevisable
-	} else if revision.Contract.RenterOutput.Value.IsZero() {
-		return rhp.RPCReplenishAccountsResult{}, 0, errContractOutOfFunds
-	} else if revision.Contract.RenterOutput.Value.Cmp(target) < 0 {
-		return rhp.RPCReplenishAccountsResult{}, 0, errContractInsufficientFunds
+		return nil, err
 	}
-
-	// prepare batch
-	batchSize := int(min(revision.Contract.RenterOutput.Value.Div(target).Big().Uint64(), proto.MaxAccountBatchSize))
-	funded := min(batchSize, len(accounts))
-	batch := accounts[:funded]
-
-	// prepare parameters
-	params := rhp.RPCReplenishAccountsParams{
-		Accounts: batch,
-		Target:   target,
-		Contract: rhp.ContractRevision{ID: contractID, Revision: revision.Contract},
-	}
-
-	res, err := rhp.RPCReplenishAccounts(ctx, t, params, c.cm.TipState(), c.signer)
-	if err != nil {
-		return rhp.RPCReplenishAccountsResult{}, 0, fmt.Errorf("failed to replenish accounts: %w", err)
-	}
-
-	return res, funded, nil
+	return client, nil
 }
 
 // NewFunder creates a new Funder.
-func NewFunder(cm ChainManager, signer rhp.ContractSigner) *Funder {
-	return &Funder{
-		client: &hostClient{cm: cm, signer: signer},
-	}
+func NewFunder(dialer rhp.Dialer) *Funder {
+	return &Funder{dialer: &wrapper{d: dialer}}
 }
 
 // FundAccounts tops up the provided accounts to the target balance using the
@@ -116,11 +70,11 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 	}
 
 	// dial the host
-	tc, err := f.client.Dial(ctx, host.SiamuxAddr(), host.PublicKey)
+	client, err := f.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to dial host %s: %w", host.PublicKey, err)
 	}
-	defer tc.Close()
+	defer client.Close()
 
 	// prepare account keys
 	accountKeys := make([]proto.Account, len(accounts))
@@ -133,12 +87,12 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 		contractLog := log.With(zap.Stringer("contractID", contractID))
 
 		// execute replenish RPC
-		res, n, err := f.client.RPCReplenishAccounts(ctx, tc, contractID, accountKeys[funded:], target)
-		if errors.Is(err, errContractInsufficientFunds) {
+		res, n, err := client.ReplenishAccounts(ctx, contractID, accountKeys[funded:], target)
+		if errors.Is(err, rhp.ErrContractInsufficientFunds) {
 			contractLog.Debug("contract has insufficient funds")
 			drained++
 			continue
-		} else if errors.Is(err, errContractNotRevisable) {
+		} else if errors.Is(err, rhp.ErrContractNotRevisable) {
 			contractLog.Debug("contract is not revisable") // sanity check
 			drained++
 			continue

--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -69,7 +69,8 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 		contractLog := log.With(zap.Stringer("contractID", contractID))
 
 		// execute replenish RPC
-		res, n, err := hc.ReplenishAccounts(ctx, contractID, accountKeys[funded:], target)
+		maxEnd := min(len(accountKeys), funded+proto.MaxAccountBatchSize)
+		res, n, err := hc.ReplenishAccounts(ctx, contractID, accountKeys[funded:maxEnd], target)
 		if errors.Is(err, client.ErrContractInsufficientFunds) {
 			contractLog.Debug("contract has insufficient funds")
 			drained++

--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -8,48 +8,30 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	rhp4 "go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/hosts"
-	"go.sia.tech/indexd/rhp"
 	"go.uber.org/zap"
 )
 
 type (
-	// Dialer defines an interface to dial a host and get a client.
-	// host.
-	Dialer interface {
-		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
-	}
-
 	// HostClient defines the interface for the funder to interact with the
 	// host.
 	HostClient interface {
 		io.Closer
 		LatestRevision(context.Context, types.FileContractID) (proto.RPCLatestRevisionResponse, error)
-		ReplenishAccounts(context.Context, types.FileContractID, []proto.Account, types.Currency) (rhp4.RPCReplenishAccountsResult, int, error)
+		ReplenishAccounts(context.Context, types.FileContractID, []proto.Account, types.Currency) (rhp.RPCReplenishAccountsResult, int, error)
 	}
 
 	// Funder dials a host and replenish a set of ephemeral accounts.
 	Funder struct {
-		dialer Dialer
+		dialer client.Dialer[HostClient]
 	}
 )
 
-type dialer struct {
-	d *rhp.SiamuxDialer
-}
-
-func (d *dialer) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
-	client, err := d.d.DialHost(ctx, hostKey, addr)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}
-
 // NewFunder creates a new Funder.
-func NewFunder(d *rhp.SiamuxDialer) *Funder {
-	return &Funder{dialer: &dialer{d: d}}
+func NewFunder(dialer client.Dialer[HostClient]) *Funder {
+	return &Funder{dialer: dialer}
 }
 
 // FundAccounts tops up the provided accounts to the target balance using the
@@ -70,11 +52,11 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 	}
 
 	// dial the host
-	client, err := f.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
+	hc, err := f.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to dial host %s: %w", host.PublicKey, err)
 	}
-	defer client.Close()
+	defer hc.Close()
 
 	// prepare account keys
 	accountKeys := make([]proto.Account, len(accounts))
@@ -87,12 +69,12 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 		contractLog := log.With(zap.Stringer("contractID", contractID))
 
 		// execute replenish RPC
-		res, n, err := client.ReplenishAccounts(ctx, contractID, accountKeys[funded:], target)
-		if errors.Is(err, rhp.ErrContractInsufficientFunds) {
+		res, n, err := hc.ReplenishAccounts(ctx, contractID, accountKeys[funded:], target)
+		if errors.Is(err, client.ErrContractInsufficientFunds) {
 			contractLog.Debug("contract has insufficient funds")
 			drained++
 			continue
-		} else if errors.Is(err, rhp.ErrContractNotRevisable) {
+		} else if errors.Is(err, client.ErrContractNotRevisable) {
 			contractLog.Debug("contract is not revisable") // sanity check
 			drained++
 			continue

--- a/accounts/funder_test.go
+++ b/accounts/funder_test.go
@@ -7,9 +7,9 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	rhp4 "go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/hosts"
-	"go.sia.tech/indexd/rhp"
 	"go.uber.org/zap"
 )
 
@@ -27,21 +27,21 @@ func (*hostClientMock) LatestRevision(context.Context, types.FileContractID) (pr
 	return proto.RPCLatestRevisionResponse{}, nil
 }
 
-func (*hostClientMock) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp4.RPCReplenishAccountsResult, int, error) {
+func (*hostClientMock) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp.RPCReplenishAccountsResult, int, error) {
 	// use contract ID to cover all possible branches
 	switch contractID {
 	case types.FileContractID{1}:
-		return rhp4.RPCReplenishAccountsResult{}, 0, rhp.ErrContractInsufficientFunds
+		return rhp.RPCReplenishAccountsResult{}, 0, client.ErrContractInsufficientFunds
 	case types.FileContractID{2}:
-		return rhp4.RPCReplenishAccountsResult{}, 0, rhp.ErrContractNotRevisable
+		return rhp.RPCReplenishAccountsResult{}, 0, client.ErrContractNotRevisable
 	case types.FileContractID{3}:
-		return rhp4.RPCReplenishAccountsResult{}, 0, errors.New("failed to replenish accounts")
+		return rhp.RPCReplenishAccountsResult{}, 0, errors.New("failed to replenish accounts")
 	case types.FileContractID{4}:
-		return rhp4.RPCReplenishAccountsResult{Revision: types.V2FileContract{RenterOutput: types.SiacoinOutput{Value: target.Sub(types.NewCurrency64(1))}}}, 1, nil
+		return rhp.RPCReplenishAccountsResult{Revision: types.V2FileContract{RenterOutput: types.SiacoinOutput{Value: target.Sub(types.NewCurrency64(1))}}}, 1, nil
 	case types.FileContractID{5}, types.FileContractID{6}:
-		return rhp4.RPCReplenishAccountsResult{Revision: types.V2FileContract{RenterOutput: types.SiacoinOutput{Value: target}}}, 1, nil
+		return rhp.RPCReplenishAccountsResult{Revision: types.V2FileContract{RenterOutput: types.SiacoinOutput{Value: target}}}, 1, nil
 	case types.FileContractID{7}:
-		return rhp4.RPCReplenishAccountsResult{Revision: types.V2FileContract{RenterOutput: types.SiacoinOutput{Value: target}}}, len(accounts) - 1, nil
+		return rhp.RPCReplenishAccountsResult{Revision: types.V2FileContract{RenterOutput: types.SiacoinOutput{Value: target}}}, len(accounts) - 1, nil
 	default:
 		panic("unexpected contract ID in mock")
 	}

--- a/accounts/funder_test.go
+++ b/accounts/funder_test.go
@@ -3,44 +3,37 @@ package accounts
 import (
 	"context"
 	"errors"
-	"net"
 	"testing"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/rhp"
 	"go.uber.org/zap"
 )
 
-type clientMock struct{}
+type dialerMock struct{}
 
-func (c *clientMock) DialStream() (net.Conn, error) { return nil, nil }
-
-func (c *clientMock) FrameSize() int           { return 0 }
-func (c *clientMock) PeerKey() types.PublicKey { return types.PublicKey{} }
-
-func (c *clientMock) Close() error { return nil }
+func (*dialerMock) DialHost(ctx context.Context, hk types.PublicKey, addr string) (HostClient, error) {
+	return &hostClientMock{}, nil
+}
 
 type hostClientMock struct{}
 
 func (*hostClientMock) Close() error { return nil }
 
-func (*hostClientMock) Dial(ctx context.Context, addr string, hk types.PublicKey) (rhp4.TransportClient, error) {
-	return &clientMock{}, nil
-}
-
-func (*hostClientMock) RPCLatestRevision(ctx context.Context, tc rhp4.TransportClient, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+func (*hostClientMock) LatestRevision(context.Context, types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
 	return proto.RPCLatestRevisionResponse{}, nil
 }
 
-func (*hostClientMock) RPCReplenishAccounts(ctx context.Context, tc rhp4.TransportClient, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp4.RPCReplenishAccountsResult, int, error) {
+func (*hostClientMock) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp4.RPCReplenishAccountsResult, int, error) {
 	// use contract ID to cover all possible branches
 	switch contractID {
 	case types.FileContractID{1}:
-		return rhp4.RPCReplenishAccountsResult{}, 0, errContractInsufficientFunds
+		return rhp4.RPCReplenishAccountsResult{}, 0, rhp.ErrContractInsufficientFunds
 	case types.FileContractID{2}:
-		return rhp4.RPCReplenishAccountsResult{}, 0, errContractNotRevisable
+		return rhp4.RPCReplenishAccountsResult{}, 0, rhp.ErrContractNotRevisable
 	case types.FileContractID{3}:
 		return rhp4.RPCReplenishAccountsResult{}, 0, errors.New("failed to replenish accounts")
 	case types.FileContractID{4}:
@@ -57,7 +50,7 @@ func (*hostClientMock) RPCReplenishAccounts(ctx context.Context, tc rhp4.Transpo
 // TestFunder is a unit test that checks the various edge cases in FundAccounts
 func TestFunder(t *testing.T) {
 	// prepare funder
-	f := &Funder{client: &hostClientMock{}}
+	f := &Funder{dialer: &dialerMock{}}
 
 	// prepare accounts
 	accounts := []HostAccount{

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"go.sia.tech/core/consensus"
 	proto "go.sia.tech/core/rhp/v4"
@@ -43,37 +42,15 @@ type (
 		TipState() consensus.State
 		rhp.TxPool
 	}
-
-	// Dialer defines an interface that allows dialing a host.
-	Dialer[T any] interface {
-		// DialHost dials the host and returns a Client that can be used to
-		// interact with the host. It uses the SiaMux protocol to establish a
-		// connection and returns a host client that exposes the RPC methods
-		// defined in the RHP.
-		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (T, error)
-	}
-
-	// client defines an interface that allows interacting with a host using the
-	// RPC methods defined in the RHP.
-	client interface {
-		io.Closer
-		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error)
-		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
-		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
-		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error)
-		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
-		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error)
-		ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp.RPCReplenishAccountsResult, int, error)
-	}
 )
 
-// hostClient is a client that can be used to interact with a host using the RHP
+// HostClient is a client that can be used to interact with a host using the RHP
 // methods. It provides methods to form contracts, append sectors, free sectors,
 // get sector roots, refresh and renew contracts, and replenish accounts. It
 // uses a transport client to communicate with the host and a signer to sign the
 // contract revisions. The client is expected to be closed when no longer
 // needed.
-type hostClient struct {
+type HostClient struct {
 	hostKey types.PublicKey
 
 	client rhp.TransportClient
@@ -86,8 +63,8 @@ type hostClient struct {
 // newHostClient creates a new HostClient that can be used to interact with a
 // host using the RHP methods. The client is expected to be closed when no
 // longer needed.
-func newHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClient, signer rhp.FormContractSigner, log *zap.Logger) client {
-	return &hostClient{
+func newHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClient, signer rhp.FormContractSigner, log *zap.Logger) *HostClient {
+	return &HostClient{
 		hostKey: hk,
 
 		client: client,
@@ -99,7 +76,7 @@ func newHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClie
 }
 
 // AppendSectors appends the given sectors to the contract.
-func (c *hostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
+func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
 	// sanity check
 	if len(sectors) > proto.MaxSectorBatchSize {
 		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
@@ -123,12 +100,12 @@ func (c *hostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 }
 
 // Close closes the underlying transport client.
-func (c *hostClient) Close() error {
+func (c *HostClient) Close() error {
 	return c.client.Close()
 }
 
 // FormContract forms a new contract with the host.
-func (c *hostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+func (c *HostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
 	res, err := rhp.RPCFormContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, c.hostKey, settings.WalletAddress, params)
 	if err != nil {
 		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to form contract: %w", err)
@@ -138,7 +115,7 @@ func (c *hostClient) FormContract(ctx context.Context, settings proto.HostSettin
 }
 
 // SectorRoots returns the sector roots for a contract.
-func (c *hostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error) {
+func (c *HostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error) {
 	// fetch revision and check if it meets the requirements
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
@@ -155,7 +132,7 @@ func (c *hostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrice
 }
 
 // FreeSectors frees the specified sectors in the contract.
-func (c *hostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error) {
+func (c *HostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error) {
 	// fetch revision and check if it meets the requirements
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
@@ -172,7 +149,7 @@ func (c *hostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrice
 }
 
 // RefreshContract refreshes the contract with the host.
-func (c *hostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+func (c *HostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, params.ContractID)
 	if err != nil {
 		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -194,7 +171,7 @@ func (c *hostClient) RefreshContract(ctx context.Context, settings proto.HostSet
 }
 
 // RenewContract renews the contract with the host.
-func (c *hostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+func (c *HostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
 		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -223,7 +200,7 @@ func (c *hostClient) RenewContract(ctx context.Context, settings proto.HostSetti
 }
 
 // ReplenishAccounts replenishes the accounts in the contract to the target value.
-func (c *hostClient) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (res rhp.RPCReplenishAccountsResult, funded int, _ error) {
+func (c *HostClient) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (res rhp.RPCReplenishAccountsResult, funded int, _ error) {
 	rev, err := c.LatestRevision(ctx, contractID)
 	if err != nil {
 		return rhp.RPCReplenishAccountsResult{}, 0, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -251,6 +228,6 @@ func (c *hostClient) ReplenishAccounts(ctx context.Context, contractID types.Fil
 }
 
 // LatestRevision retrieves the latest revision of a contract from the host.
-func (c *hostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+func (c *HostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
 	return rhp.RPCLatestRevision(ctx, c.client, contractID)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -1,9 +1,10 @@
-package rhp
+package client
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"go.sia.tech/core/consensus"
 	proto "go.sia.tech/core/rhp/v4"
@@ -42,15 +43,37 @@ type (
 		TipState() consensus.State
 		rhp.TxPool
 	}
+
+	// Dialer defines an interface that allows dialing a host.
+	Dialer[T any] interface {
+		// DialHost dials the host and returns a Client that can be used to
+		// interact with the host. It uses the SiaMux protocol to establish a
+		// connection and returns a host client that exposes the RPC methods
+		// defined in the RHP.
+		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (T, error)
+	}
+
+	// client defines an interface that allows interacting with a host using the
+	// RPC methods defined in the RHP.
+	client interface {
+		io.Closer
+		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error)
+		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
+		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
+		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error)
+		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
+		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error)
+		ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (rhp.RPCReplenishAccountsResult, int, error)
+	}
 )
 
-// HostClient is a client that can be used to interact with a host using the RHP
+// hostClient is a client that can be used to interact with a host using the RHP
 // methods. It provides methods to form contracts, append sectors, free sectors,
 // get sector roots, refresh and renew contracts, and replenish accounts. It
 // uses a transport client to communicate with the host and a signer to sign the
 // contract revisions. The client is expected to be closed when no longer
 // needed.
-type HostClient struct {
+type hostClient struct {
 	hostKey types.PublicKey
 
 	client rhp.TransportClient
@@ -60,11 +83,11 @@ type HostClient struct {
 	log *zap.Logger
 }
 
-// NewHostClient creates a new HostClient that can be used to interact with a
+// newHostClient creates a new HostClient that can be used to interact with a
 // host using the RHP methods. The client is expected to be closed when no
 // longer needed.
-func NewHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClient, signer rhp.FormContractSigner, log *zap.Logger) *HostClient {
-	return &HostClient{
+func newHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClient, signer rhp.FormContractSigner, log *zap.Logger) client {
+	return &hostClient{
 		hostKey: hk,
 
 		client: client,
@@ -76,7 +99,7 @@ func NewHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClie
 }
 
 // AppendSectors appends the given sectors to the contract.
-func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
+func (c *hostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
 	// sanity check
 	if len(sectors) > proto.MaxSectorBatchSize {
 		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
@@ -100,12 +123,12 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 }
 
 // Close closes the underlying transport client.
-func (c *HostClient) Close() error {
+func (c *hostClient) Close() error {
 	return c.client.Close()
 }
 
 // FormContract forms a new contract with the host.
-func (c *HostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+func (c *hostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
 	res, err := rhp.RPCFormContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, c.hostKey, settings.WalletAddress, params)
 	if err != nil {
 		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to form contract: %w", err)
@@ -115,7 +138,7 @@ func (c *HostClient) FormContract(ctx context.Context, settings proto.HostSettin
 }
 
 // SectorRoots returns the sector roots for a contract.
-func (c *HostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error) {
+func (c *hostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error) {
 	// fetch revision and check if it meets the requirements
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
@@ -132,7 +155,7 @@ func (c *HostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrice
 }
 
 // FreeSectors frees the specified sectors in the contract.
-func (c *HostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error) {
+func (c *hostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error) {
 	// fetch revision and check if it meets the requirements
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
@@ -149,7 +172,7 @@ func (c *HostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrice
 }
 
 // RefreshContract refreshes the contract with the host.
-func (c *HostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+func (c *hostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, params.ContractID)
 	if err != nil {
 		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -171,7 +194,7 @@ func (c *HostClient) RefreshContract(ctx context.Context, settings proto.HostSet
 }
 
 // RenewContract renews the contract with the host.
-func (c *HostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+func (c *hostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
 	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
 	if err != nil {
 		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -200,7 +223,7 @@ func (c *HostClient) RenewContract(ctx context.Context, settings proto.HostSetti
 }
 
 // ReplenishAccounts replenishes the accounts in the contract to the target value.
-func (c *HostClient) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (res rhp.RPCReplenishAccountsResult, funded int, _ error) {
+func (c *hostClient) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (res rhp.RPCReplenishAccountsResult, funded int, _ error) {
 	rev, err := c.LatestRevision(ctx, contractID)
 	if err != nil {
 		return rhp.RPCReplenishAccountsResult{}, 0, fmt.Errorf("failed to fetch latest revision: %w", err)
@@ -228,6 +251,6 @@ func (c *HostClient) ReplenishAccounts(ctx context.Context, contractID types.Fil
 }
 
 // LatestRevision retrieves the latest revision of a contract from the host.
-func (c *HostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+func (c *hostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
 	return rhp.RPCLatestRevision(ctx, c.client, contractID)
 }

--- a/client/dialer.go
+++ b/client/dialer.go
@@ -14,15 +14,15 @@ import (
 const dialTimeout = 10 * time.Second
 
 // SiamuxDialer can be used to dial a host using the SiaMux protocol.
-type SiamuxDialer[T any] struct {
+type SiamuxDialer struct {
 	cm     ChainManager
 	signer rhp.FormContractSigner
 	log    *zap.Logger
 }
 
 // NewSiamuxDialer creates a new SiamuxDialer.
-func NewSiamuxDialer[T any](cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) *SiamuxDialer[T] {
-	return &SiamuxDialer[T]{
+func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) *SiamuxDialer {
+	return &SiamuxDialer{
 		cm:     cm,
 		signer: signer,
 		log:    log,
@@ -32,21 +32,14 @@ func NewSiamuxDialer[T any](cm ChainManager, signer rhp.FormContractSigner, log 
 // DialHost dials the host and returns a Client that can be used to interact
 // with the host. It uses the SiaMux protocol to establish a connection and
 // returns a host client that exposes the RPC methods defined in the RHP.
-func (d *SiamuxDialer[T]) DialHost(ctx context.Context, hk types.PublicKey, addr string) (T, error) {
+func (d *SiamuxDialer) DialHost(ctx context.Context, hk types.PublicKey, addr string) (*HostClient, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 
 	tc, err := siamux.Dial(ctx, addr, hk)
 	if err != nil {
-		var zero T
-		return zero, fmt.Errorf("failed to dial host: %w", err)
+		return nil, fmt.Errorf("failed to dial host: %w", err)
 	}
 
-	client, ok := newHostClient(hk, d.cm, tc, d.signer, d.log.With(zap.Stringer("hostKey", hk))).(T)
-	if !ok {
-		var zero T
-		return zero, fmt.Errorf("failed to cast host client to type %T", zero)
-	}
-
-	return client, nil
+	return newHostClient(hk, d.cm, tc, d.signer, d.log.With(zap.Stringer("hostKey", hk))), nil
 }

--- a/client/dialer.go
+++ b/client/dialer.go
@@ -1,4 +1,4 @@
-package rhp
+package client
 
 import (
 	"context"
@@ -14,15 +14,15 @@ import (
 const dialTimeout = 10 * time.Second
 
 // SiamuxDialer can be used to dial a host using the SiaMux protocol.
-type SiamuxDialer struct {
+type SiamuxDialer[T any] struct {
 	cm     ChainManager
 	signer rhp.FormContractSigner
 	log    *zap.Logger
 }
 
 // NewSiamuxDialer creates a new SiamuxDialer.
-func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) *SiamuxDialer {
-	return &SiamuxDialer{
+func NewSiamuxDialer[T any](cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) *SiamuxDialer[T] {
+	return &SiamuxDialer[T]{
 		cm:     cm,
 		signer: signer,
 		log:    log,
@@ -32,14 +32,21 @@ func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Lo
 // DialHost dials the host and returns a Client that can be used to interact
 // with the host. It uses the SiaMux protocol to establish a connection and
 // returns a host client that exposes the RPC methods defined in the RHP.
-func (d *SiamuxDialer) DialHost(ctx context.Context, hk types.PublicKey, addr string) (*HostClient, error) {
+func (d *SiamuxDialer[T]) DialHost(ctx context.Context, hk types.PublicKey, addr string) (T, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 
-	client, err := siamux.Dial(ctx, addr, hk)
+	tc, err := siamux.Dial(ctx, addr, hk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial host: %w", err)
+		var zero T
+		return zero, fmt.Errorf("failed to dial host: %w", err)
 	}
 
-	return NewHostClient(hk, d.cm, client, d.signer, d.log.With(zap.Stringer("hostKey", hk))), nil
+	client, ok := newHostClient(hk, d.cm, tc, d.signer, d.log.With(zap.Stringer("hostKey", hk))).(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("failed to cast host client to type %T", zero)
+	}
+
+	return client, nil
 }

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -109,10 +109,11 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	defer hm.Close()
 
 	signer := contracts.NewFormContractSigner(wm, walletKey)
-	am := accounts.NewManager(store, accounts.NewFunder(client.NewSiamuxDialer[accounts.HostClient](cm, signer, log)), accounts.WithLogger(log.Named("accounts")))
+	dialer := client.NewSiamuxDialer(cm, signer, log)
+	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 	defer am.Close()
 
-	contracts, err := contracts.NewManager(walletKey, am, cm, store, client.NewSiamuxDialer[contracts.HostClient](cm, signer, log), hm, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, cm, store, dialer, hm, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)
 	}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -28,6 +28,7 @@ import (
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.sia.tech/indexd/pins"
+	"go.sia.tech/indexd/rhp"
 	"go.sia.tech/indexd/subscriber"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -107,11 +108,12 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer hm.Close()
 
-	funder := accounts.NewFunder(cm, wm)
-	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
+	signer := contracts.NewFormContractSigner(wm, walletKey)
+	dialer := rhp.NewSiamuxDialer(cm, signer, log)
+	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 	defer am.Close()
 
-	contracts, err := contracts.NewManager(walletKey, am, cm, hm, store, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, cm, store, dialer, hm, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)
 	}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -22,13 +22,13 @@ import (
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/config"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/explorer"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.sia.tech/indexd/pins"
-	"go.sia.tech/indexd/rhp"
 	"go.sia.tech/indexd/subscriber"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -109,11 +109,10 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	defer hm.Close()
 
 	signer := contracts.NewFormContractSigner(wm, walletKey)
-	dialer := rhp.NewSiamuxDialer(cm, signer, log)
-	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
+	am := accounts.NewManager(store, accounts.NewFunder(client.NewSiamuxDialer[accounts.HostClient](cm, signer, log)), accounts.WithLogger(log.Named("accounts")))
 	defer am.Close()
 
-	contracts, err := contracts.NewManager(walletKey, am, cm, store, dialer, hm, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, cm, store, client.NewSiamuxDialer[contracts.HostClient](cm, signer, log), hm, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)
 	}

--- a/contracts/broadcast.go
+++ b/contracts/broadcast.go
@@ -5,15 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.uber.org/zap"
 )
-
-func (c *hostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
-	return rhp.RPCLatestRevision(ctx, c.client, contractID)
-}
 
 func (cm *ContractManager) performBroadcastContractRevisions(ctx context.Context, log *zap.Logger) error {
 	broadcastLog := log.Named("broadcast")
@@ -62,13 +56,13 @@ func (cm *ContractManager) broadcastContractRevision(ctx context.Context, contra
 	}
 
 	// fetch the latest revision
-	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	client, err := cm.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		return fmt.Errorf("failed to dial host: %w", err)
 	}
-	defer hc.Close()
+	defer client.Close()
 
-	resp, err := hc.LatestRevision(ctx, contractID)
+	resp, err := client.LatestRevision(ctx, contractID)
 	if err != nil {
 		log.Warn("failed to fetch latest revision", zap.Error(err))
 		return nil

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -21,7 +21,7 @@ func TestBroadcastContractRevisions(t *testing.T) {
 	walletMock := &walletMock{}
 	store := &storeMock{}
 
-	contracts := newContractManager(types.PublicKey{}, nil, cmMock, dialer, nil, store, syncerMock, walletMock)
+	contracts := newContractManager(types.PublicKey{}, nil, cmMock, store, dialer, nil, syncerMock, walletMock)
 	contracts.revisionBroadcastInterval = time.Minute
 
 	// add host

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -598,7 +598,7 @@ func TestProcessActions(t *testing.T) {
 	cmMock := newChainManagerMock()
 	syncerMock := &syncerMock{}
 	store := &storeMock{}
-	contracts := newContractManager(types.PublicKey{}, amMock, cmMock, nil, nil, store, syncerMock, &walletMock{})
+	contracts := newContractManager(types.PublicKey{}, amMock, cmMock, store, nil, nil, syncerMock, &walletMock{})
 
 	contract := types.V2FileContractElement{
 		ID: types.FileContractID{1},

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -8,7 +8,6 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -54,67 +53,6 @@ func (s *formContractSigner) SignHash(h types.Hash256) types.Signature {
 
 func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int) {
 	s.w.SignV2Inputs(txn, toSign)
-}
-
-// dialer is an interface for dialing a host.
-type dialer interface {
-	Dial(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
-}
-
-type hostClient struct {
-	cm      ChainManager
-	client  rhp.TransportClient
-	hostKey types.PublicKey
-	signer  *formContractSigner
-}
-
-type siamuxDialer struct {
-	cm     ChainManager
-	ownKey types.PrivateKey
-	w      Wallet
-}
-
-// newSiamuxDialer creates a new Dialer that uses the SiaMux protocol to dial a
-// host.
-func newSiamuxDialer(cm ChainManager, w Wallet, ownKey types.PrivateKey) dialer {
-	return &siamuxDialer{
-		cm:     cm,
-		ownKey: ownKey,
-		w:      w,
-	}
-}
-
-// Dial creates a production HostClient that forms, refreshes and renews
-// contracts by dialing up hosts using the SiaMux protocol.
-func (d *siamuxDialer) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
-	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
-	defer cancel()
-	client, err := siamux.Dial(ctx, addr, hostKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial host: %w", err)
-	}
-	return &hostClient{
-		client:  client,
-		cm:      d.cm,
-		hostKey: hostKey,
-		signer: &formContractSigner{
-			renterKey: d.ownKey,
-			w:         d.w,
-		},
-	}, nil
-}
-
-func (c *hostClient) Close() error {
-	return c.client.Close()
-}
-
-func (c *hostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
-	res, err := rhp.RPCFormContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, c.hostKey, settings.WalletAddress, params)
-	if err != nil {
-		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to form contract: %w", err)
-	}
-
-	return res, nil
 }
 
 // performContractFormation makes sure that we have at least 'wanted' good
@@ -240,7 +178,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 
 		allowance, collateral := initialContractFunding(host.Settings.Prices, host.Settings.MaxCollateral, period)
 		formationCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		hc, err := cm.dialer.Dial(formationCtx, host.PublicKey, host.SiamuxAddr())
+		hc, err := cm.dialer.DialHost(formationCtx, host.PublicKey, host.SiamuxAddr())
 		if err != nil {
 			cancel()
 			return fmt.Errorf("failed to dial host: %w", err)

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -55,7 +55,7 @@ func (d *dialerMock) HostClient(hostKey types.PublicKey) *hostClientMock {
 	return d.clients[hostKey]
 }
 
-func (d *dialerMock) Dial(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+func (d *dialerMock) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
 	if _, ok := d.clients[hostKey]; !ok {
 		d.clients[hostKey] = newHostClientMock()
 	}
@@ -251,7 +251,7 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 	dialer := newDialerMock()
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, store, dialer, scanner, syncerMock, wallet)
 
 	// disable randomizing hosts to make test deterministic
 	contracts.shuffle = func(int, func(i, j int)) {}
@@ -417,7 +417,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	dialer := newDialerMock()
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, store, dialer, scanner, syncerMock, wallet)
 
 	// disable randomizing hosts to make test deterministic
 	contracts.shuffle = func(int, func(i, j int)) {}

--- a/contracts/fund_test.go
+++ b/contracts/fund_test.go
@@ -79,7 +79,7 @@ func (s *storeMock) ContractsForFunding(_ context.Context, hk types.PublicKey, l
 func TestPerformAccountFunding(t *testing.T) {
 	amMock := &accountsManagerMock{}
 	store := newStoreMock()
-	cm := newContractManager(types.PublicKey{}, amMock, nil, nil, nil, store, nil, nil)
+	cm := newContractManager(types.PublicKey{}, amMock, nil, store, nil, nil, nil, nil)
 
 	// fund accounts
 	err := cm.performAccountFunding(context.Background(), zap.NewNop())

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -59,6 +59,12 @@ type (
 		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error)
 	}
 
+	// Dialer defines an interface for dialing the host and returning a host client. This client can be used to
+	// interact with the host using the RHP methods. The client is expected to be closed when no longer needed.
+	Dialer interface {
+		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
+	}
+
 	// Scanner defines the minimal interface of Scanner functionality
 	// the ContractManager requires.
 	Scanner interface {
@@ -147,7 +153,7 @@ type (
 		w     Wallet
 		store Store
 
-		dialer    client.Dialer[HostClient]
+		dialer    Dialer
 		scanner   Scanner
 		renterKey types.PublicKey
 
@@ -172,11 +178,24 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 	}
 }
 
+type wrapper struct {
+	d *client.SiamuxDialer
+}
+
+// DialHost dials the host and returns a HostClient.
+func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := w.d.DialHost(ctx, hostKey, addr)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer client.Dialer[HostClient], scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, dialer, scanner, syncer, wallet, opts...)
+func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer *client.SiamuxDialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, &wrapper{d: dialer}, scanner, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {
@@ -189,7 +208,7 @@ func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chain
 	return cm, nil
 }
 
-func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer client.Dialer[HostClient], scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
+func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer Dialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
 	cm := &ContractManager{
 		am: accountManager,
 		cm: chainManager,

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -170,13 +170,13 @@ type (
 	}
 )
 
-type wrapper struct {
-	d rhp.Dialer
+type dialer struct {
+	d *rhp.SiamuxDialer
 }
 
 // DialHost dials the host and returns a HostClient.
-func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
-	client, err := w.d.DialHost(ctx, hostKey, addr)
+func (d *dialer) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := d.d.DialHost(ctx, hostKey, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +193,8 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer rhp.Dialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, &wrapper{d: dialer}, scanner, syncer, wallet, opts...)
+func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, d *rhp.SiamuxDialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, &dialer{d: d}, scanner, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -10,11 +10,11 @@ import (
 	"go.sia.tech/core/consensus"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	rhp4 "go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/threadgroup"
+	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/hosts"
-	"go.sia.tech/indexd/rhp"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -46,22 +46,17 @@ type (
 		V2TransactionSet(basis types.ChainIndex, txn types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error)
 	}
 
-	// Dialer defines an interface to dial a host and get a client.
-	Dialer interface {
-		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
-	}
-
 	// HostClient defines the dependencies required to form, renew and refresh
 	// contracts.
 	HostClient interface {
 		io.Closer
-		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp4.RPCAppendSectorsResult, error)
-		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp4.RPCFormContractResult, error)
-		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp4.RPCFreeSectorsResult, error)
+		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error)
+		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
+		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
 		LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error)
-		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp4.RPCRefreshContractResult, error)
-		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp4.RPCRenewContractResult, error)
-		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp4.RPCSectorRootsResult, error)
+		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
+		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error)
+		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error)
 	}
 
 	// Scanner defines the minimal interface of Scanner functionality
@@ -152,7 +147,7 @@ type (
 		w     Wallet
 		store Store
 
-		dialer    Dialer
+		dialer    client.Dialer[HostClient]
 		scanner   Scanner
 		renterKey types.PublicKey
 
@@ -170,19 +165,6 @@ type (
 	}
 )
 
-type dialer struct {
-	d *rhp.SiamuxDialer
-}
-
-// DialHost dials the host and returns a HostClient.
-func (d *dialer) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
-	client, err := d.d.DialHost(ctx, hostKey, addr)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}
-
 // WithLogger creates the contract manager with a custom logger
 func WithLogger(l *zap.Logger) ContractManagerOpt {
 	return func(cm *ContractManager) {
@@ -193,8 +175,8 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, d *rhp.SiamuxDialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, &dialer{d: d}, scanner, syncer, wallet, opts...)
+func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer client.Dialer[HostClient], scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, dialer, scanner, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {
@@ -207,7 +189,7 @@ func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chain
 	return cm, nil
 }
 
-func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer Dialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
+func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer client.Dialer[HostClient], scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
 	cm := &ContractManager{
 		am: accountManager,
 		cm: chainManager,

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -10,10 +10,11 @@ import (
 	"go.sia.tech/core/consensus"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
+	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/rhp"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -23,7 +24,6 @@ const (
 
 	hostsFetchLimit = 100
 
-	dialTimeout         = 10 * time.Second
 	minRemainingStorage = (10 * 1 << 30) / uint64(proto.SectorSize) // 10GB
 	maxContractSize     = 10 * 1 << 40                              // 10TB
 
@@ -46,22 +46,27 @@ type (
 		V2TransactionSet(basis types.ChainIndex, txn types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error)
 	}
 
+	// Dialer defines an interface to dial a host and get a client.
+	Dialer interface {
+		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error)
+	}
+
 	// HostClient defines the dependencies required to form, renew and refresh
 	// contracts.
 	HostClient interface {
 		io.Closer
-		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error)
-		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
-		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
+		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp4.RPCAppendSectorsResult, error)
+		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp4.RPCFormContractResult, error)
+		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp4.RPCFreeSectorsResult, error)
 		LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error)
-		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
-		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error)
-		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error)
+		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp4.RPCRefreshContractResult, error)
+		RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp4.RPCRenewContractResult, error)
+		SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp4.RPCSectorRootsResult, error)
 	}
 
-	// HostManager defines the minimal interface of HostManager functionality
+	// Scanner defines the minimal interface of Scanner functionality
 	// the ContractManager requires.
-	HostManager interface {
+	Scanner interface {
 		ScanHost(ctx context.Context, hk types.PublicKey) (hosts.Host, error)
 	}
 
@@ -147,8 +152,8 @@ type (
 		w     Wallet
 		store Store
 
-		dialer    dialer
-		scanner   HostManager
+		dialer    Dialer
+		scanner   Scanner
 		renterKey types.PublicKey
 
 		triggerFundingChan chan struct{}
@@ -165,6 +170,19 @@ type (
 	}
 )
 
+type wrapper struct {
+	d rhp.Dialer
+}
+
+// DialHost dials the host and returns a HostClient.
+func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := w.d.DialHost(ctx, hostKey, addr)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
 // WithLogger creates the contract manager with a custom logger
 func WithLogger(l *zap.Logger) ContractManagerOpt {
 	return func(cm *ContractManager) {
@@ -175,9 +193,8 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	dialer := newSiamuxDialer(chainManager, wallet, renterKey)
-	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, dialer, scanner, store, syncer, wallet, opts...)
+func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer rhp.Dialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	cm := newContractManager(renterKey.PublicKey(), accountManager, chainManager, store, &wrapper{d: dialer}, scanner, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {
@@ -190,7 +207,7 @@ func NewManager(renterKey types.PrivateKey, accountManager AccountManager, chain
 	return cm, nil
 }
 
-func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, dialer dialer, scanner HostManager, store Store, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
+func newContractManager(renterKey types.PublicKey, accountManager AccountManager, chainManager ChainManager, store Store, dialer Dialer, scanner Scanner, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
 	cm := &ContractManager{
 		am: accountManager,
 		cm: chainManager,
@@ -480,13 +497,14 @@ func (cm *ContractManager) syncContract(ctx context.Context, contract Contract, 
 	revisionCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
-	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	client, err := cm.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		contractLog.Warn("failed to dial host", zap.Error(err))
 		return err
 	}
-	defer hc.Close()
-	resp, err := hc.LatestRevision(revisionCtx, contract.ID)
+	defer client.Close()
+
+	resp, err := client.LatestRevision(revisionCtx, contract.ID)
 	if err != nil {
 		contractLog.Warn("failed to fetch latest revision", zap.Error(err))
 		return nil

--- a/contracts/manager_test.go
+++ b/contracts/manager_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestBlockBadHosts(t *testing.T) {
 	store := &storeMock{}
-	contracts := newContractManager(types.PublicKey{}, nil, nil, nil, nil, store, nil, nil)
+	contracts := newContractManager(types.PublicKey{}, nil, nil, store, nil, nil, nil, nil)
 
 	goodHost := hosts.Host{PublicKey: types.PublicKey{1}, Usability: hosts.GoodUsability, Blocked: false}
 	badHost := hosts.Host{PublicKey: types.PublicKey{2}, Usability: hosts.Usability{}, Blocked: false}

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -9,33 +9,9 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
-
-func (c *hostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
-	// sanity check
-	if len(sectors) > proto.MaxSectorBatchSize {
-		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
-	}
-
-	// fetch revision and check if it meets the requirements
-	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
-	if err != nil {
-		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
-	} else if !rev.Revisable {
-		return rhp.RPCAppendSectorsResult{}, errors.New("contract is not revisable")
-	} else if rev.Contract.RenterOutput.Value.IsZero() {
-		return rhp.RPCAppendSectorsResult{}, errors.New("contract is out of funds")
-	} else if rev.Contract.Filesize > maxContractSize {
-		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("contract is too large, %d > %d", rev.Contract.Filesize, maxContractSize)
-	}
-
-	// append sectors
-	revision := rhp.ContractRevision{ID: contractID, Revision: rev.Contract}
-	return rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, revision, sectors)
-}
 
 func (cm *ContractManager) performSectorPinning(ctx context.Context, log *zap.Logger) error {
 	start := time.Now()
@@ -105,7 +81,7 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 	}
 
 	// dial the host
-	client, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	client, err := cm.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		return fmt.Errorf("failed to dial host: %w", err)
 	}

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -261,7 +261,7 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 	scanner.settings[hk2] = h2.Settings
 
 	// prepare contract manager
-	cm := newContractManager(types.PublicKey{}, nil, nil, dialer, scanner, store, nil, nil)
+	cm := newContractManager(types.PublicKey{}, nil, nil, store, dialer, scanner, nil, nil)
 
 	// pin sectors on h1
 	h1Prices := h1.Settings.Prices

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -9,7 +9,6 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -18,43 +17,6 @@ const (
 	pruneIntervalSuccess = 24 * time.Hour
 	pruneIntervalFailure = 3 * time.Hour
 )
-
-// HostKey returns the public key of the host.
-func (c *hostClient) HostKey() types.PublicKey {
-	return c.hostKey
-}
-
-func (c *hostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error) {
-	// fetch revision and check if it meets the requirements
-	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
-	if err != nil {
-		return rhp.RPCSectorRootsResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
-	} else if !rev.Revisable {
-		return rhp.RPCSectorRootsResult{}, errors.New("contract is not revisable")
-	} else if rev.Contract.RenterOutput.Value.IsZero() {
-		return rhp.RPCSectorRootsResult{}, errors.New("contract is out of funds")
-	}
-
-	// fetch contract sectors
-	revision := rhp.ContractRevision{ID: contractID, Revision: rev.Contract}
-	return rhp.RPCSectorRoots(ctx, c.client, c.cm.TipState(), hostPrices, c.signer, revision, offset, length)
-}
-
-func (c *hostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error) {
-	// fetch revision and check if it meets the requirements
-	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
-	if err != nil {
-		return rhp.RPCFreeSectorsResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
-	} else if !rev.Revisable {
-		return rhp.RPCFreeSectorsResult{}, errors.New("contract is not revisable")
-	} else if rev.Contract.RenterOutput.Value.IsZero() {
-		return rhp.RPCFreeSectorsResult{}, errors.New("contract is out of funds")
-	}
-
-	// free sectors
-	revision := rhp.ContractRevision{ID: contractID, Revision: rev.Contract}
-	return rhp.RPCFreeSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, revision, indices)
-}
 
 func (cm *ContractManager) performContractPruning(ctx context.Context, log *zap.Logger) error {
 	start := time.Now()
@@ -125,7 +87,7 @@ func (cm *ContractManager) performContractPruningOnHost(ctx context.Context, hos
 	}
 
 	// dial the host
-	client, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	client, err := cm.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		return fmt.Errorf("failed to dial host: %w", err)
 	}

--- a/contracts/pruning_test.go
+++ b/contracts/pruning_test.go
@@ -269,7 +269,7 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 	scanner.settings[hk5] = h5.Settings
 
 	// prepare contract manager
-	cm := newContractManager(types.PublicKey{}, nil, nil, dialer, scanner, store, nil, nil)
+	cm := newContractManager(types.PublicKey{}, nil, nil, store, dialer, scanner, nil, nil)
 
 	// prune contracts on h1
 	err := cm.performContractPruningOnHost(context.Background(), h1, zap.NewNop())

--- a/contracts/refresh.go
+++ b/contracts/refresh.go
@@ -7,30 +7,8 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.uber.org/zap"
 )
-
-func (c *hostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
-	rev, err := rhp.RPCLatestRevision(ctx, c.client, params.ContractID)
-	if err != nil {
-		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
-	} else if rev.Renewed {
-		return rhp.RPCRefreshContractResult{}, fmt.Errorf("contract already renewed")
-	} else if !rev.Revisable {
-		return rhp.RPCRefreshContractResult{}, fmt.Errorf("contract not revisable")
-	}
-
-	res, err := rhp.RPCRefreshContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRefreshContractParams{
-		Allowance:  rev.Contract.RenterOutput.Value,
-		Collateral: rev.Contract.MissedHostValue,
-	})
-	if err != nil {
-		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to form contract: %w", err)
-	}
-
-	return res, nil
-}
 
 func (cm *ContractManager) performContractRefreshes(ctx context.Context, log *zap.Logger) error {
 	refreshLog := log.Named("refresh")
@@ -118,13 +96,14 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 		return nil
 	}
 
-	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	client, err := cm.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		contractLog.Debug("failed to dial host", zap.Error(err))
 		return nil
 	}
-	defer hc.Close()
-	res, err := hc.RefreshContract(ctx, host.Settings, proto.RPCRefreshContractParams{
+	defer client.Close()
+
+	res, err := client.RefreshContract(ctx, host.Settings, proto.RPCRefreshContractParams{
 		Allowance:  additionalAllowance,
 		Collateral: additionalCollateral,
 		ContractID: contract.ID,

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -149,7 +149,7 @@ func TestPerformContractRefreshes(t *testing.T) {
 	dialer := newDialerMock()
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, store, dialer, scanner, syncerMock, wallet)
 
 	assertRefresh := func(h hosts.Host, allowance, collateral types.Currency, refreshedFrom types.FileContractID, call refreshContractCall) {
 		t.Helper()

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -5,39 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.uber.org/zap"
 )
-
-func (c *hostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
-	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
-	if err != nil {
-		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
-	} else if rev.Renewed {
-		return rhp.RPCRenewContractResult{}, fmt.Errorf("contract already renewed")
-	} else if !rev.Revisable {
-		return rhp.RPCRenewContractResult{}, fmt.Errorf("contract not revisable")
-	}
-
-	// NOTE: when renewing a contract we keep the same allowance and collateral.
-	// This has the following advantages:
-	// 1. Contracts drain over time if they contain more funds than needed
-	// 2. Renewals are very "cheap" since no party needs to lock away
-	//    additional funds. Only the fees need to be paid.
-	res, err := rhp.RPCRenewContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRenewContractParams{
-		ContractID:  contractID,
-		Allowance:   rev.Contract.RenterOutput.Value,
-		Collateral:  rev.Contract.MissedHostValue,
-		ProofHeight: proofHeight,
-	})
-	if err != nil {
-		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to form contract: %w", err)
-	}
-
-	return res, nil
-}
 
 func (cm *ContractManager) performContractRenewals(ctx context.Context, period, renewWindow uint64, log *zap.Logger) error {
 	renewalLog := log.Named("renewal")
@@ -99,13 +69,14 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 		return nil
 	}
 
-	hc, err := cm.dialer.Dial(ctx, host.PublicKey, host.SiamuxAddr())
+	client, err := cm.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
 	if err != nil {
 		contractLog.Debug("failed to dial host", zap.Error(err))
 		return nil
 	}
-	defer hc.Close()
-	res, err := hc.RenewContract(ctx, host.Settings, contract.ID, proofHeight)
+	defer client.Close()
+
+	res, err := client.RenewContract(ctx, host.Settings, contract.ID, proofHeight)
 	if err != nil {
 		contractLog.Debug("failed to renew", zap.Error(err))
 		return nil

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -107,7 +107,7 @@ func TestPerformContractRenewals(t *testing.T) {
 	dialer := newDialerMock()
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
-	contracts := newContractManager(renterKey, amMock, cmMock, dialer, scanner, store, syncerMock, wallet)
+	contracts := newContractManager(renterKey, amMock, cmMock, store, dialer, scanner, syncerMock, wallet)
 
 	assertRenewal := func(h hosts.Host, renewedFrom types.FileContractID, proofHeight uint64, call renewContractCall) {
 		t.Helper()
@@ -183,7 +183,7 @@ func TestSyncRevisionState(t *testing.T) {
 	store := &storeMock{}
 	dialer := newDialerMock()
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
-	contracts := newContractManager(renterKey, amMock, nil, dialer, nil, store, nil, nil)
+	contracts := newContractManager(renterKey, amMock, nil, store, dialer, nil, nil, nil)
 
 	// add a host and contract
 	contractID := types.FileContractID{1}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -54,9 +54,10 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 	}
 
 	signer := contracts.NewFormContractSigner(wm, walletKey)
-	am := accounts.NewManager(store, accounts.NewFunder(client.NewSiamuxDialer[accounts.HostClient](c.cm, signer, log)), accounts.WithLogger(log.Named("accounts")))
+	dialer := client.NewSiamuxDialer(c.cm, signer, log)
+	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 
-	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, client.NewSiamuxDialer[contracts.HostClient](c.cm, signer, log), nil, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, nil, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -15,11 +15,11 @@ import (
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/explorer"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
-	"go.sia.tech/indexd/rhp"
 	"go.sia.tech/indexd/subscriber"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -54,10 +54,9 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 	}
 
 	signer := contracts.NewFormContractSigner(wm, walletKey)
-	dialer := rhp.NewSiamuxDialer(c.cm, signer, log)
-	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
+	am := accounts.NewManager(store, accounts.NewFunder(client.NewSiamuxDialer[accounts.HostClient](c.cm, signer, log)), accounts.WithLogger(log.Named("accounts")))
 
-	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, nil, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, client.NewSiamuxDialer[contracts.HostClient](c.cm, signer, log), nil, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -19,6 +19,7 @@ import (
 	"go.sia.tech/indexd/explorer"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
+	"go.sia.tech/indexd/rhp"
 	"go.sia.tech/indexd/subscriber"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -52,10 +53,11 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		t.Fatalf("failed to create host manager: %v", err)
 	}
 
-	funder := accounts.NewFunder(c.cm, wm)
-	am := accounts.NewManager(store, funder, accounts.WithLogger(log.Named("accounts")))
+	signer := contracts.NewFormContractSigner(wm, walletKey)
+	dialer := rhp.NewSiamuxDialer(c.cm, signer, log)
+	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 
-	contracts, err := contracts.NewManager(walletKey, am, c.cm, nil, store, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, nil, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/rhp/client.go
+++ b/rhp/client.go
@@ -42,11 +42,6 @@ type (
 		TipState() consensus.State
 		rhp.TxPool
 	}
-
-	// Dialer is an interface for dialing a host.
-	Dialer interface {
-		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (*HostClient, error)
-	}
 )
 
 // HostClient is a client that can be used to interact with a host using the RHP

--- a/rhp/client.go
+++ b/rhp/client.go
@@ -1,0 +1,238 @@
+package rhp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/consensus"
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/rhp/v4"
+	"go.uber.org/zap"
+)
+
+const (
+	maxContractSize = 10 * 1 << 40 // 10TB
+)
+
+var (
+	// ErrContractInsufficientFunds is returned when we try to revise a contract
+	// that has insufficient funds to cover the action we want to perform.
+	ErrContractInsufficientFunds = errors.New("contract has insufficient funds")
+
+	// ErrContractNotRevisable is returned when we try to revise a contract on
+	// the host that's too close to the proof height and thus deemed unrevisable
+	// by the host.
+	ErrContractNotRevisable = errors.New("contract is not revisable")
+
+	// ErrContractOutOfFunds is returned when we try to perform an action on a
+	// contract that has no funds left to cover the action.
+	ErrContractOutOfFunds = errors.New("contract is out of funds")
+
+	// ErrContractRenewed is returned when we try to revise a contract that has
+	// already been renewed.
+	ErrContractRenewed = errors.New("contract got renewed")
+)
+
+type (
+	// ChainManager defines an interface to access the chain state as well as
+	// interact with the transaction pool.
+	ChainManager interface {
+		TipState() consensus.State
+		rhp.TxPool
+	}
+
+	// Dialer is an interface for dialing a host.
+	Dialer interface {
+		DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (*HostClient, error)
+	}
+)
+
+// HostClient is a client that can be used to interact with a host using the RHP
+// methods. It provides methods to form contracts, append sectors, free sectors,
+// get sector roots, refresh and renew contracts, and replenish accounts. It
+// uses a transport client to communicate with the host and a signer to sign the
+// contract revisions. The client is expected to be closed when no longer
+// needed.
+type HostClient struct {
+	hostKey types.PublicKey
+
+	client rhp.TransportClient
+	signer rhp.FormContractSigner
+
+	cm  ChainManager
+	log *zap.Logger
+}
+
+// NewHostClient creates a new HostClient that can be used to interact with a
+// host using the RHP methods. The client is expected to be closed when no
+// longer needed.
+func NewHostClient(hk types.PublicKey, cm ChainManager, client rhp.TransportClient, signer rhp.FormContractSigner, log *zap.Logger) *HostClient {
+	return &HostClient{
+		hostKey: hk,
+
+		client: client,
+		signer: signer,
+
+		cm:  cm,
+		log: log.Named("client").With(zap.Stringer("hostKey", hk)),
+	}
+}
+
+// AppendSectors appends the given sectors to the contract.
+func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
+	// sanity check
+	if len(sectors) > proto.MaxSectorBatchSize {
+		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
+	}
+
+	// fetch revision and check if it meets the requirements
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
+	if err != nil {
+		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
+	} else if !rev.Revisable {
+		return rhp.RPCAppendSectorsResult{}, errors.New("contract is not revisable")
+	} else if rev.Contract.RenterOutput.Value.IsZero() {
+		return rhp.RPCAppendSectorsResult{}, errors.New("contract is out of funds")
+	} else if rev.Contract.Filesize > maxContractSize {
+		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("contract is too large, %d > %d", rev.Contract.Filesize, maxContractSize)
+	}
+
+	// append sectors
+	revision := rhp.ContractRevision{ID: contractID, Revision: rev.Contract}
+	return rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, revision, sectors)
+}
+
+// Close closes the underlying transport client.
+func (c *HostClient) Close() error {
+	return c.client.Close()
+}
+
+// FormContract forms a new contract with the host.
+func (c *HostClient) FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error) {
+	res, err := rhp.RPCFormContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, c.hostKey, settings.WalletAddress, params)
+	if err != nil {
+		return rhp.RPCFormContractResult{}, fmt.Errorf("failed to form contract: %w", err)
+	}
+
+	return res, nil
+}
+
+// SectorRoots returns the sector roots for a contract.
+func (c *HostClient) SectorRoots(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, offset, length uint64) (rhp.RPCSectorRootsResult, error) {
+	// fetch revision and check if it meets the requirements
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
+	if err != nil {
+		return rhp.RPCSectorRootsResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
+	} else if !rev.Revisable {
+		return rhp.RPCSectorRootsResult{}, errors.New("contract is not revisable")
+	} else if rev.Contract.RenterOutput.Value.IsZero() {
+		return rhp.RPCSectorRootsResult{}, errors.New("contract is out of funds")
+	}
+
+	// fetch contract sectors
+	revision := rhp.ContractRevision{ID: contractID, Revision: rev.Contract}
+	return rhp.RPCSectorRoots(ctx, c.client, c.cm.TipState(), hostPrices, c.signer, revision, offset, length)
+}
+
+// FreeSectors frees the specified sectors in the contract.
+func (c *HostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error) {
+	// fetch revision and check if it meets the requirements
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
+	if err != nil {
+		return rhp.RPCFreeSectorsResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
+	} else if !rev.Revisable {
+		return rhp.RPCFreeSectorsResult{}, errors.New("contract is not revisable")
+	} else if rev.Contract.RenterOutput.Value.IsZero() {
+		return rhp.RPCFreeSectorsResult{}, errors.New("contract is out of funds")
+	}
+
+	// free sectors
+	revision := rhp.ContractRevision{ID: contractID, Revision: rev.Contract}
+	return rhp.RPCFreeSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, revision, indices)
+}
+
+// RefreshContract refreshes the contract with the host.
+func (c *HostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, params.ContractID)
+	if err != nil {
+		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
+	} else if rev.Renewed {
+		return rhp.RPCRefreshContractResult{}, fmt.Errorf("contract already renewed")
+	} else if !rev.Revisable {
+		return rhp.RPCRefreshContractResult{}, fmt.Errorf("contract not revisable")
+	}
+
+	res, err := rhp.RPCRefreshContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRefreshContractParams{
+		Allowance:  rev.Contract.RenterOutput.Value,
+		Collateral: rev.Contract.MissedHostValue,
+	})
+	if err != nil {
+		return rhp.RPCRefreshContractResult{}, fmt.Errorf("failed to form contract: %w", err)
+	}
+
+	return res, nil
+}
+
+// RenewContract renews the contract with the host.
+func (c *HostClient) RenewContract(ctx context.Context, settings proto.HostSettings, contractID types.FileContractID, proofHeight uint64) (rhp.RPCRenewContractResult, error) {
+	rev, err := rhp.RPCLatestRevision(ctx, c.client, contractID)
+	if err != nil {
+		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to fetch latest revision: %w", err)
+	} else if rev.Renewed {
+		return rhp.RPCRenewContractResult{}, fmt.Errorf("contract already renewed")
+	} else if !rev.Revisable {
+		return rhp.RPCRenewContractResult{}, fmt.Errorf("contract not revisable")
+	}
+
+	// NOTE: when renewing a contract we keep the same allowance and collateral.
+	// This has the following advantages:
+	// 1. Contracts drain over time if they contain more funds than needed
+	// 2. Renewals are very "cheap" since no party needs to lock away
+	//    additional funds. Only the fees need to be paid.
+	res, err := rhp.RPCRenewContract(ctx, c.client, c.cm, c.signer, c.cm.TipState(), settings.Prices, rev.Contract, proto.RPCRenewContractParams{
+		ContractID:  contractID,
+		Allowance:   rev.Contract.RenterOutput.Value,
+		Collateral:  rev.Contract.MissedHostValue,
+		ProofHeight: proofHeight,
+	})
+	if err != nil {
+		return rhp.RPCRenewContractResult{}, fmt.Errorf("failed to form contract: %w", err)
+	}
+
+	return res, nil
+}
+
+// ReplenishAccounts replenishes the accounts in the contract to the target value.
+func (c *HostClient) ReplenishAccounts(ctx context.Context, contractID types.FileContractID, accounts []proto.Account, target types.Currency) (res rhp.RPCReplenishAccountsResult, funded int, _ error) {
+	rev, err := c.LatestRevision(ctx, contractID)
+	if err != nil {
+		return rhp.RPCReplenishAccountsResult{}, 0, fmt.Errorf("failed to fetch latest revision: %w", err)
+	} else if rev.Contract.RenterOutput.Value.Cmp(target) < 0 {
+		return rhp.RPCReplenishAccountsResult{}, 0, ErrContractInsufficientFunds
+	}
+
+	// prepare batch
+	batchSize := int(min(rev.Contract.RenterOutput.Value.Div(target).Big().Uint64(), proto.MaxAccountBatchSize))
+	funded = min(batchSize, len(accounts))
+	batch := accounts[:funded]
+
+	// prepare parameters
+	params := rhp.RPCReplenishAccountsParams{
+		Accounts: batch,
+		Target:   target,
+		Contract: rhp.ContractRevision{ID: contractID, Revision: rev.Contract},
+	}
+	res, err = rhp.RPCReplenishAccounts(ctx, c.client, params, c.cm.TipState(), c.signer)
+	if err != nil {
+		return rhp.RPCReplenishAccountsResult{}, 0, err
+	}
+
+	return res, funded, nil
+}
+
+// LatestRevision retrieves the latest revision of a contract from the host.
+func (c *HostClient) LatestRevision(ctx context.Context, contractID types.FileContractID) (proto.RPCLatestRevisionResponse, error) {
+	return rhp.RPCLatestRevision(ctx, c.client, contractID)
+}

--- a/rhp/dialer.go
+++ b/rhp/dialer.go
@@ -13,16 +13,16 @@ import (
 
 const dialTimeout = 10 * time.Second
 
-type siamuxDialer struct {
+// SiamuxDialer can be used to dial a host using the SiaMux protocol.
+type SiamuxDialer struct {
 	cm     ChainManager
 	signer rhp.FormContractSigner
 	log    *zap.Logger
 }
 
-// NewSiamuxDialer creates a new Dialer that uses the SiaMux protocol to dial a
-// host.
-func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) Dialer {
-	return &siamuxDialer{
+// NewSiamuxDialer creates a new SiamuxDialer.
+func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) *SiamuxDialer {
+	return &SiamuxDialer{
 		cm:     cm,
 		signer: signer,
 		log:    log,
@@ -32,7 +32,7 @@ func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Lo
 // DialHost dials the host and returns a Client that can be used to interact
 // with the host. It uses the SiaMux protocol to establish a connection and
 // returns a host client that exposes the RPC methods defined in the RHP.
-func (d *siamuxDialer) DialHost(ctx context.Context, hk types.PublicKey, addr string) (*HostClient, error) {
+func (d *SiamuxDialer) DialHost(ctx context.Context, hk types.PublicKey, addr string) (*HostClient, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 

--- a/rhp/dialer.go
+++ b/rhp/dialer.go
@@ -1,0 +1,45 @@
+package rhp
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.uber.org/zap"
+)
+
+const dialTimeout = 10 * time.Second
+
+type siamuxDialer struct {
+	cm     ChainManager
+	signer rhp.FormContractSigner
+	log    *zap.Logger
+}
+
+// NewSiamuxDialer creates a new Dialer that uses the SiaMux protocol to dial a
+// host.
+func NewSiamuxDialer(cm ChainManager, signer rhp.FormContractSigner, log *zap.Logger) Dialer {
+	return &siamuxDialer{
+		cm:     cm,
+		signer: signer,
+		log:    log,
+	}
+}
+
+// DialHost dials the host and returns a Client that can be used to interact
+// with the host. It uses the SiaMux protocol to establish a connection and
+// returns a host client that exposes the RPC methods defined in the RHP.
+func (d *siamuxDialer) DialHost(ctx context.Context, hk types.PublicKey, addr string) (*HostClient, error) {
+	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+
+	client, err := siamux.Dial(ctx, addr, hk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial host: %w", err)
+	}
+
+	return NewHostClient(hk, d.cm, client, d.signer, d.log.With(zap.Stringer("hostKey", hk))), nil
+}


### PR DESCRIPTION
This PR introduces a new package called `client` which houses the implementation of the host client. This allows us to easily mock a portion of the client by defining an interface that contains a subset of RPC methods required for that particular case, e.g. in the `accounts` we only need to replenish the accounts. 

This further cleans up the diff in https://github.com/SiaFoundation/indexd/pull/183 - which 'll only contain switching out the `RPCLatestRevision` for `withRevision`.