### PR TITLE
Add app auth flow

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -17,6 +17,7 @@ import (
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/build"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/explorer"
@@ -81,6 +82,10 @@ type (
 		UpdateMaintenanceSettings(ctx context.Context, ms contracts.MaintenanceSettings) error
 		PinnedSettings(ctx context.Context) (pins.PinnedSettings, error)
 		UpdatePinnedSettings(ctx context.Context, ps pins.PinnedSettings) error
+
+		AddAppConnectKey(context.Context, app.AddConnectKey) error
+		DeleteAppConnectKey(context.Context, string) error
+		AppConnectKeys(ctx context.Context, offset, limit int) ([]app.ConnectKey, error)
 	}
 
 	// A Syncer can connect to other peers and synchronize the blockchain.
@@ -179,6 +184,11 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 		// txpool endpoints
 		"GET /txpool/recommendedfee": a.handleGETTxpoolRecommendedFee,
 
+		// connect endpoints
+		"GET /apps/connect/keys":         a.handleGETAppConnectKeys,
+		"PUT /apps/connect/keys":         a.handlePUTAppConnectKeys,
+		"DELETE /apps/connect/keys/:key": a.handleDELETEAppConnectKeys,
+
 		// wallet endpoints
 		"GET /wallet":            a.handleGETWallet,
 		"GET /wallet/events":     a.handleGETWalletEvents,
@@ -247,6 +257,45 @@ func (a *admin) handlePOSTTrigger(jc jape.Context) {
 		return
 	}
 
+	jc.Encode(nil)
+}
+
+func (a *admin) handleGETAppConnectKeys(jc jape.Context) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	keys, err := a.store.AppConnectKeys(jc.Request.Context(), offset, limit)
+	if jc.Check("failed to get app connect keys", err) != nil {
+		return
+	}
+	jc.Encode(keys)
+}
+
+func (a *admin) handlePUTAppConnectKeys(jc jape.Context) {
+	var key app.AddConnectKey
+	if jc.Decode(&key) != nil {
+		return
+	}
+
+	err := a.store.AddAppConnectKey(jc.Request.Context(), key)
+	if jc.Check("failed to add app connect key", err) != nil {
+		return
+	}
+	jc.Encode(nil)
+}
+
+func (a *admin) handleDELETEAppConnectKeys(jc jape.Context) {
+	var key string
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	err := a.store.DeleteAppConnectKey(jc.Request.Context(), key)
+	if jc.Check("failed to delete app connect key", err) != nil {
+		return
+	}
 	jc.Encode(nil)
 }
 

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/hex"
 	"net/http"
 
 	"errors"
