### PR TITLE
Add GET /alerts/:id

### DIFF
--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -28,6 +28,12 @@ const (
 	severityCriticalStr = "critical"
 )
 
+var (
+	// ErrNotFound is returned when Alert cannot find an alert with the given
+	// ID.
+	ErrNotFound = errors.New("alert not found")
+)
+
 // Severity indicates the severity of an alert.
 type Severity uint8
 
@@ -174,6 +180,18 @@ func (m *Manager) Alerts(offset, limit int, opts ...AlertOpt) ([]Alert, error) {
 	}
 
 	return filtered, nil
+}
+
+// Alert retrieves an individual alert.
+func (m *Manager) Alert(id types.Hash256) (Alert, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	alert, ok := m.alerts[id]
+	if !ok {
+		return Alert{}, ErrNotFound
+	}
+	return alert, nil
 }
 
 // DismissAlerts dismisses the alerts with the given IDs.

--- a/alerts/alerts_test.go
+++ b/alerts/alerts_test.go
@@ -1,6 +1,7 @@
 package alerts
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -30,10 +31,16 @@ func TestAlertManager(t *testing.T) {
 		SeverityCritical,
 	}
 	for i, severity := range severities {
-		alert := Alert{ID: types.Hash256{byte(i + 1)}, Severity: severity, Message: severity.String(), Timestamp: time.Now()}
+		alert := Alert{ID: types.Hash256{byte(i + 1)}, Severity: severity, Message: severity.String(), Timestamp: time.Now().UTC()}
 		err := mgr.RegisterAlert(alert)
 		if err != nil {
 			t.Fatal("failed to register alert", err)
+		}
+
+		if got, err := mgr.Alert(alert.ID); err != nil {
+			t.Fatal("failed to get alert:", err)
+		} else if !reflect.DeepEqual(alert, got) {
+			t.Fatalf("expected alert %v, got %v", alert, got)
 		}
 	}
 

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -124,6 +124,7 @@ type (
 	// An Alerter manages alerts.
 	Alerter interface {
 		DismissAlerts(ids ...types.Hash256)
+		Alert(id types.Hash256) (alerts.Alert, error)
 		Alerts(offset, limit int, opts ...alerts.AlertOpt) ([]alerts.Alert, error)
 	}
 )
@@ -177,6 +178,7 @@ func NewAPI(chain ChainManager, contracts ContractManager, hosts HostManager, pm
 
 		// alerts endpoints
 		"GET    /alerts":         a.handleGETAlerts,
+		"GET    /alerts/:id":     a.handleGETAlertsID,
 		"POST   /alerts/dismiss": a.handlePOSTAlertsDismiss,
 
 		// contract endpoints
@@ -500,6 +502,22 @@ func (a *admin) handleGETAlerts(jc jape.Context) {
 		return
 	}
 	jc.Encode(alerts)
+}
+
+func (a *admin) handleGETAlertsID(jc jape.Context) {
+	var id types.Hash256
+	if jc.DecodeParam("id", &id) != nil {
+		return
+	}
+
+	alert, err := a.alerter.Alert(id)
+	if errors.Is(err, alerts.ErrNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to get alert", err) != nil {
+		return
+	}
+	jc.Encode(alert)
 }
 
 func (a *admin) handlePOSTAlertsDismiss(jc jape.Context) {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -3,6 +3,7 @@ package admin_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -232,6 +233,10 @@ func TestAlertsAPI(t *testing.T) {
 		t.Fatalf("expected 0 alerts, got %d", len(alerts))
 	}
 
+	if _, err := alerter.Alert(types.Hash256{}); !errors.Is(err, alerts.ErrNotFound) {
+		t.Fatalf("expected error %v, got %v", alerts.ErrNotFound, err)
+	}
+
 	// first alert has info severity
 	a1 := alerts.Alert{
 		ID:        types.Hash256{0: 1},
@@ -240,6 +245,12 @@ func TestAlertsAPI(t *testing.T) {
 	}
 	if err := alerter.RegisterAlert(a1); err != nil {
 		t.Fatal(err)
+	}
+
+	if alert, err := alerter.Alert(a1.ID); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(a1, alert) {
+		t.Fatalf("expected alert %v, got %v", a1, alert)
 	}
 
 	// we should have the 1 alert we just registered
@@ -266,6 +277,12 @@ func TestAlertsAPI(t *testing.T) {
 	}
 	if err := alerter.RegisterAlert(a2); err != nil {
 		t.Fatal(err)
+	}
+
+	if alert, err := alerter.Alert(a2.ID); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(a2, alert) {
+		t.Fatalf("expected alert %v, got %v", a2, alert)
 	}
 
 	// we should only get the second alert if we filter with SeverityError

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -103,6 +103,12 @@ func (c *Client) Alerts(ctx context.Context, opts ...AlertQueryParameterOption) 
 	return
 }
 
+// Alert returns an individual alert.
+func (c *Client) Alert(ctx context.Context, id types.Hash256) (alert alerts.Alert, err error) {
+	err = c.c.GET(ctx, fmt.Sprintf("/alerts/%s", id), &alert)
+	return
+}
+
 // DismissAlerts dismisses registered alerts.
 func (c *Client) DismissAlerts(ctx context.Context, ids ...types.Hash256) (err error) {
 	err = c.c.POST(ctx, "/alerts/dismiss", ids, nil)


### PR DESCRIPTION
Fixes https://github.com/SiaFoundation/indexd/issues/352

Add endpoint:

```
GET /alerts/:id - returns individual alert; 404 if alert does not exist
```