### PR TITLE
Add host dialer

### DIFF
--- a/api/app/client.go
+++ b/api/app/client.go
@@ -58,7 +58,7 @@ func (c *Client) sign(route string) string {
 }
 
 // Hosts returns all usable hosts.
-func (c *Client) Hosts(ctx context.Context, opts ...api.URLQueryParameterOption) (hosts []hosts.Host, err error) {
+func (c *Client) Hosts(ctx context.Context, opts ...api.URLQueryParameterOption) (hosts []hosts.HostInfo, err error) {
 	values := url.Values{}
 	for _, opt := range opts {
 		opt(values)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -112,7 +112,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 	}
 
 	var hostsMu sync.Mutex
-	hosts := s.dialer.Hosts()
+	hosts := shuffle(s.dialer.Hosts())
 	if len(hosts) < len(shards) {
 		return slabs.SlabPinParams{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -48,7 +48,7 @@ type (
 	HostDialer interface {
 		// Hosts returns the public keys of all hosts that are available for
 		// upload or download.
-		Hosts(context.Context) ([]types.PublicKey, error)
+		Hosts() []types.PublicKey
 
 		// WriteSector writes a sector to the host identified by the public key.
 		WriteSector(context.Context, types.PublicKey, *[proto4.SectorSize]byte) (types.Hash256, error)
@@ -112,10 +112,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 	}
 
 	var hostsMu sync.Mutex
-	hosts, err := s.dialer.Hosts(ctx)
-	if err != nil {
-		return slabs.SlabPinParams{}, fmt.Errorf("failed to get usable hosts: %w", err)
-	}
+	hosts := s.dialer.Hosts()
 	if len(hosts) < len(shards) {
 		return slabs.SlabPinParams{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -14,7 +14,9 @@ import (
 	"github.com/klauspost/reedsolomon"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/app"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
 	"golang.org/x/crypto/chacha20"
 	"lukechampine.com/frand"
@@ -38,6 +40,7 @@ type (
 		PinSlab(context.Context, slabs.SlabPinParams) (slabs.SlabID, error)
 		UnpinSlab(context.Context, slabs.SlabID) error
 
+		Hosts(context.Context, ...api.URLQueryParameterOption) ([]hosts.Host, error)
 		Slab(context.Context, slabs.SlabID) (slabs.PinnedSlab, error)
 	}
 
@@ -45,7 +48,7 @@ type (
 	HostDialer interface {
 		// Hosts returns the public keys of all hosts that are available for
 		// upload or download.
-		Hosts() []types.PublicKey
+		Hosts(context.Context) ([]types.PublicKey, error)
 
 		// WriteSector writes a sector to the host identified by the public key.
 		WriteSector(context.Context, types.PublicKey, *[proto4.SectorSize]byte) (types.Hash256, error)
@@ -109,7 +112,10 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 	}
 
 	var hostsMu sync.Mutex
-	hosts := shuffle(s.dialer.Hosts())
+	hosts, err := s.dialer.Hosts(ctx)
+	if err != nil {
+		return slabs.SlabPinParams{}, fmt.Errorf("failed to get usable hosts: %w", err)
+	}
 	if len(hosts) < len(shards) {
 		return slabs.SlabPinParams{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
 	}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -40,7 +40,7 @@ type (
 		PinSlab(context.Context, slabs.SlabPinParams) (slabs.SlabID, error)
 		UnpinSlab(context.Context, slabs.SlabID) error
 
-		Hosts(context.Context, ...api.URLQueryParameterOption) ([]hosts.Host, error)
+		Hosts(context.Context, ...api.URLQueryParameterOption) ([]hosts.HostInfo, error)
 		Slab(context.Context, slabs.SlabID) (slabs.PinnedSlab, error)
 	}
 

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -32,12 +32,12 @@ type connEntry struct {
 
 // Dialer implements the HostDialer interface.
 type Dialer struct {
-	mu  sync.Mutex
 	log *zap.Logger
 
 	c      AppClient
 	appKey types.PrivateKey
 
+	mu             sync.Mutex
 	tg             *threadgroup.ThreadGroup
 	addrs          map[types.PublicKey][]chain.NetAddress
 	conns          map[types.PublicKey]*connEntry
@@ -57,30 +57,11 @@ func NewDialer(c AppClient, appKey types.PrivateKey, log *zap.Logger) (*Dialer, 
 		conns:          make(map[types.PublicKey]*connEntry),
 		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
 	}
-
-	// Run immediately
-	if err := d.updateHosts(context.Background()); err != nil {
+	if err := d.initHosts(); err != nil {
 		return nil, err
 	}
-	go d.refreshHosts()
 
 	return d, nil
-}
-
-func (d *Dialer) refreshHosts() {
-	ticker := time.NewTicker(10 * time.Minute)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if err := d.updateHosts(context.Background()); err != nil {
-				d.log.Warn("Failed to refresh hosts list", zap.Error(err))
-			}
-		case <-d.tg.Done():
-			return
-		}
-	}
 }
 
 // Close closes all the open connections on the dialer.
@@ -101,6 +82,43 @@ func (d *Dialer) Close() {
 		entry.mu.Unlock()
 	}
 	clear(d.conns)
+}
+
+func (d *Dialer) initHosts() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// init hosts
+	err := d.updateHosts(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to refresh hosts list: %w", err)
+	}
+
+	// refresh in bg thread
+	ctx, cancel, err = d.tg.AddContext(context.Background())
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		defer cancel()
+
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				if err := d.updateHosts(context.Background()); err != nil {
+					d.log.Warn("Failed to refresh hosts list", zap.Error(err))
+				}
+			case <-d.tg.Done():
+				return
+			}
+		}
+	}()
+
+	return nil
 }
 
 func (d *Dialer) updateHosts(ctx context.Context) error {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -27,7 +27,9 @@ var _ HostDialer = (*Dialer)(nil)
 type connEntry struct {
 	mu   sync.Mutex
 	dial chan struct{} // signals dial completion
-	tc   rhp.TransportClient
+
+	hostKey types.PublicKey
+	tc      rhp.TransportClient
 }
 
 // Dialer implements the HostDialer interface.
@@ -69,19 +71,23 @@ func (d *Dialer) Close() {
 	d.tg.Stop()
 
 	d.mu.Lock()
-	defer d.mu.Unlock()
+	conns := slices.Collect(maps.Values(d.conns))
+	d.mu.Unlock()
 
-	for hostKey, entry := range d.conns {
+	for _, entry := range conns {
 		entry.mu.Lock()
 		if entry.tc != nil {
 			if err := entry.tc.Close(); err != nil {
-				d.log.Debug("Failed to close connection", zap.Stringer("pk", hostKey), zap.Error(err))
+				d.log.Debug("Failed to close connection", zap.Stringer("pk", entry.hostKey), zap.Error(err))
 			}
 		}
 		entry.tc = nil
 		entry.mu.Unlock()
 	}
+
+	d.mu.Lock()
 	clear(d.conns)
+	d.mu.Unlock()
 }
 
 func (d *Dialer) initHosts() error {
@@ -188,7 +194,7 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 	// Get or create connection entry
 	entry, exists := d.conns[hostKey]
 	if !exists {
-		entry = &connEntry{}
+		entry = &connEntry{hostKey: hostKey}
 		d.conns[hostKey] = entry
 	}
 	d.mu.Unlock()

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -86,27 +86,21 @@ func (d *Dialer) Start(ctx context.Context) (func(), error) {
 }
 
 // Close closes all the open connections on the dialer.
-func (d *Dialer) Close() error {
+func (d *Dialer) Close() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	var errs []error
-	for _, entry := range d.conns {
+	for hostKey, entry := range d.conns {
 		entry.mu.Lock()
 		if entry.tc != nil {
 			if err := entry.tc.Close(); err != nil {
-				errs = append(errs, err)
+				d.log.Debug("Failed to close connection", zap.Stringer("pk", hostKey), zap.Error(err))
 			}
-			entry.tc = nil
 		}
+		entry.tc = nil
 		entry.mu.Unlock()
 	}
 	clear(d.conns)
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-	return nil
 }
 
 func (d *Dialer) updateHosts(ctx context.Context) error {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -1,0 +1,145 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4/quic"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/indexd/hosts"
+)
+
+var _ HostDialer = (*Dialer)(nil)
+
+type Dialer struct {
+	c      AppClient
+	appKey types.PrivateKey
+
+	hosts map[types.PublicKey]hosts.Host
+	conns map[types.PublicKey]rhp.TransportClient
+}
+
+func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
+	return &Dialer{
+		c:      c,
+		appKey: appKey,
+
+		hosts: make(map[types.PublicKey]hosts.Host),
+		conns: make(map[types.PublicKey]rhp.TransportClient),
+	}
+}
+
+// Hosts returns the public keys of all hosts that are available for
+// upload or download.
+func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
+	hosts, err := d.c.Hosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	clear(d.hosts)
+	pks := make([]types.PublicKey, 0, len(hosts))
+
+	for _, host := range hosts {
+		pks = append(pks, host.PublicKey)
+		d.hosts[host.PublicKey] = host
+	}
+	return pks, nil
+}
+
+func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey, reuse bool) (rhp.TransportClient, error) {
+	if tc, ok := d.conns[hostKey]; ok && reuse {
+		// we have an existing connection
+		return tc, nil
+	}
+
+	h, ok := d.hosts[hostKey]
+	if !ok {
+		return nil, fmt.Errorf("we haven't seen host")
+	}
+
+	for _, addr := range h.Addresses {
+		if addr.Protocol == siamux.Protocol {
+			tc, err := siamux.Dial(ctx, addr.Address, hostKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to dial host over siamux: %w", err)
+			}
+			d.conns[hostKey] = tc
+			return tc, nil
+		} else if addr.Protocol == quic.Protocol {
+			tc, err := quic.Dial(ctx, addr.Address, hostKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to dial host over quic: %w", err)
+			}
+			d.conns[hostKey] = tc
+			return tc, nil
+		}
+	}
+	return nil, errors.New("host has no supported protocols")
+}
+
+func (d *Dialer) settings(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, proto.HostPrices, error) {
+	// reuse connection if we can
+	tc, err := d.dialHost(ctx, hostKey, true)
+	if err != nil {
+		return nil, proto.HostPrices{}, fmt.Errorf("failed to dial host: %w", err)
+	}
+
+	settings, err := rhp.RPCSettings(ctx, tc)
+	if proto.ErrorCode(err) == proto.ErrorCodeTransport {
+		tc, err = d.dialHost(ctx, hostKey, false)
+		if err != nil {
+			return nil, proto.HostPrices{}, fmt.Errorf("failed to retry connecting to host: %w", err)
+		}
+		settings, err = rhp.RPCSettings(ctx, tc)
+		if err != nil {
+			return nil, proto.HostPrices{}, fmt.Errorf("failed to retry getting settings: %w", err)
+		}
+	} else if err != nil {
+		return nil, proto.HostPrices{}, fmt.Errorf("failed to get settings: %w", err)
+	}
+
+	return tc, settings.Prices, nil
+}
+
+// WriteSector writes a sector to the host identified by the public key.
+func (d *Dialer) WriteSector(ctx context.Context, hostKey types.PublicKey, sector *[proto.SectorSize]byte) (types.Hash256, error) {
+	tc, prices, err := d.settings(ctx, hostKey)
+	if err != nil {
+		return types.Hash256{}, err
+	}
+
+	token := (&proto.Account{}).Token(d.appKey, hostKey)
+	result, err := rhp.RPCWriteSector(ctx, tc, prices, token, bytes.NewReader(sector[:]), proto.SectorSize)
+	if err != nil {
+		return types.Hash256{}, fmt.Errorf("failed to write sector: %w", err)
+	}
+
+	return result.Root, nil
+}
+
+// ReadSector reads a sector from the host identified by the public key.
+func (d *Dialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sectorRoot types.Hash256) (*[proto.SectorSize]byte, error) {
+	tc, prices, err := d.settings(ctx, hostKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	token := (&proto.Account{}).Token(d.appKey, hostKey)
+	if _, err := rhp.RPCReadSector(ctx, tc, prices, token, &buf, sectorRoot, 0, proto.SectorSize); err != nil {
+		return nil, fmt.Errorf("failed to read sector: %w", err)
+	} else if buf.Len() != proto.SectorSize {
+		return nil, fmt.Errorf("did not receive full sector: expected length %d, got %d", proto.SectorSize, buf.Len())
+	}
+
+	var result [proto.SectorSize]byte
+	copy(result[:], buf.Bytes())
+
+	return &result, nil
+}

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -145,6 +146,13 @@ func (d *Dialer) retry(ctx context.Context, hostKey types.PublicKey, fn func(rhp
 }
 
 func (d *Dialer) prices(ctx context.Context, hostKey types.PublicKey) (proto.HostPrices, error) {
+	d.mu.Lock()
+	if settings, ok := d.cachedSettings[hostKey]; ok && time.Now().Before(settings.Prices.ValidUntil) {
+		d.mu.Unlock()
+		return settings.Prices, nil
+	}
+	d.mu.Unlock()
+
 	var settings proto.HostSettings
 	err := d.retry(ctx, hostKey, func(tc rhp.TransportClient) (err error) {
 		settings, err = rhp.RPCSettings(ctx, tc)

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -17,6 +17,7 @@ import (
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/api"
 	"go.uber.org/zap"
 )
@@ -37,56 +38,55 @@ type Dialer struct {
 	c      AppClient
 	appKey types.PrivateKey
 
+	tg             *threadgroup.ThreadGroup
 	addrs          map[types.PublicKey][]chain.NetAddress
 	conns          map[types.PublicKey]*connEntry
 	cachedSettings map[types.PublicKey]proto.HostSettings
 }
 
 // NewDialer returns a new Dialer.
-func NewDialer(c AppClient, appKey types.PrivateKey, log *zap.Logger) *Dialer {
-	return &Dialer{
+func NewDialer(c AppClient, appKey types.PrivateKey, log *zap.Logger) (*Dialer, error) {
+	d := &Dialer{
 		log: log,
 
 		c:      c,
 		appKey: appKey,
 
+		tg:             threadgroup.New(),
 		addrs:          make(map[types.PublicKey][]chain.NetAddress),
 		conns:          make(map[types.PublicKey]*connEntry),
 		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
 	}
-}
 
-// Start starts the goroutine that periodically refreshes the map of host
-// addresses
-func (d *Dialer) Start(ctx context.Context) (func(), error) {
-	if err := d.updateHosts(ctx); err != nil {
+	// Run immediately
+	if err := d.updateHosts(context.Background()); err != nil {
 		return nil, err
 	}
+	go d.refreshHosts()
 
-	ctx, cancel := context.WithCancel(ctx)
+	return d, nil
+}
+
+func (d *Dialer) refreshHosts() {
 	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
 
-	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				if err := d.updateHosts(ctx); err != nil {
-					d.log.Warn("Failed to refresh hosts list", zap.Error(err))
-				}
-			case <-ctx.Done():
-				return
+	for {
+		select {
+		case <-ticker.C:
+			if err := d.updateHosts(context.Background()); err != nil {
+				d.log.Warn("Failed to refresh hosts list", zap.Error(err))
 			}
+		case <-d.tg.Done():
+			return
 		}
-	}()
-
-	return func() {
-		ticker.Stop()
-		cancel()
-	}, nil
+	}
 }
 
 // Close closes all the open connections on the dialer.
 func (d *Dialer) Close() {
+	d.tg.Stop()
+
 	d.mu.Lock()
 	defer d.mu.Unlock()
 

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -287,7 +287,7 @@ func (d *Dialer) WriteSector(ctx context.Context, hostKey types.PublicKey, secto
 
 	var result rhp.RPCWriteSectorResult
 	err = d.retry(ctx, hostKey, func(tc rhp.TransportClient) (err error) {
-		token := (&proto.Account{}).Token(d.appKey, hostKey)
+		token := proto.NewAccountToken(d.appKey, hostKey)
 		result, err = rhp.RPCWriteSector(ctx, tc, prices, token, bytes.NewReader(sector[:]), proto.SectorSize)
 		return
 	})
@@ -307,7 +307,7 @@ func (d *Dialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sector
 
 	var buf bytes.Buffer
 	err = d.retry(ctx, hostKey, func(tc rhp.TransportClient) (err error) {
-		token := (&proto.Account{}).Token(d.appKey, hostKey)
+		token := proto.NewAccountToken(d.appKey, hostKey)
 		_, err = rhp.RPCReadSector(ctx, tc, prices, token, &buf, sectorRoot, 0, proto.SectorSize)
 		return
 	})

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -48,13 +48,17 @@ func (d *Dialer) Close() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	for _, conn := range d.conns {
-		if err := conn.Close(); err != nil {
-			return err
+	var errs []error
+	for i := range d.conns {
+		if err := d.conns[i].Close(); err != nil {
+			errs = append(errs, err)
 		}
 	}
 	clear(d.conns)
 
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
 	return nil
 }
 

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -25,22 +25,22 @@ import (
 var _ HostDialer = (*Dialer)(nil)
 
 type connEntry struct {
+	hostKey types.PublicKey
+
 	mu   sync.Mutex
 	dial chan struct{} // signals dial completion
-
-	hostKey types.PublicKey
-	tc      rhp.TransportClient
+	tc   rhp.TransportClient
 }
 
 // Dialer implements the HostDialer interface.
 type Dialer struct {
 	log *zap.Logger
+	tg  *threadgroup.ThreadGroup
 
 	c      AppClient
 	appKey types.PrivateKey
 
 	mu             sync.Mutex
-	tg             *threadgroup.ThreadGroup
 	addrs          map[types.PublicKey][]chain.NetAddress
 	conns          map[types.PublicKey]*connEntry
 	cachedSettings map[types.PublicKey]proto.HostSettings
@@ -84,10 +84,7 @@ func (d *Dialer) Close() {
 		entry.tc = nil
 		entry.mu.Unlock()
 	}
-
-	d.mu.Lock()
 	clear(d.conns)
-	d.mu.Unlock()
 }
 
 func (d *Dialer) initHosts() error {
@@ -245,6 +242,8 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 			tc, err = siamux.Dial(ctx, addr.Address, hostKey)
 			if err == nil {
 				return tc, nil
+			} else {
+				return nil, err
 			}
 		}
 	}
@@ -253,6 +252,8 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 			tc, err = quic.Dial(ctx, addr.Address, hostKey)
 			if err == nil {
 				return tc, nil
+			} else {
+				return nil, err
 			}
 		}
 	}

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -24,8 +25,9 @@ type Dialer struct {
 	c      AppClient
 	appKey types.PrivateKey
 
-	addrs map[types.PublicKey][]chain.NetAddress
-	conns map[types.PublicKey]rhp.TransportClient
+	addrs          map[types.PublicKey][]chain.NetAddress
+	conns          map[types.PublicKey]rhp.TransportClient
+	cachedSettings map[types.PublicKey]proto.HostSettings
 }
 
 func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
@@ -33,8 +35,9 @@ func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 		c:      c,
 		appKey: appKey,
 
-		addrs: make(map[types.PublicKey][]chain.NetAddress),
-		conns: make(map[types.PublicKey]rhp.TransportClient),
+		addrs:          make(map[types.PublicKey][]chain.NetAddress),
+		conns:          make(map[types.PublicKey]rhp.TransportClient),
+		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
 	}
 }
 
@@ -107,6 +110,10 @@ func (d *Dialer) settings(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 		return nil, proto.HostPrices{}, fmt.Errorf("failed to dial host: %w", err)
 	}
 
+	if settings, ok := d.cachedSettings[hostKey]; ok && time.Now().Before(settings.Prices.ValidUntil) {
+		return tc, settings.Prices, nil
+	}
+
 	settings, err := rhp.RPCSettings(ctx, tc)
 	if proto.ErrorCode(err) == proto.ErrorCodeTransport {
 		tc, err = d.dialHost(ctx, hostKey, false)
@@ -120,6 +127,7 @@ func (d *Dialer) settings(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 	} else if err != nil {
 		return nil, proto.HostPrices{}, fmt.Errorf("failed to get settings: %w", err)
 	}
+	d.cachedSettings[hostKey] = settings
 
 	return tc, settings.Prices, nil
 }

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -156,7 +156,7 @@ func (d *Dialer) retry(ctx context.Context, hostKey types.PublicKey, fn func(rhp
 
 func (d *Dialer) prices(ctx context.Context, hostKey types.PublicKey) (proto.HostPrices, error) {
 	d.mu.Lock()
-	if settings, ok := d.cachedSettings[hostKey]; ok && time.Now().Before(settings.Prices.ValidUntil) {
+	if settings, ok := d.cachedSettings[hostKey]; ok && time.Now().Add(5*time.Second).Before(settings.Prices.ValidUntil) {
 		d.mu.Unlock()
 		return settings.Prices, nil
 	}

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -11,6 +11,7 @@ import (
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
+	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
 )
 
@@ -37,17 +38,24 @@ func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 // Hosts returns the public keys of all hosts that are available for
 // upload or download.
 func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
-	hosts, err := d.c.Hosts(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	clear(d.hosts)
-	pks := make([]types.PublicKey, 0, len(hosts))
+	offset, limit := 0, 100
+	var pks []types.PublicKey
+	for {
+		hosts, err := d.c.Hosts(ctx, api.WithOffset(offset), api.WithLimit(limit))
+		if err != nil {
+			return nil, err
+		}
 
-	for _, host := range hosts {
-		pks = append(pks, host.PublicKey)
-		d.hosts[host.PublicKey] = host
+		for _, host := range hosts {
+			pks = append(pks, host.PublicKey)
+			d.hosts[host.PublicKey] = host
+		}
+
+		offset += len(hosts)
+		if len(hosts) < limit {
+			break
+		}
 	}
 	return pks, nil
 }

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -115,47 +114,66 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey, reuse bo
 	return nil, errors.New("host has no supported protocols")
 }
 
-func (d *Dialer) settings(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, proto.HostPrices, error) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
+func (d *Dialer) retry(ctx context.Context, hostKey types.PublicKey, fn func(rhp.TransportClient) error) error {
 	// reuse connection if we can
+	d.mu.Lock()
 	tc, err := d.dialHost(ctx, hostKey, true)
 	if err != nil {
-		return nil, proto.HostPrices{}, fmt.Errorf("failed to dial host: %w", err)
+		d.mu.Unlock()
+		return fmt.Errorf("failed to dial host: %w", err)
+	}
+	d.mu.Unlock()
+
+	if err := fn(tc); err != nil && proto.ErrorCode(err) != proto.ErrorCodeTransport {
+		// we received a non transport related error
+		return err
+	} else if err == nil {
+		// success
+		return nil
 	}
 
-	if settings, ok := d.cachedSettings[hostKey]; ok && time.Now().Before(settings.Prices.ValidUntil) {
-		return tc, settings.Prices, nil
+	// we got a transport error, try reconnecting and trying again
+	d.mu.Lock()
+	tc, err = d.dialHost(ctx, hostKey, false)
+	if err != nil {
+		d.mu.Unlock()
+		return fmt.Errorf("failed to redial host: %w", err)
 	}
+	d.mu.Unlock()
 
-	settings, err := rhp.RPCSettings(ctx, tc)
-	if proto.ErrorCode(err) == proto.ErrorCodeTransport {
-		tc, err = d.dialHost(ctx, hostKey, false)
-		if err != nil {
-			return nil, proto.HostPrices{}, fmt.Errorf("failed to retry connecting to host: %w", err)
-		}
+	return fn(tc)
+}
+
+func (d *Dialer) prices(ctx context.Context, hostKey types.PublicKey) (proto.HostPrices, error) {
+	var settings proto.HostSettings
+	err := d.retry(ctx, hostKey, func(tc rhp.TransportClient) (err error) {
 		settings, err = rhp.RPCSettings(ctx, tc)
-		if err != nil {
-			return nil, proto.HostPrices{}, fmt.Errorf("failed to retry getting settings: %w", err)
-		}
-	} else if err != nil {
-		return nil, proto.HostPrices{}, fmt.Errorf("failed to get settings: %w", err)
+		return err
+	})
+	if err != nil {
+		return proto.HostPrices{}, nil
 	}
-	d.cachedSettings[hostKey] = settings
 
-	return tc, settings.Prices, nil
+	d.mu.Lock()
+	d.cachedSettings[hostKey] = settings
+	d.mu.Unlock()
+
+	return settings.Prices, nil
 }
 
 // WriteSector writes a sector to the host identified by the public key.
 func (d *Dialer) WriteSector(ctx context.Context, hostKey types.PublicKey, sector *[proto.SectorSize]byte) (types.Hash256, error) {
-	tc, prices, err := d.settings(ctx, hostKey)
+	prices, err := d.prices(ctx, hostKey)
 	if err != nil {
-		return types.Hash256{}, err
+		return types.Hash256{}, fmt.Errorf("failed to get prices: %w", err)
 	}
 
-	token := (&proto.Account{}).Token(d.appKey, hostKey)
-	result, err := rhp.RPCWriteSector(ctx, tc, prices, token, bytes.NewReader(sector[:]), proto.SectorSize)
+	var result rhp.RPCWriteSectorResult
+	err = d.retry(ctx, hostKey, func(tc rhp.TransportClient) (err error) {
+		token := (&proto.Account{}).Token(d.appKey, hostKey)
+		result, err = rhp.RPCWriteSector(ctx, tc, prices, token, bytes.NewReader(sector[:]), proto.SectorSize)
+		return
+	})
 	if err != nil {
 		return types.Hash256{}, fmt.Errorf("failed to write sector: %w", err)
 	}
@@ -165,14 +183,18 @@ func (d *Dialer) WriteSector(ctx context.Context, hostKey types.PublicKey, secto
 
 // ReadSector reads a sector from the host identified by the public key.
 func (d *Dialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sectorRoot types.Hash256) (*[proto.SectorSize]byte, error) {
-	tc, prices, err := d.settings(ctx, hostKey)
+	prices, err := d.prices(ctx, hostKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get prices: %w", err)
 	}
 
 	var buf bytes.Buffer
-	token := (&proto.Account{}).Token(d.appKey, hostKey)
-	if _, err := rhp.RPCReadSector(ctx, tc, prices, token, &buf, sectorRoot, 0, proto.SectorSize); err != nil {
+	err = d.retry(ctx, hostKey, func(tc rhp.TransportClient) (err error) {
+		token := (&proto.Account{}).Token(d.appKey, hostKey)
+		_, err = rhp.RPCReadSector(ctx, tc, prices, token, &buf, sectorRoot, 0, proto.SectorSize)
+		return
+	})
+	if err != nil {
 		return nil, fmt.Errorf("failed to read sector: %w", err)
 	} else if buf.Len() != proto.SectorSize {
 		return nil, fmt.Errorf("did not receive full sector: expected length %d, got %d", proto.SectorSize, buf.Len())
@@ -180,6 +202,5 @@ func (d *Dialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sector
 
 	var result [proto.SectorSize]byte
 	copy(result[:], buf.Bytes())
-
 	return &result, nil
 }

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -123,7 +123,7 @@ func (d *Dialer) initHosts() error {
 		return fmt.Errorf("failed to refresh hosts list: %w", err)
 	}
 
-	// refresh in bg thread
+	// refresh in background thread
 	ctx, cancel, err = d.tg.AddContext(context.Background())
 	if err != nil {
 		return err
@@ -313,7 +313,7 @@ func (d *Dialer) prices(ctx context.Context, hostKey types.PublicKey) (proto.Hos
 		return err
 	})
 	if err != nil {
-		return proto.HostPrices{}, nil
+		return proto.HostPrices{}, err
 	}
 
 	d.mu.Lock()

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -104,12 +104,18 @@ func (d *Dialer) Close() {
 }
 
 func (d *Dialer) updateHosts(ctx context.Context) error {
+	ctx, cancel, err := d.tg.AddContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to add thread to thread group: %w", err)
+	}
+	defer cancel()
+
 	offset, limit := 0, 100
 	addrs := make(map[types.PublicKey][]chain.NetAddress)
 	for {
 		hosts, err := d.c.Hosts(ctx, api.WithOffset(offset), api.WithLimit(limit))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get hosts: %w", err)
 		}
 
 		for _, host := range hosts {
@@ -280,6 +286,12 @@ func (d *Dialer) prices(ctx context.Context, hostKey types.PublicKey) (proto.Hos
 
 // WriteSector writes a sector to the host identified by the public key.
 func (d *Dialer) WriteSector(ctx context.Context, hostKey types.PublicKey, sector *[proto.SectorSize]byte) (types.Hash256, error) {
+	ctx, cancel, err := d.tg.AddContext(ctx)
+	if err != nil {
+		return types.Hash256{}, fmt.Errorf("failed to add thread to thread group: %w", err)
+	}
+	defer cancel()
+
 	prices, err := d.prices(ctx, hostKey)
 	if err != nil {
 		return types.Hash256{}, fmt.Errorf("failed to get prices: %w", err)
@@ -300,6 +312,12 @@ func (d *Dialer) WriteSector(ctx context.Context, hostKey types.PublicKey, secto
 
 // ReadSector reads a sector from the host identified by the public key.
 func (d *Dialer) ReadSector(ctx context.Context, hostKey types.PublicKey, sectorRoot types.Hash256) (*[proto.SectorSize]byte, error) {
+	ctx, cancel, err := d.tg.AddContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add thread to thread group: %w", err)
+	}
+	defer cancel()
+
 	prices, err := d.prices(ctx, hostKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get prices: %w", err)

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -41,6 +41,21 @@ func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 	}
 }
 
+// Close closes all the open connections on the dialer.
+func (d *Dialer) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for _, conn := range d.conns {
+		if err := conn.Close(); err != nil {
+			return err
+		}
+	}
+	clear(d.conns)
+
+	return nil
+}
+
 // Hosts returns the public keys of all hosts that are available for
 // upload or download.
 func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -102,17 +102,20 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey, reuse bo
 	}
 
 	for _, addr := range h {
+		if addr.Protocol == quic.Protocol {
+			tc, err := quic.Dial(ctx, addr.Address, hostKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to dial host over quic: %w", err)
+			}
+			d.conns[hostKey] = tc
+			return tc, nil
+		}
+	}
+	for _, addr := range h {
 		if addr.Protocol == siamux.Protocol {
 			tc, err := siamux.Dial(ctx, addr.Address, hostKey)
 			if err != nil {
 				return nil, fmt.Errorf("failed to dial host over siamux: %w", err)
-			}
-			d.conns[hostKey] = tc
-			return tc, nil
-		} else if addr.Protocol == quic.Protocol {
-			tc, err := quic.Dial(ctx, addr.Address, hostKey)
-			if err != nil {
-				return nil, fmt.Errorf("failed to dial host over quic: %w", err)
 			}
 			d.conns[hostKey] = tc
 			return tc, nil

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
+
+	"maps"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -15,6 +18,7 @@ import (
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/indexd/api"
+	"go.uber.org/zap"
 )
 
 var _ HostDialer = (*Dialer)(nil)
@@ -27,7 +31,8 @@ type connEntry struct {
 
 // Dialer implements the HostDialer interface.
 type Dialer struct {
-	mu sync.Mutex
+	mu  sync.Mutex
+	log *zap.Logger
 
 	c      AppClient
 	appKey types.PrivateKey
@@ -38,8 +43,10 @@ type Dialer struct {
 }
 
 // NewDialer returns a new Dialer.
-func NewDialer(c AppClient, appKey types.PrivateKey) *Dialer {
+func NewDialer(c AppClient, appKey types.PrivateKey, log *zap.Logger) *Dialer {
 	return &Dialer{
+		log: log,
+
 		c:      c,
 		appKey: appKey,
 
@@ -47,6 +54,35 @@ func NewDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 		conns:          make(map[types.PublicKey]*connEntry),
 		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
 	}
+}
+
+// Start starts the goroutine that periodically refreshes the map of host
+// addresses
+func (d *Dialer) Start(ctx context.Context) (func(), error) {
+	if err := d.updateHosts(ctx); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	ticker := time.NewTicker(10 * time.Minute)
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				if err := d.updateHosts(ctx); err != nil {
+					d.log.Warn("Failed to refresh hosts list", zap.Error(err))
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return func() {
+		ticker.Stop()
+		cancel()
+	}, nil
 }
 
 // Close closes all the open connections on the dialer.
@@ -73,6 +109,31 @@ func (d *Dialer) Close() error {
 	return nil
 }
 
+func (d *Dialer) updateHosts(ctx context.Context) error {
+	offset, limit := 0, 100
+	addrs := make(map[types.PublicKey][]chain.NetAddress)
+	for {
+		hosts, err := d.c.Hosts(ctx, api.WithOffset(offset), api.WithLimit(limit))
+		if err != nil {
+			return err
+		}
+
+		for _, host := range hosts {
+			addrs[host.PublicKey] = host.Addresses
+		}
+
+		offset += len(hosts)
+		if len(hosts) < limit {
+			break
+		}
+	}
+
+	d.mu.Lock()
+	d.addrs = addrs
+	d.mu.Unlock()
+	return nil
+}
+
 // clearHostConnection clears the connection for a host
 func (d *Dialer) clearHostConnection(hostKey types.PublicKey) {
 	d.mu.Lock()
@@ -93,30 +154,10 @@ func (d *Dialer) clearHostConnection(hostKey types.PublicKey) {
 
 // Hosts returns the public keys of all hosts that are available for
 // upload or download.
-func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
+func (d *Dialer) Hosts() []types.PublicKey {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-
-	clear(d.addrs)
-	offset, limit := 0, 100
-	var pks []types.PublicKey
-	for {
-		hosts, err := d.c.Hosts(ctx, api.WithOffset(offset), api.WithLimit(limit))
-		if err != nil {
-			return nil, err
-		}
-
-		for _, host := range hosts {
-			pks = append(pks, host.PublicKey)
-			d.addrs[host.PublicKey] = host.Addresses
-		}
-
-		offset += len(hosts)
-		if len(hosts) < limit {
-			break
-		}
-	}
-	return pks, nil
+	return slices.Collect(maps.Keys(d.addrs))
 }
 
 func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, error) {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -217,16 +217,16 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 	}()
 
 	for _, addr := range h {
-		if addr.Protocol == quic.Protocol {
-			tc, err = quic.Dial(ctx, addr.Address, hostKey)
+		if addr.Protocol == siamux.Protocol {
+			tc, err = siamux.Dial(ctx, addr.Address, hostKey)
 			if err == nil {
 				return tc, nil
 			}
 		}
 	}
 	for _, addr := range h {
-		if addr.Protocol == siamux.Protocol {
-			tc, err = siamux.Dial(ctx, addr.Address, hostKey)
+		if addr.Protocol == quic.Protocol {
+			tc, err = quic.Dial(ctx, addr.Address, hostKey)
 			if err == nil {
 				return tc, nil
 			}

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -161,8 +161,13 @@ func (d *Dialer) Hosts() []types.PublicKey {
 }
 
 func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, error) {
-	// Get or create connection entry
 	d.mu.Lock()
+	h, ok := d.addrs[hostKey]
+	if !ok {
+		d.mu.Unlock()
+		return nil, fmt.Errorf("missing host with key: %v", hostKey)
+	}
+	// Get or create connection entry
 	entry, exists := d.conns[hostKey]
 	if !exists {
 		entry = &connEntry{}
@@ -170,29 +175,33 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 	}
 	d.mu.Unlock()
 
-	entry.mu.Lock()
+	for {
+		entry.mu.Lock()
+		if entry.dial == nil {
+			// No dial in progress
+			if entry.tc != nil {
+				tc := entry.tc
+				entry.mu.Unlock()
+				return tc, nil
+			}
 
-	// Wait for any ongoing dial to complete
-	for entry.dial != nil {
+			// Start new dial
+			entry.dial = make(chan struct{})
+			entry.mu.Unlock()
+			break
+		}
+
+		// Wait for any ongoing dial to complete
+		ch := entry.dial
 		entry.mu.Unlock()
+
 		select {
-		case <-entry.dial:
+		case <-ch:
+			// dial finished
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
-		entry.mu.Lock()
 	}
-
-	// Return existing connection if available
-	if entry.tc != nil {
-		tc := entry.tc
-		entry.mu.Unlock()
-		return tc, nil
-	}
-
-	// Start new dial operation
-	entry.dial = make(chan struct{})
-	entry.mu.Unlock()
 
 	// Actually dial outside the lock
 	var tc rhp.TransportClient
@@ -206,12 +215,6 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 		entry.dial = nil
 		entry.mu.Unlock()
 	}()
-
-	// Find valid address and dial
-	h, ok := d.addrs[hostKey]
-	if !ok {
-		return nil, fmt.Errorf("missing host with key: %v", hostKey)
-	}
 
 	for _, addr := range h {
 		if addr.Protocol == quic.Protocol {
@@ -230,7 +233,8 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 		}
 	}
 
-	return nil, errors.New("host has no supported protocols")
+	err = errors.New("host has no supported protocols")
+	return nil, err
 }
 
 func (d *Dialer) retry(ctx context.Context, hostKey types.PublicKey, fn func(rhp.TransportClient) error) error {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -18,6 +19,8 @@ import (
 var _ HostDialer = (*Dialer)(nil)
 
 type Dialer struct {
+	mu sync.Mutex
+
 	c      AppClient
 	appKey types.PrivateKey
 
@@ -38,6 +41,9 @@ func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 // Hosts returns the public keys of all hosts that are available for
 // upload or download.
 func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	clear(d.hosts)
 	offset, limit := 0, 100
 	var pks []types.PublicKey
@@ -92,6 +98,9 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey, reuse bo
 }
 
 func (d *Dialer) settings(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, proto.HostPrices, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	// reuse connection if we can
 	tc, err := d.dialHost(ctx, hostKey, true)
 	if err != nil {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -19,6 +19,12 @@ import (
 
 var _ HostDialer = (*Dialer)(nil)
 
+type connEntry struct {
+	mu   sync.Mutex
+	dial chan struct{} // signals dial completion
+	tc   rhp.TransportClient
+}
+
 // Dialer implements the HostDialer interface.
 type Dialer struct {
 	mu sync.Mutex
@@ -27,7 +33,7 @@ type Dialer struct {
 	appKey types.PrivateKey
 
 	addrs          map[types.PublicKey][]chain.NetAddress
-	conns          map[types.PublicKey]rhp.TransportClient
+	conns          map[types.PublicKey]*connEntry
 	cachedSettings map[types.PublicKey]proto.HostSettings
 }
 
@@ -38,7 +44,7 @@ func NewDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 		appKey: appKey,
 
 		addrs:          make(map[types.PublicKey][]chain.NetAddress),
-		conns:          make(map[types.PublicKey]rhp.TransportClient),
+		conns:          make(map[types.PublicKey]*connEntry),
 		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
 	}
 }
@@ -49,10 +55,15 @@ func (d *Dialer) Close() error {
 	defer d.mu.Unlock()
 
 	var errs []error
-	for i := range d.conns {
-		if err := d.conns[i].Close(); err != nil {
-			errs = append(errs, err)
+	for _, entry := range d.conns {
+		entry.mu.Lock()
+		if entry.tc != nil {
+			if err := entry.tc.Close(); err != nil {
+				errs = append(errs, err)
+			}
+			entry.tc = nil
 		}
+		entry.mu.Unlock()
 	}
 	clear(d.conns)
 
@@ -60,6 +71,24 @@ func (d *Dialer) Close() error {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// clearHostConnection clears the connection for a host
+func (d *Dialer) clearHostConnection(hostKey types.PublicKey) {
+	d.mu.Lock()
+	entry, exists := d.conns[hostKey]
+	d.mu.Unlock()
+	if !exists {
+		return
+	}
+
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if entry.tc != nil {
+		entry.tc.Close()
+		entry.tc = nil
+	}
 }
 
 // Hosts returns the public keys of all hosts that are available for
@@ -90,67 +119,99 @@ func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
 	return pks, nil
 }
 
-func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey, reuse bool) (rhp.TransportClient, error) {
-	if tc, ok := d.conns[hostKey]; ok && reuse {
-		// we have an existing connection
+func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, error) {
+	// Get or create connection entry
+	d.mu.Lock()
+	entry, exists := d.conns[hostKey]
+	if !exists {
+		entry = &connEntry{}
+		d.conns[hostKey] = entry
+	}
+	d.mu.Unlock()
+
+	entry.mu.Lock()
+
+	// Wait for any ongoing dial to complete
+	for entry.dial != nil {
+		entry.mu.Unlock()
+		select {
+		case <-entry.dial:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		entry.mu.Lock()
+	}
+
+	// Return existing connection if available
+	if entry.tc != nil {
+		tc := entry.tc
+		entry.mu.Unlock()
 		return tc, nil
 	}
 
+	// Start new dial operation
+	entry.dial = make(chan struct{})
+	entry.mu.Unlock()
+
+	// Actually dial outside the lock
+	var tc rhp.TransportClient
+	var err error
+	defer func() {
+		entry.mu.Lock()
+		if err == nil {
+			entry.tc = tc
+		}
+		close(entry.dial)
+		entry.dial = nil
+		entry.mu.Unlock()
+	}()
+
+	// Find valid address and dial
 	h, ok := d.addrs[hostKey]
 	if !ok {
-		return nil, fmt.Errorf("we haven't seen host")
+		return nil, fmt.Errorf("missing host with key: %v", hostKey)
 	}
 
 	for _, addr := range h {
 		if addr.Protocol == quic.Protocol {
-			tc, err := quic.Dial(ctx, addr.Address, hostKey)
-			if err != nil {
-				return nil, fmt.Errorf("failed to dial host over quic: %w", err)
+			tc, err = quic.Dial(ctx, addr.Address, hostKey)
+			if err == nil {
+				return tc, nil
 			}
-			d.conns[hostKey] = tc
-			return tc, nil
 		}
 	}
 	for _, addr := range h {
 		if addr.Protocol == siamux.Protocol {
-			tc, err := siamux.Dial(ctx, addr.Address, hostKey)
-			if err != nil {
-				return nil, fmt.Errorf("failed to dial host over siamux: %w", err)
+			tc, err = siamux.Dial(ctx, addr.Address, hostKey)
+			if err == nil {
+				return tc, nil
 			}
-			d.conns[hostKey] = tc
-			return tc, nil
 		}
 	}
+
 	return nil, errors.New("host has no supported protocols")
 }
 
 func (d *Dialer) retry(ctx context.Context, hostKey types.PublicKey, fn func(rhp.TransportClient) error) error {
-	// reuse connection if we can
-	d.mu.Lock()
-	tc, err := d.dialHost(ctx, hostKey, true)
+	// First attempt
+	tc, err := d.dialHost(ctx, hostKey)
 	if err != nil {
-		d.mu.Unlock()
 		return fmt.Errorf("failed to dial host: %w", err)
 	}
-	d.mu.Unlock()
-
-	if err := fn(tc); err != nil && proto.ErrorCode(err) != proto.ErrorCodeTransport {
-		// we received a non transport related error
-		return err
-	} else if err == nil {
-		// success
+	if err := fn(tc); err == nil {
 		return nil
+	} else if proto.ErrorCode(err) != proto.ErrorCodeTransport {
+		return err
 	}
 
-	// we got a transport error, try reconnecting and trying again
-	d.mu.Lock()
-	tc, err = d.dialHost(ctx, hostKey, false)
+	// Clear connection if we got transport error
+	d.clearHostConnection(hostKey)
+
+	// Second attempt
+	tc, err = d.dialHost(ctx, hostKey)
 	if err != nil {
-		d.mu.Unlock()
 		return fmt.Errorf("failed to redial host: %w", err)
 	}
-	d.mu.Unlock()
-
 	return fn(tc)
 }
 

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -32,6 +32,39 @@ type connEntry struct {
 	tc   rhp.TransportClient
 }
 
+func (c *connEntry) close(log *zap.Logger) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.tc != nil {
+		if err := c.tc.Close(); err != nil {
+			log.Debug("Failed to close connection", zap.Stringer("pk", c.hostKey), zap.Error(err))
+		}
+	}
+	c.tc = nil
+}
+
+func (c *connEntry) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.tc != nil {
+		c.tc.Close()
+		c.tc = nil
+	}
+}
+
+func (c *connEntry) setTransport(tc rhp.TransportClient, assign bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if assign {
+		c.tc = tc
+	}
+	close(c.dial)
+	c.dial = nil
+}
+
 // Dialer implements the HostDialer interface.
 type Dialer struct {
 	log *zap.Logger
@@ -75,14 +108,7 @@ func (d *Dialer) Close() {
 	d.mu.Unlock()
 
 	for _, entry := range conns {
-		entry.mu.Lock()
-		if entry.tc != nil {
-			if err := entry.tc.Close(); err != nil {
-				d.log.Debug("Failed to close connection", zap.Stringer("pk", entry.hostKey), zap.Error(err))
-			}
-		}
-		entry.tc = nil
-		entry.mu.Unlock()
+		entry.close(d.log)
 	}
 	clear(d.conns)
 }
@@ -164,13 +190,7 @@ func (d *Dialer) clearHostConnection(hostKey types.PublicKey) {
 		return
 	}
 
-	entry.mu.Lock()
-	defer entry.mu.Unlock()
-
-	if entry.tc != nil {
-		entry.tc.Close()
-		entry.tc = nil
-	}
+	entry.clear()
 }
 
 // Hosts returns the public keys of all hosts that are available for
@@ -228,13 +248,7 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 	var tc rhp.TransportClient
 	var err error
 	defer func() {
-		entry.mu.Lock()
-		if err == nil {
-			entry.tc = tc
-		}
-		close(entry.dial)
-		entry.dial = nil
-		entry.mu.Unlock()
+		entry.setTransport(tc, err == nil)
 	}()
 
 	for _, addr := range h {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -19,6 +19,7 @@ import (
 
 var _ HostDialer = (*Dialer)(nil)
 
+// Dialer implements the HostDialer interface.
 type Dialer struct {
 	mu sync.Mutex
 
@@ -30,7 +31,8 @@ type Dialer struct {
 	cachedSettings map[types.PublicKey]proto.HostSettings
 }
 
-func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
+// NewDialer returns a new Dialer.
+func NewDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 	return &Dialer{
 		c:      c,
 		appKey: appKey,

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -9,11 +9,11 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/indexd/api"
-	"go.sia.tech/indexd/hosts"
 )
 
 var _ HostDialer = (*Dialer)(nil)
@@ -24,7 +24,7 @@ type Dialer struct {
 	c      AppClient
 	appKey types.PrivateKey
 
-	hosts map[types.PublicKey]hosts.Host
+	addrs map[types.PublicKey][]chain.NetAddress
 	conns map[types.PublicKey]rhp.TransportClient
 }
 
@@ -33,7 +33,7 @@ func newDialer(c AppClient, appKey types.PrivateKey) *Dialer {
 		c:      c,
 		appKey: appKey,
 
-		hosts: make(map[types.PublicKey]hosts.Host),
+		addrs: make(map[types.PublicKey][]chain.NetAddress),
 		conns: make(map[types.PublicKey]rhp.TransportClient),
 	}
 }
@@ -44,7 +44,7 @@ func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	clear(d.hosts)
+	clear(d.addrs)
 	offset, limit := 0, 100
 	var pks []types.PublicKey
 	for {
@@ -55,7 +55,7 @@ func (d *Dialer) Hosts(ctx context.Context) ([]types.PublicKey, error) {
 
 		for _, host := range hosts {
 			pks = append(pks, host.PublicKey)
-			d.hosts[host.PublicKey] = host
+			d.addrs[host.PublicKey] = host.Addresses
 		}
 
 		offset += len(hosts)
@@ -72,12 +72,12 @@ func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey, reuse bo
 		return tc, nil
 	}
 
-	h, ok := d.hosts[hostKey]
+	h, ok := d.addrs[hostKey]
 	if !ok {
 		return nil, fmt.Errorf("we haven't seen host")
 	}
 
-	for _, addr := range h.Addresses {
+	for _, addr := range h {
 		if addr.Protocol == siamux.Protocol {
 			tc, err := siamux.Dial(ctx, addr.Address, hostKey)
 			if err != nil {

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -59,9 +59,7 @@ func TestHostDialer(t *testing.T) {
 		t.Fatal("retrieved sector does not match")
 	}
 
-	if err := dialer.Close(); err != nil {
-		t.Fatal(err)
-	}
+	dialer.Close()
 
 	// read sector again after closing connection
 	sector, err = dialer.ReadSector(context.Background(), hk, root)
@@ -73,9 +71,7 @@ func TestHostDialer(t *testing.T) {
 		t.Fatal("retrieved sector does not match")
 	}
 
-	if err := dialer.Close(); err != nil {
-		t.Fatal(err)
-	}
+	dialer.Close()
 }
 
 func TestHostDialerParallel(t *testing.T) {
@@ -137,7 +133,5 @@ func TestHostDialerParallel(t *testing.T) {
 	}
 	wg.Wait()
 
-	if err := dialer.Close(); err != nil {
-		t.Fatal(err)
-	}
+	dialer.Close()
 }

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -29,12 +29,10 @@ func TestHostDialer(t *testing.T) {
 	}
 	time.Sleep(3 * time.Second)
 
-	dialer := NewDialer(app, a1, zap.NewNop())
-	cancel, err := dialer.Start(context.Background())
+	dialer, err := NewDialer(app, a1, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cancel()
 
 	hks := dialer.Hosts()
 	if len(hks) != 1 {
@@ -88,12 +86,10 @@ func TestHostDialerParallel(t *testing.T) {
 	}
 	time.Sleep(3 * time.Second)
 
-	dialer := NewDialer(app, a1, logger.Named("Dialer"))
-	cancel, err := dialer.Start(context.Background())
+	dialer, err := NewDialer(app, a1, logger.Named("Dialer"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cancel()
 
 	hks := dialer.Hosts()
 	if len(hks) != 2 {

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -54,7 +54,11 @@ func TestHostDialer(t *testing.T) {
 		t.Fatal("retrieved sector does not match")
 	}
 
-	// read sector again
+	if err := dialer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// read sector again after closing connection
 	sector, err = dialer.ReadSector(context.Background(), hk, root)
 	if err != nil {
 		t.Fatal(err)
@@ -62,5 +66,9 @@ func TestHostDialer(t *testing.T) {
 
 	if !bytes.Equal(data[:], sector[:]) {
 		t.Fatal("retrieved sector does not match")
+	}
+
+	if err := dialer.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -1,0 +1,56 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/internal/testutils"
+	"go.uber.org/zap/zaptest"
+	"lukechampine.com/frand"
+)
+
+func TestHostDialer(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(1))
+	indexer := cluster.Indexer
+
+	// add an account
+	a1 := types.GeneratePrivateKey()
+	app := indexer.App(a1)
+	err := indexer.AccountsAdd(context.Background(), a1.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dialer := newDialer(app, a1)
+	time.Sleep(3 * time.Second)
+
+	hks, err := dialer.Hosts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hks) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hks))
+	}
+
+	hk := hks[0]
+	var data [proto.SectorSize]byte
+	frand.Read(data[:])
+
+	root, err := dialer.WriteSector(context.Background(), hk, &data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sector, err := dialer.ReadSector(context.Background(), hk, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data[:], sector[:]) {
+		t.Fatal("retrieved sector does not match")
+	}
+}

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -107,7 +107,7 @@ func TestHostDialerParallel(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
-		go func() {
+		go func(i int) {
 			defer wg.Done()
 
 			var data [proto.SectorSize]byte
@@ -131,7 +131,7 @@ func TestHostDialerParallel(t *testing.T) {
 			if !bytes.Equal(data[:], sector[:]) {
 				t.Error("retrieved sector does not match")
 			}
-		}()
+		}(i)
 	}
 	wg.Wait()
 }

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -27,7 +27,7 @@ func TestHostDialer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(3 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	dialer, err := NewDialer(app, a1, zap.NewNop())
 	if err != nil {
@@ -56,13 +56,13 @@ func TestHostDialer(t *testing.T) {
 	if !bytes.Equal(data[:], sector[:]) {
 		t.Fatal("retrieved sector does not match")
 	}
-
 	dialer.Close()
 
 	dialer, err = NewDialer(app, a1, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dialer.Close()
 
 	// read sector again after closing connection
 	sector, err = dialer.ReadSector(context.Background(), hk, root)
@@ -89,12 +89,13 @@ func TestHostDialerParallel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(3 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	dialer, err := NewDialer(app, a1, logger.Named("Dialer"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dialer.Close()
 
 	hks := dialer.Hosts()
 	if len(hks) != 2 {
@@ -133,6 +134,4 @@ func TestHostDialerParallel(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-
-	dialer.Close()
 }

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -59,6 +59,11 @@ func TestHostDialer(t *testing.T) {
 
 	dialer.Close()
 
+	dialer, err = NewDialer(app, a1, zap.NewNop())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// read sector again after closing connection
 	sector, err = dialer.ReadSector(context.Background(), hk, root)
 	if err != nil {

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -80,7 +80,7 @@ func TestHostDialer(t *testing.T) {
 
 func TestHostDialerParallel(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(1))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(2))
 	indexer := cluster.Indexer
 
 	// add an account
@@ -100,10 +100,11 @@ func TestHostDialerParallel(t *testing.T) {
 	defer cancel()
 
 	hks := dialer.Hosts()
-	if len(hks) != 1 {
-		t.Fatalf("expected 1 host, got %d", len(hks))
+	if len(hks) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(hks))
 	}
-	hk := hks[0]
+	hk1 := hks[0]
+	hk2 := hks[1]
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -113,6 +114,11 @@ func TestHostDialerParallel(t *testing.T) {
 
 			var data [proto.SectorSize]byte
 			frand.Read(data[:])
+
+			hk := hk1
+			if i%2 == 0 {
+				hk = hk2
+			}
 
 			root, err := dialer.WriteSector(context.Background(), hk, &data)
 			if err != nil {

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -26,7 +26,7 @@ func TestHostDialer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dialer := newDialer(app, a1)
+	dialer := NewDialer(app, a1)
 	time.Sleep(3 * time.Second)
 
 	hks, err := dialer.Hosts(context.Background())

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -122,16 +122,16 @@ func TestHostDialerParallel(t *testing.T) {
 
 			root, err := dialer.WriteSector(context.Background(), hk, &data)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 
 			sector, err := dialer.ReadSector(context.Background(), hk, root)
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 
 			if !bytes.Equal(data[:], sector[:]) {
-				t.Fatal("retrieved sector does not match")
+				t.Error("retrieved sector does not match")
 			}
 		}()
 	}

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -3,12 +3,14 @@ package sdk
 import (
 	"bytes"
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/internal/testutils"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
@@ -27,7 +29,7 @@ func TestHostDialer(t *testing.T) {
 	}
 	time.Sleep(3 * time.Second)
 
-	dialer := NewDialer(app, a1, logger.Named("Dialer"))
+	dialer := NewDialer(app, a1, zap.NewNop())
 	cancel, err := dialer.Start(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -70,6 +72,64 @@ func TestHostDialer(t *testing.T) {
 	if !bytes.Equal(data[:], sector[:]) {
 		t.Fatal("retrieved sector does not match")
 	}
+
+	if err := dialer.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHostDialerParallel(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(1))
+	indexer := cluster.Indexer
+
+	// add an account
+	a1 := types.GeneratePrivateKey()
+	app := indexer.App(a1)
+	err := indexer.AccountsAdd(context.Background(), a1.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(3 * time.Second)
+
+	dialer := NewDialer(app, a1, logger.Named("Dialer"))
+	cancel, err := dialer.Start(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancel()
+
+	hks := dialer.Hosts()
+	if len(hks) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hks))
+	}
+	hk := hks[0]
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			var data [proto.SectorSize]byte
+			frand.Read(data[:])
+
+			root, err := dialer.WriteSector(context.Background(), hk, &data)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sector, err := dialer.ReadSector(context.Background(), hk, root)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(data[:], sector[:]) {
+				t.Fatal("retrieved sector does not match")
+			}
+		}()
+	}
+	wg.Wait()
 
 	if err := dialer.Close(); err != nil {
 		t.Fatal(err)

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -25,14 +25,17 @@ func TestHostDialer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	dialer := NewDialer(app, a1)
 	time.Sleep(3 * time.Second)
 
-	hks, err := dialer.Hosts(context.Background())
+	dialer := NewDialer(app, a1, logger.Named("Dialer"))
+	cancel, err := dialer.Start(context.Background())
 	if err != nil {
 		t.Fatal(err)
-	} else if len(hks) != 1 {
+	}
+	defer cancel()
+
+	hks := dialer.Hosts()
+	if len(hks) != 1 {
 		t.Fatalf("expected 1 host, got %d", len(hks))
 	}
 

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -53,4 +53,14 @@ func TestHostDialer(t *testing.T) {
 	if !bytes.Equal(data[:], sector[:]) {
 		t.Fatal("retrieved sector does not match")
 	}
+
+	// read sector again
+	sector, err = dialer.ReadSector(context.Background(), hk, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data[:], sector[:]) {
+		t.Fatal("retrieved sector does not match")
+	}
 }

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -170,7 +170,7 @@ func (mc *mockAppClient) Slab(_ context.Context, id slabs.SlabID) (slabs.PinnedS
 	return slab, nil
 }
 
-func (mc *mockAppClient) Hosts(context.Context, ...api.URLQueryParameterOption) ([]hosts.Host, error) {
+func (mc *mockAppClient) Hosts(context.Context, ...api.URLQueryParameterOption) ([]hosts.HostInfo, error) {
 	return nil, nil
 }
 

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -26,8 +26,8 @@ type mockHostDialer struct {
 }
 
 // Hosts implements the [HostDialer] interface.
-func (m *mockHostDialer) Hosts(context.Context) ([]types.PublicKey, error) {
-	return slices.Collect(maps.Keys(m.hosts)), nil
+func (m *mockHostDialer) Hosts() []types.PublicKey {
+	return slices.Collect(maps.Keys(m.hosts))
 }
 
 func (m *mockHostDialer) delay(ctx context.Context, hostKey types.PublicKey) error {

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -10,6 +10,8 @@ import (
 
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
 )
 
@@ -24,8 +26,8 @@ type mockHostDialer struct {
 }
 
 // Hosts implements the [HostDialer] interface.
-func (m *mockHostDialer) Hosts() []types.PublicKey {
-	return slices.Collect(maps.Keys(m.hosts))
+func (m *mockHostDialer) Hosts(context.Context) ([]types.PublicKey, error) {
+	return slices.Collect(maps.Keys(m.hosts)), nil
 }
 
 func (m *mockHostDialer) delay(ctx context.Context, hostKey types.PublicKey) error {
@@ -166,6 +168,10 @@ func (mc *mockAppClient) Slab(_ context.Context, id slabs.SlabID) (slabs.PinnedS
 		return slabs.PinnedSlab{}, errors.New("slab not found")
 	}
 	return slab, nil
+}
+
+func (mc *mockAppClient) Hosts(context.Context, ...api.URLQueryParameterOption) ([]hosts.Host, error) {
+	return nil, nil
 }
 
 func newMockAppClient() *mockAppClient {


### PR DESCRIPTION
Implement the HostDialer interface in the SDK and add an associated test.

- Cache results of Hosts() to get net addresses of hosts
- Cache open connections with hosts
- Cache host settings until they expire
- Retry if we get transport related failures due to connections randomly dropping

https://github.com/SiaFoundation/indexd/issues/271