### PR TITLE
Add store method to get hosts with lost sectors

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -726,3 +726,31 @@ func (s *Store) HostsForPruning(ctx context.Context) ([]types.PublicKey, error) 
 	}
 	return hosts, nil
 }
+
+// HostsForSectorAlert returns a list of host keys that have contracts with
+// lost sectors.
+func (s *Store) HostsForSectorAlert(ctx context.Context) ([]types.PublicKey, error) {
+	var hosts []types.PublicKey
+	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT public_key
+			FROM hosts
+			WHERE lost_sectors > 0`)
+		if err != nil {
+			return fmt.Errorf("failed to query hosts for pruning: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var hk sqlPublicKey
+			if err := rows.Scan(&hk); err != nil {
+				return err
+			}
+			hosts = append(hosts, types.PublicKey(hk))
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	return hosts, nil
+}

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -727,9 +727,9 @@ func (s *Store) HostsForPruning(ctx context.Context) ([]types.PublicKey, error) 
 	return hosts, nil
 }
 
-// HostsForSectorAlert returns a list of host keys that have contracts with
+// HostsWithLostSectors returns a list of host keys that have contracts with
 // lost sectors.
-func (s *Store) HostsForSectorAlert(ctx context.Context) ([]types.PublicKey, error) {
+func (s *Store) HostsWithLostSectors(ctx context.Context) ([]types.PublicKey, error) {
 	var hosts []types.PublicKey
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
@@ -737,7 +737,7 @@ func (s *Store) HostsForSectorAlert(ctx context.Context) ([]types.PublicKey, err
 			FROM hosts
 			WHERE lost_sectors > 0`)
 		if err != nil {
-			return fmt.Errorf("failed to query hosts for pruning: %w", err)
+			return fmt.Errorf("failed to query hosts for lost sectors alert: %w", err)
 		}
 		defer rows.Close()
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
@@ -570,6 +571,97 @@ func TestHostsForScanning(t *testing.T) {
 	} else if len(hosts) != 0 {
 		t.Fatal("unexpected", len(hosts))
 	}
