### PR TITLE
Refactor SectorVerifier

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -169,6 +170,11 @@ func (c *HostClient) FreeSectors(ctx context.Context, hostPrices proto.HostPrice
 	return res, nil
 }
 
+// ReadSector reads a sector from the host and writes it to the provided writer.
+func (c *HostClient) ReadSector(ctx context.Context, hostPrices proto.HostPrices, token proto.AccountToken, w io.Writer, root types.Hash256, offset, length uint64) (rhp.RPCReadSectorResult, error) {
+	return rhp.RPCReadSector(ctx, c.client, hostPrices, token, w, root, offset, length)
+}
+
 // RefreshContract refreshes the contract with the host.
 func (c *HostClient) RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error) {
 	var res rhp.RPCRefreshContractResult
@@ -243,6 +249,32 @@ func (c *HostClient) ReplenishAccounts(ctx context.Context, contractID types.Fil
 		return rhp.RPCReplenishAccountsResult{}, 0, fmt.Errorf("failed to replenish accounts: %w", err)
 	}
 	return res, funded, nil
+}
+
+// Settings returns the host settings.
+func (c *HostClient) Settings(ctx context.Context) (proto.HostSettings, error) {
+	return rhp.RPCSettings(ctx, c.client)
+}
+
+// VerifySector verifies the integrity of a sector on the host.
+func (c *HostClient) VerifySector(ctx context.Context, hostPrices proto.HostPrices, token proto.AccountToken, root types.Hash256) (rhp.RPCVerifySectorResult, error) {
+	return rhp.RPCVerifySector(ctx, c.client, hostPrices, token, root)
+}
+
+// WriteSector writes a sector to the host.
+func (c *HostClient) WriteSector(ctx context.Context, settings proto.HostPrices, token proto.AccountToken, data io.Reader, length uint64) (rhp.RPCWriteSectorResult, error) {
+	// sanity check
+	if length > proto.SectorSize {
+		return rhp.RPCWriteSectorResult{}, fmt.Errorf("sector size too large, %d > %d", length, proto.SectorSize) // developer error
+	}
+
+	// write sector
+	res, err := rhp.RPCWriteSector(ctx, c.client, settings, token, data, length)
+	if err != nil {
+		return rhp.RPCWriteSectorResult{}, fmt.Errorf("failed to write sector: %w", err)
+	}
+
+	return res, nil
 }
 
 func (c *HostClient) syncRevision(ctx context.Context, contractID types.FileContractID, revision types.V2FileContract) (types.V2FileContract, bool, error) {

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -27,7 +27,7 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, host ho
 
 		// perform integrity checks
 		results, err := m.verifier.VerifySectors(ctx, host, toCheck)
-		if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
 			interrupt = true
 		}
 		if err != nil {

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -4,95 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
-	"sync"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
 
-// CheckSectorsResult is the result of a sector verification. It indicates
-// whether:
-// - the sector was lost
-// - the sector failed verification for any reason
-// - the sector was successfully verified
-type CheckSectorsResult int
-
-const (
-	// SectorLost indicates that the sector was lost. This is returned if the
-	// host admits to losing the sector.
-	SectorLost = CheckSectorsResult(iota)
-
-	// SectorFailed indicates that the sector failed verification for some
-	// reason. Since we can't trust a host to not use all means necessary for us
-	// to not track a failure, we consider anything that is not a lost sector or
-	// successfully verification a failure.
-	SectorFailed
-
-	// SectorSuccess indicates that the sector was successfully verified and is
-	// still in the host's possession.
-	SectorSuccess
-)
-
-var errInsufficientServiceAccountBalance = errors.New("insufficient service account balance")
-
-type (
-	// SectorVerifier defines the interface verifying a sector's integrity on a
-	// host.
-	// TODO: Refactor this to also use the Dialer and HostClient interfaces
-	SectorVerifier interface {
-		HostKey() types.PublicKey
-		Prices() proto.HostPrices
-		VerifySector(ctx context.Context, root types.Hash256) (rhp.RPCVerifySectorResult, error)
-	}
-
-	sectorVerifier struct {
-		hostKey           types.PublicKey
-		prices            proto.HostPrices
-		serviceAccount    proto.Account
-		serviceAccountKey types.PrivateKey
-		tc                rhp.TransportClient
-	}
-)
-
-func newSectorVerifier(ctx context.Context, hostAddr string, hostKey types.PublicKey, prices proto.HostPrices) (*sectorVerifier, error) {
-	tc, err := siamux.Dial(ctx, hostAddr, hostKey)
-	if err != nil {
-		return nil, err
-	}
-	return &sectorVerifier{
-		prices: prices,
-		tc:     tc,
-	}, nil
-}
-
-func (v *sectorVerifier) Close() error {
-	return v.tc.Close()
-}
-
-func (v *sectorVerifier) HostKey() types.PublicKey {
-	return v.hostKey
-}
-
-func (v *sectorVerifier) Prices() proto.HostPrices {
-	return v.prices
-}
-
-func (v *sectorVerifier) VerifySector(ctx context.Context, root types.Hash256) (rhp.RPCVerifySectorResult, error) {
-	return rhp.RPCVerifySector(ctx, v.tc, v.prices, v.serviceAccount.Token(v.serviceAccountKey, v.hostKey), root)
-}
-
-func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, verifier SectorVerifier, logger *zap.Logger) {
-	hostKey := verifier.HostKey()
-	hostLogger := logger.With(zap.Stringer("hostKey", hostKey))
+func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, host hosts.Host, logger *zap.Logger) {
+	hostLogger := logger.With(zap.Stringer("hostKey", host.PublicKey))
 
 	const batchSize = 100 // batch size for sector retrieval
 	for interrupt := false; !interrupt; {
-		toCheck, err := m.store.SectorsForIntegrityCheck(ctx, hostKey, batchSize)
+		toCheck, err := m.store.SectorsForIntegrityCheck(ctx, host.PublicKey, batchSize)
 		if err != nil {
 			hostLogger.Error("failed to fetch sectors for integrity check", zap.Error(err))
 			return
@@ -102,7 +26,7 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, verifie
 		interrupt = len(toCheck) < batchSize
 
 		// perform integrity checks
-		results, err := m.verifySectors(ctx, verifier, toCheck)
+		results, err := m.verifier.VerifySectors(ctx, host, toCheck)
 		if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) {
 			interrupt = true
 		}
@@ -132,22 +56,22 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, verifie
 			defer cancel()
 
 			// update lost, failed and successful sectors
-			if err := m.store.MarkSectorsLost(ctx, verifier.HostKey(), lost); err != nil {
+			if err := m.store.MarkSectorsLost(ctx, host.PublicKey, lost); err != nil {
 				hostLogger.Error("failed to mark sectors as lost", zap.Error(err))
 				return fmt.Errorf("failed to mark sectors as lost: %w", err)
 			}
-			if err := m.store.RecordIntegrityCheck(ctx, false, time.Now().Add(m.failedIntegrityCheckInterval), verifier.HostKey(), failed); err != nil {
+			if err := m.store.RecordIntegrityCheck(ctx, false, time.Now().Add(m.failedIntegrityCheckInterval), host.PublicKey, failed); err != nil {
 				hostLogger.Error("failed to record integrity check for failed sectors", zap.Error(err))
 				return fmt.Errorf("failed to record integrity check for failed sectors: %w", err)
 			}
-			if err := m.store.RecordIntegrityCheck(ctx, true, time.Now().Add(m.integrityCheckInterval), verifier.HostKey(), success); err != nil {
+			if err := m.store.RecordIntegrityCheck(ctx, true, time.Now().Add(m.integrityCheckInterval), host.PublicKey, success); err != nil {
 				hostLogger.Error("failed to record integrity check for successful sectors", zap.Error(err))
 				return fmt.Errorf("failed to record integrity check for successful sectors: %w", err)
 			}
 
 			// fetch sector roots for sectors that have now failed the check 5+
 			// times and mark them lost as well
-			err := m.store.MarkFailingSectorsLost(ctx, verifier.HostKey(), m.maxFailedIntegrityChecks)
+			err := m.store.MarkFailingSectorsLost(ctx, host.PublicKey, m.maxFailedIntegrityChecks)
 			if err != nil {
 				hostLogger.Error("failed to mark failing sectors as lost", zap.Error(err))
 				return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
@@ -159,76 +83,4 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, verifie
 			return
 		}
 	}
-}
-
-// verifySectors verifies a list of sectors on a host. If verifySectors returns
-// either errInsufficientServiceAccountBalance or context.Canceled, the caller
-// should handle any remaining results and then interrupt the integrity checks
-// for the host.
-func (m *SlabManager) verifySectors(ctx context.Context, hc SectorVerifier, roots []types.Hash256) ([]CheckSectorsResult, error) {
-	// check the account balance
-	cost := hc.Prices().RPCVerifySectorCost().RenterCost()
-	balance, err := m.am.ServiceAccountBalance(ctx, hc.HostKey(), m.serviceAccount)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get service account balance: %w", err)
-	} else if balance.Cmp(cost) < 0 {
-		return nil, errInsufficientServiceAccountBalance
-	}
-
-	var results []CheckSectorsResult
-	var resetOnce sync.Once
-	for _, root := range roots {
-		// check for interruption
-		select {
-		case <-ctx.Done():
-			return results, nil
-		default:
-		}
-
-		// check if we have enough funds remaining
-		if balance.Cmp(cost) < 0 {
-			return results, errInsufficientServiceAccountBalance
-		}
-
-		// verify the sector
-		_, err := hc.VerifySector(ctx, root)
-		if errors.Is(err, context.Canceled) {
-			return results, err // interrupted
-		}
-
-		// adjust balance
-		balance = balance.Sub(cost)
-		if err := m.am.DebitServiceAccount(ctx, hc.HostKey(), m.serviceAccount, cost); err != nil {
-			return nil, fmt.Errorf("failed to debit service account: %w", err)
-		}
-
-		// check results - we need to be careful here since we can't trust the
-		// host and need to assume that anything that isn't a success is a
-		// potentially lost sector
-		if err == nil {
-			results = append(results, SectorSuccess)
-		} else if strings.Contains(err.Error(), proto.ErrSectorNotFound.Error()) {
-			results = append(results, SectorLost)
-		} else {
-			results = append(results, SectorFailed)
-		}
-
-		// if the host returned an insufficient balance error, reset the account
-		// NOTE: when this happens we don't interrupt on purpose. Instead we
-		// continue as if our internal balance was ok. So if we still expected
-		// to have enough balance to check 100 sectors, the next 100 sectors
-		// will probably also have a failure recorded. This means the host can't
-		// be clever about using an out-of-funds error to avoid penalties but we
-		// are also not harsher than necessary.
-		var resetErr error
-		resetOnce.Do(func() {
-			if err != nil && strings.Contains(err.Error(), proto.ErrNotEnoughFunds.Error()) {
-				resetErr = m.am.ResetAccountBalance(ctx, hc.HostKey(), m.serviceAccount)
-			}
-		})
-		if resetErr != nil {
-			return nil, fmt.Errorf("failed to reset service account balance: %w", err)
-		}
-	}
-	return results, nil
 }

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -2,285 +2,105 @@ package slabs
 
 import (
 	"context"
-	"errors"
 	"math"
 	"reflect"
 	"testing"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
 
-type mockSectorVerifier struct {
-	hostKey types.PublicKey
-	prices  proto.HostPrices
-	sectors map[types.Hash256]error
-}
-
-func newMockSectorVerifier(hostKey types.PublicKey, prices proto.HostPrices) *mockSectorVerifier {
-	return &mockSectorVerifier{
-		hostKey: hostKey,
-		prices:  prices,
-	}
-}
-
-func (ht *mockSectorVerifier) HostKey() types.PublicKey {
-	return ht.hostKey
-}
-
-func (ht *mockSectorVerifier) Prices() proto.HostPrices {
-	return ht.prices
-}
-
-func (ht *mockSectorVerifier) VerifySector(ctx context.Context, root types.Hash256) (rhp.RPCVerifySectorResult, error) {
-	if err, ok := ht.sectors[root]; ok {
-		if err == nil {
-			return rhp.RPCVerifySectorResult{
-				Usage: ht.prices.RPCVerifySectorCost(),
-			}, nil
-		}
-		return rhp.RPCVerifySectorResult{}, err
-	}
-	panic("unknown sector")
-}
-
-func TestVerifySectors(t *testing.T) {
-	store := newMockStore()
-	am := newMockAccountManager(store)
-	hm := newMockHostManager()
-	account := types.GeneratePrivateKey()
-	sm, err := newSlabManager(am, hm, store, nil, alerts.NewManager(), account, account)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	host := hosts.Host{
-		PublicKey: types.PublicKey{1},
-		Settings: proto.HostSettings{
-			Prices: proto.HostPrices{
-				EgressPrice: types.Siacoins(1).Div64(proto.SectorSize), // 1SC per sector
-			},
-		},
-	}
-
-	// make host scannable
-	hm.hosts[host.PublicKey] = host
-
-	// helper to call verify sectors
-	verifySectors := func(hostSectors map[types.Hash256]error, toVerify []types.Hash256, expectedResults []CheckSectorsResult) error {
-		verifier := newMockSectorVerifier(host.PublicKey, host.Settings.Prices)
-		verifier.sectors = hostSectors
-		results, err := sm.verifySectors(context.Background(), verifier, toVerify)
-		if !reflect.DeepEqual(results, expectedResults) {
-			t.Fatalf("expected %v, got %v", expectedResults, results)
-		}
-		return err
-	}
-
-	// helper to assert balance of service account
-	assertBalance := func(expected types.Currency) {
-		t.Helper()
-		balance, err := am.ServiceAccountBalance(context.Background(), host.PublicKey, proto.Account(account.PublicKey()))
-		if err != nil {
-			t.Fatal(err)
-		} else if !balance.Equals(expected) {
-			t.Fatalf("expected balance %v, got %v", expected, balance)
-		}
-	}
-
-	// helper to set balance of service account
-	updateBalance := func(amount types.Currency) {
-		t.Helper()
-		err := am.UpdateServiceAccountBalance(context.Background(), host.PublicKey, proto.Account(account.PublicKey()), amount)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	// verifying sector before funding the service account fails.
-	err = verifySectors(map[types.Hash256]error{}, []types.Hash256{
-		{1},
-	}, nil)
-	if !errors.Is(err, errInsufficientServiceAccountBalance) {
-		t.Fatalf("expected insufficient balance error, got %v", err)
-	}
-
-	// add 3SC to the account
-	updateBalance(types.Siacoins(3))
-
-	// case 1: successfully verify a lost and a good sector
-	err = verifySectors(map[types.Hash256]error{
-		{1}: proto.ErrSectorNotFound, // lost
-		{2}: nil,                     // good
-	}, []types.Hash256{
-		{1},
-		{2},
-	}, []CheckSectorsResult{SectorLost, SectorSuccess})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// assert withdrawal: 3SC-2SC = 1SC
-	assertBalance(types.Siacoins(1))
-
-	// case 2: running out of funds unexpectedly (malicious host) should reset the balance but
-	// should continue to verify sectors
-	updateBalance(types.Siacoins(10))
-	err = verifySectors(map[types.Hash256]error{
-		{1}: proto.ErrNotEnoughFunds, // unexpected OOF
-		{2}: nil,                     // good sector
-	}, []types.Hash256{
-		{1},
-		{2},
-	}, []CheckSectorsResult{SectorFailed, SectorSuccess})
-	if err != nil {
-		t.Fatal(err)
-	}
-	assertBalance(types.ZeroCurrency)
-
-	// case 3: running out of funds expectedly
-	updateBalance(types.Siacoins(2))
-	err = verifySectors(map[types.Hash256]error{
-		{1}: nil, // good sector
-		{2}: nil, // good sector
-		{3}: nil, // good sector
-	}, []types.Hash256{
-		{1},
-		{2},
-		{3},
-	}, []CheckSectorsResult{SectorSuccess, SectorSuccess})
-	if !errors.Is(err, errInsufficientServiceAccountBalance) {
-		t.Fatalf("expected insufficient balance error, got %v", err)
-	}
-
-	// case 4: interruption via context
-	updateBalance(types.Siacoins(10))
-	err = verifySectors(map[types.Hash256]error{
-		{1}: nil,              // good sector
-		{2}: context.Canceled, // verification interrupted
-	}, []types.Hash256{
-		{1},
-		{2},
-	}, []CheckSectorsResult{SectorSuccess})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled error, got %v", err)
-	}
-}
-
 func TestPerformIntegrityChecksForHost(t *testing.T) {
-	store := newMockStore()
-	am := newMockAccountManager(store)
-	hm := newMockHostManager()
-	account := types.GeneratePrivateKey()
-	alerter := alerts.NewManager()
-	sm, err := newSlabManager(am, hm, store, nil, alerter, account, account)
-	if err != nil {
-		t.Fatal(err)
-	}
+	oneSC := types.Siacoins(1)
 
+	// prepare host
+	hk := types.PublicKey{1}
 	host := hosts.Host{
-		PublicKey: types.PublicKey{1},
+		PublicKey: hk,
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{
 				EgressPrice: types.Siacoins(1).Div64(proto.SectorSize), // 1SC per sector
 			},
 		},
 	}
+	dialer := newMockDialer([]hosts.Host{host})
 
-	// make host scannable
-	hm.hosts[host.PublicKey] = host
+	// prepare managers
+	store := newMockStore()
+	am := newMockAccountManager(store)
+	hm := newMockHostManager()
+	hm.hosts[host.PublicKey] = host // make host scannable
 
-	// helper to call verify sectors
-	verifySectors := func(hostSectors map[types.Hash256]error, toVerify []types.Hash256, expectedResults []CheckSectorsResult) error {
-		verifier := newMockSectorVerifier(host.PublicKey, host.Settings.Prices)
-		verifier.sectors = hostSectors
-		results, err := sm.verifySectors(context.Background(), verifier, toVerify)
-		if !reflect.DeepEqual(results, expectedResults) {
-			t.Fatalf("expected %v, got %v", expectedResults, results)
-		}
-		return err
+	// prepare account
+	sk := types.GeneratePrivateKey()
+	acc := proto.Account(sk.PublicKey())
+
+	// prepare slab manager
+	sm, err := newSlabManager(am, hm, store, dialer, nil, sk, sk)
+	if err != nil {
+		t.Fatal(err)
 	}
-	_ = verifySectors
 
-	// helper to assert balance of service account
-	assertBalance := func(expected types.Currency) {
+	// prepare helper to reset balance to 3SC to avoid running out of funds
+	resetBalance := func() {
 		t.Helper()
-		balance, err := am.ServiceAccountBalance(context.Background(), host.PublicKey, proto.Account(account.PublicKey()))
-		if err != nil {
-			t.Fatal(err)
-		} else if !balance.Equals(expected) {
-			t.Fatalf("expected balance %v, got %v", expected, balance)
-		}
-	}
-	_ = assertBalance
-
-	// helper to set balance of service account
-	updateBalance := func(amount types.Currency) {
-		t.Helper()
-		err := am.UpdateServiceAccountBalance(context.Background(), host.PublicKey, proto.Account(account.PublicKey()), amount)
+		err = am.UpdateServiceAccountBalance(context.Background(), hk, acc, oneSC.Mul64(3))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// add plenty of money to the service account
-	updateBalance(types.Siacoins(100))
-
-	// prepare roots for each outcome, a successful check, a lost sector and a
-	// failed check
-	rootGood := types.Hash256{1}
-	rootLost := types.Hash256{2}
-	rootBad := types.Hash256{3}
-	store.sectorsForCheck = []types.Hash256{rootGood, rootLost, rootBad}
-
-	verifier := newMockSectorVerifier(host.PublicKey, host.Settings.Prices)
-	verifier.sectors = map[types.Hash256]error{
-		rootGood: nil,
-		rootLost: proto.ErrSectorNotFound,
-		rootBad:  proto.ErrNotEnoughFunds,
-	}
+	// prepare roots
+	r1 := types.Hash256{1} // good
+	r2 := types.Hash256{2} // lost
+	r3 := types.Hash256{3} // bad
+	dialer.clients[host.PublicKey].integrity[r1] = nil
+	dialer.clients[host.PublicKey].integrity[r2] = proto.ErrSectorNotFound
+	dialer.clients[host.PublicKey].integrity[r3] = proto.ErrNotEnoughFunds
+	store.sectorsForCheck = []types.Hash256{r1, r2, r3}
 
 	// perform the checks once
-	sm.performIntegrityChecksForHost(context.Background(), verifier, zap.NewNop())
+	resetBalance()
+	sm.performIntegrityChecksForHost(context.Background(), host, zap.NewNop())
 
 	// the lost sector should be marked as lost
 	if len(store.lostSectors[host.PublicKey]) != 1 {
 		t.Fatalf("expected 1 lost sector, got %d", len(store.lostSectors))
-	} else if _, exists := store.lostSectors[host.PublicKey][rootLost]; !exists {
-		t.Fatalf("expected lost sector %v, got %v", rootLost, store.lostSectors)
+	} else if _, exists := store.lostSectors[host.PublicKey][r2]; !exists {
+		t.Fatalf("expected lost sector %v, got %v", r2, store.lostSectors)
 	}
 
 	// the failed sector should be marked as failed
 	if len(store.failedChecks) != 1 {
 		t.Fatalf("expected 1 failed checks, got %d", len(store.failedChecks))
-	} else if n, exists := store.failedChecks[host.PublicKey][rootBad]; !exists || n != 1 {
-		t.Fatalf("expected failed check %v, got %v", rootBad, store.failedChecks[host.PublicKey])
+	} else if n, exists := store.failedChecks[host.PublicKey][r3]; !exists || n != 1 {
+		t.Fatalf("expected failed check %v, got %v", r3, store.failedChecks[host.PublicKey])
 	}
 
 	// perform the checks a few more time to reach the maximum number of failed
 	// checks before a bad sector gets removed
 	for i := uint(1); i < sm.maxFailedIntegrityChecks; i++ {
-		sm.performIntegrityChecksForHost(context.Background(), verifier, zap.NewNop())
+		resetBalance()
+		sm.performIntegrityChecksForHost(context.Background(), host, zap.NewNop())
 	}
 
 	// the failed sector should be marked as failed 5 times
 	if len(store.failedChecks) != 1 {
 		t.Fatalf("expected 1 failed checks, got %d", len(store.failedChecks))
-	} else if n, exists := store.failedChecks[host.PublicKey][rootBad]; !exists || n != 5 {
-		t.Fatalf("expected failed check %v, got %v", rootBad, store.failedChecks[host.PublicKey])
+	} else if n, exists := store.failedChecks[host.PublicKey][r3]; !exists || n != 5 {
+		t.Fatalf("expected failed check %v, got %v", r3, store.failedChecks[host.PublicKey])
 	}
 
 	// should have 2 lost sectors now
 	if len(store.lostSectors[host.PublicKey]) != 2 {
 		t.Fatalf("expected 2 lost sectors, got %d", len(store.lostSectors))
-	} else if _, exists := store.lostSectors[host.PublicKey][rootLost]; !exists {
-		t.Fatalf("expected lost sector %v, got %v", rootLost, store.lostSectors)
-	} else if _, exists := store.lostSectors[host.PublicKey][rootBad]; !exists {
-		t.Fatalf("expected lost sector %v, got %v", rootBad, store.lostSectors)
+	} else if _, exists := store.lostSectors[host.PublicKey][r2]; !exists {
+		t.Fatalf("expected lost sector %v, got %v", r2, store.lostSectors)
+	} else if _, exists := store.lostSectors[host.PublicKey][r3]; !exists {
+		t.Fatalf("expected lost sector %v, got %v", r3, store.lostSectors)
 	}
 }
 

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -151,7 +151,7 @@ func (m *SlabManager) downloadShard(ctx context.Context, h hosts.Host, sector Se
 		return proto.Usage{}, nil, fmt.Errorf("failed to dial host: %w", err)
 	}
 
-	settings, err := client.Settings(ctx, h.PublicKey)
+	settings, err := client.Settings(ctx)
 	if err != nil {
 		return proto.Usage{}, nil, fmt.Errorf("failed to fetch host settings: %w", err)
 	}

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -14,6 +14,7 @@ import (
 	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/alerts"
+	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -33,18 +34,19 @@ type (
 
 		migrationAccount    proto.Account
 		migrationAccountKey types.PrivateKey
-		serviceAccount      proto.Account
-		serviceAccountKey   types.PrivateKey
 
 		shardTimeout time.Duration
 
-		am      AccountManager
-		dialer  Dialer
-		hm      HostManager
-		store   Store
 		alerter AlertsManager
-		tg      *threadgroup.ThreadGroup
-		log     *zap.Logger
+		am      AccountManager
+		hm      HostManager
+
+		dialer   Dialer
+		store    Store
+		verifier *SectorVerifier
+
+		tg  *threadgroup.ThreadGroup
+		log *zap.Logger
 	}
 
 	// AccountManager defines the SlabManager's dependencies on the account
@@ -62,11 +64,13 @@ type (
 	}
 
 	// HostClient defines the dependencies required to upload and download
-	// sectors to and from hosts.
+	// sectors to and from hosts, as well as verify sectors.
 	HostClient interface {
+		io.Closer
 		ReadSector(ctx context.Context, prices proto.HostPrices, token proto.AccountToken, w io.Writer, root types.Hash256, offset, length uint64) (rhp.RPCReadSectorResult, error)
-		Settings(context.Context, types.PublicKey) (proto.HostSettings, error)
+		Settings(context.Context) (proto.HostSettings, error)
 		WriteSector(ctx context.Context, prices proto.HostPrices, token proto.AccountToken, data io.Reader, length uint64) (rhp.RPCWriteSectorResult, error)
+		VerifySector(ctx context.Context, prices proto.HostPrices, token proto.AccountToken, root types.Hash256) (rhp.RPCVerifySectorResult, error)
 	}
 
 	// HostManager defines the minimal interface of HostManager functionality
@@ -111,42 +115,37 @@ func WithLogger(l *zap.Logger) Option {
 	}
 }
 
+type wrapper struct {
+	d *client.SiamuxDialer
+}
+
+// DialHost dials the host and returns a HostClient.
+func (w *wrapper) DialHost(ctx context.Context, hostKey types.PublicKey, addr string) (HostClient, error) {
+	client, err := w.d.DialHost(ctx, hostKey, addr)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
 // NewManager creates a new slab manager.
-func NewManager(am AccountManager, hm HostManager, store Store, dialer Dialer, alerter AlertsManager, migrationAccount, serviceAccount types.PrivateKey, opts ...Option) (*SlabManager, error) {
-	m, err := newSlabManager(am, hm, store, dialer, alerter, migrationAccount, serviceAccount, opts...)
+func NewManager(am AccountManager, hm HostManager, store Store, dialer *client.SiamuxDialer, alerter AlertsManager, migrationAccount, serviceAccount types.PrivateKey, opts ...Option) (*SlabManager, error) {
+	sm, err := newSlabManager(am, hm, store, &wrapper{d: dialer}, alerter, migrationAccount, serviceAccount, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, cancel, err := m.tg.AddContext(context.Background())
+	ctx, cancel, err := sm.tg.AddContext(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
 	go func() {
 		defer cancel()
-
-		healthTicker := time.NewTicker(healthCheckInterval)
-		defer healthTicker.Stop()
-
-		for {
-			select {
-			case <-healthTicker.C:
-			case <-ctx.Done():
-				return
-			}
-
-			if err := m.performIntegrityChecks(ctx); err != nil {
-				m.log.Error("failed to perform integrity checks", zap.Error(err))
-			}
-
-			if err := m.performSlabMigrations(); err != nil {
-				m.log.Error("failed to perform slab migrations", zap.Error(err))
-			}
-		}
+		sm.maintenanceLoop(ctx)
 	}()
 
-	return m, nil
+	return sm, nil
 }
 
 func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Dialer, alerter AlertsManager, migrationAccount, serviceAccount types.PrivateKey, opts ...Option) (*SlabManager, error) {
@@ -158,18 +157,16 @@ func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Diale
 		migrationAccount:    proto.Account(migrationAccount.PublicKey()),
 		migrationAccountKey: migrationAccount,
 
-		serviceAccount:    proto.Account(serviceAccount.PublicKey()),
-		serviceAccountKey: serviceAccount,
-
 		shardTimeout: 30 * time.Second,
 
-		am:      am,
-		dialer:  dialer,
-		hm:      hm,
-		store:   store,
-		alerter: alerter,
-		tg:      threadgroup.New(),
-		log:     zap.NewNop(),
+		am:       am,
+		dialer:   dialer,
+		hm:       hm,
+		store:    store,
+		verifier: NewSectorVerifier(am, dialer, serviceAccount),
+		alerter:  alerter,
+		tg:       threadgroup.New(),
+		log:      zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -180,13 +177,13 @@ func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Diale
 	defer cancel()
 	if err := store.AddAccount(ctx, types.PublicKey(m.migrationAccount)); err != nil && !errors.Is(err, accounts.ErrExists) {
 		return nil, fmt.Errorf("failed to add migration account: %w", err)
-	} else if err := store.AddAccount(ctx, types.PublicKey(m.serviceAccount)); err != nil && !errors.Is(err, accounts.ErrExists) {
+	} else if err := store.AddAccount(ctx, types.PublicKey(proto.Account(serviceAccount.PublicKey()))); err != nil && !errors.Is(err, accounts.ErrExists) {
 		return nil, fmt.Errorf("failed to add service account: %w", err)
 	}
 
 	// let AccountManager know about the service accounts
 	am.RegisterServiceAccount(m.migrationAccount)
-	am.RegisterServiceAccount(m.serviceAccount)
+	am.RegisterServiceAccount(proto.Account(serviceAccount.PublicKey()))
 	return m, nil
 }
 
@@ -194,6 +191,29 @@ func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Diale
 func (m *SlabManager) Close() error {
 	m.tg.Stop()
 	return nil
+}
+
+// maintenanceLoop performs any background tasks that the slab manager needs to
+// perform on slabs
+func (m *SlabManager) maintenanceLoop(ctx context.Context) {
+	healthTicker := time.NewTicker(healthCheckInterval)
+	defer healthTicker.Stop()
+
+	for {
+		select {
+		case <-healthTicker.C:
+		case <-ctx.Done():
+			return
+		}
+
+		if err := m.performIntegrityChecks(ctx); err != nil {
+			m.log.Error("failed to perform integrity checks", zap.Error(err))
+		}
+
+		if err := m.performSlabMigrations(); err != nil {
+			m.log.Error("failed to perform slab migrations", zap.Error(err))
+		}
+	}
 }
 
 func newLostSectorsAlert(hks []types.PublicKey) alerts.Alert {
@@ -240,17 +260,18 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 				}()
 
 				err = m.hm.WithScannedHost(ctx, host, func(host hosts.Host) error {
-					// create verifier
-					verifier, err := newSectorVerifier(ctx, host.SiamuxAddr(), host.PublicKey, host.Settings.Prices)
-					if err != nil {
-						// NOTE: If we can't dial the host we don't mark sectors as lost.
-						// Instead we leave it up to the scan code to determine whether the host
-						// is offline.
-						return err
-					}
-					defer verifier.Close()
+					// TODO: handle
+					// // create verifier
+					// verifier, err := newSectorVerifier(ctx, host.SiamuxAddr(), host.PublicKey, host.Settings.Prices)
+					// if err != nil {
+					// 	// NOTE: If we can't dial the host we don't mark sectors as lost.
+					// 	// Instead we leave it up to the scan code to determine whether the host
+					// 	// is offline.
+					// 	return err
+					// }
+					// defer verifier.Close()
 
-					m.performIntegrityChecksForHost(ctx, verifier, logger)
+					m.performIntegrityChecksForHost(ctx, host, logger)
 					return nil
 				})
 				if err != nil {

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -259,22 +259,10 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 					wg.Done()
 				}()
 
-				err = m.hm.WithScannedHost(ctx, host, func(host hosts.Host) error {
-					// TODO: handle
-					// // create verifier
-					// verifier, err := newSectorVerifier(ctx, host.SiamuxAddr(), host.PublicKey, host.Settings.Prices)
-					// if err != nil {
-					// 	// NOTE: If we can't dial the host we don't mark sectors as lost.
-					// 	// Instead we leave it up to the scan code to determine whether the host
-					// 	// is offline.
-					// 	return err
-					// }
-					// defer verifier.Close()
-
+				if err := m.hm.WithScannedHost(ctx, host, func(host hosts.Host) error {
 					m.performIntegrityChecksForHost(ctx, host, logger)
 					return nil
-				})
-				if err != nil {
+				}); err != nil {
 					logger.With(zap.Stringer("hostKey", hostKey)).Error("failed to perform integrity checks for host", zap.Error(err))
 				}
 			}(host)

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -200,8 +200,9 @@ func newMockDialer(hosts []hosts.Host) *mockDialer {
 	clients := make(map[types.PublicKey]*mockHostClient, len(hosts))
 	for _, host := range hosts {
 		clients[host.PublicKey] = &mockHostClient{
-			sectors:  make(map[types.Hash256][proto.SectorSize]byte),
-			settings: host.Settings,
+			sectors:   make(map[types.Hash256][proto.SectorSize]byte),
+			integrity: make(map[types.Hash256]error),
+			settings:  host.Settings,
 		}
 	}
 	return &mockDialer{clients: clients}
@@ -215,9 +216,10 @@ func (d *mockDialer) DialHost(ctx context.Context, hostKey types.PublicKey, addr
 }
 
 type mockHostClient struct {
-	delay    time.Duration
-	sectors  map[types.Hash256][proto.SectorSize]byte
-	settings proto.HostSettings
+	delay     time.Duration
+	sectors   map[types.Hash256][proto.SectorSize]byte
+	integrity map[types.Hash256]error
+	settings  proto.HostSettings
 }
 
 func (c *mockHostClient) ReadSector(ctx context.Context, prices proto.HostPrices, token proto.AccountToken, w io.Writer, root types.Hash256, offset, length uint64) (rhp.RPCReadSectorResult, error) {
@@ -260,6 +262,6 @@ func (c *mockHostClient) WriteSector(ctx context.Context, prices proto.HostPrice
 	}, nil
 }
 
-func (c *mockHostClient) Settings(context.Context, types.PublicKey) (proto.HostSettings, error) {
+func (c *mockHostClient) Settings(context.Context) (proto.HostSettings, error) {
 	return c.settings, nil
 }

--- a/slabs/sectorverifier.go
+++ b/slabs/sectorverifier.go
@@ -1,0 +1,169 @@
+package slabs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/hosts"
+)
+
+const (
+	// SectorLost indicates that the sector was lost. This is returned if the
+	// host admits to losing the sector.
+	SectorLost = CheckSectorsResult(iota)
+
+	// SectorFailed indicates that the sector failed verification for some
+	// reason. Since we can't trust a host to not use all means necessary for us
+	// to not track a failure, we consider anything that is not a lost sector or
+	// successfully verification a failure.
+	SectorFailed
+
+	// SectorSuccess indicates that the sector was successfully verified and is
+	// still in the host's possession.
+	SectorSuccess
+)
+
+var (
+	errInsufficientServiceAccountBalance = errors.New("insufficient service account balance")
+	errHostUnreachable                   = errors.New("host unreachable")
+)
+
+type (
+	// SectorVerifier is responsible for verifying sectors on hosts. It uses a
+	// service account to pay for the RPCs and updates the account balance
+	// accordingly. It returns a list of CheckSectorsResult for each sector that
+	// gets verified.
+	SectorVerifier struct {
+		am             AccountManager
+		dialer         Dialer
+		serviceAccount types.PrivateKey
+	}
+
+	// CheckSectorsResult is the result of a sector verification. It indicates
+	// whether:
+	// - the sector was lost
+	// - the sector failed verification for any reason
+	// - the sector was successfully verified
+	CheckSectorsResult int
+)
+
+// NewSectorVerifier creates a new SectorVerifier.
+func NewSectorVerifier(am AccountManager, dialer Dialer, serviceAccount types.PrivateKey) *SectorVerifier {
+	return &SectorVerifier{am: am, dialer: dialer, serviceAccount: serviceAccount}
+}
+
+// CheckBalance ensures the service account balance is sufficient to cover the
+// cost of the verify sector RPC.
+func (v *SectorVerifier) CheckBalance(ctx context.Context, host hosts.Host) (types.Currency, error) {
+	balance, err := v.am.ServiceAccountBalance(ctx, host.PublicKey, v.account())
+	if err != nil {
+		return types.ZeroCurrency, fmt.Errorf("failed to get service account balance: %w", err)
+	} else if balance.Cmp(host.Settings.Prices.RPCVerifySectorCost().RenterCost()) < 0 {
+		return types.ZeroCurrency, errInsufficientServiceAccountBalance
+	}
+	return balance, nil
+}
+
+// UpdateBalance debits the service account for the cost of the verify sector RPC.
+func (v *SectorVerifier) UpdateBalance(ctx context.Context, host hosts.Host, usage proto.Usage) error {
+	if err := v.am.DebitServiceAccount(ctx, host.PublicKey, v.account(), usage.RenterCost()); err != nil {
+		return fmt.Errorf("failed to update service account balance: %w", err)
+	}
+	return nil
+}
+
+// ResetBalance resets the service account balance for the host.
+func (v *SectorVerifier) ResetBalance(ctx context.Context, host hosts.Host) error {
+	if err := v.am.ResetAccountBalance(ctx, host.PublicKey, v.account()); err != nil {
+		return fmt.Errorf("failed to reset service account balance: %w", err)
+	}
+	return nil
+}
+
+// VerifySectors verifies a list of sectors on a host. If verifySectors returns
+// either errInsufficientServiceAccountBalance or context.Canceled, the caller
+// should handle any remaining results and then interrupt the integrity checks
+// for the host.
+func (v *SectorVerifier) VerifySectors(ctx context.Context, host hosts.Host, roots []types.Hash256) ([]CheckSectorsResult, error) {
+	hc, err := v.dialer.DialHost(ctx, host.PublicKey, host.SiamuxAddr())
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to dial host %s: %w", errHostUnreachable, host.PublicKey, err)
+	}
+	defer hc.Close()
+
+	// check budget before verifying the sector
+	budget, err := v.CheckBalance(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	cost := host.Settings.Prices.RPCVerifySectorCost().RenterCost()
+	var results []CheckSectorsResult
+	var resetOnce sync.Once
+	for _, root := range roots {
+		select {
+		case <-ctx.Done():
+			return results, nil
+		default:
+		}
+
+		// check our budget before verifying the sector
+		if budget.Cmp(cost) < 0 {
+			return results, errInsufficientServiceAccountBalance
+		}
+
+		// verify the sector
+		res, err := hc.VerifySector(ctx, host.Settings.Prices, v.token(host.PublicKey), root)
+		if errors.Is(err, context.Canceled) {
+			return results, err // interrupted
+		}
+
+		// adjust the budget
+		budget = budget.Sub(res.Usage.RenterCost())
+
+		// check results - we need to be careful here since we can't trust the
+		// host and need to assume that anything that isn't a success is a
+		// potentially lost sector
+		if err == nil {
+			results = append(results, SectorSuccess)
+		} else if strings.Contains(err.Error(), proto.ErrSectorNotFound.Error()) {
+			results = append(results, SectorLost)
+		} else {
+			results = append(results, SectorFailed)
+		}
+
+		// if the host returned an insufficient balance error, reset the account
+		if err != nil && strings.Contains(err.Error(), proto.ErrNotEnoughFunds.Error()) {
+			resetOnce.Do(func() { err = v.ResetBalance(ctx, host) })
+
+			// NOTE: when this happens we don't interrupt on purpose and
+			// continue as if our internal balance was ok. So if we still
+			// expected to have enough balance to check 100 sectors, the next
+			// 100 sectors will probably also have a failure recorded. This
+			// means the host can't be clever about using an out-of-funds error
+			// to avoid penalties but we are also not harsher than necessary.
+			continue
+		}
+
+		// update the service account balance
+		err = v.UpdateBalance(ctx, host, res.Usage)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+func (v *SectorVerifier) account() proto.Account {
+	return proto.Account(v.serviceAccount.PublicKey())
+}
+
+func (v *SectorVerifier) token(hostKey types.PublicKey) proto.AccountToken {
+	acc := proto.Account(v.serviceAccount.PublicKey())
+	return acc.Token(v.serviceAccount, hostKey)
+}

--- a/slabs/sectorverifier_test.go
+++ b/slabs/sectorverifier_test.go
@@ -1,0 +1,129 @@
+package slabs
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/hosts"
+)
+
+func (c *mockHostClient) Close() error {
+	return nil
+}
+
+func (c *mockHostClient) VerifySector(ctx context.Context, hostPrices proto.HostPrices, token proto.AccountToken, root types.Hash256) (rhp.RPCVerifySectorResult, error) {
+	err, ok := c.integrity[root]
+	if !ok {
+		panic("unknown sector: " + root.String())
+	}
+	return rhp.RPCVerifySectorResult{Usage: hostPrices.RPCVerifySectorCost()}, err
+}
+
+func TestSectorVerifier(t *testing.T) {
+	oneSC := types.Siacoins(1)
+
+	// prepare manager
+	store := newMockStore()
+	am := newMockAccountManager(store)
+
+	// prepare account
+	sk := types.GeneratePrivateKey()
+	acc := proto.Account(sk.PublicKey())
+	am.RegisterServiceAccount(acc)
+
+	// prepare host
+	hk := types.PublicKey{1}
+	host := hosts.Host{
+		PublicKey: hk,
+		Settings: proto.HostSettings{
+			Prices: proto.HostPrices{
+				EgressPrice: oneSC.Div64(proto.SectorSize), // 1SC per sector
+			},
+		},
+	}
+
+	// prepare roots
+	r1 := types.Hash256{1}
+	r2 := types.Hash256{2}
+	r3 := types.Hash256{3}
+
+	// prepare verifier
+	dialer := newMockDialer([]hosts.Host{host})
+	verifier := NewSectorVerifier(am, dialer, sk)
+
+	// prepare helper to assert account balance
+	assertBalance := func(want types.Currency) {
+		t.Helper()
+		got, err := am.ServiceAccountBalance(context.Background(), hk, acc)
+		if err != nil {
+			t.Fatal(err)
+		} else if !got.Equals(want) {
+			t.Fatalf("expected balance %v, got %v", want, got)
+		}
+	}
+
+	// prepare helper to assert verify sector results
+	assertResults := func(roots []types.Hash256, want []CheckSectorsResult, expectedErr error) {
+		t.Helper()
+		got, err := verifier.VerifySectors(context.Background(), host, roots)
+		if err != nil && expectedErr == nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("expected results %v, got %v", want, got)
+		}
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("expected error %v, got %v", expectedErr, err)
+		}
+	}
+
+	// prepare helper to update account balance
+	updateBalance := func(amount types.Currency) {
+		t.Helper()
+		err := am.UpdateServiceAccountBalance(context.Background(), hk, acc, amount)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// assert [errInsufficientServiceAccountBalance] is returned
+	_, err := verifier.VerifySectors(context.Background(), host, []types.Hash256{r1})
+	if !errors.Is(err, errInsufficientServiceAccountBalance) {
+		t.Fatal("unexpected err", err)
+	}
+
+	// add 10SC to the account
+	updateBalance(oneSC.Mul64(10))
+
+	// case 1: successfully verify a lost and a good sector, should debit the
+	// account balance
+	dialer.clients[host.PublicKey].integrity[r1] = proto.ErrSectorNotFound // lost
+	dialer.clients[host.PublicKey].integrity[r2] = nil                     // good
+	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{SectorLost, SectorSuccess}, nil)
+	assertBalance(oneSC.Mul64(8))
+
+	// case 2: running out of funds unexpectedly (malicious host) should reset the balance but
+	// should continue to verify sectors
+	dialer.clients[host.PublicKey].integrity[r1] = proto.ErrNotEnoughFunds // unexpected OOF
+	dialer.clients[host.PublicKey].integrity[r2] = nil                     // good
+	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{SectorFailed, SectorSuccess}, nil)
+	assertBalance(types.ZeroCurrency)
+
+	// case 3: running out of funds expectedly
+	updateBalance(types.Siacoins(2))
+	dialer.clients[host.PublicKey].integrity[r1] = nil // good
+	dialer.clients[host.PublicKey].integrity[r2] = nil // good
+	dialer.clients[host.PublicKey].integrity[r3] = nil // good
+	assertResults([]types.Hash256{r1, r2, r3}, []CheckSectorsResult{SectorSuccess, SectorSuccess}, errInsufficientServiceAccountBalance)
+
+	// case 4: interruption via context
+	updateBalance(types.Siacoins(10))
+	dialer.clients[host.PublicKey].integrity[r1] = nil              // good sector
+	dialer.clients[host.PublicKey].integrity[r2] = context.Canceled // verification interrupted
+	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{SectorSuccess}, context.Canceled)
+}

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -114,7 +114,7 @@ func (m *SlabManager) uploadShard(ctx context.Context, h hosts.Host, shard io.Re
 		return proto.Usage{}, types.Hash256{}, fmt.Errorf("failed to dial host: %w", err)
 	}
 
-	settings, err := client.Settings(ctx, h.PublicKey)
+	settings, err := client.Settings(ctx)
 	if err != nil {
 		return proto.Usage{}, types.Hash256{}, fmt.Errorf("failed to fetch host settings: %w", err)
 	}


### PR DESCRIPTION
This PR refactors the sector verifier to use the `Dialer` and `HostClient`, which was an outstanding `TODO`. I figured I'd tackle that to familiarise myself with integrity checks before writing an integration test for them. There's no fundamental changes to the logic.

Two things though:
- I debit the service account with the renter cost that's dictated by the usage the host returned
- I check whether we want to reset the balance in every iteration, current code only does it the first time