### PR TITLE
Add database configuration to advanced config + example docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ ENV INDEXD_CONFIG_FILE=/data/indexd.yml
 
 VOLUME [ "/data" ]
 
-# API port
+# Admin API port
 EXPOSE 9980/tcp
 # Syncer port
 EXPOSE 9981/tcp
+# App API port
+EXPOSE 9982/tcp
 
 ENTRYPOINT [ "indexd", "-api.admin", ":9980" ]

--- a/cmd/indexd/config.go
+++ b/cmd/indexd/config.go
@@ -176,6 +176,7 @@ func setAPIPassword() {
 }
 
 func setAdvancedConfig() {
+	fmt.Println("")
 	if !promptYesNo("Would you like to configure advanced settings?") {
 		return
 	}
@@ -199,9 +200,91 @@ func setAdvancedConfig() {
 
 	// syncer address
 	fmt.Println("")
-	fmt.Println("The syncer address is used to exchange blocks with other nodes in the Sia network")
+	fmt.Println("The syncer address is used to exchange blocks with other nodes in the Sia network.")
 	fmt.Println("It should be exposed publicly to improve the indexer's connectivity.")
 	setListenAddress("Gateway Address", &cfg.Syncer.Address)
+
+	// database user
+	fmt.Println("")
+	fmt.Println("The database user for the postgres connection.")
+	setDatabaseUser()
+
+	// database name
+	fmt.Println("")
+	fmt.Println("The database name for the postgres connection.")
+	setDatabaseName()
+
+	// database password
+	fmt.Println("")
+	fmt.Println("The database password for the postgres connection.")
+	setDatabasePassword()
+
+	// database address
+	fmt.Println("")
+	fmt.Println("The database address is used to connect to the indexer's database.")
+	setDatabaseAddress()
+}
+
+func setDatabaseAddress() {
+	current := fmt.Sprintf("%s:%d", cfg.Database.Host, cfg.Database.Port)
+	if !promptYesNo("Would you like to change the database address? (Current: " + current + ")") {
+		return
+	}
+
+	// will continue to prompt until a valid value is entered
+	for {
+		input := readInput(fmt.Sprintf("Enter new database address (currently %q)", current))
+		if input == "" {
+			return
+		}
+
+		host, port, err := net.SplitHostPort(input)
+		if err != nil {
+			stdoutError(fmt.Sprintf("Invalid database port %q: %s", input, err.Error()))
+			continue
+		}
+
+		n, err := strconv.Atoi(port)
+		if err != nil {
+			stdoutError(fmt.Sprintf("Invalid database port %q: %s", input, err.Error()))
+			continue
+		} else if n < 0 || n > 65535 {
+			stdoutError(fmt.Sprintf("Invalid database port %q: must be between 0 and 65535", input))
+			continue
+		}
+		cfg.Database.Host = host
+		cfg.Database.Port = n
+		return
+	}
+}
+
+func setDatabaseUser() {
+	if !promptYesNo("Would you like to change the database user? (Current: " + cfg.Database.User + ")") {
+		return
+	}
+	cfg.Database.User = readInput("Enter new user")
+}
+
+func setDatabaseName() {
+	if !promptYesNo("Would you like to change the database name? (Current: " + cfg.Database.Database + ")") {
+		return
+	}
+	cfg.Database.Database = readInput("Enter new database name")
+}
+
+func setDatabasePassword() {
+	if !promptYesNo("Would you like to change the database password?") {
+		return
+	}
+
+	fmt.Println("The database password is used to connect to the indexer's database.")
+	fmt.Println("It should be a strong password that is not used for any other purpose.")
+	cfg.Database.Password = readPasswordInput("Enter new database password")
+	if len(cfg.Database.Password) < 4 {
+		fmt.Println(wrapANSI("\033[31m", "Password must be at least 4 characters!", "\033[0m"))
+		setDatabasePassword()
+		return
+	}
 }
 
 func setDataDirectory() {

--- a/cmd/indexd/config.go
+++ b/cmd/indexd/config.go
@@ -240,13 +240,13 @@ func setDatabaseAddress() {
 
 		host, port, err := net.SplitHostPort(input)
 		if err != nil {
-			stdoutError(fmt.Sprintf("Invalid database port %q: %s", input, err.Error()))
+			stdoutError(fmt.Sprintf("Invalid database address %q: %s", input, err.Error()))
 			continue
 		}
 
 		n, err := strconv.Atoi(port)
 		if err != nil {
-			stdoutError(fmt.Sprintf("Invalid database port %q: %s", input, err.Error()))
+			stdoutError(fmt.Sprintf("Invalid database port %q: %s", port, err.Error()))
 			continue
 		} else if n < 0 || n > 65535 {
 			stdoutError(fmt.Sprintf("Invalid database port %q: must be between 0 and 65535", input))

--- a/cmd/indexd/config.go
+++ b/cmd/indexd/config.go
@@ -223,6 +223,11 @@ func setAdvancedConfig() {
 	fmt.Println("")
 	fmt.Println("The database address is used to connect to the indexer's database.")
 	setDatabaseAddress()
+
+	// database SSL mode
+	fmt.Println("")
+	fmt.Println("The database SSL mode is used to configure the database connection's encryption.")
+	setDatabaseSSLMode()
 }
 
 func setDatabaseAddress() {
@@ -258,13 +263,6 @@ func setDatabaseAddress() {
 	}
 }
 
-func setDatabaseUser() {
-	if !promptYesNo("Would you like to change the database user? (Current: " + cfg.Database.User + ")") {
-		return
-	}
-	cfg.Database.User = readInput("Enter new user")
-}
-
 func setDatabaseName() {
 	if !promptYesNo("Would you like to change the database name? (Current: " + cfg.Database.Database + ")") {
 		return
@@ -285,6 +283,20 @@ func setDatabasePassword() {
 		setDatabasePassword()
 		return
 	}
+}
+
+func setDatabaseSSLMode() {
+	if !promptYesNo("Would you like to change the database SSL mode? (Current: " + cfg.Database.SSLMode + ")") {
+		return
+	}
+	cfg.Database.SSLMode = promptQuestion("Enter new database SSL mode", []string{"disable", "allow", "prefer", "require", "verify-ca", "verify-full"})
+}
+
+func setDatabaseUser() {
+	if !promptYesNo("Would you like to change the database user? (Current: " + cfg.Database.User + ")") {
+		return
+	}
+	cfg.Database.User = readInput("Enter new user")
 }
 
 func setDataDirectory() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+# This file contains an example docker-compose configuration for running indexd.
+#
+# To use this, first create a `.env` file in the same directory with the
+# POSTGRES_PASSWORD variable set to your desired password.
+# Then run 'docker compose run --rm indexd seed' to generate a new seed if you
+# don't have one already.
+# Next, run 'docker compose run --rm -it indexd config' to configure indexd. You
+# can leave the default values for most options until you get to the "advanced
+# settings". In the advanced settings, you need to set the database user,
+# database name and password to match 'indexd', 'indexd' and the password you
+# chose respectively. You also need to set the database address to
+# 'postgres:5432'.
+# Finally, run 'docker compose up -d' to start the services.
+
+services:
+  postgres:
+    image: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: indexd
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: indexd
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+  # create seed using 'docker compose run --rm indexd seed'
+  # create config using 'docker compose run --rm -it indexd config'
+  indexd:
+    depends_on:
+      - postgres
+    image: ghcr.io/siafoundation/indexd:master
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:9980:9980/tcp # expose UI on localhost
+      - 9981:9981/tcp # public syncer
+      - 9982:9982/tcp # public apps API
+    volumes:
+      - indexd:/data
+
+volumes:
+  indexd:
+  postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@
 # settings". In the advanced settings, you need to set the database user,
 # database name and password to match 'indexd', 'indexd' and the password you
 # chose respectively. You also need to set the database address to
-# 'postgres:5432'.
+# 'postgres:5432' and the SSL mode to 'disable'.
 # Finally, run 'docker compose up -d' to start the services.
 
 services:
@@ -23,8 +23,6 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
 
-  # create seed using 'docker compose run --rm indexd seed'
-  # create config using 'docker compose run --rm -it indexd config'
   indexd:
     depends_on:
       - postgres


### PR DESCRIPTION
Right now configuring the database can only be done by modifying the config file which is a bit annoying when dealing with docker. This PR adds the database settings to the advanced configuration so that an initial `docker compose run --rm -it indexd config` can be used to configure `indexd` enough for it to run.