### PR TITLE
Fix TestUpload

### DIFF
--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -43,15 +43,9 @@ func (m *mockHostDialer) delay(ctx context.Context, hostKey types.PublicKey) err
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
 	case <-time.After(delay):
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		return nil
 	}
+	return ctx.Err()
 }
 
 // WriteSector implements the [sdk.HostDialer] interface.

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -44,7 +44,12 @@ func (m *mockHostDialer) delay(ctx context.Context, hostKey types.PublicKey) err
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(m.slowHosts[hostKey]):
+	case <-time.After(delay):
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
For me it failed locally 100% of the time. On CI it was an NDF I believe, also fixes a race condition, can't access `slowHosts` without holding the lock.