### PR TITLE
Reset chain state if consensus db is not found

### DIFF
--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -40,15 +40,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer store.Close()
 
-	// ensure deleting the database forces a resync
-	chainPath := filepath.Join(cfg.Directory, "consensus.db")
-	if _, err := os.Stat(chainPath); os.IsNotExist(err) {
-		if err := store.ResetChainState(context.Background()); err != nil {
-			return fmt.Errorf("failed to reset chain state: %w", err)
-		}
-	}
-
-	bdb, err := coreutils.OpenBoltChainDB(chainPath)
+	bdb, err := coreutils.OpenBoltChainDB(filepath.Join(cfg.Directory, "consensus.db"))
 	if err != nil {
 		return fmt.Errorf("failed to open consensus database: %w", err)
 	}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -40,7 +40,15 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer store.Close()
 
-	bdb, err := coreutils.OpenBoltChainDB(filepath.Join(cfg.Directory, "consensus.db"))
+	// ensure deleting the database forces a resync
+	chainPath := filepath.Join(cfg.Directory, "consensus.db")
+	if _, err := os.Stat(chainPath); os.IsNotExist(err) {
+		if err := store.ResetChainState(context.Background()); err != nil {
+			return fmt.Errorf("failed to reset chain state: %w", err)
+		}
+	}
+
+	bdb, err := coreutils.OpenBoltChainDB(chainPath)
 	if err != nil {
 		return fmt.Errorf("failed to open consensus database: %w", err)
 	}

