### PR TITLE
Add `/hosts` endpoint to application API.

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -15,6 +15,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
+	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/build"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/explorer"
@@ -25,17 +26,7 @@ import (
 )
 
 const (
-	defaultLimit = 100
-	maxLimit     = 500
-	stdTxnSize   = 1200 // bytes
-)
-
-var (
-	// ErrInvalidOffset is returned when the requested offset is invalid.
-	ErrInvalidOffset = errors.New("offset must be non-negative")
-
-	// ErrInvalidLimit is returned when the requested limit is invalid.
-	ErrInvalidLimit = fmt.Errorf("limit must between 1 and %d", maxLimit)
+	stdTxnSize = 1200 // bytes
 )
 
 var startTime = time.Now()
@@ -242,7 +233,7 @@ func (a *admin) handlePOSTTrigger(jc jape.Context) {
 }
 
 func (a *admin) handleGETAccounts(jc jape.Context) {
-	offset, limit, ok := parseOffsetLimit(jc)
+	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
 		return
 	}
@@ -380,7 +371,7 @@ func (a *admin) handleGETContract(jc jape.Context) {
 }
 
 func (a *admin) handleGETContracts(jc jape.Context) {
-	offset, limit, ok := parseOffsetLimit(jc)
+	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
 		return
 	}
@@ -427,7 +418,7 @@ func (a *admin) handleGETHost(jc jape.Context) {
 }
 
 func (a *admin) handleGETHosts(jc jape.Context) {
-	offset, limit, ok := parseOffsetLimit(jc)
+	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
 		return
 	}
@@ -463,7 +454,7 @@ func (a *admin) handleGETHosts(jc jape.Context) {
 }
 
 func (a *admin) handleGETHostsBlocklist(jc jape.Context) {
-	offset, limit, ok := parseOffsetLimit(jc)
+	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
 		return
 	}
@@ -555,7 +546,7 @@ func (a *admin) handleGETWallet(jc jape.Context) {
 }
 
 func (a *admin) handleGETWalletEvents(jc jape.Context) {
-	offset, limit, ok := parseOffsetLimit(jc)
+	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
 		return
 	}
@@ -623,23 +614,4 @@ func (a *admin) handlePOSTWalletSend(jc jape.Context) {
 	}
 
 	jc.Encode(txn.ID())
-}
-
-func parseOffsetLimit(jc jape.Context) (offset int, limit int, ok bool) {
-	if jc.DecodeForm("offset", &offset) != nil {
-		return 0, 0, false
-	} else if offset < 0 {
-		jc.Error(ErrInvalidOffset, http.StatusBadRequest)
-		return 0, 0, false
-	}
-
-	limit = defaultLimit
-	if jc.DecodeForm("limit", &limit) != nil {
-		return 0, 0, false
-	} else if limit < 1 || limit > maxLimit {
-		jc.Error(ErrInvalidLimit, http.StatusBadRequest)
-		return 0, 0, false
-	}
-
-	return offset, limit, true
 }

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -8,6 +8,8 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -19,6 +21,7 @@ type (
 
 	// Store defines the store interface for the application API.
 	Store interface {
+		Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
 		PinSlab(context.Context, proto.Account, time.Time, slabs.SlabPinParams) (slabs.SlabID, error)
 		UnpinSlab(ctx context.Context, accountID proto.Account, slabID slabs.SlabID) error
 	}
@@ -50,6 +53,8 @@ func NewAPI(hostname string, store Store, as AccountStore, opts ...Option) http.
 	}
 
 	routes := map[string]authedHandler{
+		"GET /hosts": a.handleGETHosts,
+
 		"POST /slabs/pin":       a.handlePOSTSlabsPin,
 		"DELETE /slabs/:slabid": a.handleDELETESlab,
 	}
@@ -65,6 +70,23 @@ func NewAPI(hostname string, store Store, as AccountStore, opts ...Option) http.
 		}
 	}
 	return jape.Mux(signed)
