### PR TITLE
SDK: Wrap the io.Writer in Download function in a buffer

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -360,6 +361,7 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata []Slab, opts .
 		workCh <- work{err: io.EOF}
 	}(ctx, metadata)
 
+	bw := bufio.NewWriterSize(w, 1<<16)
 	for i := 0; ; i++ {
 		select {
 		case <-ctx.Done():
@@ -368,12 +370,15 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata []Slab, opts .
 			err := work.err
 			if errors.Is(err, io.EOF) {
 				// EOF signals completion
+				if err := bw.Flush(); err != nil {
+					return fmt.Errorf("failed to flush write: %w", err)
+				}
 				return nil
 			} else if err != nil {
 				return err
 			}
 			slab := metadata[i]
-			if err := stripedJoin(w, work.shards, int(slab.Length)); err != nil {
+			if err := stripedJoin(bw, work.shards, int(slab.Length)); err != nil {
 				return fmt.Errorf("failed to write slab %d: %w", i, err)
 			}
 		}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"runtime"
 	"testing"
 	"time"
@@ -41,6 +42,50 @@ func TestRoundtrip(t *testing.T) {
 	if !bytes.Equal(buf.Bytes(), data) {
 		t.Fatal("data mismatch")
 	}
+}
+
+type countWriter struct {
+	count int
+
+	w io.Writer
+}
+
+func (c *countWriter) Write(p []byte) (int, error) {
+	c.count++
+	return c.w.Write(p)
+}
+
+func TestRoundtripCount(t *testing.T) {
+	dialer := newMockDialer(50)
+
+	appKey := types.GeneratePrivateKey()
+
+	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 1 MB
+	data := frand.Bytes(1 << 20)
+	slabs, err := s.Upload(context.Background(), bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("failed to upload: %v", err)
+	} else if len(slabs) != 1 {
+		t.Fatalf("expected 1 slab, got %d", len(slabs))
+	} else if slabs[0].Length != uint32(len(data)) {
+		t.Fatalf("expected slab length %d, got %d", len(data), slabs[0].Length)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	cw := &countWriter{w: buf}
+	if err := s.Download(context.Background(), cw, slabs); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("data mismatch")
+	}
+	t.Logf("Downloaded: %d bytes, Write calls: %d", buf.Len(), cw.count)
 }
 
 func TestUpload(t *testing.T) {


### PR DESCRIPTION
#203 

Before:
```
    client_test.go:88: Downloaded: 1048576 bytes, Write calls: 16390
```

After:
```
    client_test.go:88: Downloaded: 1048576 bytes, Write calls: 16
```

Not sure if we actually want to keep the test since it isn't testing anything that `TestRoundtrip` isn't.