### PR TITLE
Add alerts API endpoints

### DIFF
--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -85,6 +85,23 @@ func (s Severity) String() string {
 	}
 }
 
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *Severity) UnmarshalText(b []byte) error {
+	switch string(b) {
+	case severityInfoStr:
+		*s = SeverityInfo
+	case severityWarningStr:
+		*s = SeverityWarning
+	case severityErrorStr:
+		*s = SeverityError
+	case severityCriticalStr:
+		*s = SeverityCritical
+	default:
+		return fmt.Errorf("unrecognized severity %s", b)
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaler interface.
 func (s Severity) MarshalJSON() ([]byte, error) {
 	return fmt.Appendf(nil, "%q", s.String()), nil

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -164,8 +164,8 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 		"DELETE /account/:accountkey": a.handleDELETEAccount,
 
 		// alerts endpoints
-		"GET    /alerts":     a.handleGETAlerts,
-		"DELETE /alerts/:id": a.handleDELETEAlerts,
+		"GET    /alerts":         a.handleGETAlerts,
+		"POST   /alerts/dismiss": a.handlePOSTAlertsDismiss,
 
 		// contract endpoints
 		"GET /contract/:contractid": a.handleGETContract,
@@ -452,13 +452,13 @@ func (a *admin) handleGETAlerts(jc jape.Context) {
 	jc.Encode(alerts)
 }
 
-func (a *admin) handleDELETEAlerts(jc jape.Context) {
-	var id types.Hash256
-	if jc.DecodeParam("id", &id) != nil {
+func (a *admin) handlePOSTAlertsDismiss(jc jape.Context) {
+	var ids []types.Hash256
+	if jc.Decode(&ids) != nil {
 		return
 	}
 
-	a.alerter.DismissAlerts(id)
+	a.alerter.DismissAlerts(ids...)
 	jc.Encode(nil)
 }
 

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -17,6 +17,7 @@ import (
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/wallet"
 	"go.sia.tech/indexd/accounts"
+	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/build"
@@ -110,6 +111,11 @@ type (
 		ReleaseInputs(txns []types.Transaction, v2txns []types.V2Transaction)
 		SignV2Inputs(txn *types.V2Transaction, toSign []int)
 	}
+
+	Alerter interface {
+		DismissAlerts(ids ...types.Hash256)
+		Alerts(offset, limit int, opts ...alerts.AlertOpt) ([]alerts.Alert, error)
+	}
 )
 
 type (
@@ -122,6 +128,7 @@ type (
 		store     Store
 		syncer    Syncer
 		wallet    Wallet
+		alerter   Alerter
 		log       *zap.Logger
 	}
 )
@@ -131,7 +138,7 @@ type (
 // API exposes endpoints to manage accounts, hosts, settings and the wallet.
 // This is different from the application API, which users, or rather their
 // applications, can use to pin slabs.
-func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, syncer Syncer, wallet Wallet, store Store, opts ...Option) http.Handler {
+func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, syncer Syncer, wallet Wallet, store Store, alerter Alerter, opts ...Option) http.Handler {
 	a := &admin{
 		chain:     chain,
 		contracts: contracts,
@@ -139,6 +146,7 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 		store:     store,
 		syncer:    syncer,
 		wallet:    wallet,
+		alerter:   alerter,
 		log:       zap.NewNop(),
 	}
 	for _, opt := range opts {
@@ -153,6 +161,10 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, sy
 		"POST   /account/:accountkey": a.handlePOSTAccount,
 		"PUT    /account/:accountkey": a.handlePUTAccount,
 		"DELETE /account/:accountkey": a.handleDELETEAccount,
+
+		// alerts endpoints
+		"GET    /alerts":     a.handleGETAlerts,
+		"DELETE /alerts/:id": a.handleDELETEAlerts,
 
 		// contract endpoints
 		"GET /contract/:contractid": a.handleGETContract,
@@ -415,6 +427,38 @@ func (a *admin) handleDELETEAccount(jc jape.Context) {
 	} else if jc.Check("failed to delete account", err) != nil {
 		return
 	}
+}
+
+func (a *admin) handleGETAlerts(jc jape.Context) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	var opts []alerts.AlertOpt
+	if jc.Request.FormValue("severity") != "" {
+		var severity alerts.Severity
+		if jc.DecodeForm("severity", &severity) != nil {
+			return
+		}
+		opts = append(opts, alerts.WithSeverity(severity))
+	}
+
+	alerts, err := a.alerter.Alerts(offset, limit, opts...)
+	if jc.Check("failed to get alerts", err) != nil {
+		return
+	}
+	jc.Encode(alerts)
+}
+
+func (a *admin) handleDELETEAlerts(jc jape.Context) {
+	var id types.Hash256
+	if jc.DecodeParam("id", &id) != nil {
+		return
+	}
+
+	a.alerter.DismissAlerts(id)
+	jc.Encode(nil)
 }
 
 func (a *admin) handleGETState(jc jape.Context) {

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -112,6 +112,7 @@ type (
 		SignV2Inputs(txn *types.V2Transaction, toSign []int)
 	}
 
+	// An Alerter manages alerts.
 	Alerter interface {
 		DismissAlerts(ids ...types.Hash256)
 		Alerts(offset, limit int, opts ...alerts.AlertOpt) ([]alerts.Alert, error)

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -231,12 +231,14 @@ func TestAlertsAPI(t *testing.T) {
 	indexer := testutils.NewIndexer(t, c, zap.NewNop())
 	alerter := indexer.Alerter()
 
+	// no alerts registered at this point
 	if alerts, err := indexer.Alerts(context.Background()); err != nil {
 		t.Fatal(err)
 	} else if len(alerts) != 0 {
 		t.Fatalf("expected 0 alerts, got %d", len(alerts))
 	}
 
+	// first alert has info severity
 	a1 := alerts.Alert{
 		ID:        types.Hash256{0: 1},
 		Severity:  alerts.SeverityInfo,
@@ -246,6 +248,7 @@ func TestAlertsAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// we should have the 1 alert we just registered
 	if alerts, err := indexer.Alerts(context.Background()); err != nil {
 		t.Fatal(err)
 	} else if len(alerts) != 1 {
@@ -254,12 +257,14 @@ func TestAlertsAPI(t *testing.T) {
 		t.Fatalf("expected alert %v, got %v", a1, alerts[0])
 	}
 
+	// offset = 1 with only 1 alert registered should mean no results
 	if alerts, err := indexer.Alerts(context.Background(), admin.AlertQueryParameterOption(api.WithOffset(1))); err != nil {
 		t.Fatal(err)
 	} else if len(alerts) != 0 {
 		t.Fatalf("expected 0 alerts, got %d", len(alerts))
 	}
 
+	// seocnd alert has error severity
 	a2 := alerts.Alert{
 		ID:        types.Hash256{0: 2},
 		Severity:  alerts.SeverityError,
@@ -269,6 +274,7 @@ func TestAlertsAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// we should only get the second alert if we filter with SeverityError
 	if alerts, err := indexer.Alerts(context.Background(), admin.WithSeverity(alerts.SeverityError)); err != nil {
 		t.Fatal(err)
 	} else if len(alerts) != 1 {
@@ -296,6 +302,7 @@ func TestAlertsAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// we should only have the second alert left after dismissing the first one
 	if alerts, err := indexer.Alerts(context.Background()); err != nil {
 		t.Fatal(err)
 	} else if len(alerts) != 1 {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -298,7 +298,7 @@ func TestAlertsAPI(t *testing.T) {
 		t.Fatalf("expected alert %v, got %v", a2, alerts[1])
 	}
 
-	if err := indexer.DismissAlert(context.Background(), a1.ID); err != nil {
+	if err := indexer.DismissAlerts(context.Background(), a1.ID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1,11 +1,13 @@
 package admin_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"reflect"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +16,7 @@ import (
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/coreutils/wallet"
+	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/admin"
 	"go.sia.tech/indexd/api/app"
@@ -223,6 +226,85 @@ func TestAccountsAPI(t *testing.T) {
 	}
 }
 
+func TestAlertsAPI(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+	alerter := indexer.Alerter()
+
+	if alerts, err := indexer.Alerts(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts, got %d", len(alerts))
+	}
+
+	a1 := alerts.Alert{
+		ID:        types.Hash256{0: 1},
+		Severity:  alerts.SeverityInfo,
+		Timestamp: time.Now().UTC(),
+	}
+	if err := alerter.RegisterAlert(a1); err != nil {
+		t.Fatal(err)
+	}
+
+	if alerts, err := indexer.Alerts(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if len(alerts) != 1 {
+		t.Fatalf("expected 1 alerts, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], a1) {
+		t.Fatalf("expected alert %v, got %v", a1, alerts[0])
+	}
+
+	if alerts, err := indexer.Alerts(context.Background(), admin.AlertQueryParameterOption(api.WithOffset(1))); err != nil {
+		t.Fatal(err)
+	} else if len(alerts) != 0 {
+		t.Fatalf("expected 0 alerts, got %d", len(alerts))
+	}
+
+	a2 := alerts.Alert{
+		ID:        types.Hash256{0: 2},
+		Severity:  alerts.SeverityError,
+		Timestamp: time.Now().UTC(),
+	}
+	if err := alerter.RegisterAlert(a2); err != nil {
+		t.Fatal(err)
+	}
+
+	if alerts, err := indexer.Alerts(context.Background(), admin.WithSeverity(alerts.SeverityError)); err != nil {
+		t.Fatal(err)
+	} else if len(alerts) != 1 {
+		t.Fatalf("expected 1 alerts, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], a2) {
+		t.Fatalf("expected alert %v, got %v", a2, alerts[0])
+	}
+
+	alerts, err := indexer.Alerts(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(alerts, func(i, j int) bool {
+		return bytes.Compare(alerts[i].ID[:], alerts[j].ID[:]) < 0
+	})
+	if len(alerts) != 2 {
+		t.Fatalf("expected 2 alerts, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], a1) {
+		t.Fatalf("expected alert %v, got %v", a1, alerts[0])
+	} else if !reflect.DeepEqual(alerts[1], a2) {
+		t.Fatalf("expected alert %v, got %v", a2, alerts[1])
+	}
+
+	if err := indexer.DismissAlert(context.Background(), a1.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if alerts, err := indexer.Alerts(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if len(alerts) != 1 {
+		t.Fatalf("expected 1 alerts, got %d", len(alerts))
+	} else if !reflect.DeepEqual(alerts[0], a2) {
+		t.Fatalf("expected alert %v, got %v", a2, alerts[0])
+	}
+}
+
 func TestContractsAPI(t *testing.T) {
 	// create cluster with one host
 	logger := newTestLogger(false)
@@ -329,6 +411,7 @@ func TestContractsAPI(t *testing.T) {
 		t.Fatal("expected contract to be renewed", contracts[0].RenewedFrom, contract.ID)
 	}
 }
+
 func TestExplorerAPI(t *testing.T) {
 	c := testutils.NewConsensusNode(t, zap.NewNop())
 	indexer := testutils.NewIndexer(t, c, zap.NewNop())

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -90,7 +90,7 @@ func (c *Client) Alerts(ctx context.Context, opts ...AlertQueryParameterOption) 
 }
 
 // DismissAlerts dismisses registered alerts.
-func (c *Client) DismissAlert(ctx context.Context, ids ...types.Hash256) (err error) {
+func (c *Client) DismissAlerts(ctx context.Context, ids ...types.Hash256) (err error) {
 	err = c.c.POST(ctx, "/alerts/dismiss", ids, nil)
 	return
 }

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -7,6 +7,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
+	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/contracts"
@@ -75,6 +76,22 @@ func (c *Client) AccountsAdd(ctx context.Context, accountKey types.PublicKey) (e
 // AccountsDelete deletes the account with the given account key.
 func (c *Client) AccountsDelete(ctx context.Context, accountKey types.PublicKey) (err error) {
 	err = c.c.DELETE(ctx, fmt.Sprintf("/account/%s", accountKey))
+	return
+}
+
+// Alerts returns registered alerts.
+func (c *Client) Alerts(ctx context.Context, opts ...AlertQueryParameterOption) (alerts []alerts.Alert, err error) {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	err = c.c.GET(ctx, "/alerts?"+values.Encode(), &alerts)
+	return
+}
+
+// DismissAlert dismisses a registered alert.
+func (c *Client) DismissAlert(ctx context.Context, id types.Hash256) (err error) {
+	err = c.c.DELETE(ctx, fmt.Sprintf("/alerts/%s", id))
 	return
 }
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -89,9 +89,9 @@ func (c *Client) Alerts(ctx context.Context, opts ...AlertQueryParameterOption) 
 	return
 }
 
-// DismissAlert dismisses a registered alert.
-func (c *Client) DismissAlert(ctx context.Context, id types.Hash256) (err error) {
-	err = c.c.DELETE(ctx, fmt.Sprintf("/alerts/%s", id))
+// DismissAlerts dismisses registered alerts.
+func (c *Client) DismissAlert(ctx context.Context, ids ...types.Hash256) (err error) {
+	err = c.c.POST(ctx, "/alerts/dismiss", ids, nil)
 	return
 }
 

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/api"
 	"go.uber.org/zap"
 )
@@ -79,5 +80,16 @@ func WithUsable(usable bool) HostQueryParameterOption {
 func WithActiveContracts(activeContracts bool) HostQueryParameterOption {
 	return func(q url.Values) {
 		q.Set("activecontracts", fmt.Sprint(activeContracts))
+	}
+}
+
+// AlertQueryParameterOption is an option to configure the query string for the
+// Alerts endpoint.
+type AlertQueryParameterOption api.URLQueryParameterOption
+
+// WithSeverity sets the 'severity' parameter.
+func WithSeverity(severity alerts.Severity) AlertQueryParameterOption {
+	return func(q url.Values) {
+		q.Set("severity", fmt.Sprint(severity))
 	}
 }

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -90,6 +90,6 @@ type AlertQueryParameterOption api.URLQueryParameterOption
 // WithSeverity sets the 'severity' parameter.
 func WithSeverity(severity alerts.Severity) AlertQueryParameterOption {
 	return func(q url.Values) {
-		q.Set("severity", fmt.Sprint(severity))
+		q.Set("severity", severity.String())
 	}
 }

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -125,7 +125,8 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer contracts.Close()
 
-	slabs, err := slabs.NewManager(am, hm, store, dialer, alerts.NewManager(), keys.DeriveKey(walletKey, "migration"), keys.DeriveKey(walletKey, "integrity"))
+	alerter := alerts.NewManager()
+	slabs, err := slabs.NewManager(am, hm, store, dialer, alerter, keys.DeriveKey(walletKey, "migration"), keys.DeriveKey(walletKey, "integrity"))
 	if err != nil {
 		return fmt.Errorf("failed to create slabs manager: %w", err)
 	}
@@ -165,7 +166,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 
 	adminAPI := http.Server{
 		Handler: webRouter{
-			api: jape.BasicAuth(cfg.AdminAPI.Password)(admin.NewAPI(cm, contracts, hm, s, wm, store, adminAPIOpts...)),
+			api: jape.BasicAuth(cfg.AdminAPI.Password)(admin.NewAPI(cm, contracts, hm, s, wm, store, alerter, adminAPIOpts...)),
 			ui:  indexd.Handler(),
 		},
 		ReadTimeout:  30 * time.Second,

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -54,11 +54,12 @@ type (
 		*admin.Client
 		App func(types.PrivateKey) *app.Client
 
-		cm     *chain.Manager
-		dialer *client.SiamuxDialer
-		store  *postgres.Store
-		syncer *Syncer
-		wallet *wallet.SingleAddressWallet
+		cm      *chain.Manager
+		dialer  *client.SiamuxDialer
+		alerter *alerts.Manager
+		store   *postgres.Store
+		syncer  *Syncer
+		wallet  *wallet.SingleAddressWallet
 	}
 
 	// IndexerOpt is a functional option for configuring an indexer for testing
@@ -152,10 +153,11 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		admin.WithLogger(log.Named("api.admin")),
 		admin.WithExplorer(explorer.New("https://api.siascan.com")),
 	}
+	alerter := alerts.NewManager()
 
 	password := hex.EncodeToString(frand.Bytes(16))
 	adminAPI := http.Server{
-		Handler: jape.BasicAuth(password)(admin.NewAPI(c.cm, contracts, hm, syncer, wm, store, adminAPIOpts...)),
+		Handler: jape.BasicAuth(password)(admin.NewAPI(c.cm, contracts, hm, syncer, wm, store, alerter, adminAPIOpts...)),
 	}
 
 	adminListener, err := net.Listen("tcp4", "127.0.0.1:0")
@@ -234,11 +236,12 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 			return client
 		},
 
-		cm:     c.cm,
-		dialer: dialer,
-		store:  store,
-		syncer: syncer,
-		wallet: wm,
+		cm:      c.cm,
+		dialer:  dialer,
+		alerter: alerter,
+		store:   store,
+		syncer:  syncer,
+		wallet:  wm,
 	}
 }
 
@@ -253,6 +256,11 @@ func (idx *Indexer) HostClient(t *testing.T, hk types.PublicKey) *client.HostCli
 		t.Fatalf("failed to dial host %s: %v", hk, err) // developer error
 	}
 	return hc
+}
+
+// Alerter returns the underlying alert manager.
+func (idx *Indexer) Alerter() *alerts.Manager {
+	return idx.alerter
 }
 
 // Store returns the underlying store.


### PR DESCRIPTION
Fixes [#330](https://github.com/SiaFoundation/indexd/issues/330)

Add endpoints:
```
GET /alerts - to list alerts - with optional offset, limit, and severity parameters
POST /alerts/dismiss - dismiss the given alert IDs
```