+}
+
+func (a *app) handleGETHosts(jc jape.Context, _ types.PublicKey) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	hosts, err := a.store.Hosts(jc.Request.Context(), offset, limit, []hosts.HostQueryOpt{
+		hosts.WithBlocked(false),        // only return unblocked hosts
+		hosts.WithActiveContracts(true), // only return hosts with active contracts
+		hosts.WithUsable(true),          // only return usable hosts
+	}...)
+	if jc.Check("failed to get hosts", err) != nil {
+		return
+	}
+	jc.Encode(hosts)
 }
 
 func (a *app) handlePOSTSlabsPin(jc jape.Context, pk types.PublicKey) {

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"go.uber.org/zap"
@@ -99,5 +100,39 @@ func TestApplicationAPI(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), slabs.ErrInsufficientRedundancy.Error()) {
 		t.Fatal("expected [slabs.ErrInsufficientRedundancy], got:", err)
+	}
+
+	// assert hosts returns all usable hosts
+	time.Sleep(time.Second) // allow some time to form contracts
+	usableHosts, err := indexer.App(sk).Hosts(context.Background())
+	if err != nil {
+		t.Fatal("failed to get hosts:", err)
+	} else if len(usableHosts) != 3 {
+		t.Fatal("expected 3 usable hosts, got", len(usableHosts))
+	}
+
+	// block h1
+	err = indexer.HostsBlocklistAdd(context.Background(), []types.PublicKey{h1.PublicKey()}, "test blocklist reason")
+	if err != nil {
+		t.Fatal("failed to add host to blocklist:", err)
+	}
+
+	// assert host is no longer returned
+	usableHosts, err = indexer.App(sk).Hosts(context.Background())
+	if err != nil {
+		t.Fatal("failed to get hosts:", err)
+	} else if len(usableHosts) != 2 {
+		t.Fatal("expected 2 usable hosts, got", len(usableHosts))
+	}
+
+	// assert limit and offset are applied
+	if usableHosts, err := indexer.App(sk).Hosts(context.Background(), api.WithLimit(1)); err != nil {
+		t.Fatal("failed to get hosts with limit:", err)
+	} else if len(usableHosts) != 1 {
+		t.Fatal("expected 1 usable host, got", len(usableHosts))
+	} else if usableHosts, err := indexer.App(sk).Hosts(context.Background(), api.WithOffset(2), api.WithLimit(1)); err != nil {
+		t.Fatal("failed to get hosts with limit:", err)
+	} else if len(usableHosts) != 0 {
+		t.Fatal("expected 0 usable hosts, got", len(usableHosts))
 	}
 }

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/jape"
 )
@@ -39,6 +41,16 @@ func NewClient(address string, appKey types.PrivateKey) (*Client, error) {
 		appkey:   appKey,
 		hostname: parsedURL.Hostname(),
 	}, nil
+}
+
+// Hosts returns all usable hosts.
+func (c *Client) Hosts(ctx context.Context, opts ...api.URLQueryParameterOption) (hosts []hosts.Host, err error) {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	err = c.c.GET(ctx, c.sign("/hosts?"+values.Encode()), &hosts)
+	return
 }
 
 // PinSlab pins a slab to the indexer.

--- a/api/options.go
+++ b/api/options.go
@@ -1,8 +1,25 @@
 package api
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
+
+	"go.sia.tech/jape"
+)
+
+const (
+	defaultLimit = 100
+	maxLimit     = 500
+)
+
+var (
+	// ErrInvalidOffset is returned when the requested offset is invalid.
+	ErrInvalidOffset = errors.New("offset must be non-negative")
+
+	// ErrInvalidLimit is returned when the requested limit is invalid.
+	ErrInvalidLimit = fmt.Errorf("limit must between 1 and %d", maxLimit)
 )
 
 // URLQueryParameterOption is an option to configure the query string
@@ -21,4 +38,28 @@ func WithLimit(limit int) URLQueryParameterOption {
 	return func(q url.Values) {
 		q.Set("limit", fmt.Sprint(limit))
 	}
+}
+
+// ParseOffsetLimit parses the 'offset' and 'limit' query parameters from the
+// request context. It returns the offset and limit values, and a boolean
+// indicating whether the parsing was successful. If the parameters are not
+// present or invalid, it returns false and writes an appropriate error to the
+// response body.
+func ParseOffsetLimit(jc jape.Context) (offset int, limit int, ok bool) {
+	if jc.DecodeForm("offset", &offset) != nil {
+		return 0, 0, false
+	} else if offset < 0 {
+		jc.Error(ErrInvalidOffset, http.StatusBadRequest)
+		return 0, 0, false
+	}
+
+	limit = defaultLimit
+	if jc.DecodeForm("limit", &limit) != nil {
+		return 0, 0, false
+	} else if limit < 1 || limit > maxLimit {
+		jc.Error(ErrInvalidLimit, http.StatusBadRequest)
+		return 0, 0, false
+	}
+
+	return offset, limit, true
 }

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -99,7 +99,8 @@ type (
 	}
 
 	// HostInfo is a subset of the Host struct that contains only the public
