### PR TITLE
Add `waitUntilSynced` to Contract manager

### DIFF
--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -254,6 +254,10 @@ func (s *storeMock) Hosts(ctx context.Context, offset, limit int, queryOpts ...h
 	return filter, nil
 }
 
+func (s *storeMock) LastScannedIndex(ctx context.Context) (ci types.ChainIndex, err error) {
+	return types.ChainIndex{}, nil
+}
+
 func (s *storeMock) MaintenanceSettings(ctx context.Context) (MaintenanceSettings, error) {
 	return s.settings, nil
 }
@@ -413,6 +417,10 @@ func (cm *chainManagerMock) AddV2PoolTransactions(basis types.ChainIndex, txns [
 	cm.tpool = append(cm.tpool, txns...)
 	cm.mu.Unlock()
 	return false, nil
+}
+
+func (cm *chainManagerMock) Block(id types.BlockID) (types.Block, bool) {
+	return types.Block{Timestamp: time.Now()}, true
 }
 
 func (cm *chainManagerMock) TipState() consensus.State {

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -392,37 +392,40 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 }
 
 func (cm *ContractManager) waitUntilSynced(ctx context.Context, log *zap.Logger) bool {
-	var once sync.Once
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		default:
-		}
-
+	isSynced := func() (bool, error) {
 		ci, err := cm.store.LastScannedIndex(ctx)
 		if err != nil {
-			log.Debug("failed to get last scanned index", zap.Error(err))
-			continue
+			return false, fmt.Errorf("failed to get last scanned index: %w", err)
 		}
 
 		block, ok := cm.cm.Block(ci.ID)
 		if !ok {
-			log.Debug("failed to get block for last scanned index", zap.Stringer("id", ci.ID))
-			continue
-		}
-		if time.Since(block.Timestamp) < 3*time.Hour {
-			return true
+			return false, fmt.Errorf("failed to get block for last scanned index %v", ci.ID)
 		}
 
-		once.Do(func() {
-			log.Info("waiting for wallet to be synced before doing contract maintenance")
-		})
+		return time.Since(block.Timestamp) < 3*time.Hour, nil
+	}
 
+	// check if we are synced
+	synced, _ := isSynced()
+	if synced {
+		return true
+	}
+
+	// if not, check again every minute
+	log.Info("waiting for wallet to be scanned before doing contract maintenance")
+	for {
 		select {
 		case <-ctx.Done():
 			return false
 		case <-time.After(time.Minute):
+		}
+
+		synced, err := isSynced()
+		if synced {
+			return true
+		} else if err != nil {
+			log.Debug(err.Error())
 		}
 	}
 }

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -395,9 +395,9 @@ func (cm *ContractManager) waitUntilSynced(ctx context.Context, log *zap.Logger)
 	var once sync.Once
 	for {
 		select {
-		case <-cm.tg.Done():
+		case <-ctx.Done():
 			return false
-		case <-time.After(time.Second):
+		default:
 		}
 
 		ci, err := cm.store.LastScannedIndex(ctx)
@@ -411,13 +411,19 @@ func (cm *ContractManager) waitUntilSynced(ctx context.Context, log *zap.Logger)
 			log.Debug("failed to get block for last scanned index", zap.Stringer("id", ci.ID))
 			continue
 		}
-
 		if time.Since(block.Timestamp) < 3*time.Hour {
 			return true
 		}
