### PR TITLE
Add sector stats to store

### DIFF
--- a/api/admin/types.go
+++ b/api/admin/types.go
@@ -28,6 +28,15 @@ type (
 		Reason   string            `json:"reason"`
 	}
 
+	// SectorsStatsResponse is the response body for the [GET] /stats/sectors
+	SectorsStatsResponse struct {
+		UpdatedAt              time.Time `json:"updatedAt"`
+		NumSectors             uint64    `json:"numSectors"`
+		NumUnpinnedSectors     uint64    `json:"numUnpinnedSectors"`
+		NumSectorsBadContracts uint64    `json:"numSectorsBadContracts"`
+		NumSectorsNoHosts      uint64    `json:"numSectorsNoHosts"`
+	}
+
 	// State is the response body for the [GET] /state endpoint.
 	State struct {
 		BuildState

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -256,6 +256,14 @@ CREATE TABLE sectors (
     consecutive_failed_checks SMALLINT NOT NULL DEFAULT 0
 );
 
+CREATE MATERIALIZED VIEW sectors_stats AS
+  SELECT
+    NOW() AS updated_at,
+    (SELECT COUNT(*) FROM sectors) AS num_sectors,
+    (SELECT COUNT(*) FROM sectors WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NULL) AS num_unpinned_sectors,
+    (SELECT COUNT(*) FROM sectors INNER JOIN contract_sectors_map ON sectors.contract_sectors_map_id = contract_sectors_map.id INNER JOIN contracts ON contract_sectors_map.contract_id = contracts.contract_id WHERE contracts.good = FALSE) AS num_sectors_bad_contracts,
+    (SELECT COUNT(*) FROM sectors WHERE host_id IS NULL AND contract_sectors_map_id IS NULL) AS num_sectors_no_host;
+
 -- quick lookup of sectors that failed the integrity checks too many times
 CREATE INDEX sectors_consecutive_failed_checks_idx ON sectors(host_id, consecutive_failed_checks) WHERE consecutive_failed_checks > 0;
 

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -258,6 +258,7 @@ CREATE TABLE sectors (
 
 CREATE MATERIALIZED VIEW sectors_stats AS
 SELECT
+  1 AS id, -- single row view
   now() AS updated_at,
   COUNT(*) AS num_sectors,
   COUNT(*) FILTER (WHERE s.host_id IS NOT NULL AND s.contract_sectors_map_id IS NULL) AS num_unpinned_sectors,
@@ -266,6 +267,9 @@ SELECT
 FROM sectors s
 LEFT JOIN contract_sectors_map csm ON csm.id = s.contract_sectors_map_id
 LEFT JOIN contracts c ON c.contract_id = csm.contract_id AND c.good = FALSE; -- only bad contracts
+
+-- concurrent refresh requires a unique index
+CREATE UNIQUE INDEX sectors_stats_id_idx ON sectors_stats(id);
 
 -- quick lookup of sectors that failed the integrity checks too many times
 CREATE INDEX sectors_consecutive_failed_checks_idx ON sectors(host_id, consecutive_failed_checks) WHERE consecutive_failed_checks > 0;

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -257,12 +257,15 @@ CREATE TABLE sectors (
 );
 
 CREATE MATERIALIZED VIEW sectors_stats AS
-  SELECT
-    NOW() AS updated_at,
-    (SELECT COUNT(*) FROM sectors) AS num_sectors,
-    (SELECT COUNT(*) FROM sectors WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NULL) AS num_unpinned_sectors,
-    (SELECT COUNT(*) FROM sectors INNER JOIN contract_sectors_map ON sectors.contract_sectors_map_id = contract_sectors_map.id INNER JOIN contracts ON contract_sectors_map.contract_id = contracts.contract_id WHERE contracts.good = FALSE) AS num_sectors_bad_contracts,
-    (SELECT COUNT(*) FROM sectors WHERE host_id IS NULL AND contract_sectors_map_id IS NULL) AS num_sectors_no_host;
+SELECT
+  now() AS updated_at,
+  COUNT(*) AS num_sectors,
+  COUNT(*) FILTER (WHERE s.host_id IS NOT NULL AND s.contract_sectors_map_id IS NULL) AS num_unpinned_sectors,
+  COUNT(*) FILTER (WHERE s.host_id IS NULL AND s.contract_sectors_map_id IS NULL) AS num_sectors_no_host,
+  COUNT(c.contract_id) AS num_sectors_bad_contracts
+FROM sectors s
+LEFT JOIN contract_sectors_map csm ON csm.id = s.contract_sectors_map_id
+LEFT JOIN contracts c ON c.contract_id = csm.contract_id AND c.good = FALSE; -- only bad contracts
 
 -- quick lookup of sectors that failed the integrity checks too many times
 CREATE INDEX sectors_consecutive_failed_checks_idx ON sectors(host_id, consecutive_failed_checks) WHERE consecutive_failed_checks > 0;

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -6,6 +6,8 @@ import (
 	"go.sia.tech/indexd/api/admin"
 )
 
+// SectorStats reports statistics about the sectors stored in the database. The
+// response is cached and requires a call to RefreshSectorStats to be updated.
 func (s *Store) SectorStats(ctx context.Context) (admin.SectorsStatsResponse, error) {
 	var stats admin.SectorsStatsResponse
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
@@ -15,6 +17,9 @@ func (s *Store) SectorStats(ctx context.Context) (admin.SectorsStatsResponse, er
 	return stats, err
 }
 
+// RefreshSectorStats refreshes the cached sector statistics in the database.
+// This is an expensive operation and should be called sparingly from a
+// background thread.
 func (s *Store) RefreshSectorStats(ctx context.Context) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		_, err := tx.Exec(ctx, "REFRESH MATERIALIZED VIEW sectors_stats")

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -1,0 +1,23 @@
+package postgres
+
+import (
+	"context"
+
+	"go.sia.tech/indexd/api/admin"
+)
+
+func (s *Store) SectorStats(ctx context.Context) (admin.SectorsStatsResponse, error) {
+	var stats admin.SectorsStatsResponse
+	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		row := tx.QueryRow(ctx, "SELECT updated_at, num_sectors, num_unpinned_sectors, num_sectors_bad_contracts, num_sectors_no_host FROM sectors_stats")
+		return row.Scan(&stats.UpdatedAt, &stats.NumSectors, &stats.NumUnpinnedSectors, &stats.NumSectorsBadContracts, &stats.NumSectorsNoHosts)
+	})
+	return stats, err
+}
+
+func (s *Store) RefreshSectorStats(ctx context.Context) error {
+	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, "REFRESH MATERIALIZED VIEW sectors_stats")
+		return err
+	})
+}

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -22,7 +22,7 @@ func (s *Store) SectorStats(ctx context.Context) (admin.SectorsStatsResponse, er
 // background thread.
 func (s *Store) RefreshSectorStats(ctx context.Context) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, "REFRESH MATERIALIZED VIEW sectors_stats")