-	// key, networks and addresses. It is used for listing hosts in the API.
+	// key, networks and addresses. It is used for listing usable hosts in the
+	// application API.
 	HostInfo struct {
 		PublicKey types.PublicKey    `json:"publicKey"`
 		Addresses []chain.NetAddress `json:"addresses"`

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -99,12 +99,11 @@ type (
 	}
 
 	// HostInfo is a subset of the Host struct that contains only the public
-	// key, networks and addresses. It is used for listing usable hosts in the
+	// key and addresses. It is used for listing usable hosts in the
 	// application API.
 	HostInfo struct {
 		PublicKey types.PublicKey    `json:"publicKey"`
 		Addresses []chain.NetAddress `json:"addresses"`
-		Networks  []net.IPNet        `json:"networks"`
 	}
 
 	// Usability represents a series of host checks that can be used to

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -488,8 +488,7 @@ WHERE hosts.id = computed.id RETURNING hosts.id`,
 }
 
 // UsableHosts returns a list of hosts that are not blocked, usable and have an
-// active contract. It returns only the host's public key, networks and
-// addresses.
+// active contract. It returns only the host's public key and addresses.
 func (s *Store) UsableHosts(ctx context.Context, offset, limit int) ([]hosts.HostInfo, error) {
 	if err := validateOffsetLimit(offset, limit); err != nil {
 		return nil, err
@@ -583,15 +582,12 @@ LIMIT $1 OFFSET $2;`, limit, offset)
 
 		if err := decorateHostAddresses(ctx, tx, dbHosts...); err != nil {
 			return fmt.Errorf("failed to decorate host addresses: %w", err)
-		} else if err := decorateHostNetworks(ctx, tx, dbHosts...); err != nil {
-			return fmt.Errorf("failed to decorate host networks: %w", err)
 		}
 
 		for _, h := range dbHosts {
 			usable = append(usable, hosts.HostInfo{
 				PublicKey: h.PublicKey,
 				Addresses: h.Addresses,
-				Networks:  h.Networks,
 			})
 		}
 		return nil

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -137,9 +137,9 @@ func (s *Store) Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts
 WITH globals AS (
     SELECT
 		contracts_period,
-        hosts_min_collateral,
-        hosts_max_storage_price,
-        hosts_max_ingress_price,
+		hosts_min_collateral,
+		hosts_max_storage_price,
+		hosts_max_ingress_price,
 		hosts_max_egress_price,
 		(get_byte(hosts_min_protocol_version, 0) << 16) + (get_byte(hosts_min_protocol_version, 1) << 8) + (get_byte(hosts_min_protocol_version, 2)) AS host_min_version,
 		250000::NUMERIC AS sectors_per_tb,
@@ -488,7 +488,8 @@ WHERE hosts.id = computed.id RETURNING hosts.id`,
 }
 
 // UsableHosts returns a list of hosts that are not blocked, usable and have an
-// active contract. It only returns the host's public key and addresses.
+// active contract. It returns only the host's public key, networks and
+// addresses.
 func (s *Store) UsableHosts(ctx context.Context, offset, limit int) ([]hosts.HostInfo, error) {
 	if err := validateOffsetLimit(offset, limit); err != nil {
 		return nil, err
@@ -502,9 +503,9 @@ func (s *Store) UsableHosts(ctx context.Context, offset, limit int) ([]hosts.Hos
 WITH globals AS (
     SELECT
 		contracts_period,
-        hosts_min_collateral,
-        hosts_max_storage_price,
-        hosts_max_ingress_price,
+		hosts_min_collateral,
+		hosts_max_storage_price,
+		hosts_max_ingress_price,
 		hosts_max_egress_price,
 		(get_byte(hosts_min_protocol_version, 0) << 16) + (get_byte(hosts_min_protocol_version, 1) << 8) + (get_byte(hosts_min_protocol_version, 2)) AS host_min_version,
 		250000::NUMERIC AS sectors_per_tb,
@@ -544,7 +545,7 @@ SELECT
 FROM hosts 
 CROSS JOIN globals
 WHERE
-    -- usable
+	-- usable
 	recent_uptime >= 0.9 AND
 	settings_max_contract_duration >= globals.contracts_period AND
 	settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period AND

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -604,8 +604,6 @@ func TestUsableHosts(t *testing.T) {
 		t.Fatal("unexpected hosts", hosts[0], hosts[1])
 	} else if hosts[0].Addresses == nil || hosts[1].Addresses == nil {
 		t.Fatal("expected hosts to have addresses")
-	} else if hosts[0].Networks == nil || hosts[1].Networks == nil {
-		t.Fatal("expected hosts to have networks")
 	}
 
 	// assert offset and limit are applied


### PR DESCRIPTION
This PR adds a `GET /hosts` endpoint to the application API that returns a paginated list of usable, non-blocked hosts that have an active contract.