### PR TITLE
Fix reverting contract revisions

### DIFF
--- a/contracts/chain.go
+++ b/contracts/chain.go
@@ -176,9 +176,6 @@ func (m *ContractManager) revertContractDiff(tx *updateTx, diff consensus.V2File
 
 	// update contract elements
 	fce := diff.V2FileContractElement
-	if rev, ok := diff.V2RevisionElement(); ok {
-		fce = rev
-	}
 	if err := tx.UpdateContractElements(fce); err != nil {
 		return fmt.Errorf("failed to update contract element: %w", err)
 	}

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -535,7 +535,7 @@ func TestApplyRevertDiff(t *testing.T) {
 		V2FileContractElement: fce,
 		Revision:              &revision,
 	})
-	fce.V2FileContract.RevisionNumber++
+	fce.V2FileContract.RevisionNumber = revision.RevisionNumber
 	assertContract(ContractStateActive)
 
 	// resolve contract

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -529,11 +529,13 @@ func TestApplyRevertDiff(t *testing.T) {
 	assertContract(ContractStateActive)
 
 	// revise contract
-	fce.V2FileContract.RevisionNumber++
+	revision := fce.V2FileContract
+	revision.RevisionNumber++
 	applyDiff(consensus.V2FileContractElementDiff{
 		V2FileContractElement: fce,
-		Revision:              &fce.V2FileContract,
+		Revision:              &revision,
 	})
+	fce.V2FileContract.RevisionNumber++
 	assertContract(ContractStateActive)
 
 	// resolve contract
@@ -554,9 +556,9 @@ func TestApplyRevertDiff(t *testing.T) {
 
 	// revert revision
 	fce.V2FileContract.RevisionNumber--
-	applyDiff(consensus.V2FileContractElementDiff{
+	revertDiff(consensus.V2FileContractElementDiff{
 		V2FileContractElement: fce,
-		Revision:              &fce.V2FileContract,
+		Revision:              &revision,
 	})
 	assertContract(ContractStateActive)
 


### PR DESCRIPTION
When reverting a contract diff that had a revision, we would mistakenly update the contract element with the revised element rather than the original element.  This was not caught due to a typo in `TestApplyRevertDiff`, where the `applyDiff` helper was used instead of `revertDiff` when we were supposed to be reverting the revision.