### PR TITLE
Sign Request Body and Method

### DIFF
--- a/api/app/app.go
+++ b/api/app/app.go
@@ -13,6 +13,7 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
@@ -38,7 +39,12 @@ type (
 		ValidAppConnectKey(context.Context, string) (bool, error)
 		UseAppConnectKey(context.Context, string, types.PublicKey) error
 
-		HasAccount(ctx context.Context, ak types.PublicKey) (bool, error)
+		HasAccount(context.Context, types.PublicKey) (bool, error)
+	}
+
+	// Accounts defines the account management interface for the application API.
+	Accounts interface {
+		TriggerAccountFunding(force bool) error
 	}
 
 	authReq struct {
@@ -78,8 +84,9 @@ type (
 	}
 
 	app struct {
-		store Store
-		log   *zap.Logger
+		store    Store
+		accounts Accounts
+		log      *zap.Logger
 
 		hostname     string
 		advertiseURL string
@@ -193,7 +200,7 @@ func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 
 func (a *app) handleAuthRegister(jc jape.Context) {
 	// check whether the request is properly signed
-	pk, ok := getSignedURLAuth(jc, a.hostname)
+	pk, ok := validateURLSignature(jc, a.hostname)
 	if !ok {
 		return
 	}
@@ -251,8 +258,7 @@ func (a *app) handleGETAuthCheck(jc jape.Context, _ types.PublicKey) {
 }
 
 func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
-	// check whether the request is properly signed
-	pk, ok := getSignedURLAuth(jc, a.hostname)
+	pk, ok := validateURLSignature(jc, a.hostname)
 	if !ok {
 		return
 	}
@@ -344,26 +350,44 @@ func (a *app) handlePOSTAuthConnect(jc jape.Context) {
 		return
 	}
 
-	if err := a.store.UseAppConnectKey(ctx, connectKey, req.AppKey); err != nil {
+	err := a.store.UseAppConnectKey(ctx, connectKey, req.AppKey)
+	switch {
+	case errors.Is(err, accounts.ErrExists):
+		jc.Encode(nil)
+	case errors.Is(err, ErrKeyExhausted):
+		jc.Error(ErrKeyExhausted, http.StatusForbidden)
+	case errors.Is(err, ErrKeyNotFound):
+		jc.Error(ErrKeyNotFound, http.StatusUnauthorized)
+	case err != nil:
 		a.log.Debug("failed to use app connect key", zap.Error(err))
 		jc.Error(ErrInternalError, http.StatusInternalServerError)
-		return
+	default:
+		if err := a.accounts.TriggerAccountFunding(false); err != nil {
+			a.log.Warn("failed to trigger account funding after adding account", zap.Error(err))
+			jc.Error(ErrInternalError, http.StatusInternalServerError)
+			return
+		}
+		jc.Encode(nil)
 	}
-	jc.Encode(nil)
+}
+
+func (a *app) handleGETAccount(jc jape.Context, pk types.PublicKey) {
+	jc.Encode(struct{}{}) // TODO: include account details, like storage usage
 }
 
 // NewAPI creates a new instance of the application API. This API is used by
 // users, or rather their applications, to pin slabs to the indexer.
 // Authentication happens through presigned URLs that are signed with a private
 // key that corresponds to a previously registered public key.
-func NewAPI(advertiseURL string, store Store, opts ...Option) (http.Handler, error) {
+func NewAPI(advertiseURL string, store Store, accounts Accounts, opts ...Option) (http.Handler, error) {
 	u, err := url.Parse(advertiseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse advertise URL %q: %w", advertiseURL, err)
 	}
 	a := &app{
-		store: store,
-		log:   zap.NewNop(),
+		store:    store,
+		accounts: accounts,
+		log:      zap.NewNop(),
 
 		hostname:     u.Host,
 		advertiseURL: advertiseURL,
@@ -375,7 +399,7 @@ func NewAPI(advertiseURL string, store Store, opts ...Option) (http.Handler, err
 
 	wrapSignedAuth := func(h authedHandler) jape.Handler {
 		return func(jc jape.Context) {
-			pk, ok := checkSignedURLAuth(jc, a.hostname, store)
+			pk, ok := validateSignedURLAuth(jc, a.hostname, store)
 			if !ok {
 				return
 			}
@@ -421,6 +445,8 @@ func NewAPI(advertiseURL string, store Store, opts ...Option) (http.Handler, err
 	}
 
 	return jape.Mux(map[string]jape.Handler{
+		"GET /account": wrapCORS(wrapSignedAuth(a.handleGETAccount)),
+
 		"POST /auth/connect":                  a.handleAuthRegister, // register request
 		"GET /auth/connect/:requestID":        a.handleGETAuthConnectUI,
 		"POST /auth/connect/:requestID":       wrapBasicAuth(a.handlePOSTAuthConnect), // accept/reject

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -12,6 +14,11 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/jape"
 )
+
+// maxRequestSize determines the maximum size of an incoming
+// HTTP request body. 1MB is quite generous. A Slab with the
+// maximum 255 sectors is < 50KiB
+const maxRequestSize = 1 << 20 // 1 MB
 
 type authedHandler func(jape.Context, types.PublicKey)
 
@@ -45,12 +52,20 @@ type accountStore interface {
 	HasAccount(ctx context.Context, ak types.PublicKey) (bool, error)
 }
 
-// getSignedURLAuth extracts the signed public key from the request
+// validateURLSignature extracts the signed public key from the request
 // and verifies the signature and expiration. If successful, it returns the
 // public key and true, otherwise it writes an error to the context and returns
 // an empty public key and false.
-func getSignedURLAuth(jc jape.Context, hostname string) (types.PublicKey, bool) {
+func validateURLSignature(jc jape.Context, hostname string) (types.PublicKey, bool) {
 	req := jc.Request
+	defer req.Body.Close()
+
+	buf, err := io.ReadAll(io.LimitReader(req.Body, maxRequestSize))
+	if err != nil {
+		jc.Error(errors.New("failed to read request body"), http.StatusBadRequest)
+		return types.PublicKey{}, false
+	}
+	req.Body = io.NopCloser(bytes.NewReader(buf))
 
 	// validate presence of required parameters
 	if !isSignedRequest(req) {
@@ -80,21 +95,21 @@ func getSignedURLAuth(jc jape.Context, hostname string) (types.PublicKey, bool) 
 	if ts.Before(time.Now().UTC()) {
 		jc.Error(ErrSignatureExpired, http.StatusUnauthorized)
 		return types.PublicKey{}, false
-	} else if !pk.VerifyHash(requestHash(hostname, ts), sig) {
-		jc.Error(fmt.Errorf("failed to authenticate for host %q: %w", hostname, ErrSignatureInvalid), http.StatusUnauthorized)
+	} else if !pk.VerifyHash(requestHash(req.Method, hostname, ts, buf), sig) {
+		jc.Error(fmt.Errorf("failed to authenticate for %q host %q: %w", req.Method, hostname, ErrSignatureInvalid), http.StatusUnauthorized)
 		return types.PublicKey{}, false
 	}
 	return pk, true
 }
 
-// checkSignedURLAuth validates a signed URL by checking its required query
+// validateSignedURLAuth validates a signed URL by checking its required query
 // parameters, verifying the signature and expiration, and confirming the
 // account exists. If any check fails, it writes an HTTP error and returns
 // false, otherwise it returns the public key and true.
-func checkSignedURLAuth(jc jape.Context, hostname string, store accountStore) (types.PublicKey, bool) {
+func validateSignedURLAuth(jc jape.Context, hostname string, store accountStore) (types.PublicKey, bool) {
 	req := jc.Request
 
-	pk, ok := getSignedURLAuth(jc, hostname)
+	pk, ok := validateURLSignature(jc, hostname)
 	if !ok {
 		return types.PublicKey{}, false
 	}
@@ -150,9 +165,13 @@ func isSignedRequest(req *http.Request) bool {
 		req.URL.Query().Has(queryParamValidUntil)
 }
 
-func requestHash(hostname string, validUntil time.Time) types.Hash256 {
+func requestHash(method string, hostname string, validUntil time.Time, body []byte) types.Hash256 {
 	h := types.NewHasher()
+	h.E.Write([]byte(method))
 	h.E.Write([]byte(hostname))
 	h.E.WriteUint64(uint64(validUntil.Unix()))
+	if body != nil {
+		h.E.Write(body)
+	}
 	return h.Sum()
 }

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -29,16 +30,25 @@ func TestAuth(t *testing.T) {
 
 	server := httptest.NewServer(jape.Mux(map[string]jape.Handler{
 		"GET /foo": func(jc jape.Context) {
-			if _, ok := checkSignedURLAuth(jc, hostname, s); ok {
+			if _, ok := validateSignedURLAuth(jc, hostname, s); ok {
+				jc.ResponseWriter.WriteHeader(http.StatusOK)
+			}
+		},
+		"POST /foo": func(jc jape.Context) {
+			if _, ok := validateSignedURLAuth(jc, hostname, s); ok {
 				jc.ResponseWriter.WriteHeader(http.StatusOK)
 			}
 		},
 	}))
 	defer server.Close()
 
-	doRequest := func(params url.Values) (int, string) {
+	doRequest := func(method string, params url.Values, buf []byte) (int, string) {
+		var body io.Reader = http.NoBody
+		if buf != nil {
+			body = bytes.NewReader(buf)
+		}
 		t.Helper()
-		req, err := http.NewRequest("GET", server.URL+"/foo", http.NoBody)
+		req, err := http.NewRequest(method, server.URL+"/foo", body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -62,24 +72,37 @@ func TestAuth(t *testing.T) {
 	}
 
 	validUntil := time.Now().Add(time.Hour)
-	goodParams := func() url.Values {
+	goodParams := func(method string, body []byte) url.Values {
 		val := url.Values{}
 		val.Set(queryParamValidUntil, fmt.Sprint(validUntil.Unix()))
 		val.Set(queryParamCredential, sk.PublicKey().String())
-		val.Set(queryParamSignature, sk.SignHash(requestHash(hostname, validUntil)).String())
+		val.Set(queryParamSignature, sk.SignHash(requestHash(method, hostname, validUntil, body)).String())
 		return val
 	}
 
+	// assert authorized if everything is valid
+	status, errorMsg := doRequest(http.MethodGet, goodParams(http.MethodGet, nil), nil)
+	if status != http.StatusOK {
+		t.Fatal("unexpected", status, errorMsg)
+	}
+
+	// assert authorized if the body does match
+	params := goodParams(http.MethodPost, []byte("hello, world!"))
+	status, errorMsg = doRequest(http.MethodPost, params, []byte("hello, world!"))
+	if status != http.StatusOK {
+		t.Fatal("unexpected", status)
+	}
+
 	// assert unauthorized if no auth was set
-	status, _ := doRequest(url.Values{})
+	status, _ = doRequest(http.MethodGet, url.Values{}, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatal("unexpected", status)
 	}
 
 	// assert unauthorized if 'SiaIdx-ValidUntil' is invalid
-	params := goodParams()
+	params = goodParams(http.MethodGet, nil)
 	params.Set(queryParamValidUntil, "invalid")
-	status, errorMsg := doRequest(params)
+	status, errorMsg = doRequest(http.MethodGet, params, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatal("unexpected", status)
 	} else if !strings.Contains(errorMsg, "must be a unix timestamp") {
@@ -87,9 +110,9 @@ func TestAuth(t *testing.T) {
 	}
 
 	// assert unauthorized if 'SiaIdx-Credential' is invalid
-	params = goodParams()
+	params = goodParams(http.MethodGet, nil)
 	params.Set(queryParamCredential, "invalid")
-	status, errorMsg = doRequest(params)
+	status, errorMsg = doRequest(http.MethodGet, params, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatal("unexpected", status)
 	} else if !strings.Contains(errorMsg, "must be a valid public key") {
@@ -97,34 +120,46 @@ func TestAuth(t *testing.T) {
 	}
 
 	// assert unauthorized if 'SiaIdx-Signature' is invalid
-	params = goodParams()
+	params = goodParams(http.MethodGet, nil)
 	params.Set(queryParamSignature, "invalid")
-	status, errorMsg = doRequest(params)
+	status, errorMsg = doRequest(http.MethodGet, params, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatal("unexpected", status)
 	} else if !strings.Contains(errorMsg, "must be a 64-byte hex string") {
 		t.Fatal("unexpected", errorMsg)
 	}
 
-	// assert authorized if everything is valid
-	status, errorMsg = doRequest(goodParams())
-	if status != http.StatusOK {
-		t.Fatal("unexpected", status, errorMsg)
-	}
-
 	// assert unauthorized if the timestamp is in the past
-	params = goodParams()
+	params = goodParams(http.MethodGet, nil)
 	params.Set(queryParamValidUntil, fmt.Sprint(time.Now().Unix()-1))
-	status, errorMsg = doRequest(params)
+	status, errorMsg = doRequest(http.MethodGet, params, nil)
 	if status != http.StatusUnauthorized {
 		t.Fatal("unexpected", status)
 	} else if !strings.Contains(errorMsg, ErrSignatureExpired.Error()) {
 		t.Fatal("unexpected", errorMsg)
 	}
 
+	// assert unauthorized if the body doesn't match
+	params = goodParams(http.MethodPost, []byte("invalid"))
+	status, errorMsg = doRequest(http.MethodPost, params, []byte("hello, world!"))
+	if status != http.StatusUnauthorized {
+		t.Fatal("unexpected", status)
+	} else if !strings.Contains(errorMsg, "invalid signature") {
+		t.Fatal("unexpected", errorMsg)
+	}
+
+	// assert unauthorized if the method doesn't match
+	params = goodParams(http.MethodPut, []byte("hello, world!"))
+	status, errorMsg = doRequest(http.MethodPost, params, []byte("hello, world!"))
+	if status != http.StatusUnauthorized {
+		t.Fatal("unexpected", status)
+	} else if !strings.Contains(errorMsg, "invalid signature") {
+		t.Fatal("unexpected", errorMsg)
+	}
+
 	// assert unauthorized if the account is unknown
 	s.tokens = map[types.PublicKey]struct{}{}
-	status, errorMsg = doRequest(goodParams())
+	status, errorMsg = doRequest(http.MethodGet, goodParams(http.MethodGet, nil), nil)
 	if status != http.StatusUnauthorized {
 		t.Fatal("unexpected", status)
 	} else if !strings.Contains(errorMsg, ErrUnknownAccount.Error()) {

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -1,19 +1,21 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
-	"go.sia.tech/jape"
 )
 
 const (
@@ -22,32 +24,38 @@ const (
 
 // Client is an HTTP client for the application API of the indexer.
 type Client struct {
-	c jape.Client
+	baseURL string
 
 	// the following fields are used to sign requests
 	appkey   types.PrivateKey
 	hostname string
 }
 
-func (c *Client) sign(route string) string {
+// sign signs the request with the appropriate headers and returns the signed URL
+// and request body.
+func sign(appKey types.PrivateKey, method, endpointURL string, req any) (string, io.Reader, error) {
+	u, err := url.Parse(endpointURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	var buf []byte
+	if req != nil {
+		var err error
+		buf, err = json.Marshal(req)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+	}
 	// prepare request hash
 	validUntil := time.Now().Add(defaultValidity)
-	h := types.NewHasher()
-	h.E.Write([]byte(c.hostname))
-	h.E.WriteUint64(uint64(validUntil.Unix()))
-	requestHash := h.Sum()
+	sigHash := requestHash(method, u.Host, validUntil, buf)
 
 	// prepare query parameters
 	val := url.Values{}
 	val.Set("SiaIdx-ValidUntil", fmt.Sprint(validUntil.Unix()))
-	val.Set("SiaIdx-Credential", c.appkey.PublicKey().String())
-	val.Set("SiaIdx-Signature", c.appkey.SignHash(requestHash).String())
-
-	// parse the route (which may contain existing query parameters)
-	u, err := url.Parse(route)
-	if err != nil {
-		panic(err) // developer error
-	}
+	val.Set("SiaIdx-Credential", appKey.PublicKey().String())
+	val.Set("SiaIdx-Signature", appKey.SignHash(sigHash).String())
 
 	// merge query params
 	q := u.Query()
@@ -57,7 +65,37 @@ func (c *Client) sign(route string) string {
 		}
 	}
 	u.RawQuery = q.Encode()
-	return u.String()
+	var body io.Reader = http.NoBody
+	if buf != nil {
+		body = bytes.NewReader(buf)
+	}
+	return u.String(), body, nil
+}
+
+func (c *Client) signedRequest(ctx context.Context, method, route string, data any, resp any) error {
+	u, body, err := sign(c.appkey, method, fmt.Sprintf("%s%s", c.baseURL, route), data)
+	if err != nil {
+		return fmt.Errorf("failed to sign request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, body)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	r, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer io.Copy(io.Discard, r.Body)
+	defer r.Body.Close()
+	if !(200 <= r.StatusCode && r.StatusCode < 300) {
+		err, _ := io.ReadAll(r.Body)
+		return errors.New(strings.TrimSpace(string(err)))
+	}
+	if resp == nil {
+		return nil
+	}
+	return json.NewDecoder(r.Body).Decode(resp)
 }
 
 // Hosts returns all usable hosts.
@@ -66,54 +104,53 @@ func (c *Client) Hosts(ctx context.Context, opts ...api.URLQueryParameterOption)
 	for _, opt := range opts {
 		opt(values)
 	}
-	err = c.c.GET(ctx, c.sign("/hosts?"+values.Encode()), &hosts)
+	err = c.signedRequest(ctx, http.MethodGet, "/hosts?"+values.Encode(), nil, &hosts)
 	return
 }
 
 // PinSlab pins a slab to the indexer.
 func (c *Client) PinSlab(ctx context.Context, params slabs.SlabPinParams) (slabID slabs.SlabID, err error) {
-	err = c.c.POST(ctx, c.sign("/slabs"), params, &slabID)
+	err = c.signedRequest(ctx, http.MethodPost, "/slabs", params, &slabID)
 	return
 }
 
 // UnpinSlab unpins a slab from the indexer.
 func (c *Client) UnpinSlab(ctx context.Context, slabID slabs.SlabID) error {
-	return c.c.DELETE(ctx, c.sign(fmt.Sprintf("/slabs/%s", slabID)))
+	return c.signedRequest(ctx, http.MethodDelete, fmt.Sprintf("/slabs/%s", slabID), nil, nil)
 }
 
 // Slab retrieves a slab from the indexer by its ID.
 func (c *Client) Slab(ctx context.Context, slabID slabs.SlabID) (s slabs.PinnedSlab, err error) {
-	err = c.c.GET(ctx, c.sign(fmt.Sprintf("/slabs/%s", slabID)), &s)
+	err = c.signedRequest(ctx, http.MethodGet, fmt.Sprintf("/slabs/%s", slabID), nil, &s)
 	return
 }
 
 // SlabIDs fetches the digests of slabs associated with the account. It supports
 // pagination through the provided options.
-func (c *Client) SlabIDs(ctx context.Context, opts ...api.URLQueryParameterOption) ([]slabs.SlabID, error) {
+func (c *Client) SlabIDs(ctx context.Context, opts ...api.URLQueryParameterOption) (slabIDs []slabs.SlabID, err error) {
 	values := url.Values{}
 	for _, opt := range opts {
 		opt(values)
 	}
 
-	var slabIDs []slabs.SlabID
-	err := c.c.GET(ctx, c.sign("/slabs?"+values.Encode()), &slabIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch slab digests: %w", err)
-	}
-
-	return slabIDs, nil
+	err = c.signedRequest(ctx, http.MethodGet, "/slabs?"+values.Encode(), nil, &slabIDs)
+	return
 }
 
 // RequestAppConnection requests an application connection to the indexer.
 func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
-	err = c.c.POST(ctx, c.sign("/auth/connect"), request, &resp)
+	err = c.signedRequest(ctx, http.MethodPost, "/auth/connect", request, &resp)
 	return
 }
 
 // CheckRequestStatus checks if an auth request has been approved.
 // If the auth request is still pending, it returns false.
 func (c *Client) CheckRequestStatus(ctx context.Context, statusURL string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.sign(statusURL), nil)
+	requestURL, body, err := sign(c.appkey, http.MethodGet, statusURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to sign request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, body)
 	if err != nil {
 		return false, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -142,7 +179,11 @@ func (c *Client) CheckRequestStatus(ctx context.Context, statusURL string) (bool
 // CheckAppAuth checks if the application is authenticated with the indexer.
 // It returns true if authenticated, false if not, and an error if the request fails.
 func (c *Client) CheckAppAuth(ctx context.Context) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.sign(fmt.Sprintf("%s/auth/check", c.c.BaseURL)), nil)
+	u, body, err := sign(c.appkey, http.MethodGet, fmt.Sprintf("%s/auth/check", c.baseURL), nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to sign request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, body)
 	if err != nil {
 		return false, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -176,7 +217,7 @@ func NewClient(address string, appKey types.PrivateKey) (*Client, error) {
 	}
 
 	return &Client{
-		c: jape.Client{BaseURL: address},
+		baseURL: address,
 
 		appkey:   appKey,
 		hostname: parsedURL.Host,

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -200,7 +200,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		}
 	}
 
-	appHandler, err := app.NewAPI(advertiseURL, store, appAPIOpts...)
+	appHandler, err := app.NewAPI(advertiseURL, store, contracts, appAPIOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create application API: %w", err)
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -179,7 +179,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		t.Fatalf("failed to listen on application address: %v", err)
 	}
 	appAPIAddr := fmt.Sprintf("http://%s", appListener.Addr().String())
-	appHandler, err := app.NewAPI(appAPIAddr, store, appAPIOpts...)
+	appHandler, err := app.NewAPI(appAPIAddr, store, contracts, appAPIOpts...)
 	if err != nil {
 		t.Fatalf("failed to create application API: %v", err)
 	}


### PR DESCRIPTION
Changes the signed URL to include the HTTP method and request body. I felt this change was necessary because without it the API cannot be 100% sure the rotated key is the new key the owner intended.
