### PR TITLE
Add `--debug` flag that exposes a debug endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -28,6 +28,12 @@ type (
 	// to ensure the account is funded as soon as possible.
 	ContractManager interface {
 		TriggerAccountFunding()
+		TriggerMaintenance()
+	}
+
+	// HostManager defines an interface that allows trigger a host scan.
+	HostManager interface {
+		TriggerHostScanning()
 	}
 
 	// Explorer retrieves data about the Sia network from an external source.
@@ -77,8 +83,10 @@ type (
 type (
 	// An api provides an HTTP API for the indexer
 	api struct {
+		debug     bool
 		chain     ChainManager
 		contracts ContractManager
+		hosts     HostManager
 		explorer  Explorer
 		store     Store
 		syncer    Syncer
@@ -88,10 +96,11 @@ type (
 )
 
 // NewServer initializes the API
-func NewServer(chain ChainManager, contracts ContractManager, syncer Syncer, wallet Wallet, store Store, opts ...ServerOption) http.Handler {
+func NewServer(chain ChainManager, contracts ContractManager, hosts HostManager, syncer Syncer, wallet Wallet, store Store, opts ...ServerOption) http.Handler {
 	a := &api{
 		chain:     chain,
 		contracts: contracts,
+		hosts:     hosts,
 		store:     store,
 		syncer:    syncer,
 		wallet:    wallet,
@@ -101,7 +110,7 @@ func NewServer(chain ChainManager, contracts ContractManager, syncer Syncer, wal
 		opt(a)
 	}
 
-	return jape.Mux(map[string]jape.Handler{
+	routes := map[string]jape.Handler{
 		"GET /state": a.handleGETState,
 
 		// accounts endpoints
@@ -135,5 +144,12 @@ func NewServer(chain ChainManager, contracts ContractManager, syncer Syncer, wal
 		"GET /wallet/events":  a.handleGETWalletEvents,
 		"GET /wallet/pending": a.handleGETWalletPending,
 		"POST /wallet/send":   a.handlePOSTWalletSend,
-	})
+	}
+
+	// debug endpoints
+	if a.debug {
+		routes["GET /debug/trigger/:action"] = a.handleGETTrigger
+	}
+
+	return jape.Mux(routes)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -148,6 +148,7 @@ func NewServer(chain ChainManager, contracts ContractManager, hosts HostManager,
 
 	// debug endpoints
 	if a.debug {
+		routes["GET /debug/pprof/:handler"] = a.handleGETPProf
 		routes["POST /debug/trigger/:action"] = a.handlePOSTTrigger
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -31,7 +31,7 @@ type (
 		TriggerMaintenance()
 	}
 
-	// HostManager defines an interface that allows trigger a host scan.
+	// HostManager defines an interface that allows triggering a host scan.
 	HostManager interface {
 		TriggerHostScanning()
 	}
@@ -148,7 +148,7 @@ func NewServer(chain ChainManager, contracts ContractManager, hosts HostManager,
 
 	// debug endpoints
 	if a.debug {
-		routes["GET /debug/trigger/:action"] = a.handleGETTrigger
+		routes["POST /debug/trigger/:action"] = a.handleGETTrigger
 	}
 
 	return jape.Mux(routes)

--- a/api/api.go
+++ b/api/api.go
@@ -148,7 +148,7 @@ func NewServer(chain ChainManager, contracts ContractManager, hosts HostManager,
 
 	// debug endpoints
 	if a.debug {
-		routes["POST /debug/trigger"] = a.handlePOSTTrigger
+		routes["POST /debug/trigger/:action"] = a.handlePOSTTrigger
 	}
 
 	return jape.Mux(routes)

--- a/api/api.go
+++ b/api/api.go
@@ -148,7 +148,7 @@ func NewServer(chain ChainManager, contracts ContractManager, hosts HostManager,
 
 	// debug endpoints
 	if a.debug {
-		routes["POST /debug/trigger/:action"] = a.handleGETTrigger
+		routes["POST /debug/trigger"] = a.handlePOSTTrigger
 	}
 
 	return jape.Mux(routes)

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -44,12 +44,12 @@ func (a *api) checkServerError(jc jape.Context, context string, err error) bool 
 }
 
 func (a *api) handlePOSTTrigger(jc jape.Context) {
-	var req DebugTriggerRequest
-	if jc.Decode(&req) != nil {
+	var action string
+	if jc.DecodeParam("action", &action) != nil {
 		return
 	}
 
-	switch req.Action {
+	switch action {
 	case "funding":
 		a.contracts.TriggerAccountFunding()
 	case "maintenance":
@@ -57,7 +57,7 @@ func (a *api) handlePOSTTrigger(jc jape.Context) {
 	case "scanning":
 		a.hosts.TriggerHostScanning()
 	default:
-		jc.Error(fmt.Errorf("unknown action: %q, available actions are 'funding', 'maintenance' or 'scanning'", req.Action), http.StatusBadRequest)
+		jc.Error(fmt.Errorf("unknown action: %q, available actions are 'funding', 'maintenance' or 'scanning'", action), http.StatusBadRequest)
 		return
 	}
 

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -43,6 +43,27 @@ func (a *api) checkServerError(jc jape.Context, context string, err error) bool 
 	return err == nil
 }
 
+func (a *api) handleGETTrigger(jc jape.Context) {
+	var action string
+	if jc.DecodeParam("action", &action) != nil {
+		return
+	}
+
+	switch action {
+	case "funding":
+		a.contracts.TriggerAccountFunding()
+	case "maintenance":
+		a.contracts.TriggerMaintenance()
+	case "scanning":
+		a.hosts.TriggerHostScanning()
+	default:
+		jc.Error(fmt.Errorf("unknown action: %q, available actions are 'funding', 'maintenance' or 'scanning'", action), http.StatusBadRequest)
+		return
+	}
+
+	jc.Encode(nil)
+}
+
 func (a *api) handleGETAccounts(jc jape.Context) {
 	offset, limit, ok := parseOffsetLimit(jc)
 	if !ok {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"runtime"
 	"time"
 	"unicode/utf8"
@@ -41,6 +42,26 @@ func (a *api) checkServerError(jc jape.Context, context string, err error) bool 
 		a.log.Warn(context, zap.Error(err))
 	}
 	return err == nil
+}
+
+func (a *api) handleGETPProf(jc jape.Context) {
+	var handler string
+	if err := jc.DecodeParam("handler", &handler); err != nil {
+		return
+	}
+
+	switch handler {
+	case "cmdline":
+		pprof.Cmdline(jc.ResponseWriter, jc.Request)
+	case "profile":
+		pprof.Profile(jc.ResponseWriter, jc.Request)
+	case "symbol":
+		pprof.Symbol(jc.ResponseWriter, jc.Request)
+	case "trace":
+		pprof.Trace(jc.ResponseWriter, jc.Request)
+	default:
+		pprof.Index(jc.ResponseWriter, jc.Request)
+	}
 }
 
 func (a *api) handlePOSTTrigger(jc jape.Context) {

--- a/api/endpoints.go
+++ b/api/endpoints.go
@@ -43,13 +43,13 @@ func (a *api) checkServerError(jc jape.Context, context string, err error) bool 
 	return err == nil
 }
 
-func (a *api) handleGETTrigger(jc jape.Context) {
-	var action string
-	if jc.DecodeParam("action", &action) != nil {
+func (a *api) handlePOSTTrigger(jc jape.Context) {
+	var req DebugTriggerRequest
+	if jc.Decode(&req) != nil {
 		return
 	}
 
-	switch action {
+	switch req.Action {
 	case "funding":
 		a.contracts.TriggerAccountFunding()
 	case "maintenance":
@@ -57,7 +57,7 @@ func (a *api) handleGETTrigger(jc jape.Context) {
 	case "scanning":
 		a.hosts.TriggerHostScanning()
 	default:
-		jc.Error(fmt.Errorf("unknown action: %q, available actions are 'funding', 'maintenance' or 'scanning'", action), http.StatusBadRequest)
+		jc.Error(fmt.Errorf("unknown action: %q, available actions are 'funding', 'maintenance' or 'scanning'", req.Action), http.StatusBadRequest)
 		return
 	}
 

--- a/api/options.go
+++ b/api/options.go
@@ -10,6 +10,14 @@ import (
 // ServerOption is a functional option to configure an API server.
 type ServerOption func(*api)
 
+// WithDebug sets the debug mode for the API server. In debug mode, the server
+// exposes additional debug endpoints that allow triggering certain actions.
+func WithDebug(debug bool) ServerOption {
+	return func(a *api) {
+		a.debug = debug
+	}
+}
+
 // WithExplorer sets the explorer for the API server.
 func WithExplorer(e Explorer) ServerOption {
 	return func(a *api) {

--- a/api/options.go
+++ b/api/options.go
@@ -12,9 +12,9 @@ type ServerOption func(*api)
 
 // WithDebug sets the debug mode for the API server. In debug mode, the server
 // exposes additional debug endpoints that allow triggering certain actions.
-func WithDebug(debug bool) ServerOption {
+func WithDebug() ServerOption {
 	return func(a *api) {
-		a.debug = debug
+		a.debug = true
 	}
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -12,12 +12,6 @@ type (
 		NewAccountKey types.PublicKey `json:"newAccountKey"`
 	}
 
-	// DebugTriggerRequest is the request body for the [POST] /debug/trigger
-	// endpoint.
-	DebugTriggerRequest struct {
-		Action string `json:"action"`
-	}
-
 	// HostsBlocklistRequest is the request body for the [POST] /hosts/blocklist.
 	HostsBlocklistRequest struct {
 		HostKeys []types.PublicKey `json:"hostKeys"`

--- a/api/types.go
+++ b/api/types.go
@@ -12,6 +12,12 @@ type (
 		NewAccountKey types.PublicKey `json:"newAccountKey"`
 	}
 
+	// DebugTriggerRequest is the request body for the [POST] /debug/trigger
+	// endpoint.
+	DebugTriggerRequest struct {
+		Action string `json:"action"`
+	}
+
 	// HostsBlocklistRequest is the request body for the [POST] /hosts/blocklist.
 	HostsBlocklistRequest struct {
 		HostKeys []types.PublicKey `json:"hostKeys"`

--- a/cmd/indexd/main.go
+++ b/cmd/indexd/main.go
@@ -33,6 +33,7 @@ const (
 
 var cfg = config.Config{
 	Directory: os.Getenv(dataDirEnvVar), // default to env variable
+	Debug:     false,
 	AdminAPI: config.AdminAPI{
 		Address:  "127.0.0.1:9980",
 		Password: os.Getenv(indexdAdminPasswordEnvVar),
@@ -206,6 +207,7 @@ func main() {
 	rootCmd.StringVar(&cfg.Directory, "dir", cfg.Directory, "directory to store indexd metadata in")
 	rootCmd.StringVar(&cfg.AdminAPI.Address, "api.admin", cfg.AdminAPI.Address, "address to serve admin API on")
 	rootCmd.StringVar(&cfg.ApplicationAPI.Address, "api.app", cfg.ApplicationAPI.Address, "address to serve application API on")
+	rootCmd.BoolVar(&cfg.Debug, "debug", false, "enable debug mode")
 	rootCmd.StringVar(&logLevelOverride, "log", "", "overrides the log level for all enabled loggers (debug, info, warn, error)")
 
 	versionCmd := flagg.New("version", ``)
@@ -221,6 +223,10 @@ func main() {
 		},
 	})
 
+	if cfg.Debug {
+		cfg.Log.StdOut.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+		cfg.Log.File.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	}
 	if logLevelOverride != "" {
 		level, err := zap.ParseAtomicLevel(logLevelOverride)
 		checkFatalError("failed to parse log level", err)

--- a/cmd/indexd/main.go
+++ b/cmd/indexd/main.go
@@ -207,7 +207,7 @@ func main() {
 	rootCmd.StringVar(&cfg.Directory, "dir", cfg.Directory, "directory to store indexd metadata in")
 	rootCmd.StringVar(&cfg.AdminAPI.Address, "api.admin", cfg.AdminAPI.Address, "address to serve admin API on")
 	rootCmd.StringVar(&cfg.ApplicationAPI.Address, "api.app", cfg.ApplicationAPI.Address, "address to serve application API on")
-	rootCmd.BoolVar(&cfg.Debug, "debug", false, "enable debug mode")
+	rootCmd.BoolVar(&cfg.Debug, "debug", cfg.Debug, "enable debug mode")
 	rootCmd.StringVar(&logLevelOverride, "log", "", "overrides the log level for all enabled loggers (debug, info, warn, error)")
 
 	versionCmd := flagg.New("version", ``)

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -131,7 +131,10 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 
 	apiOpts := []api.ServerOption{
 		api.WithLogger(log.Named("api")),
-		api.WithDebug(cfg.Debug),
+	}
+
+	if cfg.Debug {
+		apiOpts = append(apiOpts, api.WithDebug())
 	}
 
 	var e *explorer.Explorer

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -131,6 +131,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 
 	apiOpts := []api.ServerOption{
 		api.WithLogger(log.Named("api")),
+		api.WithDebug(cfg.Debug),
 	}
 
 	var e *explorer.Explorer
@@ -147,7 +148,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 
 	web := http.Server{
 		Handler: webRouter{
-			api: jape.BasicAuth(cfg.AdminAPI.Password)(api.NewServer(cm, contracts, s, wm, store, apiOpts...)),
+			api: jape.BasicAuth(cfg.AdminAPI.Password)(api.NewServer(cm, contracts, hm, s, wm, store, apiOpts...)),
 		},
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,

--- a/cmd/indexd/web.go
+++ b/cmd/indexd/web.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"net/http"
-	_ "net/http/pprof"
+
 	"strings"
 )
 
@@ -16,13 +16,6 @@ func (wr webRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	case strings.HasPrefix(req.URL.Path, "/api"):
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/api") // strip the prefix
 		wr.api.ServeHTTP(w, req)
-	case strings.HasPrefix(req.URL.Path, "/debug/pprof"):
-		_, password, ok := req.BasicAuth()
-		if !ok || password != cfg.AdminAPI.Password {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		http.DefaultServeMux.ServeHTTP(w, req)
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}

--- a/cmd/indexd/web.go
+++ b/cmd/indexd/web.go
@@ -13,10 +13,11 @@ type webRouter struct {
 
 func (wr webRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch {
+	case strings.HasPrefix(req.URL.Path, "/api/debug/trigger"):
+	case strings.HasPrefix(req.URL.Path, "/debug/trigger"):
+		wr.api.ServeHTTP(w, req)
 	case strings.HasPrefix(req.URL.Path, "/api"):
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/api") // strip the prefix
-		wr.api.ServeHTTP(w, req)
-	case req.URL.Path == "/debug/trigger":
 		wr.api.ServeHTTP(w, req)
 	case strings.HasPrefix(req.URL.Path, "/debug/pprof"):
 		_, password, ok := req.BasicAuth()
@@ -26,6 +27,6 @@ func (wr webRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		http.DefaultServeMux.ServeHTTP(w, req)
 	default:
-		w.WriteHeader(http.StatusNotFound)
 	}
+	w.WriteHeader(http.StatusNotFound)
 }

--- a/cmd/indexd/web.go
+++ b/cmd/indexd/web.go
@@ -16,6 +16,8 @@ func (wr webRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	case strings.HasPrefix(req.URL.Path, "/api"):
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/api") // strip the prefix
 		wr.api.ServeHTTP(w, req)
+	case req.URL.Path == "/debug/trigger":
+		wr.api.ServeHTTP(w, req)
 	case strings.HasPrefix(req.URL.Path, "/debug/pprof"):
 		_, password, ok := req.BasicAuth()
 		if !ok || password != cfg.AdminAPI.Password {

--- a/cmd/indexd/web.go
+++ b/cmd/indexd/web.go
@@ -13,9 +13,6 @@ type webRouter struct {
 
 func (wr webRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	switch {
-	case strings.HasPrefix(req.URL.Path, "/api/debug/trigger"):
-	case strings.HasPrefix(req.URL.Path, "/debug/trigger"):
-		wr.api.ServeHTTP(w, req)
 	case strings.HasPrefix(req.URL.Path, "/api"):
 		req.URL.Path = strings.TrimPrefix(req.URL.Path, "/api") // strip the prefix
 		wr.api.ServeHTTP(w, req)
@@ -27,6 +24,6 @@ func (wr webRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		http.DefaultServeMux.ServeHTTP(w, req)
 	default:
+		w.WriteHeader(http.StatusNotFound)
 	}
-	w.WriteHeader(http.StatusNotFound)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,7 @@ type (
 	Config struct {
 		Directory      string `yaml:"directory"`
 		RecoveryPhrase string `yaml:"recoveryPhrase"`
+		Debug          bool   `yaml:"debug"`
 
 		AdminAPI       AdminAPI                `yaml:"adminAPI"`
 		ApplicationAPI ApplicationAPI          `yaml:"applicationAPI"`

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -151,7 +151,8 @@ type (
 		scanner   HostManager
 		renterKey types.PublicKey
 
-		triggerFundingChan chan struct{}
+		triggerFundingChan     chan struct{}
+		triggerMaintenanceChan chan struct{}
 
 		log     *zap.Logger
 		shuffle func(int, func(i, j int))
@@ -203,7 +204,8 @@ func newContractManager(renterKey types.PublicKey, accountManager AccountManager
 		scanner: scanner,
 		store:   store,
 
-		triggerFundingChan: make(chan struct{}, 1),
+		triggerFundingChan:     make(chan struct{}, 1),
+		triggerMaintenanceChan: make(chan struct{}, 1),
 
 		log:     zap.NewNop(),
 		shuffle: frand.Shuffle,
@@ -227,6 +229,14 @@ func newContractManager(renterKey types.PublicKey, accountManager AccountManager
 func (cm *ContractManager) TriggerAccountFunding() {
 	select {
 	case cm.triggerFundingChan <- struct{}{}:
+	default:
+	}
+}
+
+// TriggerMaintenance triggers the maintenance loop to run immediately.
+func (cm *ContractManager) TriggerMaintenance() {
+	select {
+	case cm.triggerMaintenanceChan <- struct{}{}:
 	default:
 	}
 }
@@ -260,6 +270,12 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 				log.Error("account funding failed", zap.Error(err))
 			}
 			continue
+		case <-cm.triggerMaintenanceChan:
+			// reset ticker
+			ticker.Stop()
+			ticker = time.NewTicker(cm.maintenanceFrequency)
+
+			log.Debug("triggering maintenance")
 		case <-ticker.C:
 		}
 

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -52,6 +53,8 @@ type (
 		scanner       Scanner
 		store         Store
 
+		triggerHostScanningChan chan struct{}
+
 		tg  *threadgroup.ThreadGroup
 		log *zap.Logger
 	}
@@ -77,6 +80,7 @@ type (
 	// persist the scan results in the database.
 	Store interface {
 		Host(ctx context.Context, hk types.PublicKey) (Host, error)
+		Hosts(ctx context.Context, offset, limit int, queryOpts ...HostQueryOpt) ([]Host, error)
 		HostsForScanning(ctx context.Context) ([]types.PublicKey, error)
 		PruneHosts(ctx context.Context, lastSuccessfulScanCutoff time.Time, minConsecutiveFailedScans int) (int64, error)
 		UpdateHost(ctx context.Context, hk types.PublicKey, networks []net.IPNet, hs proto4.HostSettings, scanSucceeded bool, nextScan time.Time) error
@@ -117,8 +121,11 @@ func NewManager(syncer Syncer, store Store, opts ...Option) (*HostManager, error
 		resolver:      &net.Resolver{},
 		scanner:       &scanner{},
 		store:         store,
-		tg:            threadgroup.New(),
-		log:           zap.NewNop(),
+
+		triggerHostScanningChan: make(chan struct{}, 1),
+
+		tg:  threadgroup.New(),
+		log: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -150,8 +157,14 @@ func NewManager(syncer Syncer, store Store, opts ...Option) (*HostManager, error
 			select {
 			case <-pruneTicker.C:
 				m.pruneHosts(ctx)
+			case <-m.triggerHostScanningChan:
+				// reset ticker
+				scanTicker.Stop()
+				scanTicker = time.NewTicker(m.scanFrequency)
+				m.log.Debug("triggered host scanning")
+				m.scanHosts(ctx, m.hostsForScanning(ctx, true))
 			case <-scanTicker.C:
-				m.scanHosts(ctx)
+				m.scanHosts(ctx, m.hostsForScanning(ctx, false))
 			case <-ctx.Done():
 				return
 			}
@@ -165,6 +178,14 @@ func NewManager(syncer Syncer, store Store, opts ...Option) (*HostManager, error
 func (m *HostManager) Close() error {
 	m.tg.Stop()
 	return nil
+}
+
+// TriggerHostScanning triggers a scan of all hosts.
+func (m *HostManager) TriggerHostScanning() {
+	select {
+	case m.triggerHostScanningChan <- struct{}{}:
+	default:
+	}
 }
 
 // UsabilitySettings returns the current usability settings.
@@ -259,6 +280,35 @@ func (m *HostManager) UpdateChainState(tx UpdateTx, applied []chain.ApplyUpdate)
 	return nil
 }
 
+// hostsForScanning returns the public keys of the hosts that need to be
+// scanned, if force is true, this method will return the public keys of all
+// hosts in the database.
+func (m *HostManager) hostsForScanning(ctx context.Context, force bool) []types.PublicKey {
+	if !force {
+		hosts, err := m.store.HostsForScanning(ctx)
+		if err != nil {
+			m.log.Error("failed to get hosts for scanning", zap.Error(err))
+			return nil
+		}
+		return hosts
+	}
+
+	// forcing a rescan of all hosts is only exposed with the debug flag
+	// enabled, therefor it's fine to pay the price here and fetch all hosts
+	// from the database only to get their public keys
+	hosts, err := m.store.Hosts(ctx, 0, math.MaxInt)
+	if err != nil {
+		m.log.Error("failed to get hosts for scanning", zap.Error(err))
+		return nil
+	}
+
+	var hks []types.PublicKey
+	for _, h := range hosts {
+		hks = append(hks, h.PublicKey)
+	}
+	return hks
+}
+
 func (m *HostManager) pruneHosts(ctx context.Context) {
 	cutoff := time.Now().Add(-pruneMinDowntime)
 	n, err := m.store.PruneHosts(ctx, time.Now().Add(-pruneMinDowntime), pruneMinConsecutiveScanFailures)
@@ -278,18 +328,14 @@ func (m *HostManager) pruneHosts(ctx context.Context) {
 	}
 }
 
-func (m *HostManager) scanHosts(ctx context.Context) {
-	start := time.Now()
-
-	hosts, err := m.store.HostsForScanning(ctx)
-	if err != nil {
-		m.log.Error("failed to get hosts for scanning", zap.Error(err))
-		return
-	} else if len(hosts) == 0 {
-		m.log.Debug("scan skipped")
+func (m *HostManager) scanHosts(ctx context.Context, hosts []types.PublicKey) {
+	if len(hosts) == 0 {
+		m.log.Debug("scan skipped, no hosts for scanning")
 		return
 	}
-	m.log.Debug("scan started")
+
+	start := time.Now()
+	m.log.Debug("scan started", zap.Int("hosts", len(hosts)))
 
 	sema := make(chan struct{}, scanThreads)
 	defer close(sema)

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -294,7 +294,7 @@ func (m *HostManager) hostsForScanning(ctx context.Context, force bool) []types.
 	}
 
 	// forcing a rescan of all hosts is only exposed with the debug flag
-	// enabled, therefor it's fine to pay the price here and fetch all hosts
+	// enabled, therefore it's fine to pay the price here and fetch all hosts
 	// from the database only to get their public keys
 	hosts, err := m.store.Hosts(ctx, 0, math.MaxInt)
 	if err != nil {

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -41,6 +41,10 @@ func (s *mockStore) Host(ctx context.Context, hk types.PublicKey) (Host, error) 
 	return h, nil
 }
 
+func (s *mockStore) Hosts(ctx context.Context, offset, limit int, opts ...HostQueryOpt) ([]Host, error) {
+	return nil, nil
+}
+
 func (s *mockStore) HostsForScanning(ctx context.Context) ([]types.PublicKey, error) { return nil, nil }
 
 func (s *mockStore) PruneHosts(ctx context.Context, lastSuccessfulScanCutoff time.Time, minConsecutiveFailedScans int) (int64, error) {

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -81,7 +81,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 
 	password := hex.EncodeToString(frand.Bytes(16))
 	web := http.Server{
-		Handler: jape.BasicAuth(password)(api.NewServer(c.cm, contracts, s, wm, store, apiOpts...)),
+		Handler: jape.BasicAuth(password)(api.NewServer(c.cm, contracts, hm, s, wm, store, apiOpts...)),
 	}
 
 	httpListener, err := net.Listen("tcp4", "127.0.0.1:0")


### PR DESCRIPTION
This PR add a `--debug` flag that when enabled exposes a debug endpoint `POST /api/debug/trigger/:action` that allows triggering the following 3 actions: 'funding', 'maintenance' or 'scanning'

Behaviour:
```
curl -X POST localhost:9980/api/debug/trigger/scanning -> 401
curl -X POST -u :test  localhost:9980/api/debug/trigger/foo -> 400
curl -X POST -u :test  localhost:9980/api/debug/trigger/scanning -> 204 (OK)
```