### PR TITLE
Update price validity check

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -90,7 +90,7 @@ WITH globals AS (
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
-	has_settings AND settings_valid_until >= (NOW() + INTERVAL '15 minutes'),
+	has_settings AND settings_valid_until >= last_successful_scan + INTERVAL '15 minutes',
 	has_settings AND settings_accepting_contracts,
 	has_settings AND settings_contract_price <= globals.one_sc,
 	has_settings AND settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price,
@@ -165,7 +165,7 @@ WITH globals AS (
 	has_settings AND settings_max_contract_duration >= globals.contracts_period,
 	has_settings AND settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period,
 	has_settings AND settings_version >= globals.host_min_version,
-	has_settings AND settings_valid_until >= (NOW() + INTERVAL '15 minutes'),
+	has_settings AND settings_valid_until >= last_successful_scan + INTERVAL '15 minutes',
 	has_settings AND settings_accepting_contracts,
 	has_settings AND settings_contract_price <= globals.one_sc,
 	has_settings AND settings_collateral >= globals.hosts_min_collateral AND settings_collateral >= 2 * settings_storage_price,
@@ -182,7 +182,7 @@ WHERE
 		settings_max_contract_duration >= globals.contracts_period AND
 		settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period AND
 		settings_version >= globals.host_min_version AND
-		settings_valid_until >= (NOW() + INTERVAL '15 minutes') AND
+		settings_valid_until >= last_successful_scan + INTERVAL '15 minutes' AND
 		settings_accepting_contracts AND
 		settings_contract_price <= globals.one_sc AND
 		settings_collateral >= globals.hosts_min_collateral AND
@@ -516,6 +516,7 @@ WITH globals AS (
 		id,
 		hosts.public_key,
 		recent_uptime,
+		last_successful_scan,
 		settings_protocol_version,
 		settings_release,
 		settings_wallet_address,
@@ -549,7 +550,7 @@ WHERE
 	settings_max_contract_duration >= globals.contracts_period AND
 	settings_max_collateral >= settings_collateral * globals.one_tb * globals.contracts_period AND
 	settings_version >= globals.host_min_version AND
-	settings_valid_until >= (NOW() + INTERVAL '15 minutes') AND
+	settings_valid_until >= last_successful_scan + INTERVAL '15 minutes' AND
 	settings_accepting_contracts AND
 	settings_contract_price <= globals.one_sc AND
 	settings_collateral >= globals.hosts_min_collateral AND

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -285,7 +285,7 @@ func TestHostChecks(t *testing.T) {
 	assertCheckOK("ProtocolVersion")
 
 	// adjust price validity so we pass the check
-	hs.Prices.ValidUntil = time.Now().Add(time.Second * 3601)
+	hs.Prices.ValidUntil = time.Now().Add(time.Second * 1801)
 	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, true, time.Now())
 	assertCheckOK("PriceValidity")
 
@@ -331,6 +331,17 @@ func TestHostChecks(t *testing.T) {
 	} else if !h.Usability.Usable() {
 		t.Fatal("expected host to be usable")
 	}
+
+	// assert valid until takes into account the last successful scan time
+	// instead of the current time when calculating whether the price validity
+	// check passes
+	if _, err := db.pool.Exec(context.Background(), `
+		UPDATE hosts SET 
+			last_successful_scan = last_successful_scan - INTERVAL '1 day', 
+			settings_valid_until = settings_valid_until - INTERVAL '1 day'`); err != nil {
+		t.Fatal(err)
+	}
+	assertCheckOK("PriceValidity")
 }
 
 func TestHosts(t *testing.T) {


### PR DESCRIPTION
Checking minimum price validity shouldn't take into account the current time but check whether the price table we received from the host was valid for at least 15' when we scanned it. If we don't, a failure to scan the host every 15 minutes would result in an usable host.