+		_, err := tx.Exec(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY sectors_stats")
 		return err
 	})
 }

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -1,0 +1,83 @@
+package postgres
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api/admin"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestSectorStats(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t))
+
+	// prepare a host with a contract
+	hk := store.addTestHost(t)
+	fcid := store.addTestContract(t, hk)
+
+	assertStats := func(nSectors, nUnpinned, nBad, nNoHost uint64) {
+		t.Helper()
+		stats, err := store.SectorStats(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if stats.UpdatedAt.IsZero() {
+			t.Fatalf("expected stats to be updated, got %v", stats.UpdatedAt)
+		}
+		stats.UpdatedAt = time.Time{} // ignore the timestamp
+		if !reflect.DeepEqual(stats, admin.SectorsStatsResponse{
+			NumSectors:             nSectors,
+			NumUnpinnedSectors:     nUnpinned,
+			NumSectorsBadContracts: nBad,
+			NumSectorsNoHosts:      nNoHost,
+		}) {
+			t.Fatalf("expected stats (%d, %d, %d, %d), got %v", nSectors, nUnpinned, nBad, nNoHost, stats)
+		}
+	}
+
+	// initially, there are no sectors
+	assertStats(0, 0, 0, 0)
+
+	// pin a slab with 3 sectors
+	store.AddAccount(context.Background(), types.PublicKey{})
+	slabID := store.pinTestSlab(t, rhp.Account{}, 1, []types.PublicKey{hk, hk, hk})
+
+	// assert 3 unpinned sectors after refreshing the stats
+	assertStats(0, 0, 0, 0)
+	if err := store.RefreshSectorStats(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(3, 3, 0, 0)
+
+	// pin 2 sectors
+	slab, err := store.Slab(context.Background(), slabID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s1, s2 := slab.Sectors[0].Root, slab.Sectors[1].Root
+	if err := store.PinSectors(context.Background(), fcid, []types.Hash256{s1, s2}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert only 1 sector remains unpinned
+	assertStats(3, 3, 0, 0)
+	if err := store.RefreshSectorStats(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(3, 1, 0, 0)
+
+	// mark one of the sectors lost and the contract bad
+	store.MarkSectorsLost(context.Background(), hk, []types.Hash256{s1})
+	store.pool.Exec(context.Background(), `UPDATE contracts SET good = FALSE WHERE id = 1`)
+
+	// we now got 1 sector that is still unpinned, 1 sector pinned to a bad
+	// contract and 1 sector that is on no host at all
+	assertStats(3, 1, 0, 0)
+	if err := store.RefreshSectorStats(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(3, 1, 1, 1)
+}

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -3,11 +3,9 @@ package postgres
 import (
 	"context"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
-	"go.sia.tech/core/rhp/v4"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api/admin"
@@ -46,7 +44,7 @@ func TestSectorStats(t *testing.T) {
 
 	// pin a slab with 3 sectors
 	store.AddAccount(context.Background(), types.PublicKey{})
-	slabID := store.pinTestSlab(t, rhp.Account{}, 1, []types.PublicKey{hk, hk, hk})
+	slabID := store.pinTestSlab(t, proto.Account{}, 1, []types.PublicKey{hk, hk, hk})
 
 	// assert 3 unpinned sectors after refreshing the stats
 	assertStats(0, 0, 0, 0)
@@ -124,34 +122,42 @@ func BenchmarkSectorStats(b *testing.B) {
 	}
 
 	// pin every sector to a contract
-	_, err := store.pool.Exec(context.Background(), "UPDATE sectors SET contract_sectors_map_id = (sectors.id % (SELECT COUNT(*) FROM contract_sectors_map) + 1)")
+	_, err := store.pool.Exec(context.Background(), "UPDATE sectors SET contract_sectors_map_id = ((sectors.id-1) % (SELECT COUNT(*) FROM contract_sectors_map) + 1)")
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	// 10% of the sectors are lost
-	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET host_id = NULL WHERE sectors.id % 10 + 1 = 0")
+	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET host_id = NULL, contract_sectors_map_id = NULL WHERE sectors.id % 10 = 0")
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	// 10% of the sectors are unpinned
-	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET contract_sectors_map_id = NULL WHERE sectors.id % 10 + 2 = 0")
+	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET contract_sectors_map_id = NULL WHERE (sectors.id + 1) % 10 = 0")
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	b.ResetTimer()
-	var once sync.Once
 	for b.Loop() {
 		if err := store.RefreshSectorStats(context.Background()); err != nil {
 			b.Fatal(err)
-		} else if stats, err := store.SectorStats(context.Background()); err != nil {
+		}
+		stats, err := store.SectorStats(context.Background())
+		if err != nil {
 			b.Fatal(err)
-		} else {
-			once.Do(func() {
-				b.Logf("stats: %+v", stats)
-			})
+		} else if stats.UpdatedAt.IsZero() {
+			b.Fatal("expected stats to be updated, got zero timestamp")
+		}
+		stats.UpdatedAt = time.Time{}
+		if !reflect.DeepEqual(stats, admin.SectorsStatsResponse{
+			NumSectors:             1048500,
+			NumUnpinnedSectors:     104850,
+			NumSectorsBadContracts: 104850,
+			NumSectorsNoHosts:      104850,
+		}) {
+			b.Fatal("unexpected stats")
 		}
 	}
 }

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -3,12 +3,15 @@ package postgres
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	"go.sia.tech/core/rhp/v4"
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api/admin"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -80,4 +83,75 @@ func TestSectorStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertStats(3, 1, 1, 1)
+}
+
+func BenchmarkSectorStats(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	account := proto.Account{1}
+	if err := store.AddAccount(context.Background(), types.PublicKey(account)); err != nil {
+		b.Fatal("failed to add account:", err)
+	}
+
+	// 100 hosts with contracts
+	nHosts := 100
+	var hks []types.PublicKey
+	for i := byte(0); i < byte(nHosts); i++ {
+		hk := store.addTestHost(b, types.PublicKey{i})
+		hks = append(hks, hk)
+		fcid := store.addTestContract(b, hk)
+
+		// 10% of the contracts are bad
+		if i%10 == 0 {
+			res, err := store.pool.Exec(context.Background(), "UPDATE contracts SET good = FALSE WHERE contract_id = $1", sqlHash256(fcid))
+			if err != nil {
+				b.Fatal(err)
+			} else if res.RowsAffected() != 1 {
+				b.Fatal("expected to update 1 row")
+			}
+		}
+	}
+
+	// create 'dbBaseSize' bytes worth of sectors
+	var dbBaseSize = 1 << 40 // 1TiB
+
+	// each slab has a size of 4MiB per host since we add 1 shard per host
+	var slabSize = nHosts * 1 << 20 // 400MiB
+
+	// prepare base db
+	for range dbBaseSize / slabSize {
+		store.pinTestSlab(b, account, 1, hks)
+	}
+
+	// pin every sector to a contract
+	_, err := store.pool.Exec(context.Background(), "UPDATE sectors SET contract_sectors_map_id = (sectors.id % (SELECT COUNT(*) FROM contract_sectors_map) + 1)")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// 10% of the sectors are lost
+	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET host_id = NULL WHERE sectors.id % 10 + 1 = 0")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// 10% of the sectors are unpinned
+	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET contract_sectors_map_id = NULL WHERE sectors.id % 10 + 2 = 0")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	var once sync.Once
+	for b.Loop() {
+		if err := store.RefreshSectorStats(context.Background()); err != nil {
+			b.Fatal(err)
+		} else if stats, err := store.SectorStats(context.Background()); err != nil {
+			b.Fatal(err)
+		} else {
+			once.Do(func() {
+				b.Logf("stats: %+v", stats)
+			})
+		}
+	}
 }


### PR DESCRIPTION
This PR adds sector stats to the database. They can be used to get an overview of how many sectors the indexer currently manages, how many of them are unpinned, are stored on bad contracts or are not stored on a host at all.

I'm playing around with materialized views to see how long it takes to refresh them.