### PR TITLE
Add `/slab/:id` to App API

### DIFF
--- a/api/app/app.go
+++ b/api/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -20,7 +21,9 @@ type (
 	// Store defines the store interface for the application API.
 	Store interface {
 		PinSlab(context.Context, proto.Account, time.Time, slabs.SlabPinParams) (slabs.SlabID, error)
-		UnpinSlab(ctx context.Context, accountID proto.Account, slabID slabs.SlabID) error
+		UnpinSlab(context.Context, proto.Account, slabs.SlabID) error
+
+		Slab(context.Context, slabs.SlabID) (slabs.PinnedSlab, error)
 	}
 
 	app struct {
@@ -36,38 +39,7 @@ func WithLogger(log *zap.Logger) Option {
 	}
 }
 
-// NewAPI creates a new instance of the application API. This API is used by
-// users, or rather their applications, to pin slabs to the indexer.
-// Authentication happens through presigned URLs that are signed with a private
-// key that corresponds to a previously registered public key.
-func NewAPI(hostname string, store Store, as AccountStore, opts ...Option) http.Handler {
-	a := &app{
-		store: store,
-		log:   zap.NewNop(),
-	}
-	for _, opt := range opts {
-		opt(a)
-	}
-
-	routes := map[string]authedHandler{
-		"POST /slabs/pin":       a.handlePOSTSlabsPin,
-		"DELETE /slabs/:slabid": a.handleDELETESlab,
-	}
-
-	signed := make(map[string]jape.Handler)
-	for path, handler := range routes {
-		signed[path] = func(jc jape.Context) {
-			pk, ok := checkSignedURLAuth(jc, hostname, as)
-			if !ok {
-				return
-			}
-			handler(jc, pk)
-		}
-	}
-	return jape.Mux(signed)
-}
-
-func (a *app) handlePOSTSlabsPin(jc jape.Context, pk types.PublicKey) {
+func (a *app) handlePOSTSlabs(jc jape.Context, pk types.PublicKey) {
 	var params slabs.SlabPinParams
 	if err := jc.Decode(&params); err != nil {
 		jc.Error(err, http.StatusBadRequest)
@@ -85,6 +57,24 @@ func (a *app) handlePOSTSlabsPin(jc jape.Context, pk types.PublicKey) {
 	jc.Encode(slabID)
 }
 
+func (a *app) handleGETSlab(jc jape.Context, pk types.PublicKey) {
+	var slabID slabs.SlabID
+	if err := jc.DecodeParam("slabid", &slabID); err != nil {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	}
+
+	slab, err := a.store.Slab(jc.Request.Context(), slabID)
+	if errors.Is(err, slabs.ErrSlabNotFound) {
+		jc.Error(slabs.ErrSlabNotFound, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to get slab", err) != nil {
+		return
+	}
+
+	jc.Encode(slab)
+}
+
 func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 	var slabID slabs.SlabID
 	if err := jc.DecodeParam("slabid", &slabID); err != nil {
@@ -97,4 +87,36 @@ func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 	}
 
 	jc.Encode(nil)
+}
+
+// NewAPI creates a new instance of the application API. This API is used by
+// users, or rather their applications, to pin slabs to the indexer.
+// Authentication happens through presigned URLs that are signed with a private
+// key that corresponds to a previously registered public key.
+func NewAPI(hostname string, store Store, as AccountStore, opts ...Option) http.Handler {
+	a := &app{
+		store: store,
+		log:   zap.NewNop(),
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+
+	routes := map[string]authedHandler{
+		"POST /slabs":           a.handlePOSTSlabs,
+		"GET /slabs/:slabid":    a.handleGETSlab,
+		"DELETE /slabs/:slabid": a.handleDELETESlab,
+	}
+
+	signed := make(map[string]jape.Handler)
+	for path, handler := range routes {
+		signed[path] = func(jc jape.Context) {
+			pk, ok := checkSignedURLAuth(jc, hostname, as)
+			if !ok {
+				return
+			}
+			handler(jc, pk)
+		}
+	}
+	return jape.Mux(signed)
 }

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -24,34 +24,6 @@ type Client struct {
 	hostname string
 }
 
-// NewClient creates a new AppClient that can be used to interact with the
-// application API of the indexer. The address should be the full URL to the
-// application API, including the scheme (e.g., "http://indexer.sia.tech").
-func NewClient(address string, appKey types.PrivateKey) (*Client, error) {
-	parsedURL, err := url.Parse(address)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse address %q: %w", address, err)
-	}
-
-	return &Client{
-		c: jape.Client{BaseURL: address},
-
-		appkey:   appKey,
-		hostname: parsedURL.Hostname(),
-	}, nil
-}
-
-// PinSlab pins a slab to the indexer.
-func (c *Client) PinSlab(ctx context.Context, params slabs.SlabPinParams) (slabID slabs.SlabID, err error) {
-	err = c.c.POST(ctx, c.sign("/slabs/pin"), params, &slabID)
-	return
-}
-
-// UnpinSlab unpins a slab from the indexer.
-func (c *Client) UnpinSlab(ctx context.Context, slabID slabs.SlabID) error {
-	return c.c.DELETE(ctx, c.sign(fmt.Sprintf("/slabs/%s", slabID)))
-}
-
 func (c *Client) sign(route string) string {
 	// prepare request hash
 	validUntil := time.Now().Add(defaultValidity)
@@ -81,4 +53,38 @@ func (c *Client) sign(route string) string {
 	}
 	u.RawQuery = q.Encode()
 	return u.String()
+}
+
+// PinSlab pins a slab to the indexer.
+func (c *Client) PinSlab(ctx context.Context, params slabs.SlabPinParams) (slabID slabs.SlabID, err error) {
+	err = c.c.POST(ctx, c.sign("/slabs"), params, &slabID)
+	return
+}
+
+// UnpinSlab unpins a slab from the indexer.
+func (c *Client) UnpinSlab(ctx context.Context, slabID slabs.SlabID) error {
+	return c.c.DELETE(ctx, c.sign(fmt.Sprintf("/slabs/%s", slabID)))
+}
+
+// Slab retrieves a slab from the indexer by its ID.
+func (c *Client) Slab(ctx context.Context, slabID slabs.SlabID) (s slabs.PinnedSlab, err error) {
+	err = c.c.GET(ctx, c.sign(fmt.Sprintf("/slabs/%s", slabID)), &s)
+	return
+}
+
+// NewClient creates a new AppClient that can be used to interact with the
+// application API of the indexer. The address should be the full URL to the
+// application API, including the scheme (e.g., "http://indexer.sia.tech").
+func NewClient(address string, appKey types.PrivateKey) (*Client, error) {
+	parsedURL, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address %q: %w", address, err)
+	}
+
+	return &Client{
+		c: jape.Client{BaseURL: address},
+
+		appkey:   appKey,
+		hostname: parsedURL.Hostname(),
+	}, nil
 }

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1008,6 +1008,22 @@ func BenchmarkSlabs(b *testing.B) {
 		}
 	})
 
+	b.Run("Slab", func(b *testing.B) {
+		id, err := store.PinSlab(context.Background(), proto.Account{1}, time.Time{}, newSlab())
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		b.SetBytes(slabSize)
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := store.Slab(context.Background(), id)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
 	// fetch 40MiB of data at a time
 	b.Run("Slabs-40MiB", func(b *testing.B) {
 		runSlabsBenchmark(b, 1)

--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/indexd/slabs"
+)
+
+// Slab retrieves a slab from the database by its ID.
+func (s *Store) Slab(ctx context.Context, slabID slabs.SlabID) (slab slabs.PinnedSlab, err error) {
+	slab.ID = slabID
+	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		var dbID int64
+		err = tx.QueryRow(ctx, `SELECT s.id, s.encryption_key, s.min_shards FROM slabs s WHERE digest = $1`, sqlHash256(slabID)).Scan(
+			&dbID, (*sqlHash256)(&slab.EncryptionKey), &slab.MinShards)
+		if errors.Is(err, sql.ErrNoRows) {
+			return slabs.ErrSlabNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get slab %q: %w", slabID, err)
+		}
+
+		rows, err := tx.Query(ctx, `SELECT s.sector_root, h.public_key
+FROM slab_sectors ss
+INNER JOIN sectors s ON (s.id = ss.sector_id)
+LEFT JOIN hosts h ON (h.id = s.host_id)
+WHERE ss.slab_id = $1 AND s.host_id IS NOT NULL
+ORDER BY ss.slab_index ASC`, dbID)
+		if err != nil {
+			return fmt.Errorf("failed to get slab sectors: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var sector slabs.PinnedSector
+
+			if err := rows.Scan((*sqlHash256)(&sector.Root), (*sqlPublicKey)(&sector.HostKey)); err != nil {
+				return fmt.Errorf("failed to scan sector: %w", err)
+			}
+			slab.Sectors = append(slab.Sectors, sector)
+		}
+
+		if len(slab.Sectors) < int(slab.MinShards) {
+			return fmt.Errorf("recovery requires at least %d sectors, slab has %d sectors: %w", slab.MinShards, len(slab.Sectors), slabs.ErrUnrecoverable)
+		}
+		return rows.Err()
+	})
+	return
+}

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -1,0 +1,100 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/slabs"
+	"go.uber.org/zap/zaptest"
+	"lukechampine.com/frand"
+)
+
+func TestSlab(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+	account := proto.Account{1}
+
+	// add account
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		t.Fatal(err)
+	}
+
+	// add hosts
+	hosts := make([]types.PublicKey, 30)
+	for i := range hosts {
+		hosts[i] = store.addTestHost(t)
+	}
+
+	pinned := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     10,
+		Sectors:       make([]slabs.SectorPinParams, 0, len(hosts)),
+	}
+	for _, host := range hosts {
+		pinned.Sectors = append(pinned.Sectors, slabs.SectorPinParams{
+			Root:    frand.Entropy256(),
+			HostKey: host,
+		})
+	}
+	digest, err := pinned.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := slabs.PinnedSlab{
+		ID:            digest,
+		EncryptionKey: pinned.EncryptionKey,
+		MinShards:     pinned.MinShards,
+		Sectors:       make([]slabs.PinnedSector, len(pinned.Sectors)),
+	}
+	for i, sector := range pinned.Sectors {
+		expected.Sectors[i] = slabs.PinnedSector{
+			Root:    sector.Root,
+			HostKey: sector.HostKey,
+		}
+	}
+
+	slabID, err := store.PinSlab(context.Background(), account, time.Time{}, pinned)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slab, err := store.Slab(context.Background(), slabID)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(slab, expected) {
+		t.Fatalf("expected slab %v, got %v", expected, slab)
+	}
+
+	// mark some of the sectors as lost
+	for i := range slab.Sectors[:10] {
+		if err := store.MarkSectorsLost(context.Background(), slab.Sectors[i].HostKey, []types.Hash256{slab.Sectors[i].Root}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// assert the slab no longer contains the lost sectors
+	slab, err = store.Slab(context.Background(), slabID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected.Sectors = expected.Sectors[10:] // first 10 sectors are lost
+	if !reflect.DeepEqual(slab, expected) {
+		t.Fatalf("expected slab %v, got %v", expected, slab)
+	}
+
+	// mark the remaining sectors as lost
+	for i := range slab.Sectors {
+		if err := store.MarkSectorsLost(context.Background(), slab.Sectors[i].HostKey, []types.Hash256{slab.Sectors[i].Root}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err = store.Slab(context.Background(), slabID)
+	if !errors.Is(err, slabs.ErrUnrecoverable) {
+		t.Fatalf("expected ErrUnrecoverable, got %v", err)
+	}
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -13,7 +13,8 @@ import (
 	"github.com/klauspost/reedsolomon"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/api/admin"
+	"go.sia.tech/indexd/api/app"
+	"go.sia.tech/indexd/slabs"
 	"golang.org/x/crypto/chacha20"
 	"lukechampine.com/frand"
 )
@@ -29,6 +30,14 @@ type (
 	downloadOption struct {
 		hostTimeout time.Duration
 		maxInflight int
+	}
+
+	// An AppClient is an interface for the application API of the indexer.
+	AppClient interface {
+		PinSlab(context.Context, slabs.SlabPinParams) (slabs.SlabID, error)
+		UnpinSlab(context.Context, slabs.SlabID) error
+
+		Slab(context.Context, slabs.SlabID) (slabs.PinnedSlab, error)
 	}
 
 	// A HostDialer is an interface for writing and reading sectors to/from hosts.
@@ -49,19 +58,11 @@ type (
 	// A DownloadOption configures the download behavior
 	DownloadOption func(*downloadOption)
 
-	// A Shard represents a sector in a slab
-	Shard struct {
-		Root    types.Hash256
-		HostKey types.PublicKey
-	}
-
 	// A Slab represents a collection of erasure-coded sectors
 	Slab struct {
-		SectorKey [32]byte
-		MinShards uint8
-		Offset    uint32
-		Length    uint32
-		Shards    []Shard
+		ID     slabs.SlabID `json:"id"`
+		Offset uint32       `json:"offset"`
+		Length uint32       `json:"length"`
 	}
 
 	// An Object represents a collection of slabs that are associated with a
@@ -74,7 +75,7 @@ type (
 	// An SDK is a client for the indexd service.
 	SDK struct {
 		appKey types.PrivateKey
-		c      admin.Client
+		client AppClient
 
 		dialer HostDialer
 	}
@@ -90,26 +91,26 @@ var (
 	ErrNoMoreHosts = errors.New("no more hosts available")
 )
 
-func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][]byte, dataShards uint8, maxInFlight int, timeout time.Duration) (Slab, error) {
+func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][]byte, dataShards uint8, maxInFlight int, timeout time.Duration) (slabs.SlabPinParams, error) {
 	if len(shards) == 0 {
-		return Slab{}, errors.New("no shards to upload")
+		return slabs.SlabPinParams{}, errors.New("no shards to upload")
 	} else if len(shards) < int(dataShards) {
-		return Slab{}, fmt.Errorf("not enough shards to upload: %d, required: %d", len(shards), dataShards)
+		return slabs.SlabPinParams{}, fmt.Errorf("not enough shards to upload: %d, required: %d", len(shards), dataShards)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	slab := Slab{
-		SectorKey: encryptionKey,
-		MinShards: dataShards,
-		Shards:    make([]Shard, len(shards)),
+	slab := slabs.SlabPinParams{
+		EncryptionKey: encryptionKey,
+		MinShards:     uint(dataShards),
+		Sectors:       make([]slabs.SectorPinParams, len(shards)),
 	}
 
 	var hostsMu sync.Mutex
 	hosts := shuffle(s.dialer.Hosts())
 	if len(hosts) < len(shards) {
-		return Slab{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
+		return slabs.SlabPinParams{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
 	}
 
 	errCh := make(chan error, len(shards))
@@ -123,7 +124,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 
 		select {
 		case <-ctx.Done():
-			return Slab{}, ctx.Err()
+			return slabs.SlabPinParams{}, ctx.Err()
 		case sema <- struct{}{}:
 			// limit number of concurrent requests
 		}
@@ -150,7 +151,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 
 				root, err := uploadShard(ctx, sector, hostKey, s.dialer, timeout) // error can be ignored, hosts will be retried until none are left and the upload fails.
 				if err == nil {
-					slab.Shards[index] = Shard{
+					slab.Sectors[index] = slabs.SectorPinParams{
 						HostKey: hostKey,
 						Root:    root,
 					}
@@ -163,26 +164,26 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 	for range len(shards) {
 		select {
 		case <-ctx.Done():
-			return Slab{}, ctx.Err()
+			return slabs.SlabPinParams{}, ctx.Err()
 		case err := <-errCh:
 			if err != nil {
-				return Slab{}, fmt.Errorf("failed to upload shard: %w", err)
+				return slabs.SlabPinParams{}, fmt.Errorf("failed to upload shard: %w", err)
 			}
 		}
 	}
 	return slab, nil
 }
 
-func (s *SDK) downloadSlab(ctx context.Context, slab Slab, maxInflight int, timeout time.Duration) ([][]byte, error) {
+func (s *SDK) downloadSlab(ctx context.Context, slab slabs.PinnedSlab, maxInflight int, timeout time.Duration) ([][]byte, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	var successful atomic.Uint32
 	var wg sync.WaitGroup
-	shards := make([][]byte, len(slab.Shards))
+	sectors := make([][]byte, len(slab.Sectors))
 	sema := make(chan struct{}, maxInflight)
 top:
-	for i, shard := range slab.Shards {
+	for i, sector := range slab.Sectors {
 		select {
 		case <-ctx.Done():
 			break top
@@ -190,26 +191,26 @@ top:
 			// limit number of concurrent requests
 		}
 		wg.Add(1)
-		go func(ctx context.Context, shard Shard, i int) {
+		go func(ctx context.Context, sector slabs.PinnedSector, i int) {
 			defer func() { <-sema }() // release semaphore
 			defer wg.Done()
-			data, err := downloadShard(ctx, shard.Root, shard.HostKey, s.dialer, timeout)
+			data, err := downloadShard(ctx, sector.Root, sector.HostKey, s.dialer, timeout)
 			if err != nil {
 				return
 			}
-			shards[i] = data[:]
+			sectors[i] = data[:]
 			if v := successful.Add(1); v >= uint32(slab.MinShards) {
 				// got enough pieces to recover
 				cancel()
 			}
-		}(ctx, shard, i)
+		}(ctx, sector, i)
 	}
 
 	wg.Wait()
 	if n := successful.Load(); n < uint32(slab.MinShards) {
-		return nil, fmt.Errorf("retrieved %d shards, minimum required: %d: %w", n, slab.MinShards, ErrNotEnoughShards)
+		return nil, fmt.Errorf("retrieved %d sectors, minimum required: %d: %w", n, slab.MinShards, ErrNotEnoughShards)
 	}
-	return shards, nil
+	return sectors, nil
 }
 
 // Upload uploads the data to hosts and pins it to the indexer.
@@ -289,13 +290,20 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) ([]
 			} else if work.err != nil {
 				return nil, work.err
 			}
-			slab, err := s.uploadSlab(ctx, shardKey, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
+			params, err := s.uploadSlab(ctx, shardKey, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
 			if err != nil {
 				return nil, fmt.Errorf("failed to upload slab %d: %w", i, err)
 			}
-			slab.Length = uint32(work.length)
-			// TODO: pin slab
-			pinned = append(pinned, slab)
+
+			slabID, err := s.client.PinSlab(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("failed to pin slab %d: %w", i, err)
+			}
+			pinned = append(pinned, Slab{
+				ID:     slabID,
+				Offset: 0,
+				Length: uint32(work.length),
+			})
 		}
 	}
 }
@@ -308,9 +316,6 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata []Slab, opts .
 		return errors.New("no slabs to download")
 	}
 
-	dataShards := int(metadata[0].MinShards)
-	parityShards := len(metadata[0].Shards) - dataShards
-
 	do := downloadOption{
 		hostTimeout: 4 * time.Second, // ~10 Mbps
 		maxInflight: 10,
@@ -319,24 +324,38 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata []Slab, opts .
 		opt(&do)
 	}
 
-	enc, err := reedsolomon.New(dataShards, parityShards)
-	if err != nil {
-		return fmt.Errorf("failed to create encoder: %w", err)
-	}
-
 	type work struct {
 		shards [][]byte
 		err    error
 	}
 	workCh := make(chan work, 1)
 	go func(ctx context.Context, slabs []Slab) {
-		for i, slab := range metadata {
-			shards, err := s.downloadSlab(ctx, slab, do.maxInflight, do.hostTimeout)
+		for i, meta := range metadata {
+			pinned, err := s.client.Slab(ctx, meta.ID)
+			if err != nil {
+				workCh <- work{err: fmt.Errorf("failed to get slab %d metadata: %w", i, err)}
+				return
+			}
+			enc, err := reedsolomon.New(int(pinned.MinShards), len(pinned.Sectors)-int(pinned.MinShards))
+			if err != nil {
+				workCh <- work{err: fmt.Errorf("failed to create erasure coder for slab %d: %w", i, err)}
+				return
+			}
+			shards, err := s.downloadSlab(ctx, pinned, do.maxInflight, do.hostTimeout)
 			if err != nil {
 				workCh <- work{err: fmt.Errorf("failed to download slab %d: %w", i, err)}
 				return
+			} else if err := enc.ReconstructData(shards); err != nil {
+				workCh <- work{err: fmt.Errorf("failed to reconstruct slab %d data: %w", i, err)}
+				return
 			}
-			workCh <- work{shards: shards}
+			nonce := make([]byte, 24)
+			for i := range shards {
+				nonce[0] = byte(i)
+				c, _ := chacha20.NewUnauthenticatedCipher(pinned.EncryptionKey[:], nonce)
+				c.XORKeyStream(shards[i], shards[i]) // decrypt shard in place
+			}
+			workCh <- work{shards: shards[:pinned.MinShards]}
 		}
 		workCh <- work{err: io.EOF}
 	}(ctx, metadata)
@@ -354,16 +373,7 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata []Slab, opts .
 				return err
 			}
 			slab := metadata[i]
-			encryptionKey := slab.SectorKey
-			shards := work.shards
-			nonce := make([]byte, 24)
-			for i := range shards {
-				nonce[0] = byte(i)
-				c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce)
-				c.XORKeyStream(shards[i], shards[i]) // decrypt shard in place
-			}
-			enc.ReconstructData(shards)
-			if err := stripedJoin(w, shards[:slab.MinShards], int(slab.Length)); err != nil {
+			if err := stripedJoin(w, work.shards, int(slab.Length)); err != nil {
 				return fmt.Errorf("failed to write slab %d: %w", i, err)
 			}
 		}
@@ -505,11 +515,24 @@ func WithDownloadInflight(maxInflight int) DownloadOption {
 	}
 }
 
-// NewSDK creates a new indexd client with the given app key and base URL.
-func NewSDK(baseURL string, appKey types.PrivateKey, dialer HostDialer) *SDK {
+func initSDK(client AppClient, dialer HostDialer, appKey types.PrivateKey) (*SDK, error) {
+	if client == nil {
+		return nil, errors.New("app client is required")
+	} else if dialer == nil {
+		return nil, errors.New("host dialer is required")
+	}
 	return &SDK{
 		appKey: appKey,
+		client: client,
 		dialer: dialer,
-		c:      *admin.NewClient(baseURL, ""),
+	}, nil
+}
+
+// NewSDK creates a new indexd client with the given app key and base URL.
+func NewSDK(baseURL string, appKey types.PrivateKey) (*SDK, error) {
+	c, err := app.NewClient(baseURL, appKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create app client: %w", err)
 	}
+	return initSDK(c, nil, appKey) // TODO: init dialer
 }

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1,136 +1,27 @@
-package sdk_test
+package sdk
 
 import (
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"runtime"
-	"slices"
-	"sync"
 	"testing"
 	"time"
 
-	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/sdk"
 	"lukechampine.com/frand"
 )
-
-type mockHostDialer struct {
-	hosts map[types.PublicKey]struct{}
-
-	delayMu   sync.Mutex
-	slowHosts map[types.PublicKey]time.Duration
-
-	sectorsMu   sync.Mutex
-	hostSectors map[types.PublicKey]map[types.Hash256][proto4.SectorSize]byte
-}
-
-// Hosts implements the [sdk.HostDialer] interface.
-func (m *mockHostDialer) Hosts() []types.PublicKey {
-	return slices.Collect(maps.Keys(m.hosts))
-}
-
-func (m *mockHostDialer) delay(ctx context.Context, hostKey types.PublicKey) error {
-	m.delayMu.Lock()
-	delay, ok := m.slowHosts[hostKey]
-	m.delayMu.Unlock()
-	if !ok || delay <= 0 {
-		return nil
-	}
-
-	select {
-	case <-ctx.Done():
-	case <-time.After(delay):
-	}
-	return ctx.Err()
-}
-
-// WriteSector implements the [sdk.HostDialer] interface.
-func (m *mockHostDialer) WriteSector(ctx context.Context, hostKey types.PublicKey, sector *[proto4.SectorSize]byte) (types.Hash256, error) {
-	if _, ok := m.hosts[hostKey]; !ok {
-		panic("host not found: " + hostKey.String()) // developer error
-	}
-
-	// simulate i/o
-	if err := m.delay(ctx, hostKey); err != nil {
-		return types.Hash256{}, err
-	}
-
-	m.sectorsMu.Lock()
-	defer m.sectorsMu.Unlock()
-
-	root := proto4.SectorRoot(sector)
-	if _, ok := m.hostSectors[hostKey]; !ok {
-		m.hostSectors[hostKey] = make(map[types.Hash256][proto4.SectorSize]byte)
-	}
-	m.hostSectors[hostKey][root] = *sector
-	return root, nil
-}
-
-// ReadSector implements the [sdk.HostDialer] interface.
-func (m *mockHostDialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sectorRoot types.Hash256) (*[proto4.SectorSize]byte, error) {
-	// simulate timeout
-	if err := m.delay(ctx, hostKey); err != nil {
-		return nil, err
-	}
-
-	m.sectorsMu.Lock()
-	defer m.sectorsMu.Unlock()
-
-	var sector [proto4.SectorSize]byte
-	sectors, ok := m.hostSectors[hostKey]
-	if !ok {
-		return nil, errors.New("host not found")
-	}
-	sector, ok = sectors[sectorRoot]
-	if !ok {
-		return nil, errors.New("sector not found")
-	}
-	return &sector, nil
-}
-
-func (m *mockHostDialer) ResetSlowHosts() {
-	m.delayMu.Lock()
-	defer m.delayMu.Unlock()
-	m.slowHosts = make(map[types.PublicKey]time.Duration)
-}
-
-func (m *mockHostDialer) SetSlowHosts(n int, d time.Duration) {
-	m.delayMu.Lock()
-	defer m.delayMu.Unlock()
-
-	var set int
-	for hostKey := range maps.Keys(m.hosts) {
-		if set >= n {
-			break // already set enough hosts
-		}
-		set++
-		m.slowHosts[hostKey] = d
-	}
-}
-
-func newMockDialer(hosts int) *mockHostDialer {
-	m := &mockHostDialer{
-		hosts:       make(map[types.PublicKey]struct{}),
-		slowHosts:   make(map[types.PublicKey]time.Duration),
-		hostSectors: make(map[types.PublicKey]map[types.Hash256][proto4.SectorSize]byte),
-	}
-	for range hosts {
-		sk := types.GeneratePrivateKey()
-		m.hosts[sk.PublicKey()] = struct{}{}
-	}
-	return m
-}
 
 func TestRoundtrip(t *testing.T) {
 	dialer := newMockDialer(50)
 
 	appKey := types.GeneratePrivateKey()
 
-	s := sdk.NewSDK("", appKey, dialer)
+	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	data := frand.Bytes(4096)
 	slabs, err := s.Upload(context.Background(), bytes.NewReader(data))
@@ -155,15 +46,18 @@ func TestRoundtrip(t *testing.T) {
 func TestUpload(t *testing.T) {
 	dialer := newMockDialer(50)
 	appKey := types.GeneratePrivateKey()
-	s := sdk.NewSDK("", appKey, dialer)
+	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data := frand.Bytes(4096)
 
 	t.Run("timeout", func(t *testing.T) {
 		dialer.ResetSlowHosts()
 		// make enough hosts timeout to fail
 		dialer.SetSlowHosts(30, time.Second)
-		_, err := s.Upload(context.Background(), bytes.NewReader(data), sdk.WithUploadHostTimeout(100*time.Millisecond))
-		if !errors.Is(err, sdk.ErrNoMoreHosts) {
+		_, err := s.Upload(context.Background(), bytes.NewReader(data), WithUploadHostTimeout(100*time.Millisecond))
+		if !errors.Is(err, ErrNoMoreHosts) {
 			t.Fatalf("expected ErrNoMoreHosts, got %v", err)
 		}
 	})
@@ -173,7 +67,7 @@ func TestUpload(t *testing.T) {
 		// make most of the hosts slow,
 		// but not enough to fail to upload
 		dialer.SetSlowHosts(20, time.Second)
-		slabs, err := s.Upload(context.Background(), bytes.NewReader(data), sdk.WithUploadHostTimeout(100*time.Millisecond))
+		slabs, err := s.Upload(context.Background(), bytes.NewReader(data), WithUploadHostTimeout(100*time.Millisecond))
 		if err != nil {
 			t.Fatal(err)
 		} else if len(slabs) != 1 {
@@ -187,7 +81,10 @@ func TestDownload(t *testing.T) {
 
 	appKey := types.GeneratePrivateKey()
 
-	s := sdk.NewSDK("", appKey, dialer)
+	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	data := frand.Bytes(4096)
 	slabs, err := s.Upload(context.Background(), bytes.NewReader(data))
@@ -205,8 +102,8 @@ func TestDownload(t *testing.T) {
 		// make enough hosts timeout to fail to download
 		dialer.SetSlowHosts(21, time.Second)
 		buf := bytes.NewBuffer(nil)
-		err = s.Download(context.Background(), buf, slabs, sdk.WithDownloadHostTimeout(200*time.Millisecond))
-		if !errors.Is(err, sdk.ErrNotEnoughShards) {
+		err = s.Download(context.Background(), buf, slabs, WithDownloadHostTimeout(200*time.Millisecond))
+		if !errors.Is(err, ErrNotEnoughShards) {
 			t.Fatalf("expected ErrNotEnoughShards, got %v", err)
 		}
 	})
@@ -216,7 +113,7 @@ func TestDownload(t *testing.T) {
 		// make most of the hosts timeout
 		dialer.SetSlowHosts(20, time.Second)
 		buf := bytes.NewBuffer(nil)
-		err = s.Download(context.Background(), buf, slabs, sdk.WithDownloadHostTimeout(200*time.Millisecond))
+		err = s.Download(context.Background(), buf, slabs, WithDownloadHostTimeout(200*time.Millisecond))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -236,14 +133,17 @@ func BenchmarkUpload(b *testing.B) {
 			dialer.SetSlowHosts(slow, time.Second)       // slow, but not too slow
 			dialer.SetSlowHosts(timeout, 30*time.Second) // longer than the default timeout
 
-			s := sdk.NewSDK("", appKey, dialer)
+			s, err := initSDK(newMockAppClient(), dialer, appKey)
+			if err != nil {
+				b.Fatal(err)
+			}
 
 			r := bytes.NewReader(data)
 			b.SetBytes(benchmarkSize)
 			b.ResetTimer()
 			for b.Loop() {
 				r.Reset(data)
-				if _, err := s.Upload(context.Background(), r, sdk.WithUploadInflight(inflight)); err != nil {
+				if _, err := s.Upload(context.Background(), r, WithUploadInflight(inflight)); err != nil {
 					b.Fatalf("failed to upload: %v", err)
 				}
 			}
@@ -269,7 +169,10 @@ func BenchmarkDownload(b *testing.B) {
 
 	appKey := types.GeneratePrivateKey()
 
-	s := sdk.NewSDK("", appKey, dialer)
+	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	data := frand.Bytes(benchmarkSize)
 	slabs, err := s.Upload(context.Background(), bytes.NewReader(data))
@@ -288,7 +191,7 @@ func BenchmarkDownload(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				buf.Reset()
-				err = s.Download(context.Background(), buf, slabs, sdk.WithDownloadInflight(inflight))
+				err = s.Download(context.Background(), buf, slabs, WithDownloadInflight(inflight))
 				if err != nil {
 					b.Fatalf("failed to download: %v", err)
 				}

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -1,0 +1,175 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	proto4 "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/slabs"
+)
+
+type mockHostDialer struct {
+	hosts map[types.PublicKey]struct{}
+
+	delayMu   sync.Mutex
+	slowHosts map[types.PublicKey]time.Duration
+
+	sectorsMu   sync.Mutex
+	hostSectors map[types.PublicKey]map[types.Hash256][proto4.SectorSize]byte
+}
+
+// Hosts implements the [HostDialer] interface.
+func (m *mockHostDialer) Hosts() []types.PublicKey {
+	return slices.Collect(maps.Keys(m.hosts))
+}
+
+func (m *mockHostDialer) delay(ctx context.Context, hostKey types.PublicKey) error {
+	m.delayMu.Lock()
+	delay, ok := m.slowHosts[hostKey]
+	m.delayMu.Unlock()
+	if !ok || delay <= 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(delay):
+	}
+	return ctx.Err()
+}
+
+// WriteSector implements the [HostDialer] interface.
+func (m *mockHostDialer) WriteSector(ctx context.Context, hostKey types.PublicKey, sector *[proto4.SectorSize]byte) (types.Hash256, error) {
+	if _, ok := m.hosts[hostKey]; !ok {
+		panic("host not found: " + hostKey.String()) // developer error
+	}
+
+	// simulate i/o
+	if err := m.delay(ctx, hostKey); err != nil {
+		return types.Hash256{}, err
+	}
+
+	m.sectorsMu.Lock()
+	defer m.sectorsMu.Unlock()
+
+	root := proto4.SectorRoot(sector)
+	if _, ok := m.hostSectors[hostKey]; !ok {
+		m.hostSectors[hostKey] = make(map[types.Hash256][proto4.SectorSize]byte)
+	}
+	m.hostSectors[hostKey][root] = *sector
+	return root, nil
+}
+
+// ReadSector implements the [HostDialer] interface.
+func (m *mockHostDialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sectorRoot types.Hash256) (*[proto4.SectorSize]byte, error) {
+	// simulate timeout
+	if err := m.delay(ctx, hostKey); err != nil {
+		return nil, err
+	}
+
+	m.sectorsMu.Lock()
+	defer m.sectorsMu.Unlock()
+
+	var sector [proto4.SectorSize]byte
+	sectors, ok := m.hostSectors[hostKey]
+	if !ok {
+		return nil, errors.New("host not found")
+	}
+	sector, ok = sectors[sectorRoot]
+	if !ok {
+		return nil, errors.New("sector not found")
+	}
+	return &sector, nil
+}
+
+func (m *mockHostDialer) ResetSlowHosts() {
+	m.delayMu.Lock()
+	defer m.delayMu.Unlock()
+	m.slowHosts = make(map[types.PublicKey]time.Duration)
+}
+
+func (m *mockHostDialer) SetSlowHosts(n int, d time.Duration) {
+	m.delayMu.Lock()
+	defer m.delayMu.Unlock()
+
+	var set int
+	for hostKey := range maps.Keys(m.hosts) {
+		if set >= n {
+			break // already set enough hosts
+		}
+		set++
+		m.slowHosts[hostKey] = d
+	}
+}
+
+func newMockDialer(hosts int) *mockHostDialer {
+	m := &mockHostDialer{
+		hosts:       make(map[types.PublicKey]struct{}),
+		slowHosts:   make(map[types.PublicKey]time.Duration),
+		hostSectors: make(map[types.PublicKey]map[types.Hash256][proto4.SectorSize]byte),
+	}
+	for range hosts {
+		sk := types.GeneratePrivateKey()
+		m.hosts[sk.PublicKey()] = struct{}{}
+	}
+	return m
+}
+
+type mockAppClient struct {
+	mu     sync.Mutex
+	pinned map[slabs.SlabID]slabs.PinnedSlab
+}
+
+// PinSlab implements the [AppClient] interface.
+func (mc *mockAppClient) PinSlab(_ context.Context, s slabs.SlabPinParams) (slabs.SlabID, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	id, err := s.Digest()
+	if err != nil {
+		return slabs.SlabID{}, err
+	}
+	ps := slabs.PinnedSlab{
+		ID:            id,
+		EncryptionKey: s.EncryptionKey,
+		MinShards:     s.MinShards,
+		Sectors:       make([]slabs.PinnedSector, len(s.Sectors)),
+	}
+	for i, sector := range s.Sectors {
+		ps.Sectors[i] = slabs.PinnedSector{
+			Root:    sector.Root,
+			HostKey: sector.HostKey,
+		}
+	}
+	mc.pinned[id] = ps
+	return id, nil
+}
+
+// UnpinSlab implements the [AppClient] interface.
+func (mc *mockAppClient) UnpinSlab(_ context.Context, id slabs.SlabID) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	delete(mc.pinned, id)
+	return nil
+}
+
+// Slab implements the [AppClient] interface.
+func (mc *mockAppClient) Slab(_ context.Context, id slabs.SlabID) (slabs.PinnedSlab, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	slab, ok := mc.pinned[id]
+	if !ok {
+		return slabs.PinnedSlab{}, errors.New("slab not found")
+	}
+	return slab, nil
+}
+
+func newMockAppClient() *mockAppClient {
+	return &mockAppClient{
+		pinned: make(map[slabs.SlabID]slabs.PinnedSlab),
+	}
+}

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -21,6 +21,9 @@ var (
 
 	// ErrSlabNotFound is returned when a slab is not found in the database.
 	ErrSlabNotFound = errors.New("slab not found")
+
+	// ErrUnrecoverable is returned when a slab is unrecoverable, meaning it cannot be repaired or migrated.
+	ErrUnrecoverable = errors.New("slab is unrecoverable")
 )
 
 type (
@@ -61,6 +64,20 @@ type (
 		EncryptionKey [32]byte          `json:"encryptionKey"`
 		MinShards     uint              `json:"minShards"`
 		Sectors       []SectorPinParams `json:"sectors"`
+	}
+
+	// A PinnedSector is a sector that has been pinned to a host.
+	PinnedSector struct {
+		Root    types.Hash256   `json:"root"`
+		HostKey types.PublicKey `json:"hostKey"`
+	}
+
+	// A PinnedSlab is a slab that has been pinned to hosts.
+	PinnedSlab struct {
+		ID            SlabID         `json:"id"`
+		EncryptionKey [32]byte       `json:"encryptionKey"`
+		MinShards     uint           `json:"minShards"`
+		Sectors       []PinnedSector `json:"sectors"`
 	}
 )
 


### PR DESCRIPTION
Adds a new endpoint `[GET] /slab/:id` to the App SDK to fetch slab metadata from the indexer. 

Also adjusts the SDK to use data from the AppAPI

```
BenchmarkSlabs/Slab-16                       531           2234295 ns/op        18772.38 MB/s      15079 B/op        296 allocs/op
```

Prefer this over `[GET] /slabs/:id` in #235 since the pointers to `HostKey` and `ContractID` are only useful for the Admin API and not actionable from an App.