### PR TITLE
Make UnhealthySlabs consider `state` of contract

### DIFF
--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -554,14 +554,15 @@ func (s *Store) UnhealthySlabs(ctx context.Context, maxRepairAttempt time.Time, 
 						(
 							-- stored on bad contract
 							(sectors.contract_sectors_map_id IS NOT NULL AND contracts.good = FALSE) OR
+							NOT (contracts.state = $2 OR contracts.state = $3) OR
 							-- not stored on any host
 							(sectors.host_id IS NULL)
 						)
-						AND (slabs.last_repair_attempt < $2)
+						AND (slabs.last_repair_attempt < $4)
 					LIMIT 1
 				)
 				RETURNING digest
-		`, now, maxRepairAttempt).Scan((*sqlHash256)(&slabID))
+		`, now, sqlContractState(contracts.ContractStateActive), sqlContractState(contracts.ContractStatePending), maxRepairAttempt).Scan((*sqlHash256)(&slabID))
 			if errors.Is(err, sql.ErrNoRows) {
 				break
 			} else if err != nil {

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -554,7 +554,7 @@ func (s *Store) UnhealthySlabs(ctx context.Context, maxRepairAttempt time.Time, 
 						(
 							-- stored on bad contract
 							(sectors.contract_sectors_map_id IS NOT NULL AND contracts.good = FALSE) OR
-							NOT (contracts.state = $2 OR contracts.state = $3) OR
+							contracts.state NOT IN ($2, $3) OR
 							-- not stored on any host
 							(sectors.host_id IS NULL)
 						)

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1064,6 +1064,22 @@ func TestUnhealthySlabs(t *testing.T) {
 	// assert no slabs are unhealthy
 	assertUnhealthySlabs(0, 10, now)
 
+	// update the contract to be no longer active or pending
+	_, err = store.pool.Exec(context.Background(), "UPDATE contracts SET state = $1", sqlContractState(contracts.ContractStateExpired))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert both slabs are unhealthy
+	assertUnhealthySlabs(2, 10, now)
+
+	// reset the LRA-time and make the contract good again
+	resetLastRepairAttempt(oneHourAgo)
+	_, err = store.pool.Exec(context.Background(), "UPDATE contracts SET state = $1", sqlContractState(contracts.ContractStateActive))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// remove a sector from its host - the unhealthy slab should be back
 	_, err = store.pool.Exec(context.Background(), "UPDATE sectors SET host_id = NULL, contract_sectors_map_id = NULL WHERE id = 1")
 	if err != nil {

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1073,7 +1073,7 @@ func TestUnhealthySlabs(t *testing.T) {
 	// assert both slabs are unhealthy
 	assertUnhealthySlabs(2, 10, now)
 
-	// reset the LRA-time and make the contract good again
+	// reset the LRA-time and set the state back to active
 	resetLastRepairAttempt(oneHourAgo)
 	_, err = store.pool.Exec(context.Background(), "UPDATE contracts SET state = $1", sqlContractState(contracts.ContractStateActive))
 	if err != nil {


### PR DESCRIPTION
#272

```
goos: linux
goarch: amd64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkUnhealthySlabs
    logger.go:146: 2025-08-14T16:48:45.031-0400	INFO	postgres.postgres	connected	{"database": "postgres", "host": "localhost", "port": 5432}
BenchmarkUnhealthySlabs/10
BenchmarkUnhealthySlabs/10-4         	      79	  17460966 ns/op
BenchmarkUnhealthySlabs/25
BenchmarkUnhealthySlabs/25-4         	      82	  37390349 ns/op
BenchmarkUnhealthySlabs/50
BenchmarkUnhealthySlabs/50-4         	      36	  70748628 ns/op
PASS
```