### PR TITLE
Fix host usability

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -146,12 +146,16 @@ func TestHostsAPI(t *testing.T) {
 		t.Fatal("expected h1 to be scanned successfully")
 	} else if !h1.LastFailedScan.IsZero() {
 		t.Fatal("expected h1 to not have failed scans")
+	} else if !h1.Usability.Usable() {
+		t.Fatal("expected h1 to be usable", h1.Usability)
 	} else if h2, err := indexer.Host(context.Background(), h2.PublicKey()); err != nil {
 		t.Fatal(err)
 	} else if h2.LastSuccessfulScan.IsZero() {
 		t.Fatal("expected h2 to be scanned successfully")
 	} else if !h2.LastFailedScan.IsZero() {
 		t.Fatal("expected h2 to not have failed scans")
+	} else if !h2.Usability.Usable() {
+		t.Fatal("expected h2 to be usable", h2.Usability)
 	}
 
 	// assert blocklist is empty and unblocking unknown host is noop
@@ -207,17 +211,17 @@ func TestHostsAPI(t *testing.T) {
 		t.Fatalf("invalid hosts were returned (%d): %+v", len(blocked), blocked)
 	}
 
-	// filter by usable hosts - none of them should be usable
+	// filter by usable hosts - all of them should be usable
 	usable, err := indexer.Hosts(context.Background(), api.WithUsable(true))
 	if err != nil {
 		t.Fatal(err)
-	} else if len(usable) != 0 {
+	} else if len(usable) != 2 {
 		t.Fatalf("invalid number of hosts: %d", len(usable))
 	}
 	unusable, err := indexer.Hosts(context.Background(), api.WithUsable(false))
 	if err != nil {
 		t.Fatal(err)
-	} else if len(unusable) != 2 {
+	} else if len(unusable) != 0 {
 		t.Fatalf("invalid number of hosts: %d", len(unusable))
 	}
 

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -35,11 +35,7 @@ import (
 )
 
 func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateKey, network *consensus.Network, genesis types.Block, log *zap.Logger) error {
-	pool, err := postgres.Connect(ctx, cfg.Database, log.Named("postgres"))
-	if err != nil {
-		return fmt.Errorf("failed to connect to postgres database: %w", err)
-	}
-	store, err := postgres.NewStore(ctx, pool, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log.Named("postgres"))
+	store, err := postgres.NewStore(ctx, cfg.Database, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log.Named("postgres"))
 	if err != nil {
 		return fmt.Errorf("failed to create postgres store: %w", err)
 	}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -34,9 +34,13 @@ import (
 )
 
 func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateKey, network *consensus.Network, genesis types.Block, log *zap.Logger) error {
-	store, err := postgres.Connect(ctx, cfg.Database, log.Named("postgres"))
+	pool, err := postgres.Connect(ctx, cfg.Database, log.Named("postgres"))
 	if err != nil {
 		return fmt.Errorf("failed to connect to postgres database: %w", err)
+	}
+	store, err := postgres.NewStore(ctx, pool, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log.Named("postgres"))
+	if err != nil {
+		return fmt.Errorf("failed to create postgres store: %w", err)
 	}
 	defer store.Close()
 

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -30,6 +30,18 @@ const (
 	fundTimeout = 2 * time.Minute
 )
 
+var (
+	// DefaultMaintenanceSettings are the default settings for contract
+	// maintenance. These settings are configured in the database as defaults
+	// when the global settings are initialized.
+	DefaultMaintenanceSettings = MaintenanceSettings{
+		Enabled:         false,
+		Period:          144 * 7 * 6, // 6 weeks
+		RenewWindow:     144 * 7 * 2, // 2 weeks
+		WantedContracts: 50,
+	}
+)
+
 type (
 	// AccountManager defines an interface that allows funding accounts on the
 	// host using a given set of contracts.

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -10,6 +10,11 @@ import (
 	"go.sia.tech/coreutils/chain"
 )
 
+const (
+	blocksPerMonth = 144 * 30
+	oneTB          = 1e12
+)
+
 var (
 	// ErrNotFound is returned by database operations that fail due to a host
 	// not being found.
@@ -19,13 +24,25 @@ var (
 	// should.
 	ErrNoNetworks = errors.New("host has no networks")
 )
+var (
+	// DefaultHostsQueryOpts re the default options applied when querying hosts. By
+	// default no hosts are filtered out.
+	DefaultHostsQueryOpts = hostsQueryOpts{
+		Blocked: nil,
+		Good:    nil,
+	}
 
-// DefaultHostsQueryOpts re the default options applied when querying hosts. By
-// default no hosts are filtered out.
-var DefaultHostsQueryOpts = hostsQueryOpts{
-	Blocked: nil,
-	Good:    nil,
-}
+	// DefaultUsabilitySettings are the default settings used to determine
+	// whether a host is usable or not. These settings are configured in the
+	// database as defaults when the global settings are initialized.
+	DefaultUsabilitySettings = UsabilitySettings{
+		MaxEgressPrice:     types.Siacoins(3000).Div64(oneTB),                       // 3000 SC / TB
+		MaxIngressPrice:    types.Siacoins(3000).Div64(oneTB),                       // 3000 SC / TB
+		MaxStoragePrice:    types.Siacoins(3000).Div64(oneTB).Div64(blocksPerMonth), // 3000 SC / TB / month
+		MinCollateral:      types.Siacoins(100).Div64(oneTB).Div64(blocksPerMonth),  // 100 SC / TB / month
+		MinProtocolVersion: [3]uint8{1, 0, 0},
+	}
+)
 
 type (
 	// HostQueryOpt is a functional option for querying hosts.

--- a/internal/testutils/db.go
+++ b/internal/testutils/db.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.uber.org/zap"
 )
@@ -40,9 +42,15 @@ func NewDB(t testing.TB, log *zap.Logger) *postgres.Store {
 	ci.Database = dbName
 
 	// connect
-	store, err := postgres.Connect(context.Background(), ci, log.Named("postgres"))
+	log = log.Named("postgres")
+	pool, err = postgres.Connect(context.Background(), ci, log)
 	if err != nil {
 		t.Fatalf("failed to connect to postgres database: %v", err)
+	}
+
+	store, err := postgres.NewStore(context.Background(), pool, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
 	}
 	return store
 }

--- a/internal/testutils/db.go
+++ b/internal/testutils/db.go
@@ -41,14 +41,8 @@ func NewDB(t testing.TB, log *zap.Logger) *postgres.Store {
 	pool.Close()
 	ci.Database = dbName
 
-	// connect
-	log = log.Named("postgres")
-	pool, err = postgres.Connect(context.Background(), ci, log)
-	if err != nil {
-		t.Fatalf("failed to connect to postgres database: %v", err)
-	}
-
-	store, err := postgres.NewStore(context.Background(), pool, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
+	// create store
+	store, err := postgres.NewStore(context.Background(), ci, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
 	if err != nil {
 		t.Fatalf("failed to create store: %v", err)
 	}

--- a/internal/testutils/host.go
+++ b/internal/testutils/host.go
@@ -17,6 +17,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	blocksPerMonth = 144 * 30
+	oneTB          = 1e12
+)
+
 type (
 	// A Host is an ephemeral host that can be used for testing.
 	Host struct {
@@ -108,16 +113,16 @@ func (c *ConsensusNode) NewHost(t testing.TB, pk types.PrivateKey, log *zap.Logg
 		Release:             "test",
 		AcceptingContracts:  true,
 		WalletAddress:       w.Address(),
-		MaxCollateral:       types.Siacoins(10000),
-		MaxContractDuration: 1000,
+		MaxCollateral:       types.Siacoins(1000), // 1 KS
+		MaxContractDuration: blocksPerMonth * 3,   // 3 months
 		RemainingStorage:    100 * proto4.SectorSize,
 		TotalStorage:        100 * proto4.SectorSize,
 		Prices: proto4.HostPrices{
-			ContractPrice: types.Siacoins(1).Div64(5), // 0.2 SC
-			StoragePrice:  types.NewCurrency64(100),   // 100 H / byte / block
-			IngressPrice:  types.NewCurrency64(100),   // 100 H / byte
-			EgressPrice:   types.NewCurrency64(100),   // 100 H / byte
-			Collateral:    types.NewCurrency64(200),
+			ContractPrice: types.Siacoins(1).Div64(5),                                      // 0.2 SC
+			StoragePrice:  types.Siacoins(150).Div64(oneTB).Div64(blocksPerMonth),          // 150 SC / TB / month
+			EgressPrice:   types.Siacoins(500).Div64(oneTB),                                // 500 SC / TB
+			IngressPrice:  types.Siacoins(10).Div64(oneTB),                                 // 10 SC / TB
+			Collateral:    types.Siacoins(150).Div64(oneTB).Div64(blocksPerMonth).Mul64(2), // 2x storage
 		},
 	})
 	ss := testutil.NewEphemeralSectorStore()
@@ -143,7 +148,7 @@ func (c *ConsensusNode) NewHost(t testing.TB, pk types.PrivateKey, log *zap.Logg
 	}
 	c.addSyncFn(syncFn)
 
-	rs := rhp4.NewServer(pk, c.cm, s, contractor, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
+	rs := rhp4.NewServer(pk, c.cm, s, contractor, w, sr, ss, rhp4.WithPriceTableValidity(24*time.Hour))
 	rhp4Listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/testutils/host.go
+++ b/internal/testutils/host.go
@@ -148,7 +148,7 @@ func (c *ConsensusNode) NewHost(t testing.TB, pk types.PrivateKey, log *zap.Logg
 	}
 	c.addSyncFn(syncFn)
 
-	rs := rhp4.NewServer(pk, c.cm, s, contractor, w, sr, ss, rhp4.WithPriceTableValidity(24*time.Hour))
+	rs := rhp4.NewServer(pk, c.cm, s, contractor, w, sr, ss, rhp4.WithPriceTableValidity(30*time.Minute))
 	rhp4Listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatal(err)

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -85,7 +85,7 @@ WITH globals AS (
 	WHERE hosts.public_key = $1
 ) SELECT
 	hosts.*,
-	recent_uptime > 0.9,
+	recent_uptime >= 0.894,
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
@@ -159,7 +159,7 @@ WITH globals AS (
 	LEFT JOIN hosts_blocklist hb ON hosts.public_key = hb.public_key
 ) SELECT
  	hosts.*,
-	recent_uptime > 0.9,
+	recent_uptime >= 0.894,
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
@@ -175,7 +175,7 @@ FROM hosts CROSS JOIN globals
 WHERE
 	-- good host filter
 	(($3::boolean IS NULL) OR ($3::boolean = (
-		recent_uptime > 0.9 AND
+		recent_uptime >= 0.894 AND
 		has_settings AND
 		settings_max_contract_duration >= globals.contracts_period AND
 		settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period AND

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -66,6 +66,7 @@ WITH globals AS (
 		hosts_max_ingress_price,
 		hosts_max_egress_price,
 		(get_byte(hosts_min_protocol_version, 0) << 16) + (get_byte(hosts_min_protocol_version, 1) << 8) + (get_byte(hosts_min_protocol_version, 2)) AS host_min_version,
+		250000::NUMERIC AS sectors_per_tb,
 		1E12::NUMERIC AS one_tb,
 		1E24::NUMERIC AS one_sc
 	FROM global_settings
@@ -96,7 +97,7 @@ WITH globals AS (
 	has_settings AND settings_storage_price <= globals.hosts_max_storage_price,
 	has_settings AND settings_ingress_price <= globals.hosts_max_ingress_price,
 	has_settings AND settings_egress_price <= globals.hosts_max_egress_price,
-	has_settings AND settings_free_sector_price <= globals.one_sc / globals.one_tb
+	has_settings AND settings_free_sector_price <= globals.one_sc / globals.sectors_per_tb
 FROM hosts CROSS JOIN globals;`, sqlPublicKey(hk)))
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("host %q: %w", hk, hosts.ErrNotFound)
@@ -141,6 +142,7 @@ WITH globals AS (
         hosts_max_ingress_price,
 		hosts_max_egress_price,
 		(get_byte(hosts_min_protocol_version, 0) << 16) + (get_byte(hosts_min_protocol_version, 1) << 8) + (get_byte(hosts_min_protocol_version, 2)) AS host_min_version,
+		250000::NUMERIC AS sectors_per_tb,
 		1E12::NUMERIC AS one_tb,
 		1E24::NUMERIC AS one_sc
     FROM global_settings
@@ -170,7 +172,7 @@ WITH globals AS (
 	has_settings AND settings_storage_price <= globals.hosts_max_storage_price,
 	has_settings AND settings_ingress_price <= globals.hosts_max_ingress_price,
 	has_settings AND settings_egress_price <= globals.hosts_max_egress_price,
-	has_settings AND settings_free_sector_price <= globals.one_sc / globals.one_tb
+	has_settings AND settings_free_sector_price <= globals.one_sc / globals.sectors_per_tb
 FROM hosts CROSS JOIN globals
 WHERE
 	-- good host filter
@@ -188,7 +190,7 @@ WHERE
 		settings_storage_price <= globals.hosts_max_storage_price AND
 		settings_ingress_price <= globals.hosts_max_ingress_price AND
 		settings_egress_price <= globals.hosts_max_egress_price AND
-		settings_free_sector_price <= globals.one_sc / globals.one_tb
+		settings_free_sector_price <= globals.one_sc / globals.sectors_per_tb
 		)
 	))
 	-- blocked host filter

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -85,11 +85,11 @@ WITH globals AS (
 	WHERE hosts.public_key = $1
 ) SELECT
 	hosts.*,
-	recent_uptime >= 0.894,
+	recent_uptime >= 0.9,
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
-	has_settings AND settings_valid_until >= (NOW() + INTERVAL '1 hour'),
+	has_settings AND settings_valid_until >= (NOW() + INTERVAL '15 minutes'),
 	has_settings AND settings_accepting_contracts,
 	has_settings AND settings_contract_price <= globals.one_sc,
 	has_settings AND settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price,
@@ -159,11 +159,11 @@ WITH globals AS (
 	LEFT JOIN hosts_blocklist hb ON hosts.public_key = hb.public_key
 ) SELECT
  	hosts.*,
-	recent_uptime >= 0.894,
+	recent_uptime >= 0.9,
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
-	has_settings AND settings_valid_until >= (NOW() + INTERVAL '1 hour'),
+	has_settings AND settings_valid_until >= (NOW() + INTERVAL '15 minutes'),
 	has_settings AND settings_accepting_contracts,
 	has_settings AND settings_contract_price <= globals.one_sc,
 	has_settings AND settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price,
@@ -175,12 +175,12 @@ FROM hosts CROSS JOIN globals
 WHERE
 	-- good host filter
 	(($3::boolean IS NULL) OR ($3::boolean = (
-		recent_uptime >= 0.894 AND
+		recent_uptime >= 0.9 AND
 		has_settings AND
 		settings_max_contract_duration >= globals.contracts_period AND
 		settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period AND
 		settings_version >= globals.host_min_version AND
-		settings_valid_until >= (NOW() + INTERVAL '1 hour') AND
+		settings_valid_until >= (NOW() + INTERVAL '15 minutes') AND
 		settings_accepting_contracts AND
 		settings_contract_price <= globals.one_sc AND
 		settings_collateral >= globals.hosts_min_collateral AND

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -234,7 +234,7 @@ func TestHostChecks(t *testing.T) {
 			EgressPrice:     settingMaxEgressPrice.Add(oneH),
 			Collateral:      settingMinCollataral.Sub(oneH),
 			FreeSectorPrice: oneSC.Div64(oneTB).Add(oneH),
-			ValidUntil:      time.Now().Add(59 * time.Minute).Round(time.Microsecond),
+			ValidUntil:      time.Now().Add(14 * time.Minute).Round(time.Microsecond),
 			TipHeight:       frand.Uint64n(1e3),
 		},
 	}, true, time.Now())
@@ -263,7 +263,7 @@ func TestHostChecks(t *testing.T) {
 	hs := h.Settings
 
 	// adjust recent uptime so we pass the check
-	if _, err := db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .91`); err != nil {
+	if _, err := db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .9`); err != nil {
 		t.Fatal(err)
 	}
 	assertCheckOK("Uptime")
@@ -425,11 +425,6 @@ func TestHosts(t *testing.T) {
 	hk2 := addHost(2, false, false, true) // bad, pending contract
 	hk3 := addHost(3, true, true, false)  // good, blocked, no contract
 	hk4 := addHost(4, false, true, false) //  bad, blocked, no contract
-
-	// make sure the hosts have a good uptime
-	if _, err := db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .91`); err != nil {
-		t.Fatal(err)
-	}
 
 	assertHosts := func(hks []types.PublicKey, offset, limit int, queryOpts ...hosts.HostQueryOpt) {
 		t.Helper()
@@ -614,7 +609,16 @@ func TestHostsRecentUptime(t *testing.T) {
 	// add a host
 	hk = db.addTestHost(t)
 
-	// assert default uptime
+	// manually override the default uptime to .894, this very specific value
+	// gives us the uptime properties that are laid out in the spec, for the
+	// time being though the recent uptime defaults to 0.9 to ensure host pass
+	// uptime checks by default
+	_, err := db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .894`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert uptime
 	if uptime() != .894 {
 		t.Fatal("unexpected", uptime())
 	}
@@ -651,7 +655,7 @@ func TestHostsRecentUptime(t *testing.T) {
 	}
 
 	// assert uptime is halved after the the half life
-	_, err := db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .999999999`)
+	_, err = db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .999999999`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -611,9 +611,8 @@ func TestHostsRecentUptime(t *testing.T) {
 	hk = db.addTestHost(t)
 
 	// manually override the default uptime to .894, this very specific value
-	// gives us the uptime properties that are laid out in the spec, for the
-	// time being though the recent uptime defaults to 0.9 to ensure host pass
-	// uptime checks by default
+	// gives us the uptime properties that are laid out in the spec. The recent
+	// uptime defaults to 0.9 to ensure hosts pass uptime checks by default.
 	_, err := db.pool.Exec(context.Background(), `UPDATE hosts SET recent_uptime = .894`)
 	if err != nil {
 		t.Fatal(err)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -183,6 +183,7 @@ func TestHostChecks(t *testing.T) {
 	oneSC := types.Siacoins(1)
 	oneH := types.NewCurrency64(1)
 	oneTB := uint64(1e12)
+	sectorsPerTB := uint64(250000)
 	settingPeriod := uint64(6084)
 	settingMinCollataral := types.Siacoins(1).Div64(oneTB)
 	settingMaxStoragePrice := types.Siacoins(2).Div64(oneTB)
@@ -233,7 +234,7 @@ func TestHostChecks(t *testing.T) {
 			IngressPrice:    settingMaxIngressPrice.Add(oneH),
 			EgressPrice:     settingMaxEgressPrice.Add(oneH),
 			Collateral:      settingMinCollataral.Sub(oneH),
-			FreeSectorPrice: oneSC.Div64(oneTB).Add(oneH),
+			FreeSectorPrice: oneSC.Div64(sectorsPerTB).Add(oneH),
 			ValidUntil:      time.Now().Add(14 * time.Minute).Round(time.Microsecond),
 			TipHeight:       frand.Uint64n(1e3),
 		},
@@ -320,7 +321,7 @@ func TestHostChecks(t *testing.T) {
 	assertCheckOK("IngressPrice")
 
 	// adjust free sector price so we pass the check
-	hs.Prices.FreeSectorPrice = oneSC.Div64(oneTB)
+	hs.Prices.FreeSectorPrice = oneSC.Div64(sectorsPerTB)
 	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("FreeSectorPrice")
 

--- a/persist/postgres/init.go
+++ b/persist/postgres/init.go
@@ -18,9 +18,15 @@ import (
 //go:embed init.sql
 var initDatabase string
 
-func initSettings(ctx context.Context, tx *txn) error {
-	_, err := tx.Exec(ctx, `INSERT INTO global_settings(id, db_version) VALUES (0, 1);`)
-	return err
+func initSettings(ctx context.Context, tx *txn, ms contracts.MaintenanceSettings, us hosts.UsabilitySettings) error {
+	if _, err := tx.Exec(ctx, `INSERT INTO global_settings(id, db_version) VALUES (0, 1);`); err != nil {
+		return fmt.Errorf("failed to insert initial global settings: %w", err)
+	} else if err := setMaintenanceSettings(ctx, tx, ms); err != nil {
+		return fmt.Errorf("failed to set initial maintenance settings %v: %w", ms, err)
+	} else if err := setUsabilitySettings(ctx, tx, us); err != nil {
+		return fmt.Errorf("failed to set initial usability settings %v: %w", us, err)
+	}
+	return nil
 }
 
 // getDBVersion returns the current version of the database.
@@ -37,18 +43,14 @@ func setDBVersion(ctx context.Context, tx *txn, version int64) error {
 	return tx.QueryRow(ctx, query, version).Scan(&dbID)
 }
 
-func (s *Store) initNewDatabase(ctx context.Context, target int64, defaultMaintenanceSettings contracts.MaintenanceSettings, defaultUsabilitySettings hosts.UsabilitySettings) error {
+func (s *Store) initNewDatabase(ctx context.Context, target int64, ms contracts.MaintenanceSettings, us hosts.UsabilitySettings) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		if _, err := tx.Exec(ctx, initDatabase); err != nil {
 			return err
-		} else if err := initSettings(ctx, tx); err != nil {
+		} else if err := initSettings(ctx, tx, ms, us); err != nil {
 			return fmt.Errorf("failed to init settings: %w", err)
 		} else if err := setDBVersion(ctx, tx, target); err != nil {
 			return fmt.Errorf("failed to set initial database version: %w", err)
-		} else if err := setMaintenanceSettings(ctx, tx, defaultMaintenanceSettings); err != nil {
-			return fmt.Errorf("failed to set initial maintenance settings: %w", err)
-		} else if err := setUsabilitySettings(ctx, tx, defaultUsabilitySettings); err != nil {
-			return fmt.Errorf("failed to set initial usability settings: %w", err)
 		}
 		return nil
 	})

--- a/persist/postgres/init.go
+++ b/persist/postgres/init.go
@@ -8,6 +8,8 @@ import (
 	_ "embed"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
 
@@ -35,7 +37,7 @@ func setDBVersion(ctx context.Context, tx *txn, version int64) error {
 	return tx.QueryRow(ctx, query, version).Scan(&dbID)
 }
 
-func (s *Store) initNewDatabase(ctx context.Context, target int64) error {
+func (s *Store) initNewDatabase(ctx context.Context, target int64, defaultMaintenanceSettings contracts.MaintenanceSettings, defaultUsabilitySettings hosts.UsabilitySettings) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		if _, err := tx.Exec(ctx, initDatabase); err != nil {
 			return err
@@ -43,6 +45,10 @@ func (s *Store) initNewDatabase(ctx context.Context, target int64) error {
 			return fmt.Errorf("failed to init settings: %w", err)
 		} else if err := setDBVersion(ctx, tx, target); err != nil {
 			return fmt.Errorf("failed to set initial database version: %w", err)
+		} else if err := setMaintenanceSettings(ctx, tx, defaultMaintenanceSettings); err != nil {
+			return fmt.Errorf("failed to set initial maintenance settings: %w", err)
+		} else if err := setUsabilitySettings(ctx, tx, defaultUsabilitySettings); err != nil {
+			return fmt.Errorf("failed to set initial usability settings: %w", err)
 		}
 		return nil
 	})
@@ -66,25 +72,5 @@ func (s *Store) upgradeDatabase(ctx context.Context, current, target int64) erro
 		}
 		log.Info("migration complete", zap.Duration("elapsed", time.Since(start)))
 	}
-	return nil
-}
-
-func (s *Store) init(ctx context.Context) error {
-	target := int64(len(migrations) + 1) // init.sql is the initial schema
-	version := getDBVersion(ctx, s.pool)
-	switch {
-	case version == 0:
-		if err := s.initNewDatabase(ctx, target); err != nil {
-			return fmt.Errorf("failed to initialize database: %w", err)
-		}
-	case version < target:
-		s.log.Info("database version is out of date;", zap.Int64("version", version), zap.Int64("target", target))
-		if err := s.upgradeDatabase(ctx, version, target); err != nil {
-			return fmt.Errorf("failed to upgrade database: %w", err)
-		}
-	case version > target:
-		return fmt.Errorf("database version %v is newer than expected %v. database downgrades are not supported", version, target)
-	}
-	// nothing to do
 	return nil
 }

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -136,10 +136,10 @@ CREATE TABLE global_settings (
 
     -- host manager settings
     hosts_min_protocol_version BYTEA NOT NULL DEFAULT '\x010000', -- used for host checks
-    hosts_min_collateral NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte / block
-    hosts_max_storage_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte / block
-    hosts_max_ingress_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte
-    hosts_max_egress_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte
+    hosts_min_collateral NUMERIC(50,0) NOT NULL DEFAULT ((100 * POWER(10,24)) / POWER(10,12) / 4320), -- 100 SC / TB month
+    hosts_max_storage_price NUMERIC(50,0) NOT NULL DEFAULT ((3000 * POWER(10,24)) / POWER(10,12) / 4320),-- 3000 SC / TB / month
+    hosts_max_ingress_price NUMERIC(50,0) NOT NULL DEFAULT ((3000 * POWER(10,24)) / POWER(10,12)),-- 3000 SC / TB
+    hosts_max_egress_price NUMERIC(50,0) NOT NULL DEFAULT ((3000 * POWER(10,24)) / POWER(10,12)), -- 3000 SC / TB
 
     -- pin manager settings
     pins_currency VARCHAR(3) NOT NULL DEFAULT '',

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -135,11 +135,11 @@ CREATE TABLE global_settings (
     contracts_period INTEGER NOT NULL DEFAULT 144 * 7 * 6 CHECK(contracts_period > contracts_renew_window), -- 6 weeks
 
     -- host manager settings
-    hosts_min_protocol_version BYTEA NOT NULL DEFAULT '\x010000', -- used for host checks
-    hosts_min_collateral NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte / block
-    hosts_max_storage_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte / block
-    hosts_max_ingress_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte
-    hosts_max_egress_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte
+    hosts_min_protocol_version BYTEA, -- used for host checks
+    hosts_min_collateral NUMERIC(50,0), -- hastings / byte / block
+    hosts_max_storage_price NUMERIC(50,0), -- hastings / byte / block
+    hosts_max_ingress_price NUMERIC(50,0), -- hastings / byte
+    hosts_max_egress_price NUMERIC(50,0), -- hastings / byte
 
     -- pin manager settings
     pins_currency VARCHAR(3) NOT NULL DEFAULT '',

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -135,11 +135,11 @@ CREATE TABLE global_settings (
     contracts_period INTEGER NOT NULL DEFAULT 144 * 7 * 6 CHECK(contracts_period > contracts_renew_window), -- 6 weeks
 
     -- host manager settings
-    hosts_min_protocol_version BYTEA NOT NULL DEFAULT '\x010000',
-    hosts_min_collateral NUMERIC(50,0) DEFAULT 0 NOT NULL,
-    hosts_max_storage_price NUMERIC(50,0) DEFAULT 0 NOT NULL,
-    hosts_max_ingress_price NUMERIC(50,0) DEFAULT 0 NOT NULL,
-    hosts_max_egress_price NUMERIC(50,0) DEFAULT 0 NOT NULL,
+    hosts_min_protocol_version BYTEA NOT NULL DEFAULT '\x010000', -- used for host checks
+    hosts_min_collateral NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte / block
+    hosts_max_storage_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte / block
+    hosts_max_ingress_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte
+    hosts_max_egress_price NUMERIC(50,0) NOT NULL DEFAULT 0, -- hastings / byte
 
     -- pin manager settings
     pins_currency VARCHAR(3) NOT NULL DEFAULT '',

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -7,7 +7,7 @@ CREATE TABLE hosts (
     id SERIAL PRIMARY KEY,
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
     consecutive_failed_scans INTEGER NOT NULL DEFAULT 0,
-    recent_uptime DOUBLE PRECISION NOT NULL DEFAULT 0.894 CHECK (recent_uptime > 0 AND recent_uptime < 1),
+    recent_uptime DOUBLE PRECISION NOT NULL DEFAULT 0.9 CHECK (recent_uptime > 0 AND recent_uptime < 1),
     last_integrity_check TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     last_failed_scan TIMESTAMP WITH TIME ZONE,
     last_successful_scan TIMESTAMP WITH TIME ZONE,
@@ -135,11 +135,11 @@ CREATE TABLE global_settings (
     contracts_period INTEGER NOT NULL DEFAULT 144 * 7 * 6 CHECK(contracts_period > contracts_renew_window), -- 6 weeks
 
     -- host manager settings
-    hosts_min_protocol_version BYTEA NOT NULL DEFAULT '\x010000', -- used for host checks
-    hosts_min_collateral NUMERIC(50,0) NOT NULL DEFAULT ((100 * POWER(10,24)) / POWER(10,12) / 4320), -- 100 SC / TB month
-    hosts_max_storage_price NUMERIC(50,0) NOT NULL DEFAULT ((3000 * POWER(10,24)) / POWER(10,12) / 4320),-- 3000 SC / TB / month
-    hosts_max_ingress_price NUMERIC(50,0) NOT NULL DEFAULT ((3000 * POWER(10,24)) / POWER(10,12)),-- 3000 SC / TB
-    hosts_max_egress_price NUMERIC(50,0) NOT NULL DEFAULT ((3000 * POWER(10,24)) / POWER(10,12)), -- 3000 SC / TB
+    hosts_min_protocol_version BYTEA NOT NULL DEFAULT '\x010000',
+    hosts_min_collateral NUMERIC(50,0) DEFAULT 0 NOT NULL,
+    hosts_max_storage_price NUMERIC(50,0) DEFAULT 0 NOT NULL,
+    hosts_max_ingress_price NUMERIC(50,0) DEFAULT 0 NOT NULL,
+    hosts_max_egress_price NUMERIC(50,0) DEFAULT 0 NOT NULL,
 
     -- pin manager settings
     pins_currency VARCHAR(3) NOT NULL DEFAULT '',

--- a/persist/postgres/settings.go
+++ b/persist/postgres/settings.go
@@ -35,11 +35,7 @@ func (s *Store) UpdatePinnedSettings(ctx context.Context, ps pins.PinnedSettings
 
 // UpdateMaintenanceSettings updates the maintenance settings.
 func (s *Store) UpdateMaintenanceSettings(ctx context.Context, settings contracts.MaintenanceSettings) error {
-	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, `UPDATE global_settings SET contracts_maintenance_enabled = $1, contracts_wanted = $2, contracts_renew_window = $3, contracts_period = $4`,
-			settings.Enabled, settings.WantedContracts, settings.RenewWindow, settings.Period)
-		return err
-	})
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error { return setMaintenanceSettings(ctx, tx, settings) })
 }
 
 // UsabilitySettings returns the usability settings used in the host's usability checks.
@@ -59,11 +55,7 @@ func (s *Store) UsabilitySettings(ctx context.Context) (us hosts.UsabilitySettin
 
 // UpdateUsabilitySettings updates the usability settings.
 func (s *Store) UpdateUsabilitySettings(ctx context.Context, us hosts.UsabilitySettings) error {
-	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		query := `UPDATE global_settings SET hosts_max_egress_price = $1, hosts_max_ingress_price = $2, hosts_max_storage_price = $3, hosts_min_collateral = $4, hosts_min_protocol_version = $5`
-		_, err := tx.Exec(ctx, query, sqlCurrency(us.MaxEgressPrice), sqlCurrency(us.MaxIngressPrice), sqlCurrency(us.MaxStoragePrice), sqlCurrency(us.MinCollateral), sqlProtocolVersion(us.MinProtocolVersion))
-		return err
-	})
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error { return setUsabilitySettings(ctx, tx, us) })
 }
 
 // LastScannedIndex returns the last scanned index.
@@ -77,5 +69,17 @@ func (s *Store) LastScannedIndex(ctx context.Context) (ci types.ChainIndex, err 
 // UpdateLastScannedIndex updates the last scanned index.
 func (u *updateTx) UpdateLastScannedIndex(ctx context.Context, ci types.ChainIndex) error {
 	_, err := u.tx.Exec(ctx, `UPDATE global_settings SET scanned_height = $1, scanned_block_id = $2`, ci.Height, sqlHash256(ci.ID))
+	return err
+}
+
+func setMaintenanceSettings(ctx context.Context, tx *txn, settings contracts.MaintenanceSettings) error {
+	_, err := tx.Exec(ctx, `UPDATE global_settings SET contracts_maintenance_enabled = $1, contracts_wanted = $2, contracts_renew_window = $3, contracts_period = $4`,
+		settings.Enabled, settings.WantedContracts, settings.RenewWindow, settings.Period)
+	return err
+}
+
+func setUsabilitySettings(ctx context.Context, tx *txn, settings hosts.UsabilitySettings) error {
+	query := `UPDATE global_settings SET hosts_max_egress_price = $1, hosts_max_ingress_price = $2, hosts_max_storage_price = $3, hosts_min_collateral = $4, hosts_min_protocol_version = $5`
+	_, err := tx.Exec(ctx, query, sqlCurrency(settings.MaxEgressPrice), sqlCurrency(settings.MaxIngressPrice), sqlCurrency(settings.MaxStoragePrice), sqlCurrency(settings.MinCollateral), sqlProtocolVersion(settings.MinProtocolVersion))
 	return err
 }

--- a/persist/postgres/settings_test.go
+++ b/persist/postgres/settings_test.go
@@ -51,13 +51,7 @@ func TestHostSettings(t *testing.T) {
 	us, err := db.UsabilitySettings(context.Background())
 	if err != nil {
 		t.Fatal(err)
-	} else if !reflect.DeepEqual(us, hosts.UsabilitySettings{
-		MinProtocolVersion: [3]uint8{1, 0, 0},
-		MinCollateral:      types.Siacoins(100).Div64(1e12).Div64(30 * 144),
-		MaxEgressPrice:     types.Siacoins(3000).Div64(1e12),
-		MaxIngressPrice:    types.Siacoins(3000).Div64(1e12),
-		MaxStoragePrice:    types.Siacoins(3000).Div64(1e12).Div64(30 * 144),
-	}) {
+	} else if !reflect.DeepEqual(us, hosts.DefaultUsabilitySettings) {
 		t.Fatalf("unexpected settings: \n%+v", us)
 	}
 

--- a/persist/postgres/settings_test.go
+++ b/persist/postgres/settings_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
@@ -50,16 +51,14 @@ func TestHostSettings(t *testing.T) {
 	us, err := db.UsabilitySettings(context.Background())
 	if err != nil {
 		t.Fatal(err)
-	} else if !us.MaxEgressPrice.IsZero() {
-		t.Fatal("unexpected", us.MaxEgressPrice)
-	} else if !us.MaxIngressPrice.IsZero() {
-		t.Fatal("unexpected", us.MaxIngressPrice)
-	} else if !us.MaxStoragePrice.IsZero() {
-		t.Fatal("unexpected", us.MaxStoragePrice)
-	} else if !us.MinCollateral.IsZero() {
-		t.Fatal("unexpected", us.MinCollateral)
-	} else if us.MinProtocolVersion != ([3]uint8{1, 0, 0}) {
-		t.Fatal("unexpected", us.MinProtocolVersion)
+	} else if !reflect.DeepEqual(us, hosts.UsabilitySettings{
+		MinProtocolVersion: [3]uint8{1, 0, 0},
+		MinCollateral:      types.Siacoins(100).Div64(1e12).Div64(30 * 144),
+		MaxEgressPrice:     types.Siacoins(3000).Div64(1e12),
+		MaxIngressPrice:    types.Siacoins(3000).Div64(1e12),
+		MaxStoragePrice:    types.Siacoins(3000).Div64(1e12).Div64(30 * 144),
+	}) {
+		t.Fatalf("unexpected settings: \n%+v", us)
 	}
 
 	us.MaxEgressPrice = types.NewCurrency64(frand.Uint64n(1e6))

--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -59,10 +59,11 @@ func (s *Store) Close() error {
 	return nil
 }
 
-// Connect connects to a running PostgresSQL server. The passed in context
-// determines the lifecycle of necessary migrations. If the context is cancelled,
-// the running migration will be interupted and an error returned.
-func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*pgxpool.Pool, error) {
+// NewStore creates a new Store instance, initializing the database if
+// necessary.  The passed in context determines the lifecycle of necessary
+// migrations. If the context is cancelled, the running migration will be
+// interupted and an error returned.
+func NewStore(ctx context.Context, ci ConnectionInfo, defaultMaintenanceSettings contracts.MaintenanceSettings, defaultUsabilitySettings hosts.UsabilitySettings, log *zap.Logger) (*Store, error) {
 	if err := ensureDatabase(ctx, ci); err != nil {
 		return nil, fmt.Errorf("failed to ensure database %q exists: %w", ci.Database, err)
 	}
@@ -75,11 +76,7 @@ func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*pgxpool.
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 	log.Info("connected", zap.String("database", ci.Database), zap.String("host", ci.Host), zap.Int("port", ci.Port))
-	return pool, nil
-}
 
-// NewStore creates a new Store instance, initializing the database if necessary.
-func NewStore(ctx context.Context, pool *pgxpool.Pool, defaultMaintenanceSettings contracts.MaintenanceSettings, defaultUsabilitySettings hosts.UsabilitySettings, log *zap.Logger) (*Store, error) {
 	s := &Store{
 		pool: pool,
 		log:  log,

--- a/persist/postgres/store.go
+++ b/persist/postgres/store.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -60,7 +62,7 @@ func (s *Store) Close() error {
 // Connect connects to a running PostgresSQL server. The passed in context
 // determines the lifecycle of necessary migrations. If the context is cancelled,
 // the running migration will be interupted and an error returned.
-func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*Store, error) {
+func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*pgxpool.Pool, error) {
 	if err := ensureDatabase(ctx, ci); err != nil {
 		return nil, fmt.Errorf("failed to ensure database %q exists: %w", ci.Database, err)
 	}
@@ -73,15 +75,33 @@ func Connect(ctx context.Context, ci ConnectionInfo, log *zap.Logger) (*Store, e
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 	log.Info("connected", zap.String("database", ci.Database), zap.String("host", ci.Host), zap.Int("port", ci.Port))
+	return pool, nil
+}
 
-	store := &Store{
+// NewStore creates a new Store instance, initializing the database if necessary.
+func NewStore(ctx context.Context, pool *pgxpool.Pool, defaultMaintenanceSettings contracts.MaintenanceSettings, defaultUsabilitySettings hosts.UsabilitySettings, log *zap.Logger) (*Store, error) {
+	s := &Store{
 		pool: pool,
 		log:  log,
 	}
-	if err := store.init(ctx); err != nil {
-		return nil, fmt.Errorf("failed to initialize store: %w", err)
+
+	target := int64(len(migrations) + 1) // init.sql is the initial schema
+	version := getDBVersion(ctx, pool)
+	switch {
+	case version == 0:
+		if err := s.initNewDatabase(ctx, target, defaultMaintenanceSettings, defaultUsabilitySettings); err != nil {
+			return nil, fmt.Errorf("failed to initialize database: %w", err)
+		}
+	case version < target:
+		s.log.Info("database version is out of date;", zap.Int64("version", version), zap.Int64("target", target))
+		if err := s.upgradeDatabase(ctx, version, target); err != nil {
+			return nil, fmt.Errorf("failed to upgrade database: %w", err)
+		}
+	case version > target:
+		return nil, fmt.Errorf("database version %v is newer than expected %v. database downgrades are not supported", version, target)
 	}
-	return store, nil
+
+	return s, nil
 }
 
 func ensureDatabase(ctx context.Context, ci ConnectionInfo) error {

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/hosts"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
@@ -50,7 +52,12 @@ func initPostgres(t testing.TB, log *zap.Logger) *Store {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	db, err := Connect(ctx, connectionInfoFromEnv(), log)
+	log = log.Named("postgres")
+	pool, err := Connect(ctx, connectionInfoFromEnv(), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := NewStore(ctx, pool, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -52,8 +52,7 @@ func initPostgres(t testing.TB, log *zap.Logger) *Store {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	log = log.Named("postgres")
-	db, err := NewStore(ctx, connectionInfoFromEnv(), contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
+	db, err := NewStore(ctx, connectionInfoFromEnv(), contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log.Named("postgres"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/store_test.go
+++ b/persist/postgres/store_test.go
@@ -53,11 +53,7 @@ func initPostgres(t testing.TB, log *zap.Logger) *Store {
 	defer cancel()
 
 	log = log.Named("postgres")
-	pool, err := Connect(ctx, connectionInfoFromEnv(), log)
-	if err != nil {
-		t.Fatal(err)
-	}
-	db, err := NewStore(ctx, pool, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
+	db, err := NewStore(ctx, connectionInfoFromEnv(), contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR essentially sets us up to start forming contracts with hosts as soon as we enable maintenance. Currently, a freshly announced host fails three checks: uptime, gouging and price table validity. I added default settings that should match what we want to use in production. I also updated the uptime requirement and set price table validity to 24 hours, those are not ideal but probably good enough for now, we can always revisit these later.

Closes #189 