### PR TITLE
Add slabs API

### DIFF
--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -14,12 +14,14 @@ import (
 	"go.sia.tech/jape"
 )
 
-// A Client provides methods for interacting with an indexer.
+// A Client provides methods for interacting with the admin API of the
+// indexer.
 type Client struct {
 	c jape.Client
 }
 
-// NewClient returns a new indexer client.
+// NewClient returns a new client that can be used to interact with the admin
+// API of the indexer.
 func NewClient(addr, password string) *Client {
 	return &Client{jape.Client{
 		BaseURL:  addr,

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -1,9 +1,13 @@
 package app
 
 import (
+	"context"
 	"net/http"
+	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
 )
@@ -12,8 +16,15 @@ type (
 	// Option is a function that applies an option to the application API.
 	Option func(*app)
 
+	// Store defines the store interface for the application API.
+	Store interface {
+		PinSlab(context.Context, proto.Account, time.Time, slabs.SlabPinParams) (slabs.SlabID, error)
+		UnpinSlab(ctx context.Context, accountID proto.Account, slabID slabs.SlabID) error
+	}
+
 	app struct {
-		log *zap.Logger
+		store Store
+		log   *zap.Logger
 	}
 )
 
@@ -28,31 +39,24 @@ func WithLogger(log *zap.Logger) Option {
 // users, or rather their applications, to pin slabs to the indexer.
 // Authentication happens through presigned URLs that are signed with a private
 // key that corresponds to a previously registered public key.
-func NewAPI(hostname string, store AccountStore, opts ...Option) http.Handler {
+func NewAPI(hostname string, store Store, as AccountStore, opts ...Option) http.Handler {
 	a := &app{
-		log: zap.NewNop(),
+		store: store,
+		log:   zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(a)
 	}
 
-	handlers := map[string]authedHandler{
-		"GET /foo": func(jc jape.Context, pk types.PublicKey) {
-			if ok, err := store.HasAccount(jc.Request.Context(), pk); err != nil {
-				jc.ResponseWriter.WriteHeader(http.StatusInternalServerError)
-				return
-			} else if !ok {
-				jc.Error(ErrUnknownAccount, http.StatusUnauthorized)
-				return
-			}
-			jc.ResponseWriter.WriteHeader(http.StatusOK)
-		},
+	routes := map[string]authedHandler{
+		"POST /slabs/pin":       a.handlePOSTSlabsPin,
+		"DELETE /slabs/:slabid": a.handleDELETESlab,
 	}
 
 	signed := make(map[string]jape.Handler)
-	for path, handler := range handlers {
+	for path, handler := range routes {
 		signed[path] = func(jc jape.Context) {
-			pk, ok := checkSignedURLAuth(jc, hostname, store)
+			pk, ok := checkSignedURLAuth(jc, hostname, as)
 			if !ok {
 				return
 			}
@@ -60,4 +64,33 @@ func NewAPI(hostname string, store AccountStore, opts ...Option) http.Handler {
 		}
 	}
 	return jape.Mux(signed)
+}
+
+func (a *app) handlePOSTSlabsPin(jc jape.Context, pk types.PublicKey) {
+	var params slabs.SlabPinParams
+	if err := jc.Decode(&params); err != nil {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	}
+
+	slabID, err := a.store.PinSlab(jc.Request.Context(), proto.Account(pk), time.Now(), params)
+	if jc.Check("failed to pin slab", err) != nil {
+		return
+	}
+
+	jc.Encode(slabID)
+}
+
+func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
+	var slabID slabs.SlabID
+	if err := jc.DecodeParam("slabid", &slabID); err != nil {
+		return
+	}
+
+	err := a.store.UnpinSlab(jc.Request.Context(), proto.Account(pk), slabID)
+	if jc.Check("failed to unpin slab", err) != nil {
+		return
+	}
+
+	jc.Encode(nil)
 }

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -2,20 +2,47 @@ package app_test
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/url"
+	"errors"
 	"testing"
 	"time"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/internal/testutils"
+	"go.sia.tech/indexd/slabs"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
 )
 
 func TestApplicationAPI(t *testing.T) {
-	cs := testutils.NewConsensusNode(t, zap.NewNop())
-	indexer := testutils.NewIndexer(t, cs, zap.NewNop())
+	// create cluster with two hosts
+	logger := testutils.NewLogger(false)
+	c := testutils.NewConsensusNode(t, logger)
+	h1 := c.NewHost(t, types.GeneratePrivateKey(), zap.NewNop())
+	h2 := c.NewHost(t, types.GeneratePrivateKey(), zap.NewNop())
+
+	// create indexer
+	indexer := testutils.NewIndexer(t, c, logger)
+
+	// fund hosts and indexer wallet
+	c.MineBlocks(t, h1.WalletAddress(), 1)
+	c.MineBlocks(t, h2.WalletAddress(), 1)
+	c.MineBlocks(t, indexer.WalletAddr(), 1)
+	c.MineBlocks(t, types.Address{}, c.Network().MaturityDelay)
+
+	// announce hosts
+	if err := errors.Join(h1.Announce(), h2.Announce()); err != nil {
+		t.Fatal(err)
+	}
+	c.MineBlocks(t, types.Address{}, 1)
+	time.Sleep(time.Second)
+
+	// assert hosts are registered
+	hosts, err := indexer.Hosts(context.Background())
+	if err != nil {
+		t.Fatal("failed to get hosts:", err)
+	} else if len(hosts) != 2 {
+		t.Fatal("expected 2 hosts, got", len(hosts))
+	}
 
 	// prepare account
 	sk := types.GeneratePrivateKey()
@@ -23,35 +50,27 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// prepare request
-	req, err := http.NewRequest("GET", indexer.ApplicationAPIAddress()+"/foo", http.NoBody)
+	// pin the slab
+	slabID, err := indexer.App(sk).PinSlab(context.Background(), slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.SectorPinParams{
+			{
+				Root:    frand.Entropy256(),
+				HostKey: h1.PublicKey(),
+			},
+			{
+				Root:    frand.Entropy256(),
+				HostKey: h2.PublicKey(),
+			},
+		},
+	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("failed to pin slab:", err)
 	}
 
-	// prepare request hash
-	validUntil := time.Now().Add(time.Hour)
-	h := types.NewHasher()
-	h.E.Write([]byte(testutils.DefaultHostname))
-	h.E.WriteUint64(uint64(validUntil.Unix()))
-	requestHash := h.Sum()
-
-	// prepare query parameters
-	val := url.Values{}
-	val.Set("SiaIdx-ValidUntil", fmt.Sprint(validUntil.Unix()))
-	val.Set("SiaIdx-Credential", sk.PublicKey().String())
-	val.Set("SiaIdx-Signature", sk.SignHash(requestHash).String())
-	req.URL.RawQuery = val.Encode()
-
-	// execute the request
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	// assert we successfully authenticated
-	if resp.StatusCode != http.StatusOK {
-		t.Fatal("unexpected status code:", resp.StatusCode)
+	// unpin the slab
+	if err := indexer.App(sk).UnpinSlab(context.Background(), slabID); err != nil {
+		t.Fatal("failed to unpin slab:", err)
 	}
 }

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/slabs"
+	"go.sia.tech/jape"
+)
+
+const (
+	defaultValidity = time.Hour
+)
+
+// Client is an HTTP client for the application API of the indexer.
+type Client struct {
+	c jape.Client
+
+	// the following fields are used to sign requests
+	appkey   types.PrivateKey
+	hostname string
+}
+
+// NewClient creates a new AppClient that can be used to interact with the
+// application API of the indexer. The address should be the full URL to the
+// application API, including the scheme (e.g., "http://indexer.sia.tech").
+func NewClient(address string, appKey types.PrivateKey) (*Client, error) {
+	parsedURL, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address %q: %w", address, err)
+	}
+
+	return &Client{
+		c: jape.Client{BaseURL: address},
+
+		appkey:   appKey,
+		hostname: parsedURL.Hostname(),
+	}, nil
+}
+
+// PinSlab pins a slab to the indexer.
+func (c *Client) PinSlab(ctx context.Context, params slabs.SlabPinParams) (slabID slabs.SlabID, err error) {
+	err = c.c.POST(ctx, c.sign("/slabs/pin"), params, &slabID)
+	return
+}
+
+// UnpinSlab unpins a slab from the indexer.
+func (c *Client) UnpinSlab(ctx context.Context, slabID slabs.SlabID) error {
+	return c.c.DELETE(ctx, c.sign(fmt.Sprintf("/slabs/%s", slabID)))
+}
+
+func (c *Client) sign(route string) string {
+	// prepare request hash
+	validUntil := time.Now().Add(defaultValidity)
+	h := types.NewHasher()
+	h.E.Write([]byte(c.hostname))
+	h.E.WriteUint64(uint64(validUntil.Unix()))
+	requestHash := h.Sum()
+
+	// prepare query parameters
+	val := url.Values{}
+	val.Set("SiaIdx-ValidUntil", fmt.Sprint(validUntil.Unix()))
+	val.Set("SiaIdx-Credential", c.appkey.PublicKey().String())
+	val.Set("SiaIdx-Signature", c.appkey.SignHash(requestHash).String())
+
+	// parse the route (which may contain existing query parameters)
+	u, err := url.Parse(route)
+	if err != nil {
+		panic(err) // developer error
+	}
+
+	// merge query params
+	q := u.Query()
+	for k, v := range val {
+		for _, s := range v {
+			q.Add(k, s)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -179,7 +179,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 
 	appAPI := http.Server{
-		Handler:      app.NewAPI(cfg.ApplicationAPI.Hostname, store, appAPIOpts...),
+		Handler:      app.NewAPI(cfg.ApplicationAPI.Hostname, store, store, appAPIOpts...),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api/admin"
 	"go.sia.tech/indexd/api/app"
+
 	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/explorer"
@@ -36,17 +38,12 @@ const (
 // indexer and useful helpers for testing.
 type Indexer struct {
 	*admin.Client
-	appAPIAddress string
+	App func(types.PrivateKey) *app.Client
 
 	db     *postgres.Store
 	cm     *chain.Manager
 	syncer *Syncer
 	wallet *wallet.SingleAddressWallet
-}
-
-// ApplicationAPIAddress returns the address of the application API.
-func (i *Indexer) ApplicationAPIAddress() string {
-	return i.appAPIAddress
 }
 
 // NewIndexer creates a new indexer for testing that is automatically closed up
@@ -103,6 +100,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 	if err != nil {
 		t.Fatalf("failed to start admin API listener: %v", err)
 	}
+	adminAPIAddr := fmt.Sprintf("http://%s", adminListener.Addr().String())
 
 	go func() {
 		if err := adminAPI.Serve(adminListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -114,23 +112,29 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		app.WithLogger(log.Named("api.application")),
 	}
 
-	applicationAPI := http.Server{
-		Handler: app.NewAPI(DefaultHostname, store, appAPIOpts...),
-	}
-
-	applicationListener, err := net.Listen("tcp4", "127.0.0.1:0")
+	appListener, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen on application address: %v", err)
 	}
+	appAPIAddr := fmt.Sprintf("http://%s", appListener.Addr().String())
+
+	parsedURL, err := url.Parse(appAPIAddr)
+	if err != nil {
+		t.Fatalf("failed to parse address %q: %v", appAPIAddr, err)
+	}
+
+	appAPI := http.Server{
+		Handler: app.NewAPI(parsedURL.Hostname(), store, store, appAPIOpts...),
+	}
 
 	go func() {
-		if err := applicationAPI.Serve(applicationListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := appAPI.Serve(appListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error("failed to serve application API", zap.Error(err))
 		}
 	}()
 
 	t.Cleanup(func() {
-		if err := shutdownWithTimeout(applicationAPI.Shutdown); err != nil {
+		if err := shutdownWithTimeout(appAPI.Shutdown); err != nil {
 			t.Errorf("failed to shutdown application API: %v", err)
 		}
 		if err := shutdownWithTimeout(adminAPI.Shutdown); err != nil {
@@ -159,9 +163,11 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger) *Indexer {
 		}
 	})
 	return &Indexer{
-		Client: admin.NewClient(fmt.Sprintf("http://%s", adminListener.Addr().String()), password),
-
-		appAPIAddress: fmt.Sprintf("http://%s", applicationListener.Addr().String()),
+		Client: admin.NewClient(adminAPIAddr, password),
+		App: func(appKey types.PrivateKey) *app.Client {
+			client, _ := app.NewClient(appAPIAddr, appKey)
+			return client
+		},
 
 		db:     store,
 		cm:     c.cm,

--- a/internal/testutils/logger.go
+++ b/internal/testutils/logger.go
@@ -1,0 +1,26 @@
+package testutils
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// NewLogger creates a console logger used for testing.
+func NewLogger(enable bool) *zap.Logger {
+	if !enable {
+		return zap.NewNop()
+	}
+	config := zap.NewProductionEncoderConfig()
+	config.EncodeTime = zapcore.RFC3339TimeEncoder
+	config.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	config.StacktraceKey = ""
+	consoleEncoder := zapcore.NewConsoleEncoder(config)
+
+	return zap.New(
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stdout), zap.DebugLevel),
+		zap.AddCaller(),
+		zap.AddStacktrace(zap.DebugLevel),
+	)
+}

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -61,6 +61,16 @@ func (s SlabID) String() string {
 	return types.Hash256(s).String()
 }
 
+// MarshalText implements encoding.TextMarshaler.
+func (s SlabID) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *SlabID) UnmarshalText(b []byte) error {
+	return (*types.Hash256)(s).UnmarshalText(b)
+}
+
 // Digest creates a unique digest for the slab to be pinned by SlabPinParams. It
 // is important, that the same params always result in the same hash since we
 // deduplicate slabs using it. So if one user makes the mistake of pinning a


### PR DESCRIPTION
This PR adds an application client that exposes an initial slabs API. I'm going to F/U with adding `POST /slabs` which returns slabs with given IDs. We also have to do this https://github.com/SiaFoundation/indexd/issues/148 . Probably going to extend the test with more assertions too but missing some routes at the moment.