### PR TITLE
Fix TestMigrations

### DIFF
--- a/internal/testutils/cluster.go
+++ b/internal/testutils/cluster.go
@@ -150,12 +150,12 @@ func (c *Cluster) AnnounceHosts(ctx context.Context, t testing.TB, hosts ...*Hos
 	}
 }
 
-// FundHosts funds the hosts with one block, then waits for the funds to mature.
+// FundHosts funds the hosts with multiple blocks, then waits for the funds to mature.
 func (c *Cluster) FundHosts(ctx context.Context, t testing.TB, hosts ...*Host) {
 	t.Helper()
 
 	for _, h := range hosts {
-		c.ConsensusNode.MineBlocks(t, h.w.Address(), 1)
+		c.ConsensusNode.MineBlocks(t, h.w.Address(), 5)
 	}
 	c.ConsensusNode.MineBlocks(t, types.Address{}, c.ConsensusNode.network.MaturityDelay)
 

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -298,6 +298,7 @@ func shutdownWithTimeout(shutdownFn func(context.Context) error) error {
 	})
 }
 
+// WaitForHosts waits for the given number of hosts and returns them.
 func WaitForHosts(t *testing.T, app *app.Client, n int) []hosts.HostInfo {
 	t.Helper()
 	start := time.Now()
@@ -309,7 +310,7 @@ func WaitForHosts(t *testing.T, app *app.Client, n int) []hosts.HostInfo {
 		} else if len(hosts) == n {
 			return hosts
 		} else if time.Since(start) > limit {
-			t.Fatal(fmt.Sprintf("timed out waiting for %d hosts, got %d", n, len(hosts)))
+			t.Fatalf("timed out waiting for %d hosts, got %d", n, len(hosts))
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -297,3 +297,20 @@ func shutdownWithTimeout(shutdownFn func(context.Context) error) error {
 		return shutdownFn(context.Background())
 	})
 }
+
+func WaitForHosts(t *testing.T, app *app.Client, n int) []hosts.HostInfo {
+	t.Helper()
+	start := time.Now()
+	limit := 10 * time.Second
+	for {
+		hosts, err := app.Hosts(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if len(hosts) == n {
+			return hosts
+		} else if time.Since(start) > limit {
+			t.Fatal(fmt.Sprintf("timed out waiting for %d hosts, got %d", n, len(hosts)))
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -22,7 +22,6 @@ func TestMigrations(t *testing.T) {
 	// create some more utxos
 	indexer := cluster.Indexer
 	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 10)
-	time.Sleep(3 * time.Second)
 
 	// add an account
 	a1 := types.GeneratePrivateKey()
@@ -35,12 +34,9 @@ func TestMigrations(t *testing.T) {
 	app := indexer.App(a1)
 
 	// fetch hosts
-	time.Sleep(2 * time.Second)
-	hosts, err := app.Hosts(context.Background())
+	hosts := testutils.WaitForHosts(t, app, 7)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(hosts) != 7 {
-		t.Fatalf("expected 7 hosts, got %d", len(hosts))
 	}
 
 	// upload sectors to hosts


### PR DESCRIPTION
The issue was that hosts failed to fund the formation due to not having any outputs. Mining a few more blocks per host fixed it.

Fixes https://github.com/SiaFoundation/indexd/issues/338