@@ -25,6 +26,7 @@ import (
 	"go.sia.tech/indexd/pins"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -83,7 +85,8 @@ type (
 		PinnedSettings(ctx context.Context) (pins.PinnedSettings, error)
 		UpdatePinnedSettings(ctx context.Context, ps pins.PinnedSettings) error
 
-		AddAppConnectKey(context.Context, app.AddConnectKey) error
+		AddAppConnectKey(context.Context, app.UpdateAppConnectKey) (app.ConnectKey, error)
+		UpdateAppConnectKey(context.Context, app.UpdateAppConnectKey) (app.ConnectKey, error)
 		DeleteAppConnectKey(context.Context, string) error
 		AppConnectKeys(ctx context.Context, offset, limit int) ([]app.ConnectKey, error)
 	}
@@ -186,6 +189,7 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 
 		// connect endpoints
 		"GET /apps/connect/keys":         a.handleGETAppConnectKeys,
+		"POST /apps/connect/keys":        a.handlePOSTAppConnectKeys,
 		"PUT /apps/connect/keys":         a.handlePUTAppConnectKeys,
 		"DELETE /apps/connect/keys/:key": a.handleDELETEAppConnectKeys,
 
@@ -273,16 +277,37 @@ func (a *admin) handleGETAppConnectKeys(jc jape.Context) {
 	jc.Encode(keys)
 }
 
-func (a *admin) handlePUTAppConnectKeys(jc jape.Context) {
-	var key app.AddConnectKey
+func (a *admin) handlePOSTAppConnectKeys(jc jape.Context) {
+	var key app.AddConnectKeyRequest
 	if jc.Decode(&key) != nil {
 		return
 	}
 
-	err := a.store.AddAppConnectKey(jc.Request.Context(), key)
-	if jc.Check("failed to add app connect key", err) != nil {
+	created, err := a.store.AddAppConnectKey(jc.Request.Context(), app.UpdateAppConnectKey{
+		Key:           hex.EncodeToString(frand.Bytes(16)),
+		Description:   key.Description,
+		RemainingUses: key.RemainingUses,
+	})
+	if jc.Check("failed to update app connect key", err) != nil {
 		return
 	}
+	jc.Encode(created)
+}
+
+func (a *admin) handlePUTAppConnectKeys(jc jape.Context) {
+	var key app.UpdateAppConnectKey
+	if jc.Decode(&key) != nil {
+		return
+	}
+
+	_, err := a.store.UpdateAppConnectKey(jc.Request.Context(), key)
+	if errors.Is(err, app.ErrKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to update app connect key", err) != nil {
+		return
+	}
+	// PUT doesn't expect a body
 	jc.Encode(nil)
 }
 
@@ -293,7 +318,10 @@ func (a *admin) handleDELETEAppConnectKeys(jc jape.Context) {
 	}
 
 	err := a.store.DeleteAppConnectKey(jc.Request.Context(), key)
-	if jc.Check("failed to delete app connect key", err) != nil {
+	if errors.Is(err, app.ErrKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to delete app connect key", err) != nil {
 		return
 	}
 	jc.Encode(nil)

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -2,8 +2,11 @@ package admin_test
 
 import (
 	"context"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +17,7 @@ import (
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/admin"
+	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/pins"
@@ -22,6 +26,96 @@ import (
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
+
+func TestAppConnectKeys(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+	admin := indexer.Client
+
+	keys, err := admin.AppConnectKeys(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 0 {
+		t.Fatal("unexpected keys", keys)
+	}
+
+	var generated []app.ConnectKey
+	for i := range 100 {
+		key := app.ConnectKey{
+			Key:           hex.EncodeToString(frand.Bytes(32)),
+			Description:   fmt.Sprintf("key %d", i),
+			RemainingUses: frand.Intn(1000) + 1,
+		}
+		err = admin.AddAppConnectKey(context.Background(), app.AddConnectKey{
+			Key:           key.Key,
+			Description:   key.Description,
+			RemainingUses: key.RemainingUses,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		generated = append(generated, key)
+	}
+	slices.Reverse(generated)
+
+	// verify keys were added
+	keys, err = admin.AppConnectKeys(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 10 {
+		t.Fatal("unexpected keys", keys)
+	}
+	for i := range keys {
+		generated[i].DateCreated = keys[i].DateCreated
+		if !reflect.DeepEqual(keys[i], generated[i]) {
+			t.Fatal("unexpected key", keys[i], generated[i])
+		}
+	}
+
+	keys, err = admin.AppConnectKeys(context.Background(), 10, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 10 {
+		t.Fatal("unexpected keys", keys)
+	}
+	filtered := generated[10:20]
+	for i := range keys {
+		filtered[i].DateCreated = keys[i].DateCreated
+		if !reflect.DeepEqual(keys[i], filtered[i]) {
+			t.Fatal("unexpected key", keys[i], filtered[i])
+		}
+	}
+
+	key := generated[0]
+	key.Description = "foobar"
+
+	if err := admin.AddAppConnectKey(context.Background(), app.AddConnectKey{
+		Key:           key.Key,
+		Description:   key.Description,
+		RemainingUses: key.RemainingUses,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err = admin.AppConnectKeys(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(keys[0], key) {
+		t.Fatal("unexpected key", keys[0], key)
+	}
+
+	err = admin.DeleteAppConnectKey(context.Background(), key.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err = admin.AppConnectKeys(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(keys[0], generated[1]) {
+		t.Fatal("unexpected key", keys[0], generated[1])
+	}
+}
 
 func TestAccountsAPI(t *testing.T) {
 	c := testutils.NewConsensusNode(t, zap.NewNop())

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -2,7 +2,6 @@ package admin_test
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"reflect"
@@ -41,20 +40,32 @@ func TestAppConnectKeys(t *testing.T) {
 
 	var generated []app.ConnectKey
 	for i := range 100 {
-		key := app.ConnectKey{
-			Key:           hex.EncodeToString(frand.Bytes(32)),
-			Description:   fmt.Sprintf("key %d", i),
-			RemainingUses: frand.Intn(1000) + 1,
-		}
-		err = admin.AddAppConnectKey(context.Background(), app.AddConnectKey{
-			Key:           key.Key,
-			Description:   key.Description,
-			RemainingUses: key.RemainingUses,
+		description := fmt.Sprintf("key %d", i)
+		uses := frand.Intn(1000) + 1
+		created, err := admin.AddAppConnectKey(context.Background(), app.AddConnectKeyRequest{
+			Description:   description,
+			RemainingUses: uses,
 		})
+		switch {
+		case err != nil:
+			t.Fatal(err)
+		case created.Key == "":
+			t.Fatal("expected key to be generated")
+		case created.RemainingUses != uses:
+			t.Fatal("expected remaining uses to match")
+		case created.TotalUses != 0:
+			t.Fatal("expected total uses to be 0")
+		case !created.LastUsed.IsZero():
+			t.Fatal("expected last used to be zero")
+		case created.DateCreated.IsZero():
+			t.Fatal("expected date created to be set")
+		case created.LastUpdated.IsZero():
+			t.Fatal("expected last updated to be set")
+		}
 		if err != nil {
 			t.Fatal(err)
 		}
-		generated = append(generated, key)
+		generated = append(generated, created)
 	}
 	slices.Reverse(generated)
 
@@ -89,11 +100,12 @@ func TestAppConnectKeys(t *testing.T) {
 	key := generated[0]
 	key.Description = "foobar"
 
-	if err := admin.AddAppConnectKey(context.Background(), app.AddConnectKey{
+	err = admin.UpdateAppConnectKey(context.Background(), app.UpdateAppConnectKey{
 		Key:           key.Key,
 		Description:   key.Description,
 		RemainingUses: key.RemainingUses,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -8,6 +8,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/pins"
@@ -27,6 +28,27 @@ func NewClient(addr, password string) *Client {
 		BaseURL:  addr,
 		Password: password,
 	}}
+}
+
+// AppConnectKeys retrieves a paginated list of application connection keys.
+func (c *Client) AppConnectKeys(ctx context.Context, offset, limit int) (keys []app.ConnectKey, err error) {
+	values := url.Values{}
+	values.Set("offset", fmt.Sprintf("%d", offset))
+	values.Set("limit", fmt.Sprintf("%d", limit))
+	err = c.c.GET(ctx, "/apps/connect/keys?"+values.Encode(), &keys)
+	return
+}
+
+// DeleteAppConnectKey removes the application connection key with the given key.
+func (c *Client) DeleteAppConnectKey(ctx context.Context, key string) (err error) {
+	err = c.c.DELETE(ctx, fmt.Sprintf("/apps/connect/keys/%s", key))
+	return
+}
+
+// AddAppConnectKey adds a new application connection key.
+func (c *Client) AddAppConnectKey(ctx context.Context, key app.AddConnectKey) (err error) {
+	err = c.c.PUT(ctx, "/apps/connect/keys", key)
+	return
 }
 
 // Accounts returns all accounts registered in the indexer.

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -46,9 +46,14 @@ func (c *Client) DeleteAppConnectKey(ctx context.Context, key string) (err error
 }
 
 // AddAppConnectKey adds a new application connection key.
-func (c *Client) AddAppConnectKey(ctx context.Context, key app.AddConnectKey) (err error) {
-	err = c.c.PUT(ctx, "/apps/connect/keys", key)
+func (c *Client) AddAppConnectKey(ctx context.Context, req app.AddConnectKeyRequest) (key app.ConnectKey, err error) {
+	err = c.c.POST(ctx, "/apps/connect/keys", req, &key)
 	return
+}
+
+// UpdateAppConnectKey updates an existing application connection key.
+func (c *Client) UpdateAppConnectKey(ctx context.Context, req app.UpdateAppConnectKey) error {
+	return c.c.PUT(ctx, "/apps/connect/keys", req)
 }
 
 // Accounts returns all accounts registered in the indexer.

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -344,11 +344,14 @@ func NewAPI(advertiseURL string, store Store, opts ...Option) (http.Handler, err
 			}
 
 			ok, err := store.ValidAppConnectKey(jc.Request.Context(), password)
-			if err != nil {
+			if errors.Is(err, ErrKeyNotFound) {
+				jc.Error(errors.New("invalid app connect key"), http.StatusUnauthorized)
+				return
+			} else if err != nil {
 				jc.Error(ErrInternalError, http.StatusInternalServerError)
 				return
 			} else if !ok {
-				jc.Error(errors.New("unauthorized"), http.StatusUnauthorized)
+				jc.Error(errors.New("no more uses"), http.StatusForbidden)
 				return
 			}
 

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -2,9 +2,12 @@ package app
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"html/template"
 	"net/http"
+	"sync"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -14,6 +17,9 @@ import (
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
+
+	_ "embed"
 )
 
 type (
@@ -27,18 +33,71 @@ type (
 		SlabIDs(ctx context.Context, accountID proto.Account, offset, limit int) ([]slabs.SlabID, error)
 		UnpinSlab(context.Context, proto.Account, slabs.SlabID) error
 		UsableHosts(ctx context.Context, offset, limit int) ([]hosts.HostInfo, error)
+
+		HasAccount(ctx context.Context, ak types.PublicKey) (bool, error)
+		AddAccount(ctx context.Context, pk types.PublicKey) error
+	}
+
+	authReq struct {
+		Request     RegisterAppRequest
+		ResponseURL string
+		AppKey      types.PublicKey
+		Approved    bool
+		Expiration  time.Time
+	}
+
+	RegisterAppRequest struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		LogoURL     string `json:"logoURL"`
+		ServiceURL  string `json:"serviceURL"`
+		CallbackURL string `json:"callbackURL"`
+	}
+
+	RegisterAppResponse struct {
+		ResponseURL string    `json:"responseURL"`
+		Expiration  time.Time `json:"expiration"`
+	}
+
+	ApproveAppRequest struct {
+		Approve bool `json:"approve"`
 	}
 
 	app struct {
 		store Store
 		log   *zap.Logger
+
+		hostname        string
+		authRequiresTLS bool
+
+		mu           sync.Mutex
+		authRequests map[string]authReq // maps request ID to auth request
 	}
+)
+
+var (
+	//go:embed auth.html
+	authHTML string
+
+	authTemplate = template.Must(template.New("auth").Parse(authHTML))
+
+	// ErrAlreadyConnected is returned when an application that
+	// is already connected tries to connect again.
+	ErrAlreadyConnected = errors.New("account already connected")
 )
 
 // WithLogger sets the logger for application API.
 func WithLogger(log *zap.Logger) Option {
 	return func(api *app) {
 		api.log = log
+	}
+}
+
+// WithAuthRequiresTLS sets whether the application API requires TLS when
+// connecting with new apps.
+func WithAuthRequiresTLS(requiresTLS bool) Option {
+	return func(api *app) {
+		api.authRequiresTLS = requiresTLS
 	}
 }
 
@@ -122,37 +181,193 @@ func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 	jc.Encode(nil)
 }
 
+func (a *app) handleAuthRegister(jc jape.Context) {
+	// check whether the request is properly signed
+	pk, ok := getSignedURLAuth(jc, a.hostname)
+	if !ok {
+		return
+	}
+
+	// check if the account is already connected
+	if known, err := a.store.HasAccount(jc.Request.Context(), pk); err != nil {
+		jc.Error(ErrInternalError, http.StatusInternalServerError)
+		return
+	} else if known {
+		jc.Error(ErrAlreadyConnected, http.StatusConflict)
+		return
+	}
+
+	var req RegisterAppRequest
+	if err := jc.Decode(&req); err != nil {
+		return
+	}
+
+	switch {
+	case req.Name == "":
+		jc.Error(errors.New("name is required"), http.StatusBadRequest)
+		return
+	case req.Description == "":
+		jc.Error(errors.New("description is required"), http.StatusBadRequest)
+		return
+	case req.ServiceURL == "":
+		jc.Error(errors.New("service URL is required"), http.StatusBadRequest)
+		return
+	}
+
+	requestID := hex.EncodeToString(frand.Bytes(16))
+	expiration := time.Now().Add(10 * time.Minute)
+
+	a.mu.Lock()
+	a.authRequests[requestID] = authReq{
+		Request:    req,
+		AppKey:     pk,
+		Expiration: expiration,
+	}
+	a.mu.Unlock()
+	time.AfterFunc(time.Until(expiration), func() {
+		a.mu.Lock()
+		delete(a.authRequests, requestID)
+		a.mu.Unlock()
+	})
+	proto := "https"
+	if !a.authRequiresTLS {
+		proto = "http"
+	}
+	jc.Encode(RegisterAppResponse{
+		ResponseURL: fmt.Sprintf("%s://%s/auth/connect/%s", proto, a.hostname, requestID),
+		Expiration:  expiration,
+	})
+}
+
+func (a *app) handleGETAuthCheck(jc jape.Context, _ types.PublicKey) {
+	jc.Encode(nil) // if we reached this point, account is already authenticated
+}
+
+func (a *app) handleGETAuthConnectUI(jc jape.Context) {
+	var requestID string
+	jc.DecodeParam("requestID", &requestID)
+	jc.ResponseWriter.Header().Set("Content-Type", "text/html")
+
+	a.mu.Lock()
+	authReq, ok := a.authRequests[requestID]
+	a.mu.Unlock()
+	if !ok {
+		jc.Error(fmt.Errorf("unknown request ID %q", requestID), http.StatusNotFound)
+		return
+	}
+
+	authTemplate.Execute(jc.ResponseWriter, authReq) // skip error check since it could be an io error
+}
+
+func (a *app) handlePOSTAuthConnect(jc jape.Context) {
+	ctx := jc.Request.Context()
+
+	if jc.Request.Host != a.hostname {
+		jc.Error(fmt.Errorf("invalid hostname %q", jc.Request.Host), http.StatusBadRequest)
+		return
+	} else if jc.Request.TLS == nil && a.authRequiresTLS {
+		jc.Error(errors.New("application API requires TLS"), http.StatusBadRequest)
+		return
+	}
+
+	var requestID string
+	if err := jc.DecodeParam("requestID", &requestID); err != nil {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	}
+
+	a.mu.Lock()
+	req, ok := a.authRequests[requestID]
+	a.mu.Unlock()
+	if !ok {
+		jc.Error(fmt.Errorf("unknown request ID %q", requestID), http.StatusNotFound)
+		return
+	}
+
+	var approveReq ApproveAppRequest
+	if err := jc.Decode(&approveReq); err != nil {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	}
+
+	a.mu.Lock()
+	delete(a.authRequests, requestID)
+	a.mu.Unlock()
+
+	if !approveReq.Approve {
+		// request is rejected, nothing to do
+		jc.Encode(nil)
+		return
+	}
+
+	if err := a.store.AddAccount(ctx, req.AppKey); err != nil {
+		jc.Error(ErrInternalError, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(nil)
+}
+
 // NewAPI creates a new instance of the application API. This API is used by
 // users, or rather their applications, to pin slabs to the indexer.
 // Authentication happens through presigned URLs that are signed with a private
 // key that corresponds to a previously registered public key.
-func NewAPI(hostname string, store Store, as AccountStore, opts ...Option) http.Handler {
+func NewAPI(hostname string, store Store, registerAppPassword string, opts ...Option) http.Handler {
 	a := &app{
 		store: store,
 		log:   zap.NewNop(),
+
+		hostname:        hostname,
+		authRequests:    make(map[string]authReq),
+		authRequiresTLS: true,
 	}
 	for _, opt := range opts {
 		opt(a)
 	}
 
-	routes := map[string]authedHandler{
-		"GET /hosts": a.handleGETHosts,
-
-		"GET /slabs":            a.handleGETSlabs,
-		"POST /slabs":           a.handlePOSTSlabs,
-		"GET /slabs/:slabid":    a.handleGETSlab,
-		"DELETE /slabs/:slabid": a.handleDELETESlab,
-	}
-
-	signed := make(map[string]jape.Handler)
-	for path, handler := range routes {
-		signed[path] = func(jc jape.Context) {
-			pk, ok := checkSignedURLAuth(jc, hostname, as)
+	wrapSignedAuth := func(h authedHandler) jape.Handler {
+		return func(jc jape.Context) {
+			pk, ok := checkSignedURLAuth(jc, a.hostname, store)
 			if !ok {
 				return
 			}
-			handler(jc, pk)
+			h(jc, pk)
 		}
 	}
-	return jape.Mux(signed)
+
+	wrapBasicAuth := func(h jape.Handler) jape.Handler {
+		return func(jc jape.Context) {
+			_, password, ok := jc.Request.BasicAuth()
+			if !ok || password != registerAppPassword {
+				jc.Error(errors.New("unauthorized"), http.StatusUnauthorized)
+				return
+			}
+			h(jc)
+		}
+	}
+
+	wrapCORS := func(h jape.Handler) jape.Handler {
+		return func(jc jape.Context) {
+			jc.ResponseWriter.Header().Set("Access-Control-Allow-Origin", "*")
+			jc.ResponseWriter.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE")
+			jc.ResponseWriter.Header().Set("Access-Control-Allow-Headers", "*")
+			if jc.Request.Method == http.MethodOptions {
+				jc.ResponseWriter.WriteHeader(http.StatusNoContent)
+				return
+			}
+			h(jc)
+		}
+	}
+
+	return jape.Mux(map[string]jape.Handler{
+		"POST /auth/connect":            a.handleAuthRegister, // register request
+		"GET /auth/connect/:requestID":  a.handleGETAuthConnectUI,
+		"POST /auth/connect/:requestID": wrapBasicAuth(a.handlePOSTAuthConnect),         // accept/reject
+		"GET /auth/check":               wrapCORS(wrapSignedAuth(a.handleGETAuthCheck)), // check auth status
+
+		"GET /hosts":            wrapCORS(wrapSignedAuth(a.handleGETHosts)),
+		"GET /slabs":            wrapCORS(wrapSignedAuth(a.handleGETSlabs)),
+		"POST /slabs":           wrapCORS(wrapSignedAuth(a.handlePOSTSlabs)),
+		"GET /slabs/:slabid":    wrapCORS(wrapSignedAuth(a.handleGETSlab)),
+		"DELETE /slabs/:slabid": wrapCORS(wrapSignedAuth(a.handleDELETESlab)),
+	})
 }

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -251,7 +251,10 @@ func (a *app) handleGETAuthConnectUI(jc jape.Context) {
 		return
 	}
 
-	authTemplate.Execute(jc.ResponseWriter, authReq) // skip error check since it could be an io error
+	if err := authTemplate.Execute(jc.ResponseWriter, authReq); err != nil {
+		// cannot return an error at this point, just log it
+		a.log.Debug("failed to execute auth template", zap.Error(err))
+	}
 }
 
 func (a *app) handlePOSTAuthConnect(jc jape.Context) {

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -57,6 +57,12 @@ type (
 		CallbackURL string `json:"callbackURL"`
 	}
 
+	// AuthConnectStatusResponse is the response body for checking the status of an
+	// application connection request.
+	AuthConnectStatusResponse struct {
+		Approved bool `json:"approved"`
+	}
+
 	// RegisterAppResponse is the response body for registering a new application.
 	// It contains the URL to redirect the user to for authentication.
 	// The user must approve the request before the expiration time.
@@ -242,10 +248,6 @@ func (a *app) handleAuthRegister(jc jape.Context) {
 
 func (a *app) handleGETAuthCheck(jc jape.Context, _ types.PublicKey) {
 	jc.Encode(nil) // if we reached this point, account is already authenticated
-}
-
-type AuthConnectStatusResponse struct {
-	Approved bool `json:"approved"`
 }
 
 func (a *app) handleGETAuthConnectStatus(jc jape.Context) {

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -34,8 +35,10 @@ type (
 		UnpinSlab(context.Context, proto.Account, slabs.SlabID) error
 		UsableHosts(ctx context.Context, offset, limit int) ([]hosts.HostInfo, error)
 
+		ValidAppConnectKey(context.Context, string) (bool, error)
+		UseAppConnectKey(context.Context, string, types.PublicKey) error
+
 		HasAccount(ctx context.Context, ak types.PublicKey) (bool, error)
-		AddAccount(ctx context.Context, pk types.PublicKey) error
 	}
 
 	authReq struct {
@@ -71,8 +74,8 @@ type (
 		store Store
 		log   *zap.Logger
 
-		hostname        string
-		authRequiresTLS bool
+		hostname     string
+		advertiseURL string
 
 		mu           sync.Mutex
 		authRequests map[string]authReq // maps request ID to auth request
@@ -94,14 +97,6 @@ var (
 func WithLogger(log *zap.Logger) Option {
 	return func(api *app) {
 		api.log = log
-	}
-}
-
-// WithAuthRequiresTLS sets whether the application API requires TLS when
-// connecting with new apps.
-func WithAuthRequiresTLS(requiresTLS bool) Option {
-	return func(api *app) {
-		api.authRequiresTLS = requiresTLS
 	}
 }
 
@@ -233,12 +228,8 @@ func (a *app) handleAuthRegister(jc jape.Context) {
 		delete(a.authRequests, requestID)
 		a.mu.Unlock()
 	})
-	proto := "https"
-	if !a.authRequiresTLS {
-		proto = "http"
-	}
 	jc.Encode(RegisterAppResponse{
-		ResponseURL: fmt.Sprintf("%s://%s/auth/connect/%s", proto, a.hostname, requestID),
+		ResponseURL: fmt.Sprintf("%s/auth/connect/%s", a.advertiseURL, requestID),
 		Expiration:  expiration,
 	})
 }
@@ -264,13 +255,11 @@ func (a *app) handleGETAuthConnectUI(jc jape.Context) {
 }
 
 func (a *app) handlePOSTAuthConnect(jc jape.Context) {
+	_, connectKey, _ := jc.Request.BasicAuth()
 	ctx := jc.Request.Context()
 
 	if jc.Request.Host != a.hostname {
 		jc.Error(fmt.Errorf("invalid hostname %q", jc.Request.Host), http.StatusBadRequest)
-		return
-	} else if jc.Request.TLS == nil && a.authRequiresTLS {
-		jc.Error(errors.New("application API requires TLS"), http.StatusBadRequest)
 		return
 	}
 
@@ -304,9 +293,8 @@ func (a *app) handlePOSTAuthConnect(jc jape.Context) {
 		return
 	}
 
-	if err := a.store.AddAccount(ctx, req.AppKey); err != nil {
-		jc.Error(ErrInternalError, http.StatusInternalServerError)
-		return
+	if err := a.store.UseAppConnectKey(ctx, connectKey, req.AppKey); err != nil {
+		a.log.Debug("failed to use connect key", zap.Error(err)) // no need to fail
 	}
 	jc.Encode(nil)
 }
@@ -315,14 +303,18 @@ func (a *app) handlePOSTAuthConnect(jc jape.Context) {
 // users, or rather their applications, to pin slabs to the indexer.
 // Authentication happens through presigned URLs that are signed with a private
 // key that corresponds to a previously registered public key.
-func NewAPI(hostname string, store Store, registerAppPassword string, opts ...Option) http.Handler {
+func NewAPI(advertiseURL string, store Store, opts ...Option) (http.Handler, error) {
+	u, err := url.Parse(advertiseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse advertise URL %q: %w", advertiseURL, err)
+	}
 	a := &app{
 		store: store,
 		log:   zap.NewNop(),
 
-		hostname:        hostname,
-		authRequests:    make(map[string]authReq),
-		authRequiresTLS: true,
+		hostname:     u.Host,
+		advertiseURL: advertiseURL,
+		authRequests: make(map[string]authReq),
 	}
 	for _, opt := range opts {
 		opt(a)
@@ -341,10 +333,20 @@ func NewAPI(hostname string, store Store, registerAppPassword string, opts ...Op
 	wrapBasicAuth := func(h jape.Handler) jape.Handler {
 		return func(jc jape.Context) {
 			_, password, ok := jc.Request.BasicAuth()
-			if !ok || password != registerAppPassword {
+			if !ok {
+				jc.Error(errors.New("missing basic auth credentials"), http.StatusUnauthorized)
+				return
+			}
+
+			ok, err := store.ValidAppConnectKey(jc.Request.Context(), password)
+			if err != nil {
+				jc.Error(ErrInternalError, http.StatusInternalServerError)
+				return
+			} else if !ok {
 				jc.Error(errors.New("unauthorized"), http.StatusUnauthorized)
 				return
 			}
+
 			h(jc)
 		}
 	}
@@ -373,5 +375,5 @@ func NewAPI(hostname string, store Store, registerAppPassword string, opts ...Op
 		"POST /slabs":           wrapCORS(wrapSignedAuth(a.handlePOSTSlabs)),
 		"GET /slabs/:slabid":    wrapCORS(wrapSignedAuth(a.handleGETSlab)),
 		"DELETE /slabs/:slabid": wrapCORS(wrapSignedAuth(a.handleDELETESlab)),
-	})
+	}), nil
 }

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -62,6 +62,7 @@ type (
 	// The user must approve the request before the expiration time.
 	RegisterAppResponse struct {
 		ResponseURL string    `json:"responseURL"`
+		StatusURL   string    `json:"statusURL"`
 		Expiration  time.Time `json:"expiration"`
 	}
 
@@ -91,6 +92,10 @@ var (
 	// ErrAlreadyConnected is returned when an application that
 	// is already connected tries to connect again.
 	ErrAlreadyConnected = errors.New("account already connected")
+
+	// ErrUserRejected is returned when a user rejects an application
+	// connection request.
+	ErrUserRejected = errors.New("user rejected connection request")
 )
 
 // WithLogger sets the logger for application API.
@@ -230,6 +235,7 @@ func (a *app) handleAuthRegister(jc jape.Context) {
 	})
 	jc.Encode(RegisterAppResponse{
 		ResponseURL: fmt.Sprintf("%s/auth/connect/%s", a.advertiseURL, requestID),
+		StatusURL:   fmt.Sprintf("%s/auth/connect/%s/status", a.advertiseURL, requestID),
 		Expiration:  expiration,
 	})
 }
@@ -238,6 +244,46 @@ func (a *app) handleGETAuthCheck(jc jape.Context, _ types.PublicKey) {
 	jc.Encode(nil) // if we reached this point, account is already authenticated
 }
 
+type AuthConnectStatusResponse struct {
+	Approved bool `json:"approved"`
+}
+
+func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
+	// check whether the request is properly signed
+	pk, ok := getSignedURLAuth(jc, a.hostname)
+	if !ok {
+		return
+	}
+
+	if ok, err := a.store.HasAccount(jc.Request.Context(), pk); err != nil {
+		jc.Error(ErrInternalError, http.StatusInternalServerError)
+		return
+	} else if ok {
+		jc.Encode(AuthConnectStatusResponse{
+			Approved: true,
+		})
+		return
+	}
+
+	var requestID string
+	jc.DecodeParam("requestID", &requestID)
+
+	a.mu.Lock()
+	authReq, ok := a.authRequests[requestID]
+	a.mu.Unlock()
+	switch {
+	case !ok:
+		jc.Error(fmt.Errorf("unknown request ID %q", requestID), http.StatusNotFound)
+	case authReq.AppKey != pk:
+		jc.Error(fmt.Errorf("invalid app key"), http.StatusBadRequest)
+	case time.Now().After(authReq.Expiration):
+		jc.Error(fmt.Errorf("request expired"), http.StatusGone)
+	default:
+		jc.Encode(AuthConnectStatusResponse{
+			Approved: false,
+		})
+	}
+}
 func (a *app) handleGETAuthConnectUI(jc jape.Context) {
 	var requestID string
 	jc.DecodeParam("requestID", &requestID)
@@ -373,10 +419,11 @@ func NewAPI(advertiseURL string, store Store, opts ...Option) (http.Handler, err
 	}
 
 	return jape.Mux(map[string]jape.Handler{
-		"POST /auth/connect":            a.handleAuthRegister, // register request
-		"GET /auth/connect/:requestID":  a.handleGETAuthConnectUI,
-		"POST /auth/connect/:requestID": wrapBasicAuth(a.handlePOSTAuthConnect),         // accept/reject
-		"GET /auth/check":               wrapCORS(wrapSignedAuth(a.handleGETAuthCheck)), // check auth status
+		"POST /auth/connect":                  a.handleAuthRegister, // register request
+		"GET /auth/connect/:requestID":        a.handleGETAuthConnectUI,
+		"POST /auth/connect/:requestID":       wrapBasicAuth(a.handlePOSTAuthConnect), // accept/reject
+		"GET /auth/connect/:requestID/status": wrapCORS(a.handleGETAuthConnectStatus),
+		"GET /auth/check":                     wrapCORS(wrapSignedAuth(a.handleGETAuthCheck)),
 
 		"GET /hosts":            wrapCORS(wrapSignedAuth(a.handleGETHosts)),
 		"GET /slabs":            wrapCORS(wrapSignedAuth(a.handleGETSlabs)),

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -294,7 +294,9 @@ func (a *app) handlePOSTAuthConnect(jc jape.Context) {
 	}
 
 	if err := a.store.UseAppConnectKey(ctx, connectKey, req.AppKey); err != nil {
-		a.log.Debug("failed to use connect key", zap.Error(err)) // no need to fail
+		a.log.Debug("failed to use app connect key", zap.Error(err))
+		jc.Error(ErrInternalError, http.StatusInternalServerError)
+		return
 	}
 	jc.Encode(nil)
 }

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -42,10 +42,10 @@ type (
 		Request     RegisterAppRequest
 		ResponseURL string
 		AppKey      types.PublicKey
-		Approved    bool
 		Expiration  time.Time
 	}
 
+	// A RegisterAppRequest is the request body for registering a new application.
 	RegisterAppRequest struct {
 		Name        string `json:"name"`
 		Description string `json:"description"`
@@ -54,11 +54,15 @@ type (
 		CallbackURL string `json:"callbackURL"`
 	}
 
+	// RegisterAppResponse is the response body for registering a new application.
+	// It contains the URL to redirect the user to for authentication.
+	// The user must approve the request before the expiration time.
 	RegisterAppResponse struct {
 		ResponseURL string    `json:"responseURL"`
 		Expiration  time.Time `json:"expiration"`
 	}
 
+	// ApproveAppRequest is the request body for approving or rejecting an application connection request.
 	ApproveAppRequest struct {
 		Approve bool `json:"approve"`
 	}

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -1,7 +1,10 @@
 package app_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -9,12 +12,40 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"lukechampine.com/frand"
 )
 
+func respondToAppConnection(t *testing.T, responseURL string, approve bool) {
+	t.Helper()
+
+	buf, err := json.Marshal(app.ApproveAppRequest{
+		Approve: approve,
+	})
+	if err != nil {
+		t.Fatal("failed to marshal approve request:", err)
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, responseURL, bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal("failed to create request:", err)
+	}
+	req.SetBasicAuth("", "foobar")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("failed to send request:", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatal("unexpected response status:", resp.Status)
+	}
+}
+
 func TestApplicationAPI(t *testing.T) {
+	ctx := t.Context()
 	// create cluster with three hosts
 	logger := testutils.NewLogger(false)
 	cluster := testutils.NewCluster(t, testutils.WithHosts(3), testutils.WithLogger(logger))
@@ -22,7 +53,7 @@ func TestApplicationAPI(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// assert hosts are registered
-	hosts, err := indexer.Hosts(context.Background())
+	hosts, err := indexer.Hosts(ctx)
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
 	} else if len(hosts) != 3 {
@@ -35,8 +66,33 @@ func TestApplicationAPI(t *testing.T) {
 
 	// prepare account
 	sk := types.GeneratePrivateKey()
-	if err := indexer.AccountsAdd(context.Background(), sk.PublicKey()); err != nil {
+	client := indexer.App(sk)
+
+	connectResp, err := client.RequestAppConnection(ctx, app.RegisterAppRequest{
+		Name:        "Test App",
+		Description: "A test application",
+		LogoURL:     "foo",
+		ServiceURL:  "bar",
+	})
+	if err != nil {
+		t.Fatal("failed to request app connection:", err)
+	}
+
+	// check the app is not authenticated yet
+	if ok, err := client.CheckAppAuth(ctx); err != nil {
 		t.Fatal(err)
+	} else if ok {
+		t.Fatal("expected app to not be authenticated yet")
+	}
+
+	// approve the app
+	respondToAppConnection(t, connectResp.ResponseURL, true)
+
+	// check the app is not authenticated yet
+	if ok, err := client.CheckAppAuth(ctx); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("expected app to be authenticated")
 	}
 
 	// helper to generate slab pin parameters
@@ -62,27 +118,27 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// pin the slab
-	slabID, err := indexer.App(sk).PinSlab(context.Background(), params())
+	slabID, err := client.PinSlab(context.Background(), params())
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}
 
 	// unpin the slab
-	if err := indexer.App(sk).UnpinSlab(context.Background(), slabID); err != nil {
+	if err := client.UnpinSlab(context.Background(), slabID); err != nil {
 		t.Fatal("failed to unpin slab:", err)
 	}
 
 	// assert minimum redundancy is enforced
 	p := params()
 	p.Sectors = p.Sectors[:2]
-	_, err = indexer.App(sk).PinSlab(context.Background(), p)
+	_, err = client.PinSlab(context.Background(), p)
 	if err == nil || !strings.Contains(err.Error(), slabs.ErrInsufficientRedundancy.Error()) {
 		t.Fatal("expected [slabs.ErrInsufficientRedundancy], got:", err)
 	}
 
 	// assert hosts returns all usable hosts
 	time.Sleep(time.Second) // allow some time to form contracts
-	usableHosts, err := indexer.App(sk).Hosts(context.Background())
+	usableHosts, err := client.Hosts(context.Background())
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
 	} else if len(usableHosts) != 3 {
@@ -96,7 +152,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// assert host is no longer returned
-	usableHosts, err = indexer.App(sk).Hosts(context.Background())
+	usableHosts, err = client.Hosts(context.Background())
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
 	} else if len(usableHosts) != 2 {
@@ -104,11 +160,11 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// assert limit and offset are applied
-	if usableHosts, err := indexer.App(sk).Hosts(context.Background(), api.WithLimit(1)); err != nil {
+	if usableHosts, err := client.Hosts(context.Background(), api.WithLimit(1)); err != nil {
 		t.Fatal("failed to get hosts with limit:", err)
 	} else if len(usableHosts) != 1 {
 		t.Fatal("expected 1 usable host, got", len(usableHosts))
-	} else if usableHosts, err := indexer.App(sk).Hosts(context.Background(), api.WithOffset(2), api.WithLimit(1)); err != nil {
+	} else if usableHosts, err := client.Hosts(context.Background(), api.WithOffset(2), api.WithLimit(1)); err != nil {
 		t.Fatal("failed to get hosts with limit:", err)
 	} else if len(usableHosts) != 0 {
 		t.Fatal("expected 0 usable hosts, got", len(usableHosts))
@@ -117,17 +173,17 @@ func TestApplicationAPI(t *testing.T) {
 	// pin 2 slabs
 	slab1Params := params()
 	slab2Params := params()
-	slabID1, err := indexer.App(sk).PinSlab(context.Background(), slab1Params)
+	slabID1, err := client.PinSlab(context.Background(), slab1Params)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}
-	slabID2, err := indexer.App(sk).PinSlab(context.Background(), slab2Params)
+	slabID2, err := client.PinSlab(context.Background(), slab2Params)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}
 
 	// assert slab IDs are returned
-	slabsIDs, err := indexer.App(sk).SlabIDs(context.Background())
+	slabsIDs, err := client.SlabIDs(context.Background())
 	if err != nil {
 		t.Fatal("failed to fetch slabs:", err)
 	} else if len(slabsIDs) != 2 {
@@ -137,7 +193,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// assert offset and limit are passed
-	slabsIDs, err = indexer.App(sk).SlabIDs(context.Background(), api.WithOffset(1), api.WithLimit(1))
+	slabsIDs, err = client.SlabIDs(context.Background(), api.WithOffset(1), api.WithLimit(1))
 	if err != nil {
 		t.Fatal("failed to fetch slabs with offset and limit:", err)
 	} else if len(slabsIDs) != 1 {
@@ -147,7 +203,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// assert slab is returned
-	slab1, err := indexer.App(sk).Slab(context.Background(), slabID1)
+	slab1, err := client.Slab(context.Background(), slabID1)
 	if err != nil {
 		t.Fatal("failed to fetch slab:", err)
 	} else if slab1.EncryptionKey != slab1Params.EncryptionKey {
@@ -159,7 +215,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// assert slab is returned
-	slab2, err := indexer.App(sk).Slab(context.Background(), slabID2)
+	slab2, err := client.Slab(context.Background(), slabID2)
 	if err != nil {
 		t.Fatal("failed to fetch slab:", err)
 	} else if slab2.EncryptionKey != slab2Params.EncryptionKey {

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"reflect"
 	"strings"
@@ -249,5 +250,70 @@ func TestApplicationAPI(t *testing.T) {
 		slab2.Sectors[1].Root != slab2Params.Sectors[1].Root ||
 		slab2.Sectors[2].Root != slab2Params.Sectors[2].Root {
 		t.Fatal("unexpected sector roots in slab")
+	}
+}
+
+func TestAppConnect(t *testing.T) {
+	ctx := t.Context()
+	// create cluster with three hosts
+	logger := testutils.NewLogger(false)
+	cluster := testutils.NewCluster(t, testutils.WithHosts(3), testutils.WithLogger(logger))
+	indexer := cluster.Indexer
+	admin := indexer.Client
+
+	connectKey, err := admin.AddAppConnectKey(ctx, app.AddConnectKeyRequest{
+		Description:   "hello world",
+		RemainingUses: 1,
+	})
+
+	sk := types.GeneratePrivateKey()
+	appClient := indexer.App(sk)
+
+	connected, err := appClient.CheckAppAuth(ctx)
+	if err != nil {
+		t.Fatal("failed to check app auth:", err)
+	} else if connected {
+		t.Fatal("expected app to not be authenticated yet")
+	}
+
+	resp, err := appClient.RequestAppConnection(ctx, app.RegisterAppRequest{
+		Name:        "test-app",
+		Description: "A test app",
+		ServiceURL:  "http://test-app.com",
+	})
+	if err != nil {
+		t.Fatal("failed to request app connection:", err)
+	}
+
+	if ok, err := appClient.CheckRequestStatus(ctx, resp.StatusURL); err != nil {
+		t.Fatal("failed to check request status:", err)
+	} else if ok {
+		t.Fatal("expected request to not be approved")
+	}
+
+	// reject the request
+	respondToAppConnection(t, resp.ResponseURL, connectKey.Key, false)
+
+	if _, err := appClient.CheckRequestStatus(ctx, resp.StatusURL); !errors.Is(err, app.ErrUserRejected) {
+		t.Fatalf("expected request to be rejected, got: %v", err)
+	}
+
+	// try again
+
+	resp, err = appClient.RequestAppConnection(ctx, app.RegisterAppRequest{
+		Name:        "test-app",
+		Description: "A test app",
+		ServiceURL:  "http://test-app.com",
+	})
+	if err != nil {
+		t.Fatal("failed to request app connection:", err)
+	}
+
+	respondToAppConnection(t, resp.ResponseURL, connectKey.Key, true)
+
+	if ok, err := appClient.CheckRequestStatus(ctx, resp.StatusURL); err != nil {
+		t.Fatal("failed to check request status:", err)
+	} else if !ok {
+		t.Fatal("expected request to be approved")
 	}
 }

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -68,6 +68,15 @@ func TestApplicationAPI(t *testing.T) {
 	sk := types.GeneratePrivateKey()
 	client := indexer.App(sk)
 
+	admin := indexer.Client
+	err = admin.AddAppConnectKey(ctx, app.AddConnectKey{
+		Key:           "foobar",
+		RemainingUses: 1,
+	})
+	if err != nil {
+		t.Fatal("failed to add app connect key:", err)
+	}
+
 	connectResp, err := client.RequestAppConnection(ctx, app.RegisterAppRequest{
 		Name:        "Test App",
 		Description: "A test application",

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -18,7 +18,7 @@ import (
 	"lukechampine.com/frand"
 )
 
-func respondToAppConnection(t *testing.T, responseURL string, approve bool) {
+func respondToAppConnection(t *testing.T, responseURL string, connectKey string, approve bool) {
 	t.Helper()
 
 	buf, err := json.Marshal(app.ApproveAppRequest{
@@ -31,7 +31,7 @@ func respondToAppConnection(t *testing.T, responseURL string, approve bool) {
 	if err != nil {
 		t.Fatal("failed to create request:", err)
 	}
-	req.SetBasicAuth("", "foobar")
+	req.SetBasicAuth("", connectKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -69,8 +69,7 @@ func TestApplicationAPI(t *testing.T) {
 	client := indexer.App(sk)
 
 	admin := indexer.Client
-	err = admin.AddAppConnectKey(ctx, app.AddConnectKey{
-		Key:           "foobar",
+	key, err := admin.AddAppConnectKey(ctx, app.AddConnectKeyRequest{
 		RemainingUses: 1,
 	})
 	if err != nil {
@@ -95,13 +94,30 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// approve the app
-	respondToAppConnection(t, connectResp.ResponseURL, true)
+	respondToAppConnection(t, connectResp.ResponseURL, key.Key, true)
 
-	// check the app is not authenticated yet
+	// check the app is now authenticated
 	if ok, err := client.CheckAppAuth(ctx); err != nil {
 		t.Fatal(err)
 	} else if !ok {
 		t.Fatal("expected app to be authenticated")
+	}
+
+	// check that the key has been used
+	keys, err := admin.AppConnectKeys(ctx, 0, 1)
+	switch {
+	case err != nil:
+		t.Fatal(err)
+	case len(keys) != 1:
+		t.Fatal("expected 1 key, got", len(keys))
+	case keys[0].Key != key.Key:
+		t.Fatal("expected key to match", keys[0].Key, key.Key)
+	case keys[0].RemainingUses != 0:
+		t.Fatal("expected remaining uses to be 0, got", keys[0].RemainingUses)
+	case keys[0].TotalUses != 1:
+		t.Fatal("expected total uses to be 1, got", keys[0].TotalUses)
+	case keys[0].LastUsed.IsZero():
+		t.Fatal("expected last used to be set, got", keys[0].LastUsed)
 	}
 
 	// helper to generate slab pin parameters

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -39,17 +39,17 @@ const (
 	queryParamValidUntil = "SiaIdx-ValidUntil"
 )
 
-// AccountStore defines the interface for checking if a public key corresponds
+// accountStore defines the interface for checking if a public key corresponds
 // to a known account.
-type AccountStore interface {
+type accountStore interface {
 	HasAccount(ctx context.Context, ak types.PublicKey) (bool, error)
 }
 
-// checkSignedURLAuth validates a signed URL by checking its required query
-// parameters, verifying the signature and expiration, and confirming the
-// account exists. If any check fails, it writes an HTTP error and returns
-// false, otherwise it returns the public key and true.
-func checkSignedURLAuth(jc jape.Context, hostname string, store AccountStore) (types.PublicKey, bool) {
+// getSignedURLAuth extracts the signed public key from the request
+// and verifies the signature and expiration. If successful, it returns the
+// public key and true, otherwise it writes an error to the context and returns
+// an empty public key and false.
+func getSignedURLAuth(jc jape.Context, hostname string) (types.PublicKey, bool) {
 	req := jc.Request
 
 	// validate presence of required parameters
@@ -81,7 +81,21 @@ func checkSignedURLAuth(jc jape.Context, hostname string, store AccountStore) (t
 		jc.Error(ErrSignatureExpired, http.StatusUnauthorized)
 		return types.PublicKey{}, false
 	} else if !pk.VerifyHash(requestHash(hostname, ts), sig) {
-		jc.Error(ErrSignatureInvalid, http.StatusUnauthorized)
+		jc.Error(fmt.Errorf("failed to authenticate for host %q: %w", hostname, ErrSignatureInvalid), http.StatusUnauthorized)
+		return types.PublicKey{}, false
+	}
+	return pk, true
+}
+
+// checkSignedURLAuth validates a signed URL by checking its required query
+// parameters, verifying the signature and expiration, and confirming the
+// account exists. If any check fails, it writes an HTTP error and returns
+// false, otherwise it returns the public key and true.
+func checkSignedURLAuth(jc jape.Context, hostname string, store accountStore) (types.PublicKey, bool) {
+	req := jc.Request
+
+	pk, ok := getSignedURLAuth(jc, hostname)
+	if !ok {
 		return types.PublicKey{}, false
 	}
 

--- a/api/app/auth.html
+++ b/api/app/auth.html
@@ -1,53 +1,298 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<title>Register Application</title>
-</head>
-<body>
-	<h1>Connect {{.Request.Name}}</h1>
-	<p>{{.Request.Description}}</p>
-	<p>Connecting to this application will allow it to upload data on your behalf.</p>
-	<p>Apps cannot access data from other apps and you can revoke access at any time.</p>
-    <input type="password" id="appPassword" placeholder="Enter your app password" required>
-	<button id="rejectButton">Reject</button>
-	<button id="acceptButton">Accept</button>
+  <head>
+    <title>Connect Application</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #0d1104;
+        --panel: #1f2425;
+        --panel-hi: #262b2d;
+        --border: #2b2f31;
+        --text: #eff2ed;
+        --muted: #a9b1aa;
+        --accent: #36d955;
+        --accent-600: #1e9d36;
+        --danger: #d93636;
+        --danger-600: #9d1e1e;
+        --ring: #6ee38a;
+        --radius: 12px;
+        --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+      }
 
-	<script type="text/javascript">
-        async function respondToRequest(approve) {
-            const response = await fetch("{{.ResponseURL}}", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Basic ${btoa(`:${document.getElementById("appPassword").value}`)}`
-                },
-                body: JSON.stringify({ approve }),
-            });
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        margin: 0;
+        background: radial-gradient(
+            1200px 600px at 60% -10%,
+            #15200f 0%,
+            var(--bg) 45%
+          )
+          fixed;
+        color: var(--text);
+        font-family: "IBM Plex Sans", system-ui, -apple-system, Segoe UI, Roboto,
+          Arial, sans-serif;
+        line-height: 1.45;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+      }
 
-            if (response.status !== 204) {
-                const error = await response.text();
-                throw new Error(error);
-            }
+      /* overlay + modal */
+      .overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        backdrop-filter: blur(2px);
+      }
+      .card {
+        position: relative;
+        z-index: 1;
+        width: min(560px, 92vw);
+        background: linear-gradient(180deg, var(--panel-hi), var(--panel));
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 24px;
+      }
+
+      /* header */
+      .header {
+        display: flex;
+        gap: 14px;
+        align-items: center;
+        margin-bottom: 10px;
+      }
+      .logo {
+        width: 44px;
+        height: 44px;
+        border-radius: 10px;
+        flex: 0 0 44px;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+        background: #141816;
+        border: 1px solid var(--border);
+      }
+      .title {
+        margin: 0;
+        font-weight: 700;
+        font-size: 1.1rem;
+      }
+      .subtitle {
+        margin: 2px 0 0;
+        color: var(--muted);
+        font-size: 0.92rem;
+      }
+
+      /* body copy */
+      .copy {
+        margin: 14px 0 18px;
+      }
+      .caption {
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 0.82rem;
+        font-style: italic;
+      }
+
+      /* input */
+      label {
+        display: block;
+        font-size: 0.88rem;
+        color: var(--muted);
+        margin: 14px 0 6px;
+      }
+      input {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        background: #151819;
+        border: 1px solid #3a3f40;
+        color: var(--text);
+        outline: none;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+      }
+      input::placeholder {
+        color: #7d8680;
+      }
+      input:focus {
+        border-color: var(--accent-600);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 35%, transparent);
+      }
+
+      /* actions */
+      .actions {
+        display: flex;
+        gap: 10px;
+        justify-content: flex-end;
+        margin-top: 18px;
+      }
+      .btn {
+        appearance: none;
+        border: 1px solid transparent;
+        border-radius: 10px;
+        padding: 10px 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.04s ease, filter 0.15s ease,
+          border-color 0.15s ease;
+      }
+      .btn:active {
+        transform: translateY(1px);
+      }
+      .btn-primary {
+        background: var(--accent);
+        color: #102012;
+        border-color: var(--accent-600);
+      }
+      .btn-primary:hover {
+        filter: brightness(1.05);
+      }
+      .btn-danger {
+        background: var(--danger);
+        color: #230c0c;
+        border-color: var(--danger-600);
+      }
+      .btn-danger:hover {
+        filter: brightness(1.04);
+      }
+      .btn-ghost {
+        background: transparent;
+        color: var(--text);
+        border-color: #3a3f40;
+      }
+      .btn:focus-visible {
+        outline: 0;
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 35%, transparent);
+      }
+
+      /* footer */
+      .app-footer {
+        position: fixed;
+        bottom: 10px;
+        inset-inline: 0;
+        display: grid;
+        place-items: center;
+        opacity: 0.6;
+      }
+      .app-footer img {
+        height: 22px;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          transition: none !important;
         }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="overlay"></div>
+    <div
+      class="card"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="dlg-title"
+    >
+      <div class="header">
+        <div class="logo">
+          <img
+            src="{{.Request.LogoURL}}"
+            alt="app logo"
+            style="width: 100%; height: 100%; object-fit: cover"
+          />
+        </div>
+        <div>
+          <h1 id="dlg-title" class="title">Connect to app?</h1>
+          <p class="subtitle">{{.Request.Name}}</p>
+        </div>
+    </div>
+    
+    <div class="copy">
+        <p class="subtitle">{{.Request.Description}}</p>
+        <p>
+          Connecting to this application will allow it to upload and download
+          data on your behalf.
+        </p>
+        <p class="caption">
+          Apps cannot access data from other connected apps and you can revoke access at
+          any time from the admin interface.
+        </p>
+      </div>
 
-		document.getElementById("acceptButton").addEventListener("click", async (event) => {
-			event.preventDefault();
-            try {
-			    await respondToRequest(true);
-                document.body.innerHTML = "<h2>Connection Approved</h2><p>Please return to the application.</p>";
-            } catch (error) {
-                console.error(error);
-            }
-		});
+      <input
+        type="password"
+        id="appPassword"
+        placeholder="Enter your app password"
+        required
+      />
 
-        document.getElementById("rejectButton").addEventListener("click", async (event) => {
-            event.preventDefault();
-            try {
-                await respondToRequest(false);
-                document.body.innerHTML = "<h2>Connection Rejected</h2><p>Please return to the application.</p>";
-            } catch (error) {
-                console.error(error);
-            }
+      <div class="actions">
+        <button id="rejectButton" class="btn btn-danger">Reject</button>
+        <button id="acceptButton" class="btn btn-primary">Accept</button>
+      </div>
+    </div>
+
+    <div class="app-footer">
+      <img src="https://sia.tech/api/media/file/token.svg" alt="Sia" />
+    </div>
+
+    <script type="text/javascript">
+      async function respondToRequest(approve) {
+        const response = await fetch("{{.ResponseURL}}", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Basic ${btoa(
+              `:${document.getElementById("appPassword").value}`
+            )}`,
+          },
+          body: JSON.stringify({ approve }),
         });
-	</script>
-</body>
+
+        if (response.status !== 204) {
+          const error = await response.text();
+          throw new Error(error);
+        }
+      }
+
+      document
+        .getElementById("acceptButton")
+        .addEventListener("click", async (event) => {
+          event.preventDefault();
+          try {
+            await respondToRequest(true);
+            document.body.innerHTML =
+              "<h2>Connection Approved</h2><p>Please return to the application.</p>";
+          } catch (error) {
+            console.error(error);
+          }
+        });
+
+      document
+        .getElementById("rejectButton")
+        .addEventListener("click", async (event) => {
+          event.preventDefault();
+          try {
+            await respondToRequest(false);
+            document.body.innerHTML =
+              "<h2>Connection Rejected</h2><p>Please return to the application.</p>";
+          } catch (error) {
+            console.error(error);
+          }
+        });
+    </script>
+  </body>
 </html>

--- a/api/app/auth.html
+++ b/api/app/auth.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Register Application</title>
+</head>
+<body>
+	<h1>Connect {{.Request.Name}}</h1>
+	<p>{{.Request.Description}}</p>
+	<p>Connecting to this application will allow it to upload data on your behalf.</p>
+	<p>Apps cannot access data from other apps and you can revoke access at any time.</p>
+    <input type="password" id="appPassword" placeholder="Enter your app password" required>
+	<button id="rejectButton">Reject</button>
+	<button id="acceptButton">Accept</button>
+	</form>
+
+	<script type="text/javascript">
+        async function respondToRequest(approve) {
+            const response = await fetch("{{.ResponseURL}}", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Basic ${btoa(`:${document.getElementById("appPassword").value}`)}`
+                },
+                body: JSON.stringify({ approve }),
+            });
+
+            if (response.status !== 204) {
+                const error = await response.text();
+                throw new Error(error);
+            }
+        }
+
+		document.getElementById("acceptButton").addEventListener("click", async (event) => {
+			event.preventDefault();
+            try {
+			    await respondToRequest(true);
+                document.body.innerHTML = "<h2>Connection Approved</h2><p>Please return to the application.</p>";
+            } catch (error) {
+                console.error(error);
+            }
+		});
+
+        document.getElementById("rejectButton").addEventListener("click", async (event) => {
+            event.preventDefault();
+            try {
+                await respondToRequest(false);
+                document.body.innerHTML = "<h2>Connection Rejected</h2><p>Please return to the application.</p>";
+            } catch (error) {
+                console.error(error);
+            }
+        });
+	</script>
+</body>
+</html>

--- a/api/app/auth.html
+++ b/api/app/auth.html
@@ -11,7 +11,6 @@
     <input type="password" id="appPassword" placeholder="Enter your app password" required>
 	<button id="rejectButton">Reject</button>
 	<button id="acceptButton">Accept</button>
-	</form>
 
 	<script type="text/javascript">
         async function respondToRequest(approve) {

--- a/api/app/auth.html
+++ b/api/app/auth.html
@@ -2,10 +2,18 @@
 <html>
   <head>
     <title>Connect Application</title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0D1104" />
+    <meta
+      name="description"
+      content="Approve or reject application connection requests securely."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
     <style>
@@ -178,6 +186,45 @@
         box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 35%, transparent);
       }
 
+      /* result states share the same modal */
+      .result-head {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 6px;
+      }
+      .pill {
+        width: 36px;
+        height: 36px;
+        border-radius: 9px;
+        display: grid;
+        place-items: center;
+        font-weight: 700;
+        border: 1px solid transparent;
+      }
+      .pill.success {
+        background: color-mix(in srgb, var(--accent) 25%, #0b1a0d);
+        border-color: var(--accent-600);
+      }
+      .pill.reject {
+        background: color-mix(in srgb, var(--danger) 25%, #1a0b0b);
+        border-color: var(--danger-600);
+      }
+      .result-title {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 700;
+      }
+      .result-copy {
+        margin: 6px 0 0;
+        color: var(--muted);
+      }
+      .center-actions {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 18px;
+      }
+
       /* footer */
       .app-footer {
         position: fixed;
@@ -200,7 +247,9 @@
   </head>
   <body>
     <div class="overlay"></div>
+
     <div
+      id="modal"
       class="card"
       role="dialog"
       aria-modal="true"
@@ -218,20 +267,21 @@
           <h1 id="dlg-title" class="title">Connect to app?</h1>
           <p class="subtitle">{{.Request.Name}}</p>
         </div>
-    </div>
-    
-    <div class="copy">
+      </div>
+
+      <div class="copy">
         <p class="subtitle">{{.Request.Description}}</p>
         <p>
           Connecting to this application will allow it to upload and download
           data on your behalf.
         </p>
         <p class="caption">
-          Apps cannot access data from other connected apps and you can revoke access at
-          any time from the admin interface.
+          Apps cannot access data from other connected apps and you can revoke
+          access at any time from the admin interface.
         </p>
       </div>
 
+      <label for="appPassword">App password</label>
       <input
         type="password"
         id="appPassword"
@@ -249,48 +299,74 @@
       <img src="https://sia.tech/api/media/file/token.svg" alt="Sia" />
     </div>
 
-    <script type="text/javascript">
+    <script>
       async function respondToRequest(approve) {
         const response = await fetch("{{.ResponseURL}}", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
             Authorization: `Basic ${btoa(
-              `:${document.getElementById("appPassword").value}`
+              ":" + document.getElementById("appPassword").value
             )}`,
           },
           body: JSON.stringify({ approve }),
         });
-
         if (response.status !== 204) {
           const error = await response.text();
           throw new Error(error);
         }
       }
 
+      function renderResult(approved) {
+        const modal = document.getElementById("modal");
+        const state = approved ? "success" : "reject";
+        const title = approved ? "Connection approved" : "Connection rejected";
+        const note = approved
+          ? "You can return to the application."
+          : "You can close this window and return to the application.";
+        const btnClass = approved ? "btn-primary" : "btn-danger";
+        const btnText = approved ? "Return to app" : "Close";
+
+        modal.setAttribute("aria-labelledby", "result-title");
+        modal.innerHTML = `
+          <div class="result-head">
+            <div class="pill ${state}" aria-hidden="true">${
+          approved ? "✓" : "!"
+        }</div>
+            <h2 id="result-title" class="result-title">${title}</h2>
+          </div>
+          <p class="result-copy">${note}</p>
+          <div class="center-actions">
+            <button class="btn ${btnClass}" id="resultBtn">${btnText}</button>
+          </div>
+        `;
+
+        document.getElementById("resultBtn").addEventListener("click", () => {
+          window.close();
+        });
+      }
+
       document
         .getElementById("acceptButton")
-        .addEventListener("click", async (event) => {
-          event.preventDefault();
+        .addEventListener("click", async (e) => {
+          e.preventDefault();
           try {
             await respondToRequest(true);
-            document.body.innerHTML =
-              "<h2>Connection Approved</h2><p>Please return to the application.</p>";
-          } catch (error) {
-            console.error(error);
+            renderResult(true);
+          } catch (err) {
+            console.error(err);
           }
         });
 
       document
         .getElementById("rejectButton")
-        .addEventListener("click", async (event) => {
-          event.preventDefault();
+        .addEventListener("click", async (e) => {
+          e.preventDefault();
           try {
             await respondToRequest(false);
-            document.body.innerHTML =
-              "<h2>Connection Rejected</h2><p>Please return to the application.</p>";
-          } catch (error) {
-            console.error(error);
+            renderResult(false);
+          } catch (err) {
+            console.error(err);
           }
         });
     </script>

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -101,6 +103,36 @@ func (c *Client) SlabIDs(ctx context.Context, opts ...api.URLQueryParameterOptio
 	return slabIDs, nil
 }
 
+func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
+	err = c.c.POST(ctx, c.sign("/auth/connect"), request, &resp)
+	return
+}
+
+func (c *Client) CheckAppAuth(ctx context.Context) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.sign(fmt.Sprintf("%s/auth/check", c.c.BaseURL)), nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to check app auth: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return false, nil // not authenticated
+	case http.StatusNoContent:
+		return true, nil // authenticated
+	default:
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if err != nil {
+			return false, fmt.Errorf("failed to read response body: %w", err)
+		}
+		return false, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, body)
+	}
+}
+
 // NewClient creates a new AppClient that can be used to interact with the
 // application API of the indexer. The address should be the full URL to the
 // application API, including the scheme (e.g., "http://indexer.sia.tech").
@@ -114,6 +146,6 @@ func NewClient(address string, appKey types.PrivateKey) (*Client, error) {
 		c: jape.Client{BaseURL: address},
 
 		appkey:   appKey,
-		hostname: parsedURL.Hostname(),
+		hostname: parsedURL.Host,
 	}, nil
 }

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -107,6 +108,35 @@ func (c *Client) SlabIDs(ctx context.Context, opts ...api.URLQueryParameterOptio
 func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
 	err = c.c.POST(ctx, c.sign("/auth/connect"), request, &resp)
 	return
+}
+
+// CheckRequestStatus checks if an auth request has been approved.
+// If the auth request is still pending, it returns false.
+func (c *Client) CheckRequestStatus(ctx context.Context, statusURL string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.sign(statusURL), nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to check app auth: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return false, ErrUserRejected
+	case http.StatusOK:
+		var connectResp AuthConnectStatusResponse
+		err = json.NewDecoder(resp.Body).Decode(&connectResp)
+		return connectResp.Approved, err
+	default:
+		buf, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if err != nil {
+			return false, fmt.Errorf("failed to read response error: %w", err)
+		}
+		return false, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, buf)
+	}
 }
 
 // CheckAppAuth checks if the application is authenticated with the indexer.

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -103,11 +103,14 @@ func (c *Client) SlabIDs(ctx context.Context, opts ...api.URLQueryParameterOptio
 	return slabIDs, nil
 }
 
+// RequestAppConnection requests an application connection to the indexer.
 func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
 	err = c.c.POST(ctx, c.sign("/auth/connect"), request, &resp)
 	return
 }
 
+// CheckAppAuth checks if the application is authenticated with the indexer.
+// It returns true if authenticated, false if not, and an error if the request fails.
 func (c *Client) CheckAppAuth(ctx context.Context) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.sign(fmt.Sprintf("%s/auth/check", c.c.BaseURL)), nil)
 	if err != nil {

--- a/api/app/connect.go
+++ b/api/app/connect.go
@@ -1,0 +1,22 @@
+package app
+
+import "time"
+
+type (
+	// A ConnectKey represents a key used to authenticate
+	// when connecting a new application.
+	ConnectKey struct {
+		Key           string
+		Description   string
+		RemainingUses int
+		DateCreated   time.Time
+	}
+
+	// AddConnectKey represents a request to add or update
+	// an app connect key.
+	AddConnectKey struct {
+		Key           string
+		Description   string
+		RemainingUses int
+	}
+)

--- a/api/app/connect.go
+++ b/api/app/connect.go
@@ -1,22 +1,42 @@
 package app
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrKeyExhausted is returned when an app connect key has
+	// no remaining uses.
+	ErrKeyExhausted = errors.New("key has no remaining uses")
+	// ErrKeyNotFound is returned when an app connect key is not found.
+	ErrKeyNotFound = errors.New("key not found")
+)
 
 type (
 	// A ConnectKey represents a key used to authenticate
 	// when connecting a new application.
 	ConnectKey struct {
-		Key           string
-		Description   string
-		RemainingUses int
-		DateCreated   time.Time
+		Key           string    `json:"key"`
+		Description   string    `json:"description"`
+		TotalUses     int       `json:"totalUses"`
+		RemainingUses int       `json:"remainingUses"`
+		DateCreated   time.Time `json:"dateCreated"`
+		LastUpdated   time.Time `json:"lastUpdated"`
+		LastUsed      time.Time `json:"lastUsed"`
 	}
 
-	// AddConnectKey represents a request to add or update
+	// AddConnectKeyRequest is the request type for adding a new app connect key.
+	AddConnectKeyRequest struct {
+		Description   string `json:"description"`
+		RemainingUses int    `json:"remainingUses"`
+	}
+
+	// UpdateAppConnectKey represents a request to add or update
 	// an app connect key.
-	AddConnectKey struct {
-		Key           string
-		Description   string
-		RemainingUses int
+	UpdateAppConnectKey struct {
+		Key           string `json:"key"`
+		Description   string `json:"description"`
+		RemainingUses int    `json:"remainingUses"`
 	}
 )

--- a/cmd/indexd/main.go
+++ b/cmd/indexd/main.go
@@ -40,7 +40,8 @@ var cfg = config.Config{
 		Password: os.Getenv(indexdAdminPasswordEnvVar),
 	},
 	ApplicationAPI: config.ApplicationAPI{
-		Address: ":9982",
+		Address:  ":9982",
+		Hostname: "127.0.0.1:9982",
 	},
 	Syncer: config.Syncer{
 		Address:   ":9981",
@@ -271,10 +272,13 @@ func main() {
 		}
 
 		if cfg.AdminAPI.Password == "" {
-			os.Stderr.WriteString(fmt.Sprintf("missing admin password - needs to be set either via config file or '%s' env var\n", indexdAdminPasswordEnvVar))
+			fmt.Fprintf(os.Stderr, "missing admin password - needs to be set either via config file or '%s' env var\n", indexdAdminPasswordEnvVar)
 			os.Exit(1)
 		} else if cfg.RecoveryPhrase == "" {
-			os.Stderr.WriteString("missing recovery phrase - needs to be set via config file\n")
+			fmt.Fprintf(os.Stderr, "missing recovery phrase - needs to be set via config file\n")
+			os.Exit(1)
+		} else if cfg.ApplicationAPI.Password == "" {
+			fmt.Fprintf(os.Stderr, "missing application API password - needs to be set via config file\n")
 			os.Exit(1)
 		}
 

--- a/cmd/indexd/main.go
+++ b/cmd/indexd/main.go
@@ -40,8 +40,7 @@ var cfg = config.Config{
 		Password: os.Getenv(indexdAdminPasswordEnvVar),
 	},
 	ApplicationAPI: config.ApplicationAPI{
-		Address:  ":9982",
-		Hostname: "127.0.0.1:9982",
+		Address: ":9982",
 	},
 	Syncer: config.Syncer{
 		Address:   ":9981",
@@ -276,9 +275,6 @@ func main() {
 			os.Exit(1)
 		} else if cfg.RecoveryPhrase == "" {
 			fmt.Fprintf(os.Stderr, "missing recovery phrase - needs to be set via config file\n")
-			os.Exit(1)
-		} else if cfg.ApplicationAPI.Password == "" {
-			fmt.Fprintf(os.Stderr, "missing application API password - needs to be set via config file\n")
 			os.Exit(1)
 		}
 

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -39,7 +45,34 @@ import (
 	"go.sia.tech/jape"
 	"go.sia.tech/web/indexd"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
 )
+
+func selfSignedCert(hostname string) ([]tls.Certificate, error) {
+	key, err := rsa.GenerateKey(frand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key: %w", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: hostname,
+		},
+		DNSNames: []string{hostname},
+	}
+	certDER, err := x509.CreateCertificate(frand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tls cert: %w", err)
+	}
+	return []tls.Certificate{cert}, nil
+}
 
 func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateKey, network *consensus.Network, genesis types.Block, log *zap.Logger) error {
 	store, err := postgres.NewStore(ctx, cfg.Database, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log.Named("postgres"))
@@ -94,7 +127,6 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		}
 	}
 
-	log.Debug("starting syncer", zap.String("syncer address", syncerAddr))
 	s := syncer.New(syncerListener, cm, store, gateway.Header{
 		GenesisID:  genesis.ID(),
 		UniqueID:   gateway.GenerateUniqueID(),
@@ -191,15 +223,51 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		app.WithLogger(log.Named("api.application")),
 	}
 
+	hostname := cfg.ApplicationAPI.Hostname
+	if hostname == "" {
+		host, port, _ := net.SplitHostPort(appAPIListener.Addr().String())
+		if ip := net.ParseIP(host); ip == nil || ip.IsUnspecified() {
+			hostname = net.JoinHostPort("127.0.0.1", port)
+		} else {
+			hostname = net.JoinHostPort(host, port)
+		}
+	}
+
+	if cfg.ApplicationAPI.TLS.Disable {
+		appAPIOpts = append(appAPIOpts, app.WithAuthRequiresTLS(false))
+	} else if cfg.ApplicationAPI.TLS.CertFile != "" || cfg.ApplicationAPI.TLS.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.ApplicationAPI.TLS.CertFile, cfg.ApplicationAPI.TLS.KeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to load TLS certificate: %w", err)
+		}
+
+		appAPIListener = tls.NewListener(appAPIListener, &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+		})
+		defer appAPIListener.Close()
+	} else {
+		log.Warn("TLS is enabled but no certificate or key file is provided,using self-signed certificate. Some apps may not be able to connect")
+		cert, err := selfSignedCert(hostname)
+		if err != nil {
+			return fmt.Errorf("failed to generate self-signed certificate: %w", err)
+		}
+		appAPIListener = tls.NewListener(appAPIListener, &tls.Config{
+			Certificates: cert,
+			MinVersion:   tls.VersionTLS12,
+		})
+		defer appAPIListener.Close()
+	}
+
 	appAPI := http.Server{
-		Handler:      app.NewAPI(cfg.ApplicationAPI.Hostname, store, store, appAPIOpts...),
+		Handler:      app.NewAPI(hostname, store, cfg.ApplicationAPI.Password, appAPIOpts...),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
 	defer appAPI.Close()
 
 	go func() {
-		log.Debug("starting application API", zap.String("applicationAddress", cfg.ApplicationAPI.Address))
+		log.Debug("starting application API", zap.String("hostname", hostname), zap.String("applicationAddress", cfg.ApplicationAPI.Address))
 		if err := appAPI.Serve(appAPIListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error("failed to serve application API", zap.Error(err))
 		}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -2,14 +2,8 @@ package main
 
 import (
 	"context"
-	"crypto/rsa"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -45,34 +39,7 @@ import (
 	"go.sia.tech/jape"
 	"go.sia.tech/web/indexd"
 	"go.uber.org/zap"
-	"lukechampine.com/frand"
 )
-
-func selfSignedCert(hostname string) ([]tls.Certificate, error) {
-	key, err := rsa.GenerateKey(frand.Reader, 2048)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate key: %w", err)
-	}
-	template := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject: pkix.Name{
-			CommonName: hostname,
-		},
-		DNSNames: []string{hostname},
-	}
-	certDER, err := x509.CreateCertificate(frand.Reader, &template, &template, &key.PublicKey, key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cert: %w", err)
-	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-
-	cert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tls cert: %w", err)
-	}
-	return []tls.Certificate{cert}, nil
-}
 
 func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateKey, network *consensus.Network, genesis types.Block, log *zap.Logger) error {
 	store, err := postgres.NewStore(ctx, cfg.Database, contracts.DefaultMaintenanceSettings, hosts.DefaultUsabilitySettings, log.Named("postgres"))
@@ -223,51 +190,30 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		app.WithLogger(log.Named("api.application")),
 	}
 
-	hostname := cfg.ApplicationAPI.Hostname
-	if hostname == "" {
+	advertiseURL := cfg.ApplicationAPI.AdvertiseURL
+	if advertiseURL == "" {
 		host, port, _ := net.SplitHostPort(appAPIListener.Addr().String())
 		if ip := net.ParseIP(host); ip == nil || ip.IsUnspecified() {
-			hostname = net.JoinHostPort("127.0.0.1", port)
+			advertiseURL = "http://" + net.JoinHostPort("127.0.0.1", port)
 		} else {
-			hostname = net.JoinHostPort(host, port)
+			advertiseURL = "http://" + net.JoinHostPort(host, port)
 		}
 	}
 
-	if cfg.ApplicationAPI.TLS.Disable {
-		appAPIOpts = append(appAPIOpts, app.WithAuthRequiresTLS(false))
-	} else if cfg.ApplicationAPI.TLS.CertFile != "" || cfg.ApplicationAPI.TLS.KeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(cfg.ApplicationAPI.TLS.CertFile, cfg.ApplicationAPI.TLS.KeyFile)
-		if err != nil {
-			return fmt.Errorf("failed to load TLS certificate: %w", err)
-		}
-
-		appAPIListener = tls.NewListener(appAPIListener, &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
-		})
-		defer appAPIListener.Close()
-	} else {
-		log.Warn("TLS is enabled but no certificate or key file is provided. Using self-signed certificate. Some apps may not be able to connect")
-		cert, err := selfSignedCert(hostname)
-		if err != nil {
-			return fmt.Errorf("failed to generate self-signed certificate: %w", err)
-		}
-		appAPIListener = tls.NewListener(appAPIListener, &tls.Config{
-			Certificates: cert,
-			MinVersion:   tls.VersionTLS12,
-		})
-		defer appAPIListener.Close()
+	appHandler, err := app.NewAPI(advertiseURL, store, appAPIOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to create application API: %w", err)
 	}
 
 	appAPI := http.Server{
-		Handler:      app.NewAPI(hostname, store, cfg.ApplicationAPI.Password, appAPIOpts...),
+		Handler:      appHandler,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
 	defer appAPI.Close()
 
 	go func() {
-		log.Debug("starting application API", zap.String("hostname", hostname), zap.String("applicationAddress", cfg.ApplicationAPI.Address))
+		log.Debug("starting application API", zap.String("appAddress", advertiseURL), zap.String("applicationAddress", cfg.ApplicationAPI.Address))
 		if err := appAPI.Serve(appAPIListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error("failed to serve application API", zap.Error(err))
 		}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -247,7 +247,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		})
 		defer appAPIListener.Close()
 	} else {
-		log.Warn("TLS is enabled but no certificate or key file is provided,using self-signed certificate. Some apps may not be able to connect")
+		log.Warn("TLS is enabled but no certificate or key file is provided. Using self-signed certificate. Some apps may not be able to connect")
 		cert, err := selfSignedCert(hostname)
 		if err != nil {
 			return fmt.Errorf("failed to generate self-signed certificate: %w", err)

--- a/cmd/junkd/main.go
+++ b/cmd/junkd/main.go
@@ -16,10 +16,10 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
-	"go.sia.tech/indexd/api/admin"
-	"go.sia.tech/indexd/keys"
+	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/sdk"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"lukechampine.com/frand"
 )
 
@@ -32,13 +32,10 @@ const (
 )
 
 var (
-	adminURL      string
-	adminPassword string
+	appSecret  string
+	indexerURL string
 
-	appSecret string
-	appURL    string
-
-	logLevel string
+	logLevel zap.AtomicLevel
 	logPath  string
 
 	threads int
@@ -52,13 +49,10 @@ var (
 )
 
 func init() {
-	flag.StringVar(&adminURL, "admin.url", "http://localhost:9980/api", "the URL of the admin API")
-	flag.StringVar(&adminPassword, "admin.password", "", "the password for the admin API")
-
+	flag.StringVar(&indexerURL, "indexer.url", "http://localhost:9982", "the URL of the indexer API")
 	flag.StringVar(&appSecret, "app.secret", "", "a secret used to derive the application key")
-	flag.StringVar(&appURL, "app.url", "http://localhost:9880", "the URL of the application API")
 
-	flag.StringVar(&logLevel, "log.level", "info", "the log level to use")
+	flag.TextVar(&logLevel, "log.level", zap.NewAtomicLevelAt(zap.InfoLevel), "the log level to use")
 	flag.StringVar(&logPath, "log.path", "", "the path to write the log to")
 
 	flag.IntVar(&threads, "threads", 1, "the number of upload threads")
@@ -67,18 +61,60 @@ func init() {
 }
 
 func main() {
-	log, err := newLogger()
-	if err != nil {
-		log.Fatal("failed to build logger", zap.Error(err))
-	}
+	log := newLogger()
 
 	sk, err := loadPrivateKey()
 	if err != nil {
 		log.Fatal("failed to load private key", zap.Error(err))
 	}
 
+	client, err := app.NewClient(indexerURL, sk)
+	if err != nil {
+		log.Fatal("failed to create app client", zap.Error(err))
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	if ok, err := client.CheckAppAuth(ctx); err != nil {
+		log.Fatal("failed to check app auth", zap.Error(err))
+	} else if !ok {
+		log.Info("authenticating new application", zap.String("indexerURL", indexerURL))
+		connectResp, err := client.RequestAppConnection(ctx, app.RegisterAppRequest{
+			Name:        "junkd Uploader",
+			Description: "A tool to upload junk data to the indexer",
+			LogoURL:     "https://example.com/logo.png",
+			ServiceURL:  "https://example.com/service",
+		})
+		if err != nil {
+			log.Fatal("failed to request app connection", zap.Error(err))
+		}
+		log.Info("waiting for app connection approval", zap.String("approvalURL", connectResp.ResponseURL))
+
+		authCtx, authCancel := context.WithDeadline(ctx, connectResp.Expiration)
+		defer authCancel()
+
+		log.Info("waiting for app connection approval", zap.Time("expiration", connectResp.Expiration))
+	top:
+		for {
+			select {
+			case <-authCtx.Done():
+				log.Fatal("timed out waiting for app connection approval", zap.Error(authCtx.Err()))
+			case <-time.After(time.Second):
+				if ok, err := client.CheckAppAuth(authCtx); err != nil {
+					log.Fatal("failed to check app auth", zap.Error(err))
+				} else if ok {
+					break top
+				}
+			}
+		}
+	}
+	log.Info("junkd connected")
+
+	sdkClient, err := sdk.NewSDK(indexerURL, sk, sdk.WithLogger(log.Named("sdk")))
+	if err != nil {
+		log.Fatal("failed to create SDK client", zap.Error(err))
+	}
 
 	var wg sync.WaitGroup
 	for n := 1; n <= threads; n++ {
@@ -89,19 +125,9 @@ func main() {
 
 		loop:
 			for {
-				// prepare client (refresh the app key daily)
-				client, err := loadClient(ctx, sk, log)
-				if err != nil {
-					log.Error("failed to load client, timing out for 5 minutes", zap.Error(err))
-					if ok := <-waitFor(ctx, 5*time.Minute); ok {
-						continue loop
-					}
-					break loop
-				}
-
 				// upload slab
 				start := time.Now()
-				slabs, err := client.Upload(ctx, io.LimitReader(frand.Reader, slabSize), sdk.WithRedundancy(dataShards, parityShards))
+				slabs, err := sdkClient.Upload(ctx, io.LimitReader(frand.Reader, slabSize), sdk.WithRedundancy(dataShards, parityShards))
 				if err != nil {
 					log.Error("failed to upload slab, timing out for 5 minutes", zap.Error(err), zap.Duration("duration", time.Since(start)))
 					if ok := <-waitFor(ctx, 5*time.Minute); ok {
@@ -140,32 +166,6 @@ func waitFor(ctx context.Context, d time.Duration) <-chan bool {
 	return c
 }
 
-func loadClient(ctx context.Context, masterKey types.PrivateKey, log *zap.Logger) (*sdk.SDK, error) {
-	clientMu.Lock()
-	defer clientMu.Unlock()
-
-	// return cached client
-	if time.Now().Before(clientUntil) {
-		return client, nil
-	}
-
-	// register application key
-	appKey := keys.DeriveKey(masterKey, fmt.Sprintf("junkd-%s", time.Now().Format(time.DateOnly)))
-	err := admin.NewClient(adminURL, adminPassword).AccountsAdd(ctx, appKey.PublicKey())
-	if err != nil {
-		return nil, fmt.Errorf("failed to add app key to admin API: %w", err)
-	}
-
-	// create new client
-	clientUntil = time.Now().AddDate(0, 0, 1)
-	client, err = sdk.NewSDK(appURL, appKey, sdk.WithLogger(log))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create SDK: %w", err)
-	}
-
-	return client, nil
-}
-
 func loadPrivateKey() (types.PrivateKey, error) {
 	if appSecret == "" {
 		return types.PrivateKey{}, fmt.Errorf("app secret is required")
@@ -181,26 +181,12 @@ func loadPrivateKey() (types.PrivateKey, error) {
 	return wallet.KeyFromSeed(&seed, 0), nil
 }
 
-func newLogger() (*zap.Logger, error) {
-	cfg := zap.NewProductionConfig()
-	switch logLevel {
-	case "debug":
-		cfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	case "info":
-		cfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-	case "warn":
-		cfg.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
-	default:
-		cfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
-	}
-
-	cfg.OutputPaths = []string{"stdout"}
-	if logPath != "" {
-		cfg.OutputPaths = append(cfg.OutputPaths, logPath)
-	}
-	cfg.DisableStacktrace = true
-
-	return cfg.Build()
+func newLogger() *zap.Logger {
+	cfg := zap.NewProductionEncoderConfig()
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	cfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	cfg.EncodeDuration = zapcore.MillisDurationEncoder
+	return zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(cfg), zapcore.Lock(os.Stdout), logLevel))
 }
 
 func formatBpsString(b int64, t time.Duration) string {

--- a/cmd/junkd/main.go
+++ b/cmd/junkd/main.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/signal"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -46,19 +44,6 @@ var (
 	elapsed   []time.Duration
 )
 
-func openBrowser(url string) error {
-	switch runtime.GOOS {
-	case "linux":
-		return exec.Command("xdg-open", url).Start()
-	case "windows":
-		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		return exec.Command("open", url).Start()
-	default:
-		return fmt.Errorf("unsupported platform %q", runtime.GOOS)
-	}
-}
-
 func init() {
 	flag.StringVar(&indexerURL, "indexer.url", "http://localhost:9982", "the URL of the indexer API")
 	flag.StringVar(&appSecret, "app.secret", "", "a secret used to derive the application key")
@@ -82,39 +67,17 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	if connected, err := sdk.Connected(ctx, indexerURL, sk); err != nil {
-		log.Fatal("failed to check app connection", zap.Error(err))
-	} else if !connected {
-		log.Info("app is not connected, requesting connection", zap.String("indexerURL", indexerURL))
-		resp, err := sdk.ConnectApp(ctx, indexerURL, sk, app.RegisterAppRequest{
-			Name:        "junkd Uploader",
-			Description: "A tool to upload junk data to the indexer",
-			LogoURL:     "https://example.com/logo.png",
-			ServiceURL:  "https://example.com/service",
-		})
-		if err != nil {
-			log.Fatal("failed to request app connection", zap.Error(err))
-		}
-		log.Info("waiting for app connection approval", zap.String("approvalURL", resp.ResponseURL), zap.Duration("expiration", time.Until(resp.Expiration)))
-
-		authCtx, authCancel := context.WithDeadline(ctx, resp.Expiration)
-		defer authCancel()
-
-	top:
-		for {
-			select {
-			case <-authCtx.Done():
-				log.Fatal("timed out waiting for app connection approval", zap.Error(authCtx.Err()))
-			case <-time.After(time.Second):
-				if ok, err := sdk.Connected(authCtx, indexerURL, sk); err != nil {
-					log.Fatal("failed to check app auth", zap.Error(err))
-				} else if ok {
-					break top
-				}
-			}
-		}
+	ok, err := sdk.Connect(ctx, indexerURL, sk, app.RegisterAppRequest{
+		Name:        "junkd Uploader",
+		Description: "A tool to upload junk data to the indexer",
+		LogoURL:     "https://example.com/logo.png",
+		ServiceURL:  "https://example.com/service",
+	})
+	if err != nil {
+		log.Fatal("failed to connect app", zap.Error(err))
+	} else if !ok {
+		log.Fatal("user denied app connection")
 	}
-
 	log.Info("junkd connected")
 
 	sdkClient, err := sdk.NewSDK(indexerURL, sk, sdk.WithLogger(log.Named("sdk")))

--- a/cmd/junkd/main.go
+++ b/cmd/junkd/main.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -44,6 +46,19 @@ var (
 	elapsed   []time.Duration
 )
 
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		return exec.Command("open", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform %q", runtime.GOOS)
+	}
+}
+
 func init() {
 	flag.StringVar(&indexerURL, "indexer.url", "http://localhost:9982", "the URL of the indexer API")
 	flag.StringVar(&appSecret, "app.secret", "", "a secret used to derive the application key")
@@ -64,19 +79,14 @@ func main() {
 		log.Fatal("failed to load private key", zap.Error(err))
 	}
 
-	client, err := app.NewClient(indexerURL, sk)
-	if err != nil {
-		log.Fatal("failed to create app client", zap.Error(err))
-	}
-
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	if ok, err := client.CheckAppAuth(ctx); err != nil {
-		log.Fatal("failed to check app auth", zap.Error(err))
-	} else if !ok {
-		log.Info("authenticating new application", zap.String("indexerURL", indexerURL))
-		connectResp, err := client.RequestAppConnection(ctx, app.RegisterAppRequest{
+	if connected, err := sdk.Connected(ctx, indexerURL, sk); err != nil {
+		log.Fatal("failed to check app connection", zap.Error(err))
+	} else if !connected {
+		log.Info("app is not connected, requesting connection", zap.String("indexerURL", indexerURL))
+		resp, err := sdk.ConnectApp(ctx, indexerURL, sk, app.RegisterAppRequest{
 			Name:        "junkd Uploader",
 			Description: "A tool to upload junk data to the indexer",
 			LogoURL:     "https://example.com/logo.png",
@@ -85,19 +95,18 @@ func main() {
 		if err != nil {
 			log.Fatal("failed to request app connection", zap.Error(err))
 		}
-		log.Info("waiting for app connection approval", zap.String("approvalURL", connectResp.ResponseURL))
+		log.Info("waiting for app connection approval", zap.String("approvalURL", resp.ResponseURL), zap.Duration("expiration", time.Until(resp.Expiration)))
 
-		authCtx, authCancel := context.WithDeadline(ctx, connectResp.Expiration)
+		authCtx, authCancel := context.WithDeadline(ctx, resp.Expiration)
 		defer authCancel()
 
-		log.Info("waiting for app connection approval", zap.Time("expiration", connectResp.Expiration))
 	top:
 		for {
 			select {
 			case <-authCtx.Done():
 				log.Fatal("timed out waiting for app connection approval", zap.Error(authCtx.Err()))
 			case <-time.After(time.Second):
-				if ok, err := client.CheckAppAuth(authCtx); err != nil {
+				if ok, err := sdk.Connected(authCtx, indexerURL, sk); err != nil {
 					log.Fatal("failed to check app auth", zap.Error(err))
 				} else if ok {
 					break top
@@ -105,6 +114,7 @@ func main() {
 			}
 		}
 	}
+
 	log.Info("junkd connected")
 
 	sdkClient, err := sdk.NewSDK(indexerURL, sk, sdk.WithLogger(log.Named("sdk")))

--- a/cmd/junkd/main.go
+++ b/cmd/junkd/main.go
@@ -40,10 +40,6 @@ var (
 
 	threads int
 
-	clientMu    sync.Mutex
-	client      *sdk.SDK
-	clientUntil time.Time
-
 	elapsedMu sync.Mutex
 	elapsed   []time.Duration
 )

--- a/cmd/junkd/main.go
+++ b/cmd/junkd/main.go
@@ -67,7 +67,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	ok, err := sdk.Connect(ctx, indexerURL, sk, app.RegisterAppRequest{
+	resp, connected, err := sdk.Connect(ctx, indexerURL, sk, app.RegisterAppRequest{
 		Name:        "junkd Uploader",
 		Description: "A tool to upload junk data to the indexer",
 		LogoURL:     "https://example.com/logo.png",
@@ -75,8 +75,13 @@ func main() {
 	})
 	if err != nil {
 		log.Fatal("failed to connect app", zap.Error(err))
-	} else if !ok {
-		log.Fatal("user denied app connection")
+	} else if !connected {
+		log.Info("please approve app connection", zap.String("url", resp.ResponseURL))
+		if connected, err := resp.WaitForApproval(ctx); err != nil {
+			log.Fatal("failed to wait for app approval", zap.Error(err))
+		} else if !connected {
+			log.Fatal("user denied app connection")
+		}
 	}
 	log.Info("junkd connected")
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,11 +18,23 @@ type (
 		Password string `yaml:"password"`
 	}
 
+	// TLS contains the configuration for TLS
+	TLS struct {
+		Disable bool `yaml:"disable"`
+
+		CertFile string `yaml:"certFile"`
+		KeyFile  string `yaml:"keyFile"`
+	}
+
 	// ApplicationAPI contains the configuration for the HTTP server serving the
 	// application API
 	ApplicationAPI struct {
-		Address  string `yaml:"address"`
+		Address string `yaml:"address"`
+		// Password is used to register new app keys with the indexer.
+		Password string `yaml:"password"`
 		Hostname string `yaml:"hostname"`
+
+		TLS TLS `yaml:"tls"`
 	}
 
 	// Syncer contains the configuration for the p2p syncer.

--- a/config/config.go
+++ b/config/config.go
@@ -18,23 +18,15 @@ type (
 		Password string `yaml:"password"`
 	}
 
-	// TLS contains the configuration for TLS
-	TLS struct {
-		Disable bool `yaml:"disable"`
-
-		CertFile string `yaml:"certFile"`
-		KeyFile  string `yaml:"keyFile"`
-	}
-
 	// ApplicationAPI contains the configuration for the HTTP server serving the
 	// application API
 	ApplicationAPI struct {
 		Address string `yaml:"address"`
-		// Password is used to register new app keys with the indexer.
-		Password string `yaml:"password"`
-		Hostname string `yaml:"hostname"`
-
-		TLS TLS `yaml:"tls"`
+		// AdvertiseURL can be used to override the URL
+		// that is generated for auth requests and
+		// the hostname that is valid for signed
+		// requests.
+		AdvertiseURL string `yaml:"advertiseURL"`
 	}
 
 	// Syncer contains the configuration for the p2p syncer.

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"testing"
 	"time"
 
@@ -173,6 +172,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 
 	appAPIOpts := []app.Option{
 		app.WithLogger(log.Named("api.application")),
+		app.WithAuthRequiresTLS(false), // allow non-TLS connections for testing
 	}
 
 	appListener, err := net.Listen("tcp4", "127.0.0.1:0")
@@ -180,14 +180,8 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		t.Fatalf("failed to listen on application address: %v", err)
 	}
 	appAPIAddr := fmt.Sprintf("http://%s", appListener.Addr().String())
-
-	parsedURL, err := url.Parse(appAPIAddr)
-	if err != nil {
-		t.Fatalf("failed to parse address %q: %v", appAPIAddr, err)
-	}
-
 	appAPI := http.Server{
-		Handler: app.NewAPI(parsedURL.Hostname(), store, store, appAPIOpts...),
+		Handler: app.NewAPI(appListener.Addr().String(), store, "foobar", appAPIOpts...),
 	}
 
 	go func() {

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -172,7 +172,6 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 
 	appAPIOpts := []app.Option{
 		app.WithLogger(log.Named("api.application")),
-		app.WithAuthRequiresTLS(false), // allow non-TLS connections for testing
 	}
 
 	appListener, err := net.Listen("tcp4", "127.0.0.1:0")
@@ -180,8 +179,13 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		t.Fatalf("failed to listen on application address: %v", err)
 	}
 	appAPIAddr := fmt.Sprintf("http://%s", appListener.Addr().String())
+	appHandler, err := app.NewAPI(appAPIAddr, store, appAPIOpts...)
+	if err != nil {
+		t.Fatalf("failed to create application API: %v", err)
+	}
+
 	appAPI := http.Server{
-		Handler: app.NewAPI(appListener.Addr().String(), store, "foobar", appAPIOpts...),
+		Handler: appHandler,
 	}
 
 	go func() {

--- a/internal/testutils/wallet.go
+++ b/internal/testutils/wallet.go
@@ -9,8 +9,6 @@ import (
 	"go.sia.tech/coreutils/wallet"
 )
 
-type mockSyncer struct{}
-
 // NewWallet creates a new SingleAddressWallet for testing which is connected to
 // all the other components created via the ConsensusNode.
 func NewWallet(t testing.TB, c *ConsensusNode, walletKey types.PrivateKey) *wallet.SingleAddressWallet {

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -50,13 +50,7 @@ func (s *Store) Accounts(ctx context.Context, offset, limit int) ([]types.Public
 // AddAccount adds a new account in the database with given account key.
 func (s *Store) AddAccount(ctx context.Context, ak types.PublicKey) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key) VALUES ($1) ON CONFLICT DO NOTHING`, sqlPublicKey(ak))
-		if err != nil {
-			return fmt.Errorf("failed to add account: %w", err)
-		} else if res.RowsAffected() == 0 {
-			return accounts.ErrExists
-		}
-		return nil
+		return addAccount(ctx, tx, ak)
 	})
 }
 
@@ -252,6 +246,16 @@ func (s *Store) ServiceAccountBalance(ctx context.Context, hostKey types.PublicK
 		return err
 	})
 	return balance, err
+}
+
+func addAccount(ctx context.Context, tx *txn, account types.PublicKey) error {
+	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key) VALUES ($1) ON CONFLICT DO NOTHING`, sqlPublicKey(account))
+	if err != nil {
+		return fmt.Errorf("failed to add account: %w", err)
+	} else if res.RowsAffected() == 0 {
+		return accounts.ErrExists
+	}
+	return nil
 }
 
 func newHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, limit int) ([]accounts.HostAccount, error) {

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -1,0 +1,95 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api/app"
+)
+
+// AddAppConnectKey adds or updates an application connection key in the database.
+func (s *Store) AddAppConnectKey(ctx context.Context, key app.AddConnectKey) error {
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `
+			INSERT INTO app_connect_keys (app_key, use_description, remaining_uses) VALUES ($1, $2, $3)
+			ON CONFLICT (app_key) DO UPDATE SET (use_description, remaining_uses) = (EXCLUDED.use_description, EXCLUDED.remaining_uses);
+		`, key.Key, key.Description, key.RemainingUses)
+		return err
+	})
+}
+
+// ValidAppConnectKey checks if an application connection key is valid.
+func (s *Store) ValidAppConnectKey(ctx context.Context, key string) (bool, error) {
+	var count int
+	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		return tx.QueryRow(ctx, `
+			SELECT remaining_uses FROM app_connect_keys WHERE app_key = $1 AND remaining_uses > 0
+		`, key).Scan(&count)
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// AppConnectKeys retrieves a list of application connection keys from the database.
+func (s *Store) AppConnectKeys(ctx context.Context, offset, limit int) (keys []app.ConnectKey, err error) {
+	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT app_key, use_description, remaining_uses, date_created 
+			FROM app_connect_keys
+			ORDER BY date_created DESC
+			LIMIT $1 OFFSET $2
+		`, limit, offset)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var key app.ConnectKey
+			if err := rows.Scan(&key.Key, &key.Description, &key.RemainingUses, &key.DateCreated); err != nil {
+				return err
+			}
+			keys = append(keys, key)
+		}
+		return rows.Err()
+	})
+	return
+}
+
+// DeleteAppConnectKey deletes an application connection key from the database.
+func (s *Store) DeleteAppConnectKey(ctx context.Context, connectKey string) error {
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `
+			DELETE FROM app_connect_keys WHERE app_key = $1
+		`, connectKey)
+		return err
+	})
+}
+
+// UseAppConnectKey decrements the remaining uses of a connect key
+// and adds the app account.
+func (s *Store) UseAppConnectKey(ctx context.Context, connectKey string, appKey types.PublicKey) error {
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		if err := addAccount(ctx, tx, appKey); err != nil {
+			return fmt.Errorf("failed to add app account: %w", err)
+		}
+
+		res, err := tx.Exec(ctx, `
+			UPDATE app_connect_keys SET remaining_uses = remaining_uses - 1
+			WHERE app_key = $1 AND remaining_uses > 0
+		`, connectKey)
+		if err != nil {
+			return fmt.Errorf("failed to update app connect key %q: %w", connectKey, err)
+		} else if res.RowsAffected() != 1 {
+			return fmt.Errorf("failed to use app connect key %q", connectKey)
+		}
+		return nil
+	})
+}

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -10,40 +10,77 @@ import (
 	"go.sia.tech/indexd/api/app"
 )
 
+func scanConnectKey(s scanner) (key app.ConnectKey, err error) {
+	var lastUsed sql.NullTime
+	err = s.Scan(
+		&key.Key,
+		&key.Description,
+		&key.RemainingUses,
+		&key.TotalUses,
+		&key.DateCreated,
+		&key.LastUpdated,
+		&lastUsed,
+	)
+	if lastUsed.Valid {
+		key.LastUsed = lastUsed.Time
+	}
+	return
+}
+
 // AddAppConnectKey adds or updates an application connection key in the database.
-func (s *Store) AddAppConnectKey(ctx context.Context, key app.AddConnectKey) error {
-	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, `
+func (s *Store) AddAppConnectKey(ctx context.Context, meta app.UpdateAppConnectKey) (key app.ConnectKey, err error) {
+	if meta.RemainingUses <= 0 {
+		return app.ConnectKey{}, app.ErrKeyExhausted
+	}
+	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		key, err = scanConnectKey(tx.QueryRow(ctx, `
 			INSERT INTO app_connect_keys (app_key, use_description, remaining_uses) VALUES ($1, $2, $3)
-			ON CONFLICT (app_key) DO UPDATE SET (use_description, remaining_uses) = (EXCLUDED.use_description, EXCLUDED.remaining_uses);
-		`, key.Key, key.Description, key.RemainingUses)
+			RETURNING app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used;
+		`, meta.Key, meta.Description, meta.RemainingUses))
 		return err
 	})
+	return
+}
+
+// UpdateAppConnectKey updates an existing application connection key in the database.
+// If the key does not exist, it returns [app.ErrKeyNotFound].
+func (s *Store) UpdateAppConnectKey(ctx context.Context, meta app.UpdateAppConnectKey) (key app.ConnectKey, err error) {
+	if meta.RemainingUses <= 0 {
+		return app.ConnectKey{}, app.ErrKeyExhausted
+	}
+	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		key, err = scanConnectKey(tx.QueryRow(ctx, `
+			UPDATE app_connect_keys SET (use_description, remaining_uses) = ($2, $3) WHERE app_key = $1
+			RETURNING app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used;
+		`, meta.Key, meta.Description, meta.RemainingUses))
+		return err
+	})
+	return
 }
 
 // ValidAppConnectKey checks if an application connection key is valid.
 func (s *Store) ValidAppConnectKey(ctx context.Context, key string) (bool, error) {
-	var count int
+	var uses int
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		return tx.QueryRow(ctx, `
-			SELECT remaining_uses FROM app_connect_keys WHERE app_key = $1 AND remaining_uses > 0
-		`, key).Scan(&count)
+			SELECT remaining_uses FROM app_connect_keys WHERE app_key = $1
+		`, key).Scan(&uses)
 	})
 	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+		return false, app.ErrKeyNotFound
 	} else if err != nil {
 		return false, err
 	}
-	return count > 0, nil
+	return uses > 0, nil
 }
 
 // AppConnectKeys retrieves a list of application connection keys from the database.
 func (s *Store) AppConnectKeys(ctx context.Context, offset, limit int) (keys []app.ConnectKey, err error) {
 	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-			SELECT app_key, use_description, remaining_uses, date_created 
+			SELECT app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used
 			FROM app_connect_keys
-			ORDER BY date_created DESC
+			ORDER BY created_at DESC
 			LIMIT $1 OFFSET $2
 		`, limit, offset)
 		if err != nil {
@@ -52,8 +89,8 @@ func (s *Store) AppConnectKeys(ctx context.Context, offset, limit int) (keys []a
 		defer rows.Close()
 
 		for rows.Next() {
-			var key app.ConnectKey
-			if err := rows.Scan(&key.Key, &key.Description, &key.RemainingUses, &key.DateCreated); err != nil {
+			key, err := scanConnectKey(rows)
+			if err != nil {
 				return err
 			}
 			keys = append(keys, key)
@@ -81,14 +118,18 @@ func (s *Store) UseAppConnectKey(ctx context.Context, connectKey string, appKey 
 			return fmt.Errorf("failed to add app account: %w", err)
 		}
 
-		res, err := tx.Exec(ctx, `
-			UPDATE app_connect_keys SET remaining_uses = remaining_uses - 1
-			WHERE app_key = $1 AND remaining_uses > 0
-		`, connectKey)
-		if err != nil {
+		var uses int
+		err := tx.QueryRow(ctx, `
+			UPDATE app_connect_keys SET (remaining_uses, total_uses, last_used) = (remaining_uses - 1, total_uses + 1, NOW())
+			WHERE app_key = $1 RETURNING remaining_uses
+		`, connectKey).Scan(&uses)
+		if errors.Is(err, sql.ErrNoRows) {
+			return app.ErrKeyNotFound
+		} else if err != nil {
 			return fmt.Errorf("failed to update app connect key %q: %w", connectKey, err)
-		} else if res.RowsAffected() != 1 {
-			return fmt.Errorf("failed to use app connect key %q", connectKey)
+		} else if uses < 0 {
+			// uses is returned after updating, -1 would mean the key is exhausted
+			return app.ErrKeyExhausted
 		}
 		return nil
 	})

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"testing"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api/app"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestAppConnectKeys(t *testing.T) {
+	ctx := t.Context()
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+		t.Fatal("failed to validate app connect key:", err)
+	} else if ok {
+		t.Fatal("expected app connect key to be invalid")
+	}
+
+	if err := store.AddAppConnectKey(ctx, app.AddConnectKey{
+		Key:           "foobar",
+		Description:   "Test key",
+		RemainingUses: 1,
+	}); err != nil {
+		t.Fatal("failed to add app connect key:", err)
+	}
+
+	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+		t.Fatal("failed to validate app connect key:", err)
+	} else if !ok {
+		t.Fatal("expected app connect key to be valid")
+	}
+
+	if err := store.UseAppConnectKey(ctx, "foobar", types.GeneratePrivateKey().PublicKey()); err != nil {
+		t.Fatal("failed to remove app connect key:", err)
+	}
+
+	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+		t.Fatal("failed to validate app connect key:", err)
+	} else if ok {
+		t.Fatal("expected app connect key to be invalid")
+	}
+
+	if err := store.AddAppConnectKey(ctx, app.AddConnectKey{
+		Key:           "foobar",
+		Description:   "Test key",
+		RemainingUses: 1,
+	}); err != nil {
+		t.Fatal("failed to add app connect key:", err)
+	}
+
+	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+		t.Fatal("failed to validate app connect key:", err)
+	} else if !ok {
+		t.Fatal("expected app connect key to be valid")
+	}
+
+	if err := store.DeleteAppConnectKey(ctx, "foobar"); err != nil {
+		t.Fatal("failed to delete app connect key:", err)
+	}
+
+	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+		t.Fatal("failed to validate app connect key:", err)
+	} else if ok {
+		t.Fatal("expected app connect key to be invalid")
+	}
+}

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"errors"
 	"testing"
 
 	"go.sia.tech/core/types"
@@ -12,18 +13,18 @@ func TestAppConnectKeys(t *testing.T) {
 	ctx := t.Context()
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
-		t.Fatal("failed to validate app connect key:", err)
-	} else if ok {
-		t.Fatal("expected app connect key to be invalid")
+	if _, err := store.ValidAppConnectKey(ctx, "foobar"); !errors.Is(err, app.ErrKeyNotFound) {
+		t.Fatalf("expected err %q, got %q", app.ErrKeyNotFound, err)
 	}
 
-	if err := store.AddAppConnectKey(ctx, app.AddConnectKey{
+	if key, err := store.AddAppConnectKey(ctx, app.UpdateAppConnectKey{
 		Key:           "foobar",
-		Description:   "Test key",
+		Description:   "test key",
 		RemainingUses: 1,
 	}); err != nil {
 		t.Fatal("failed to add app connect key:", err)
+	} else if key.Key != "foobar" || key.Description != "test key" || key.RemainingUses != 1 {
+		t.Fatalf("unexpected app connect key: %+v", key)
 	}
 
 	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
@@ -33,7 +34,22 @@ func TestAppConnectKeys(t *testing.T) {
 	}
 
 	if err := store.UseAppConnectKey(ctx, "foobar", types.GeneratePrivateKey().PublicKey()); err != nil {
-		t.Fatal("failed to remove app connect key:", err)
+		t.Fatal("failed to use app connect key:", err)
+	}
+
+	// ensure the key's last used field was updated
+	keys, err := store.AppConnectKeys(ctx, 0, 1)
+	if err != nil {
+		t.Fatal("failed to retrieve app connect keys:", err)
+	} else if len(keys) != 1 {
+		t.Fatalf("expected 1 app connect key, got %d", len(keys))
+	} else if keys[0].LastUsed.IsZero() {
+		t.Fatal("expected app connect key's last used field to be set")
+	}
+
+	// try again on an exhausted key
+	if err := store.UseAppConnectKey(ctx, "foobar", types.GeneratePrivateKey().PublicKey()); !errors.Is(err, app.ErrKeyExhausted) {
+		t.Fatalf("expected err %q, got %q", app.ErrKeyExhausted, err)
 	}
 
 	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
@@ -42,12 +58,14 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("expected app connect key to be invalid")
 	}
 
-	if err := store.AddAppConnectKey(ctx, app.AddConnectKey{
+	if updated, err := store.UpdateAppConnectKey(ctx, app.UpdateAppConnectKey{
 		Key:           "foobar",
-		Description:   "Test key",
+		Description:   "updated key",
 		RemainingUses: 1,
 	}); err != nil {
 		t.Fatal("failed to add app connect key:", err)
+	} else if updated.Key != "foobar" || updated.Description != "updated key" || updated.RemainingUses != 1 {
+		t.Fatalf("unexpected updated app connect key: %+v", updated)
 	}
 
 	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
@@ -60,9 +78,7 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("failed to delete app connect key:", err)
 	}
 
-	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
-		t.Fatal("failed to validate app connect key:", err)
-	} else if ok {
-		t.Fatal("expected app connect key to be invalid")
+	if _, err := store.ValidAppConnectKey(ctx, "foobar"); !errors.Is(err, app.ErrKeyNotFound) {
+		t.Fatalf("expected err %q, got %q", app.ErrKeyNotFound, err)
 	}
 }

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -3,6 +3,13 @@ CREATE TABLE accounts (
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32)
 );
 
+CREATE TABLE app_connect_keys (
+    app_key TEXT PRIMARY KEY,
+    use_description TEXT NOT NULL,
+    remaining_uses INTEGER NOT NULL,
+    date_created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
 CREATE TABLE hosts (
     id SERIAL PRIMARY KEY,
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -7,7 +7,10 @@ CREATE TABLE app_connect_keys (
     app_key TEXT PRIMARY KEY,
     use_description TEXT NOT NULL,
     remaining_uses INTEGER NOT NULL,
-    date_created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    total_uses INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE hosts (

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -6,4 +6,15 @@ import (
 	"go.uber.org/zap"
 )
 
-var migrations = []func(context.Context, *txn, *zap.Logger) error{}
+var migrations = []func(context.Context, *txn, *zap.Logger) error{
+	// adds the app_connect_keys table
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `CREATE TABLE app_connect_keys (
+    app_key TEXT PRIMARY KEY,
+    use_description TEXT NOT NULL,
+    remaining_uses INTEGER NOT NULL,
+    date_created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);`)
+		return err
+	},
+}

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -13,7 +13,10 @@ var migrations = []func(context.Context, *txn, *zap.Logger) error{
     app_key TEXT PRIMARY KEY,
     use_description TEXT NOT NULL,
     remaining_uses INTEGER NOT NULL,
-    date_created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    total_uses INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used TIMESTAMP WITH TIME ZONE
 );`)
 		return err
 	},

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -96,24 +96,6 @@ var (
 	ErrNoMoreHosts = errors.New("no more hosts available")
 )
 
-// ConnectApp requests permission to connect an application to the indexer.
-func ConnectApp(ctx context.Context, indexerURL string, appKey types.PrivateKey, meta app.RegisterAppRequest) (app.RegisterAppResponse, error) {
-	client, err := app.NewClient(indexerURL, appKey)
-	if err != nil {
-		return app.RegisterAppResponse{}, err
-	}
-	return client.RequestAppConnection(ctx, meta)
-}
-
-// Connected checks if the app key is connected to the indexer.
-func Connected(ctx context.Context, indexerURL string, appKey types.PrivateKey) (bool, error) {
-	client, err := app.NewClient(indexerURL, appKey)
-	if err != nil {
-		return false, err
-	}
-	return client.CheckAppAuth(ctx)
-}
-
 func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][]byte, dataShards uint8, maxInFlight int, timeout time.Duration) (slabs.SlabPinParams, error) {
 	if len(shards) == 0 {
 		return slabs.SlabPinParams{}, errors.New("no shards to upload")

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -96,6 +96,24 @@ var (
 	ErrNoMoreHosts = errors.New("no more hosts available")
 )
 
+// ConnectApp requests permission to connect an application to the indexer.
+func ConnectApp(ctx context.Context, indexerURL string, appKey types.PrivateKey, meta app.RegisterAppRequest) (app.RegisterAppResponse, error) {
+	client, err := app.NewClient(indexerURL, appKey)
+	if err != nil {
+		return app.RegisterAppResponse{}, err
+	}
+	return client.RequestAppConnection(ctx, meta)
+}
+
+// Connected checks if the app key is connected to the indexer.
+func Connected(ctx context.Context, indexerURL string, appKey types.PrivateKey) (bool, error) {
+	client, err := app.NewClient(indexerURL, appKey)
+	if err != nil {
+		return false, err
+	}
+	return client.CheckAppAuth(ctx)
+}
+
 func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][]byte, dataShards uint8, maxInFlight int, timeout time.Duration) (slabs.SlabPinParams, error) {
 	if len(shards) == 0 {
 		return slabs.SlabPinParams{}, errors.New("no shards to upload")

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -1,0 +1,63 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api/app"
+)
+
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		return exec.Command("open", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform %q", runtime.GOOS)
+	}
+}
+
+// Connect requests permission to connect an application to the indexer.
+// If the app is already connected, it returns (true, nil).
+// If the user rejects the connection,
+func Connect(ctx context.Context, indexerURL string, appKey types.PrivateKey, meta app.RegisterAppRequest) (bool, error) {
+	client, err := app.NewClient(indexerURL, appKey)
+	if err != nil {
+		return false, err
+	}
+
+	if ok, err := client.CheckAppAuth(ctx); err != nil {
+		return false, fmt.Errorf("failed to check app auth: %w", err)
+	} else if ok {
+		return true, nil
+	}
+
+	resp, err := client.RequestAppConnection(ctx, meta)
+	if err != nil {
+		return false, fmt.Errorf("failed to request app connection: %w", err)
+	}
+	openBrowser(resp.ResponseURL)
+
+	ctx, cancel := context.WithDeadline(ctx, resp.Expiration)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case <-time.After(time.Second):
+			if ok, err := client.CheckRequestStatus(ctx, resp.StatusURL); err != nil {
+				return false, fmt.Errorf("failed to check request status: %w", err)
+			} else if ok {
+				return true, nil
+			}
+		}
+	}
+}

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -24,6 +24,8 @@ func openBrowser(url string) error {
 	}
 }
 
+// A ConnectAppRequest is a request to connect an application
+// to the indexer.
 type ConnectAppRequest struct {
 	app.RegisterAppResponse
 

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -24,40 +24,53 @@ func openBrowser(url string) error {
 	}
 }
 
-// Connect requests permission to connect an application to the indexer.
-// If the app is already connected, it returns (true, nil).
-// If the user rejects the connection,
-func Connect(ctx context.Context, indexerURL string, appKey types.PrivateKey, meta app.RegisterAppRequest) (bool, error) {
-	client, err := app.NewClient(indexerURL, appKey)
-	if err != nil {
-		return false, err
+type ConnectAppRequest struct {
+	app.RegisterAppResponse
+
+	client *app.Client
+}
+
+// WaitForApproval waits for the user to approve the app connection request.
+// It will block until the request is either approved or denied.
+// The app should display the response URL to the user before
+// calling this function.
+func (cr *ConnectAppRequest) WaitForApproval(ctx context.Context) (bool, error) {
+	if time.Until(cr.Expiration) <= 0 {
+		return false, fmt.Errorf("request expired")
 	}
 
-	if ok, err := client.CheckAppAuth(ctx); err != nil {
-		return false, fmt.Errorf("failed to check app auth: %w", err)
-	} else if ok {
-		return true, nil
-	}
-
-	resp, err := client.RequestAppConnection(ctx, meta)
-	if err != nil {
-		return false, fmt.Errorf("failed to request app connection: %w", err)
-	}
-	openBrowser(resp.ResponseURL)
-
-	ctx, cancel := context.WithDeadline(ctx, resp.Expiration)
+	ctx, cancel := context.WithDeadline(ctx, cr.Expiration)
 	defer cancel()
 
+	openBrowser(cr.ResponseURL)
 	for {
 		select {
 		case <-ctx.Done():
 			return false, ctx.Err()
 		case <-time.After(time.Second):
-			if ok, err := client.CheckRequestStatus(ctx, resp.StatusURL); err != nil {
+			if ok, err := cr.client.CheckRequestStatus(ctx, cr.StatusURL); err != nil {
 				return false, fmt.Errorf("failed to check request status: %w", err)
 			} else if ok {
 				return true, nil
 			}
 		}
 	}
+}
+
+// Connect requests permission to connect an application to the indexer.
+// If the app is already connected, it returns ((), true, nil).
+func Connect(ctx context.Context, indexerURL string, appKey types.PrivateKey, meta app.RegisterAppRequest) (ConnectAppRequest, bool, error) {
+	client, err := app.NewClient(indexerURL, appKey)
+	if err != nil {
+		return ConnectAppRequest{}, false, err
+	}
+
+	if ok, err := client.CheckAppAuth(ctx); err != nil {
+		return ConnectAppRequest{}, false, fmt.Errorf("failed to check app auth: %w", err)
+	} else if ok {
+		return ConnectAppRequest{}, true, nil
+	}
+
+	resp, err := client.RequestAppConnection(ctx, meta)
+	return ConnectAppRequest{RegisterAppResponse: resp, client: client}, false, err
 }


### PR DESCRIPTION
Adds an auth flow for registering apps with an indexer, changes the app API to require TLS, and changes the junk uploader to use the new auth flow.

note: you will need to explicitly disable TLS to use the junk uploader locally.

Flow:
1. App requests connection
2. User visits response URL and approves or denies the connection
3. App can poll `/auth/check` to verify status

Good follow ups would be to style the page and redirect to `CallbackURL` if provided. Closes #313 