+}
+
+func TestHostsForAlert(t *testing.T) {
+	// create database
+	log := zaptest.NewLogger(t)
+	db := initPostgres(t, log.Named("postgres"))
+
+	// add account
+	account := proto.Account{1}
+	if err := db.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		t.Fatal("failed to add account:", err)
+	}
+
+	// add two hosts
+	hk1 := db.addTestHost(t)
+	hk2 := db.addTestHost(t)
+
+	// add a contract for each host
+	db.addTestContract(t, hk1)
+	db.addTestContract(t, hk2)
+
+	// pin a slab that adds 2 sectors to each host
+	root1 := frand.Entropy256()
+	root2 := frand.Entropy256()
+	root3 := frand.Entropy256()
+	root4 := frand.Entropy256()
+	_, err := db.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     10,
+		Sectors: []slabs.SectorPinParams{
+			{
+				Root:    root1,
+				HostKey: hk1,
+			},
+			{
+				Root:    root2,
+				HostKey: hk1,
+			},
+			{
+				Root:    root3,
+				HostKey: hk2,
+			},
+			{
+				Root:    root4,
+				HostKey: hk2,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	markSectorLost := func(hk types.PublicKey, roots []types.Hash256) {
+		t.Helper()
+		if err := db.MarkSectorsLost(context.Background(), hk, roots); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertHosts := func(hks []types.PublicKey) {
+		t.Helper()
+		hosts, err := db.HostsForSectorAlert(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if len(hks) != len(hosts) {
+			t.Fatalf("expected %d hosts, got %d", len(hks), len(hosts))
+		}
+		for i, host := range hosts {
+			if host != hks[i] {
+				t.Fatalf("expected hk %v, got %v", hks[i], host)
+			}
+		}
+	}
+
+	// assert no hosts are returned because no sectors are lost yet
+	assertHosts(nil)
+
+	markSectorLost(hk1, []types.Hash256{root1})
+
+	// hk1 should be returned after one of its sectors is marked as lost
+	assertHosts([]types.PublicKey{hk1})
+
+	markSectorLost(hk1, []types.Hash256{root2})
+
+	// still only hk1 should be returned after another one of its sectors is
+	// marked as lost
+	assertHosts([]types.PublicKey{hk1})
+
+	markSectorLost(hk2, []types.Hash256{root3, root4})
+
+	// hk1 and hk2 should be returned after both have lost sectors
+	assertHosts([]types.PublicKey{hk1, hk2})
 }
 
 func TestHostsRecentUptime(t *testing.T) {

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1607,6 +1607,63 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 	}
 }
 
+// BenchmarkHostsWithLostSectors benchmarks HostsWithLostSectors.
+func BenchmarkHostsWithLostSectors(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+	account := proto4.Account{1}
+
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal("failed to add account:", err)
+	}
+
+	const (
+		nHosts          = 10000
+		dbBaseSize      = 1 << 40 // 1TiB of sectors
+		nSectorsPerHost = dbBaseSize / proto4.SectorSize / nHosts
+	)
+
+	// add hosts
+	for range nHosts {
+		hk := store.addTestHost(b)
+
+		// add sectors
+		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
+			batchSize := min(remainingSectors, 10000)
+			remainingSectors -= batchSize
+			var sectors []slabs.SectorPinParams
+			for range batchSize {
+				root := frand.Entropy256()
+				sectors = append(sectors, slabs.SectorPinParams{
+					Root:    root,
+					HostKey: hk,
+				})
+			}
+			if _, err := store.PinSlab(context.Background(), account, time.Now().Add(time.Hour), slabs.SlabPinParams{
+				MinShards:     1,
+				EncryptionKey: frand.Entropy256(),
+				Sectors:       sectors,
+			}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	// 10% of hosts have lost sectors
+	_, err := store.pool.Exec(context.Background(), `UPDATE hosts SET lost_sectors = floor(random() * 100) + 1 WHERE id % 10 = 0`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		batch, err := store.HostsWithLostSectors(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		} else if len(batch) == 0 {
+			b.Fatal("expected hosts, got none")
+		}
+	}
+}
+
 func (s *Store) addTestHost(t testing.TB, hks ...types.PublicKey) types.PublicKey {
 	t.Helper()
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -572,7 +572,7 @@ func TestHostsForScanning(t *testing.T) {
 	}
 }
 
-func TestHostsForAlert(t *testing.T) {
+func TestHostsWithLostSectors(t *testing.T) {
 	// create database
 	log := zaptest.NewLogger(t)
 	db := initPostgres(t, log.Named("postgres"))
@@ -622,15 +622,9 @@ func TestHostsForAlert(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	markSectorLost := func(hk types.PublicKey, roots []types.Hash256) {
-		t.Helper()
-		if err := db.MarkSectorsLost(context.Background(), hk, roots); err != nil {
-			t.Fatal(err)
-		}
-	}
 	assertHosts := func(hks []types.PublicKey) {
 		t.Helper()
-		hosts, err := db.HostsForSectorAlert(context.Background())
+		hosts, err := db.HostsWithLostSectors(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		} else if len(hks) != len(hosts) {
@@ -646,18 +640,24 @@ func TestHostsForAlert(t *testing.T) {
 	// assert no hosts are returned because no sectors are lost yet
 	assertHosts(nil)
 
-	markSectorLost(hk1, []types.Hash256{root1})
+	if err := db.MarkSectorsLost(context.Background(), hk1, []types.Hash256{root1}); err != nil {
+		t.Fatal(err)
+	}
 
 	// hk1 should be returned after one of its sectors is marked as lost
 	assertHosts([]types.PublicKey{hk1})
 
-	markSectorLost(hk1, []types.Hash256{root2})
+	if err := db.MarkSectorsLost(context.Background(), hk1, []types.Hash256{root2}); err != nil {
+		t.Fatal(err)
+	}
 
 	// still only hk1 should be returned after another one of its sectors is
 	// marked as lost
 	assertHosts([]types.PublicKey{hk1})
 
-	markSectorLost(hk2, []types.Hash256{root3, root4})
+	if err := db.MarkSectorsLost(context.Background(), hk2, []types.Hash256{root3}); err != nil {
+		t.Fatal(err)
+	}
 
 	// hk1 and hk2 should be returned after both have lost sectors
 	assertHosts([]types.PublicKey{hk1, hk2})

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
@@ -579,7 +578,7 @@ func TestHostsForAlert(t *testing.T) {
 	db := initPostgres(t, log.Named("postgres"))
 
 	// add account
-	account := proto.Account{1}
+	account := proto4.Account{1}
 	if err := db.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
 		t.Fatal("failed to add account:", err)
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -36,6 +36,7 @@ CREATE TABLE hosts (
 CREATE INDEX hosts_next_scan_idx ON hosts(next_scan);
 
 CREATE INDEX hosts_last_integrity_check_idx ON hosts(last_integrity_check ASC);
+CREATE INDEX hosts_lost_sectors_idx ON hosts(lost_sectors);
 
 CREATE TABLE account_hosts (
     account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,


### PR DESCRIPTION
This PR adds a method to the Postgres store, `HostsForSectorAlert` to retrieve the public keys of all hosts that have lost sectors.  This is used in https://github.com/SiaFoundation/indexd/pull/225, where we generate alerts for these hosts in the slab manager's `performIntegrityChecks`.