### PR TITLE
Add UI API endpoints

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -13,6 +13,7 @@ import (
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
@@ -82,6 +83,7 @@ type (
 
 	// A Syncer can connect to other peers and synchronize the blockchain.
 	Syncer interface {
+		Connect(ctx context.Context, addr string) (*syncer.Peer, error)
 		BroadcastV2TransactionSet(index types.ChainIndex, txns []types.V2Transaction) error
 	}
 
@@ -134,6 +136,12 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 
 	routes := map[string]jape.Handler{
 		"GET /state": a.handleGETState,
+
+		// syncer endpoints
+		"POST /syncer/connect": a.handlePOSTSyncerConnect,
+
+		// txpool endpoints
+		"GET /txpool/recommendedfee": a.handleGETTxpoolRecommendedFee,
 
 		// accounts endpoints
 		"GET    /accounts":            a.handleGETAccounts,
@@ -332,6 +340,22 @@ func (a *admin) handleGETState(jc jape.Context) {
 		},
 		ScanHeight: ci.Height,
 	})
+}
+
+func (a *admin) handlePOSTSyncerConnect(jc jape.Context) {
+	var addr string
+	if jc.Decode(&addr) != nil {
+		return
+	}
+	_, err := a.syncer.Connect(jc.Request.Context(), addr)
+	if jc.Check("couldn't connect to peer", err) != nil {
+		return
+	}
+	jc.Encode(nil)
+}
+
+func (a *admin) handleGETTxpoolRecommendedFee(jc jape.Context) {
+	jc.Encode(a.chain.RecommendedFee())
 }
 
 func (a *admin) handleGETExplorerSiacoinExchangeRate(jc jape.Context) {

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -52,6 +52,7 @@ type (
 	// HostManager defines an interface that allows triggering a host scan.
 	HostManager interface {
 		TriggerHostScanning()
+		ScanHost(ctx context.Context, hk types.PublicKey) (hosts.Host, error)
 	}
 
 	// Explorer retrieves data about the Sia network from an external source.
@@ -159,7 +160,8 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 		"GET /explorer/exchange-rate/siacoin/:currency": a.handleGETExplorerSiacoinExchangeRate,
 
 		// host endpoints
-		"GET    /host/:hostkey": a.handleGETHost,
+		"GET    /host/:hostkey":      a.handleGETHost,
+		"POST   /host/:hostkey/scan": a.handlePOSTHostScan,
 
 		// hosts endpoints
 		"GET    /hosts":                    a.handleGETHosts,
@@ -436,6 +438,21 @@ func (a *admin) handleGETHost(jc jape.Context) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if jc.Check("failed to get host", err) != nil {
+		return
+	}
+	jc.Encode(host)
+}
+
+func (a *admin) handlePOSTHostScan(jc jape.Context) {
+	var hk types.PublicKey
+	if jc.DecodeParam("hostkey", &hk) != nil {
+		return
+	}
+	host, err := a.hosts.ScanHost(jc.Request.Context(), hk)
+	if errors.Is(err, hosts.ErrNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to scan host", err) != nil {
 		return
 	}
 	jc.Encode(host)

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -138,12 +138,6 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 	routes := map[string]jape.Handler{
 		"GET /state": a.handleGETState,
 
-		// syncer endpoints
-		"POST /syncer/connect": a.handlePOSTSyncerConnect,
-
-		// txpool endpoints
-		"GET /txpool/recommendedfee": a.handleGETTxpoolRecommendedFee,
-
 		// accounts endpoints
 		"GET    /accounts":            a.handleGETAccounts,
 		"POST   /account/:accountkey": a.handlePOSTAccount,
@@ -176,6 +170,12 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 		"PUT /settings/hosts":        a.handlePUTSettingsHosts,
 		"GET /settings/pricepinning": a.handleGETSettingsPricePinning,
 		"PUT /settings/pricepinning": a.handlePUTSettingsPricePinning,
+
+		// syncer endpoints
+		"POST /syncer/connect": a.handlePOSTSyncerConnect,
+
+		// txpool endpoints
+		"GET /txpool/recommendedfee": a.handleGETTxpoolRecommendedFee,
 
 		// wallet endpoints
 		"GET /wallet":         a.handleGETWallet,

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -395,6 +395,25 @@ func TestHostsAPI(t *testing.T) {
 	} else if len(notContracted) != 2 {
 		t.Fatalf("invalid number of hosts: %d", len(notContracted))
 	}
+
+	// manually scan host
+	host1, err := indexer.Host(context.Background(), h1.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanHost1, err := indexer.ScanHost(context.Background(), h1.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanHost1.LastSuccessfulScan = host1.LastSuccessfulScan
+	scanHost1.NextScan = host1.NextScan
+	scanHost1.RecentUptime = host1.RecentUptime
+	scanHost1.Settings.Prices.ValidUntil = host1.Settings.Prices.ValidUntil
+	scanHost1.Settings.Prices.Signature = host1.Settings.Prices.Signature
+
+	if !reflect.DeepEqual(host1, scanHost1) {
+		t.Fatalf("expected host %+v, got %+v", host1, scanHost1)
+	}
 }
 
 func TestSettingsAPI(t *testing.T) {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
@@ -19,6 +21,7 @@ import (
 	"go.sia.tech/indexd/pins"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
 
@@ -233,6 +236,37 @@ func TestExplorerAPI(t *testing.T) {
 		t.Fatal(err)
 	} else if rate == 0 {
 		t.Fatal("expected non-zero rate")
+	}
+}
+
+func TestSyncerAPI(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+
+	log := zaptest.NewLogger(t)
+	network, genesis := testutil.V2Network()
+	dbstore, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, chain.NewZapMigrationLogger(log.Named("chaindb")))
+	if err != nil {
+		t.Fatalf("failed to create chain store: %v", err)
+	}
+	cm := chain.NewManager(dbstore, tipState, chain.WithLog(log.Named("chain")))
+	s := testutils.NewSyncer(t, genesis.ID(), cm)
+	defer s.Close()
+
+	if err := indexer.SyncerConnect(s.Addr()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTxpoolAPI(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+
+	fee, err := indexer.TxpoolRecommendedFee()
+	if err != nil {
+		t.Fatal(err)
+	} else if fee == types.ZeroCurrency {
+		t.Fatal("expected non-zero fee")
 	}
 }
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -105,6 +105,12 @@ func (c *Client) Host(ctx context.Context, hostKey types.PublicKey) (h hosts.Hos
 	return
 }
 
+// ScanHost triggers a manual host scan.
+func (c *Client) ScanHost(hostKey types.PublicKey) (resp hosts.Host, err error) {
+	err = c.c.POST(context.Background(), fmt.Sprintf("/host/%s/scan", hostKey), nil, &resp)
+	return
+}
+
 // Hosts returns all hosts known to the indexer.
 func (c *Client) Hosts(ctx context.Context, opts ...HostQueryParameterOption) (hosts []hosts.Host, err error) {
 	values := url.Values{}

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -106,8 +106,8 @@ func (c *Client) Host(ctx context.Context, hostKey types.PublicKey) (h hosts.Hos
 }
 
 // ScanHost triggers a manual host scan.
-func (c *Client) ScanHost(hostKey types.PublicKey) (resp hosts.Host, err error) {
-	err = c.c.POST(context.Background(), fmt.Sprintf("/host/%s/scan", hostKey), nil, &resp)
+func (c *Client) ScanHost(ctx context.Context, hostKey types.PublicKey) (resp hosts.Host, err error) {
+	err = c.c.POST(ctx, fmt.Sprintf("/host/%s/scan", hostKey), nil, &resp)
 	return
 }
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -74,6 +74,19 @@ func (c *Client) Contracts(ctx context.Context, opts ...ContractQueryParameterOp
 	return
 }
 
+// SyncerConnect adds the address as a peer of the syncer.
+func (c *Client) SyncerConnect(addr string) (err error) {
+	err = c.c.POST(context.Background(), "/syncer/connect", addr, nil)
+	return
+}
+
+// TxpoolRecommendedFee returns the recommended fee (per weight unit) to ensure
+// a high probability of inclusion in the next block.
+func (c *Client) TxpoolRecommendedFee() (resp types.Currency, err error) {
+	err = c.c.GET(context.Background(), "/txpool/recommendedfee", &resp)
+	return
+}
+
 // State returns the current state of the indexer.
 func (c *Client) State(ctx context.Context) (state State, err error) {
 	err = c.c.GET(ctx, "/state", &state)

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -229,7 +229,7 @@ func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, f
 	logger.Debug("host has outdated prices, rescan")
 
 	// scan the host if the prices were outdated
-	host, err = m.scanHost(ctx, hk)
+	host, err = m.ScanHost(ctx, hk)
 	if err != nil {
 		return fmt.Errorf("failed to scan host, %w", err)
 	} else if !host.IsGood() {
@@ -320,9 +320,9 @@ func (m *HostManager) pruneHosts(ctx context.Context) {
 	}
 }
 
-// scanHost scans the host with given host key and returns it with updated
+// ScanHost scans the host with given host key and returns it with updated
 // settings and checks.
-func (m *HostManager) scanHost(ctx context.Context, hk types.PublicKey) (Host, error) {
+func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (Host, error) {
 	logger := m.log.With(zap.Stringer("hk", hk))
 
 	ctx, cancel := context.WithTimeout(ctx, scanTimeout)
@@ -398,7 +398,7 @@ loop:
 				wg.Done()
 			}()
 
-			if _, err := m.scanHost(ctx, hk); errors.Is(err, context.Canceled) {
+			if _, err := m.ScanHost(ctx, hk); errors.Is(err, context.Canceled) {
 				return
 			} else if errors.Is(err, errNodeOffline) {
 				once.Do(func() { m.log.Warn("indexer is offline, skipping scans") })

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -240,6 +240,55 @@ func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, f
 	return fn(host)
 }
 
+// ScanHost scans the host with given host key and returns it with updated
+// settings and checks.
+func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (Host, error) {
+	logger := m.log.With(zap.Stringer("hk", hk))
+
+	ctx, cancel := context.WithTimeout(ctx, scanTimeout)
+	defer cancel()
+
+	host, err := m.store.Host(ctx, hk)
+	if err != nil {
+		return Host{}, fmt.Errorf("failed to get host, %w", err)
+	}
+
+	addrs, networks, err := resolveHost(ctx, m.resolver, host.Addresses, logger)
+	if err != nil {
+		return Host{}, fmt.Errorf("failed to resolve host, %w", err)
+	}
+
+	settings, err := fetchSettings(ctx, m.scanner, hk, addrs, logger)
+	if err != nil {
+		return Host{}, fmt.Errorf("failed to fetch settings, %w", err)
+	}
+
+	consecutiveFailures := host.ConsecutiveFailedScans
+	success := settings != (proto4.HostSettings{})
+	if !success && !m.onlineChecker.IsOnline() {
+		return Host{}, errNodeOffline
+	} else if !success {
+		consecutiveFailures++
+	}
+
+	nextScan := calculateNextScanTime(
+		time.Now(),
+		success,
+		consecutiveFailures,
+		m.scanInterval,
+		scanIntervalOffsetHours,
+		scanExponentialBackoffHours,
+		scanExponentialBackoffMaxHours,
+	)
+
+	err = m.store.UpdateHost(ctx, hk, networks, settings, success, nextScan)
+	if err != nil {
+		return Host{}, fmt.Errorf("failed to update host, %w", err)
+	}
+
+	return m.store.Host(ctx, hk)
+}
+
 // UpdateChainState updates the host announcements in the database.
 func (m *HostManager) UpdateChainState(tx UpdateTx, applied []chain.ApplyUpdate) error {
 	for _, update := range applied {
@@ -318,55 +367,6 @@ func (m *HostManager) pruneHosts(ctx context.Context) {
 			zap.Int64("removed", n),
 		)
 	}
-}
-
-// ScanHost scans the host with given host key and returns it with updated
-// settings and checks.
-func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (Host, error) {
-	logger := m.log.With(zap.Stringer("hk", hk))
-
-	ctx, cancel := context.WithTimeout(ctx, scanTimeout)
-	defer cancel()
-
-	host, err := m.store.Host(ctx, hk)
-	if err != nil {
-		return Host{}, fmt.Errorf("failed to get host, %w", err)
-	}
-
-	addrs, networks, err := resolveHost(ctx, m.resolver, host.Addresses, logger)
-	if err != nil {
-		return Host{}, fmt.Errorf("failed to resolve host, %w", err)
-	}
-
-	settings, err := fetchSettings(ctx, m.scanner, hk, addrs, logger)
-	if err != nil {
-		return Host{}, fmt.Errorf("failed to fetch settings, %w", err)
-	}
-
-	consecutiveFailures := host.ConsecutiveFailedScans
-	success := settings != (proto4.HostSettings{})
-	if !success && !m.onlineChecker.IsOnline() {
-		return Host{}, errNodeOffline
-	} else if !success {
-		consecutiveFailures++
-	}
-
-	nextScan := calculateNextScanTime(
-		time.Now(),
-		success,
-		consecutiveFailures,
-		m.scanInterval,
-		scanIntervalOffsetHours,
-		scanExponentialBackoffHours,
-		scanExponentialBackoffMaxHours,
-	)
-
-	err = m.store.UpdateHost(ctx, hk, networks, settings, success, nextScan)
-	if err != nil {
-		return Host{}, fmt.Errorf("failed to update host, %w", err)
-	}
-
-	return m.store.Host(ctx, hk)
 }
 
 func (m *HostManager) scanHosts(ctx context.Context, hosts []types.PublicKey) {

--- a/internal/testutils/host.go
+++ b/internal/testutils/host.go
@@ -88,7 +88,7 @@ func (h *Host) Announce() error {
 
 // Connect connects the host's syncer with the given peer.
 func (h *Host) Connect(ctx context.Context, addr string) error {
-	_, err := h.s.Connect(addr)
+	_, err := h.s.Connect(ctx, addr)
 	return err
 }
 

--- a/internal/testutils/syncer.go
+++ b/internal/testutils/syncer.go
@@ -68,8 +68,8 @@ func (s *Syncer) Close() error {
 }
 
 // Connect forms an outbound connection to a peer.
-func (s *Syncer) Connect(addr string) (*syncer.Peer, error) {
-	return s.s.Connect(context.Background(), addr)
+func (s *Syncer) Connect(ctx context.Context, addr string) (*syncer.Peer, error) {
+	return s.s.Connect(ctx, addr)
 }
 
 // Peers returns the set of currently-connected peers.


### PR DESCRIPTION
Add:
- `/syncer/connect`
- `/host/:hostkey/scan`
- `/txpool/recommendedfee`

with tests.  It doesn't seem possible to get a single event from a `SingleAddressWallet` which is needed for `/wallet/event/:id` if we want it to be efficient.  Do we want to make a PR in coreutils?

#246