### PR TITLE
Batch update siacoin elements

### DIFF
--- a/persist/postgres/chain_test.go
+++ b/persist/postgres/chain_test.go
@@ -12,6 +12,7 @@ import (
 	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"lukechampine.com/frand"
 )
 
 type testProofUpdater struct{ fn func(*types.StateElement) }
@@ -191,5 +192,40 @@ func TestUpdateChainState(t *testing.T) {
 		t.Fatal(err)
 	} else if tip != expectedTip {
 		t.Fatal("unexpected tip", tip, expectedTip)
+	}
+}
+
+func BenchmarkUpdateWalletSiacoinElementProofs(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	for range 1000 {
+		se := newTestSiacoinElement()
+		frand.Read(se.ID[:])
+		if _, err := store.pool.Exec(context.Background(), `INSERT INTO wallet_siacoin_elements (output_id, value, address, merkle_proof, leaf_index, maturity_height) VALUES ($1, $2, $3, $4, $5, $6)`,
+			sqlHash256(se.ID),
+			sqlCurrency(se.SiacoinOutput.Value),
+			sqlHash256(se.SiacoinOutput.Address),
+			sqlMerkleProof(se.StateElement.MerkleProof),
+			se.StateElement.LeafIndex,
+			se.MaturityHeight,
+		); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	for b.Loop() {
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.UpdateWalletSiacoinElementProofs(testProofUpdater{
+				fn: func(se *types.StateElement) {
+					se.LeafIndex++
+					se.MerkleProof = append(se.MerkleProof, frand.Entropy256())
+					if len(se.MerkleProof) > 16 {
+						se.MerkleProof = se.MerkleProof[len(se.MerkleProof)-16:]
+					}
+				},
+			})
+		}); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/persist/postgres/wallet.go
+++ b/persist/postgres/wallet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
 )
@@ -173,32 +174,23 @@ func (u *updateTx) UpdateWalletSiacoinElementProofs(updater wallet.ProofUpdater)
 	}
 	defer rows.Close()
 
-	type sce struct {
-		id          sqlHash256
-		leafIndex   uint64
-		merkleProof sqlMerkleProof
-	}
-
-	sces := make(map[sqlHash256]*types.StateElement)
+	batch := &pgx.Batch{}
 	for rows.Next() {
-		var sce sce
-		if err := rows.Scan(&sce.id, &sce.leafIndex, &sce.merkleProof); err != nil {
+		var id sqlHash256
+		var el types.StateElement
+		if err := rows.Scan(&id, &el.LeafIndex, (*sqlMerkleProof)(&el.MerkleProof)); err != nil {
 			return fmt.Errorf("failed to scan siacoin element: %w", err)
 		}
-		sces[sce.id] = &types.StateElement{
-			LeafIndex:   sce.leafIndex,
-			MerkleProof: sce.merkleProof,
-		}
-		updater.UpdateElementProof(sces[sce.id])
+		updater.UpdateElementProof(&el)
+		batch.Queue(`UPDATE wallet_siacoin_elements SET leaf_index = $1, merkle_proof = $2 WHERE output_id = $3`, el.LeafIndex, sqlMerkleProof(el.MerkleProof), id)
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
 
-	for id, se := range sces {
-		const query = `UPDATE wallet_siacoin_elements SET leaf_index = $1, merkle_proof = $2 WHERE output_id = $3`
-		if _, err := u.tx.Exec(u.ctx, query, se.LeafIndex, sqlMerkleProof(se.MerkleProof), id); err != nil {
-			return fmt.Errorf("failed to update siacoin element: %w", err)
+	if batch.Len() > 0 {
+		if err := u.tx.Tx.SendBatch(u.ctx, batch).Close(); err != nil {
+			return fmt.Errorf("failed to update siacoin element proofs: %w", err)
 		}
 	}
 	return nil

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -87,7 +87,7 @@ func (s *Subscriber) Close() error {
 // processing chain updates and needs to be closed.
 func New(cm ChainManager, hm HostManager, contracts ContractManager, wm WalletManager, store Store, opts ...Option) (*Subscriber, error) {
 	s := &Subscriber{
-		updateBatchSize: 1000,
+		updateBatchSize: 100,
 
 		cm:        cm,
 		contracts: contracts,


### PR DESCRIPTION
It's about a 6x speedup on my machine (coming from `180 ms/op`)

```
cpu: Apple M1 Max
BenchmarkUpdateWalletSiacoinElementProofs-10                  61          27519759 ns/op
PASS
```