+
 		once.Do(func() {
 			log.Info("waiting for wallet to be synced before doing contract maintenance")
 		})
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(time.Minute):
+		}
 	}
 }
 

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -53,6 +53,7 @@ type (
 	// ContractManager requires.
 	ChainManager interface {
 		AddV2PoolTransactions(basis types.ChainIndex, txns []types.V2Transaction) (known bool, err error)
+		Block(id types.BlockID) (types.Block, bool)
 		RecommendedFee() types.Currency
 		TipState() consensus.State
 		V2TransactionSet(basis types.ChainIndex, txn types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error)
@@ -100,6 +101,7 @@ type (
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
 		HostsForPruning(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPinning(ctx context.Context) ([]types.PublicKey, error)
+		LastScannedIndex(ctx context.Context) (ci types.ChainIndex, err error)
 		MaintenanceSettings(ctx context.Context) (MaintenanceSettings, error)
 		MarkSectorsLost(ctx context.Context, hostKey types.PublicKey, roots []types.Hash256) error
 		MarkBroadcastAttempt(ctx context.Context, contractID types.FileContractID) error
@@ -338,16 +340,16 @@ func (cm *ContractManager) Close() error {
 // maintenanceLoop performs any background tasks that the contract manager needs
 // to perform on contracts
 func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
-	// block until we are online and the consensus is synced
 	log := cm.log.Named("maintenance")
-	if !cm.blockUntilReady(log) {
-		return // shutdown
-	}
 
 	ticker := time.NewTicker(cm.maintenanceFrequency)
 	defer ticker.Stop()
 
 	for {
+		if !cm.waitUntilSynced(ctx, log) {
+			return
+		}
+
 		select {
 		case <-ctx.Done():
 			return
@@ -389,7 +391,7 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 	}
 }
 
-func (cm *ContractManager) blockUntilReady(log *zap.Logger) bool {
+func (cm *ContractManager) waitUntilSynced(ctx context.Context, log *zap.Logger) bool {
 	var once sync.Once
 	for {
 		select {
@@ -397,11 +399,24 @@ func (cm *ContractManager) blockUntilReady(log *zap.Logger) bool {
 			return false
 		case <-time.After(time.Second):
 		}
-		if time.Since(cm.cm.TipState().PrevTimestamps[0]) < 3*time.Hour {
+
+		ci, err := cm.store.LastScannedIndex(ctx)
+		if err != nil {
+			log.Debug("failed to get last scanned index", zap.Error(err))
+			continue
+		}
+
+		block, ok := cm.cm.Block(ci.ID)
+		if !ok {
+			log.Debug("failed to get block for last scanned index", zap.Stringer("id", ci.ID))
+			continue
+		}
+
+		if time.Since(block.Timestamp) < 3*time.Hour {
 			return true
 		}
 		once.Do(func() {
-			log.Info("waiting for consensus to be synced before starting maintenance")
+			log.Info("waiting for wallet to be synced before doing contract maintenance")
 		})
 	}
 }

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -191,6 +191,7 @@ type (
 		maintenanceFrequency              time.Duration
 		pruneIntervalSuccess              time.Duration
 		pruneIntervalFailure              time.Duration
+		syncPollInterval                  time.Duration
 		revisionBroadcastInterval         time.Duration
 	}
 )
@@ -214,6 +215,14 @@ func WithDisabledCIDRChecks() ContractManagerOpt {
 func WithMaintenanceFrequency(frequency time.Duration) ContractManagerOpt {
 	return func(cm *ContractManager) {
 		cm.maintenanceFrequency = frequency
+	}
+}
+
+// WithSyncPollInterval sets the interval at which the contract manager checks
+// if the wallet is synced. The default is 1 minute.
+func WithSyncPollInterval(interval time.Duration) ContractManagerOpt {
+	return func(cm *ContractManager) {
+		cm.syncPollInterval = interval
 	}
 }
 
@@ -277,6 +286,7 @@ func newContractManager(renterKey types.PublicKey, accountManager AccountManager
 		pruneIntervalSuccess:              24 * time.Hour,     // 1 day
 		pruneIntervalFailure:              3 * time.Hour,      // 3 hours
 		revisionBroadcastInterval:         7 * 24 * time.Hour, // 1 week,
+		syncPollInterval:                  time.Minute,
 	}
 	for _, opt := range opts {
 		opt(cm)
@@ -418,7 +428,7 @@ func (cm *ContractManager) waitUntilSynced(ctx context.Context, log *zap.Logger)
 		select {
 		case <-ctx.Done():
 			return false
-		case <-time.After(time.Minute):
+		case <-time.After(cm.syncPollInterval):
 		}
 
 		synced, err := isSynced()

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -435,7 +435,7 @@ func (cm *ContractManager) waitUntilSynced(ctx context.Context, log *zap.Logger)
 		if synced {
 			return true
 		} else if err != nil {
-			log.Debug(err.Error())
+			log.Debug("failed to check synced", zap.Error(err))
 		}
 	}
 }

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -108,7 +108,13 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	dialer := client.NewSiamuxDialer(c.cm, signer, store, log)
 	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 
-	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, hm, s, wm, contracts.WithLogger(log.Named("contracts")), contracts.WithMaintenanceFrequency(200*time.Millisecond), contracts.WithDisabledCIDRChecks())
+	contractOpts := []contracts.ContractManagerOpt{
+		contracts.WithDisabledCIDRChecks(),
+		contracts.WithLogger(log.Named("contracts")),
+		contracts.WithMaintenanceFrequency(200 * time.Millisecond),
+		contracts.WithSyncPollInterval(100 * time.Millisecond),
+	}
+	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, hm, s, wm, contractOpts...)
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -181,7 +181,7 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 			break
 		}
 
-		updateCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		updateCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 		err = s.store.UpdateChainState(updateCtx, func(tx UpdateTx) error {
 			if err := s.hm.UpdateChainState(tx, aus); err != nil {
 				return fmt.Errorf("failed to update host chain state: %w", err)

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -181,7 +181,7 @@ func (s *Subscriber) Sync(ctx context.Context) error {
 			break
 		}
 
-		updateCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+		updateCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		err = s.store.UpdateChainState(updateCtx, func(tx UpdateTx) error {
 			if err := s.hm.UpdateChainState(tx, aus); err != nil {
 				return fmt.Errorf("failed to update host chain state: %w", err)


### PR DESCRIPTION
Instead of waiting until our chain manager's tip is synced once, we should instead make sure that our wallet is synced, and check this before doing any contract maintenance that requires the wallet. If we don't we run into reorg errors because the basis is too far in the past.

```
 ERROR   contracts.maintenance.formation failed to form contract {“hostKey”: “ed25519:3077686e977dbe016b6f03ddf6fb9828af8136c10ae6062ec7b2ef99ab3098c2", “full”: false, “error”: “failed to form contract: failed to form contract: failed to get transaction set: failed to update transaction set basis: reorg path from 435999::b78a6a52 to 534253::05e0519a is too long (-0 +98254)“}
 ```