--- a/persist/postgres/chain.go
+++ b/persist/postgres/chain.go
@@ -17,11 +17,11 @@ type updateTx struct {
 // global settings. This is typically used to force a resync of consensus.
 func (s *Store) ResetChainState(ctx context.Context) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		if _, err := tx.Exec(ctx, `DELETE FROM wallet_siacoin_elements`); err != nil {
+		if _, err := tx.Exec(ctx, `TRUNCATE wallet_siacoin_elements`); err != nil {
 			return fmt.Errorf("failed to clear wallet_siacoin_elements: %w", err)
-		} else if _, err := tx.Exec(ctx, `DELETE FROM wallet_locked_utxos`); err != nil {
+		} else if _, err := tx.Exec(ctx, `TRUNCATE wallet_locked_utxos`); err != nil {
 			return fmt.Errorf("failed to clear wallet_locked_utxos: %w", err)
-		} else if _, err := tx.Exec(ctx, `DELETE FROM wallet_events`); err != nil {
+		} else if _, err := tx.Exec(ctx, `TRUNCATE wallet_events`); err != nil {
 			return fmt.Errorf("failed to clear wallet_events: %w", err)
 		} else if res, err := tx.Exec(ctx, `UPDATE global_settings SET scanned_height = 0, scanned_block_id = '\x0000000000000000000000000000000000000000000000000000000000000000'`); err != nil {
 			return fmt.Errorf("failed to reset global_settings: %w", err)

--- a/persist/postgres/chain.go
+++ b/persist/postgres/chain.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 
 	"go.sia.tech/indexd/subscriber"
 )
@@ -9,6 +10,27 @@ import (
 type updateTx struct {
 	ctx context.Context
 	tx  *txn
+}
+
+// ResetChainState resets the chain state in the store, clearing all
+// wallet-related data and resetting the scanned height and block ID in the
+// global settings. This is typically used to force a resync of consensus.
+func (s *Store) ResetChainState(ctx context.Context) error {
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		if _, err := tx.Exec(ctx, `DELETE FROM wallet_siacoin_elements`); err != nil {
+			return fmt.Errorf("failed to clear wallet_siacoin_elements: %w", err)
+		} else if _, err := tx.Exec(ctx, `DELETE FROM wallet_locked_utxos`); err != nil {
+			return fmt.Errorf("failed to clear wallet_locked_utxos: %w", err)
+		} else if _, err := tx.Exec(ctx, `DELETE FROM wallet_events`); err != nil {
+			return fmt.Errorf("failed to clear wallet_events: %w", err)
+		} else if res, err := tx.Exec(ctx, `UPDATE global_settings SET scanned_height = 0, scanned_block_id = '\x0000000000000000000000000000000000000000000000000000000000000000'`); err != nil {
+			return fmt.Errorf("failed to reset global_settings: %w", err)
+		} else if rowsAffected := res.RowsAffected(); rowsAffected != 1 {
+			return fmt.Errorf("expected to update 1 row in global_settings, got %d", rowsAffected)
+		} else {
+			return nil
+		}
+	})
 }
 
 // UpdateChainState applies a chain update to the store.

--- a/persist/postgres/chain_test.go
+++ b/persist/postgres/chain_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -10,13 +11,79 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/subscriber"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"lukechampine.com/frand"
 )
 
 type testProofUpdater struct{ fn func(*types.StateElement) }
 
 func (u testProofUpdater) UpdateElementProof(se *types.StateElement) {
 	u.fn(se)
+}
+
+func TestResetChainState(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	// define helper to assert number of rows in a table
+	assertTableCount := func(table string, want int) {
+		t.Helper()
+		var got int
+		if err := store.pool.QueryRow(context.Background(), "SELECT COUNT(*) FROM "+table).Scan(&got); err != nil {
+			t.Fatal(err)
+		} else if got != want {
+			t.Fatalf("expected %d rows in %s, got %d", want, table, got)
+		}
+	}
+
+	// prepare random index
+	var bID types.BlockID
+	frand.Read(bID[:])
+	index := types.ChainIndex{Height: frand.Uint64n(math.MaxInt64), ID: bID}
+
+	// prepare test elements and events
+	utxos := []types.SiacoinOutputID{frand.Entropy256()}
+	created := []types.SiacoinElement{newTestSiacoinElement()}
+	events := []wallet.Event{newTestEvent()}
+	events[0].Index = index
+
+	// prepare store with random chain state
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return errors.Join(
+			tx.WalletApplyIndex(index, created, nil, events, time.Now()),
+			tx.UpdateLastScannedIndex(context.Background(), index),
+		)
+	}); err != nil {
+		t.Fatal(err)
+	} else if err := store.LockUTXOs(utxos, time.Now().Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert chain state before reset
+	if ci, err := store.LastScannedIndex(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if ci != index {
+		t.Fatal("unexpected last scanned index", ci, index)
+	}
+
+	assertTableCount("wallet_siacoin_elements", 1)
+	assertTableCount("wallet_locked_utxos", 1)
+	assertTableCount("wallet_events", 1)
+
+	if err := store.ResetChainState(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert chain state after reset
+	if ci, err := store.LastScannedIndex(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if ci != (types.ChainIndex{}) {
+		t.Fatal("unexpected last scanned index", ci, index)
+	}
+
+	assertTableCount("wallet_siacoin_elements", 0)
+	assertTableCount("wallet_locked_utxos", 0)
+	assertTableCount("wallet_events", 0)
 }
 
 func TestUpdateChainState(t *testing.T) {

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -38,6 +39,7 @@ type (
 
 	// Store is a persistent store for the chain subscriber.
 	Store interface {
+		ResetChainState(ctx context.Context) error
 		UpdateChainState(ctx context.Context, fn func(tx UpdateTx) error) error
 		LastScannedIndex(context.Context) (types.ChainIndex, error)
 	}
@@ -163,7 +165,13 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 		}
 
 		rus, aus, err := s.cm.UpdatesSince(index, s.updateBatchSize)
-		if err != nil {
+		if err != nil && strings.Contains(err.Error(), "missing block at index") {
+			s.log.Warn("missing block at index, resetting chain state")
+			if err := s.store.ResetChainState(ctx); err != nil {
+				return fmt.Errorf("failed to reset consensus state: %w", err)
+			}
+			return nil
+		} else if err != nil {
 			return fmt.Errorf("failed to fetch updates since %v: %w", index, err)
 		} else if len(rus) == 0 && len(aus) == 0 {
 			break

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -165,12 +164,14 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 		}
 
 		rus, aus, err := s.cm.UpdatesSince(index, s.updateBatchSize)
-		if err != nil && strings.Contains(err.Error(), "missing block at index") {
-			s.log.Warn("missing block at index, resetting chain state")
+		if errors.Is(err, chain.ErrMissingBlock) {
+			s.log.Warn("missing block at index, resetting chain state", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID))
 			if err := s.store.ResetChainState(ctx); err != nil {
 				return fmt.Errorf("failed to reset consensus state: %w", err)
+			} else if index, err = s.store.LastScannedIndex(ctx); err != nil {
+				return fmt.Errorf("failed to get last scanned index after reset: %w", err)
 			}
-			return nil
+			continue
 		} else if err != nil {
 			return fmt.Errorf("failed to fetch updates since %v: %w", index, err)
 		} else if len(rus) == 0 && len(aus) == 0 {

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -154,6 +154,7 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 		return fmt.Errorf("failed to get last scanned index: %w", err)
 	}
 
+	var resetAttempts int
 	lastUpdate := time.Now()
 	s.log.Debug("syncing", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID))
 	for index != s.cm.Tip() {
@@ -165,7 +166,11 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 
 		rus, aus, err := s.cm.UpdatesSince(index, s.updateBatchSize)
 		if err != nil {
-			s.log.Warn("failed to fetch updates, resetting chain state", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID), zap.Error(err))
+			resetAttempts++
+			if resetAttempts > 3 {
+				return fmt.Errorf("failed to sync chain state after multiple attempts: %w", err)
+			}
+			s.log.Warn("failed to fetch updates, resetting chain state", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID), zap.Int("attempt", resetAttempts), zap.Error(err))
 			if err := s.store.ResetChainState(ctx); err != nil {
 				return fmt.Errorf("failed to reset consensus state: %w", err)
 			} else if index, err = s.store.LastScannedIndex(ctx); err != nil {

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -164,16 +164,14 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 		}
 
 		rus, aus, err := s.cm.UpdatesSince(index, s.updateBatchSize)
-		if errors.Is(err, chain.ErrMissingBlock) {
-			s.log.Warn("missing block at index, resetting chain state", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID))
+		if err != nil {
+			s.log.Warn("failed to fetch updates, resetting chain state", zap.Uint64("height", index.Height), zap.Stringer("id", index.ID), zap.Error(err))
 			if err := s.store.ResetChainState(ctx); err != nil {
 				return fmt.Errorf("failed to reset consensus state: %w", err)
 			} else if index, err = s.store.LastScannedIndex(ctx); err != nil {
 				return fmt.Errorf("failed to get last scanned index after reset: %w", err)
 			}
 			continue
-		} else if err != nil {
-			return fmt.Errorf("failed to fetch updates since %v: %w", index, err)
 		} else if len(rus) == 0 && len(aus) == 0 {
 			break
 		}


### PR DESCRIPTION
This allows forcing a resync by removing consensus.db, similar to how we do it for other daemons.