### PR TITLE
Improve SDK Perf

### DIFF
--- a/cmd/junkd/main.go
+++ b/cmd/junkd/main.go
@@ -97,20 +97,18 @@ func main() {
 			defer wg.Done()
 			log.Debug("starting upload thread")
 
-		loop:
 			for {
+				if ctx.Err() != nil {
+					return
+				}
 				// upload slab
 				start := time.Now()
 				slabs, err := sdkClient.Upload(ctx, io.LimitReader(frand.Reader, slabSize), sdk.WithRedundancy(dataShards, parityShards))
 				if err != nil {
-					log.Error("failed to upload slab, timing out for 5 minutes", zap.Error(err), zap.Duration("duration", time.Since(start)))
-					if ok := <-waitFor(ctx, 5*time.Minute); ok {
-						continue loop
-					}
-					break loop
+					log.Error("failed to upload slab", zap.Error(err), zap.Duration("duration", time.Since(start)))
+					continue
 				} else if len(slabs) != 1 {
-					log.Error(fmt.Sprintf("expected 1 slab, got %d", len(slabs)))
-					break loop
+					log.Panic("incorrect number of slabs", zap.Int("expected", 1), zap.Int("got", len(slabs)))
 				}
 
 				elapsedMu.Lock()
@@ -125,19 +123,6 @@ func main() {
 	wg.Wait()
 
 	log.Info("all upload threads finished, exiting")
-}
-
-func waitFor(ctx context.Context, d time.Duration) <-chan bool {
-	c := make(chan bool, 1)
-	go func() {
-		select {
-		case <-ctx.Done():
-			c <- false
-		case <-time.After(d):
-			c <- true
-		}
-	}()
-	return c
 }
 
 func loadPrivateKey() (types.PrivateKey, error) {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -82,10 +82,11 @@ type (
 
 	// An SDK is a client for the indexd service.
 	SDK struct {
-		appKey types.PrivateKey
+		log    *zap.Logger
 		client AppClient
-
 		dialer HostDialer
+
+		appKey types.PrivateKey
 	}
 )
 
@@ -115,36 +116,35 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 		Sectors:       make([]slabs.SectorPinParams, len(shards)),
 	}
 
-	var hostsMu sync.Mutex
-	activeHosts := shuffle(s.dialer.ActiveHosts())
-	allHosts := shuffle(s.dialer.Hosts())
+	hostCh := make(chan types.PublicKey, maxInFlight)
+	go func() {
+		defer close(hostCh)
 
-	hosts := make([]types.PublicKey, 0, len(allHosts))
-	seen := make(map[types.PublicKey]struct{}, len(activeHosts))
-	for _, pk := range activeHosts {
-		seen[pk] = struct{}{}
-		hosts = append(hosts, pk)
-	}
-	for _, pk := range allHosts {
-		if _, ok := seen[pk]; ok {
-			continue
+		seen := make(map[types.PublicKey]struct{})
+		for _, host := range shuffle(s.dialer.ActiveHosts()) {
+			select {
+			case <-ctx.Done():
+				return
+			case hostCh <- host:
+				seen[host] = struct{}{}
+			}
 		}
-		hosts = append(hosts, pk)
-	}
-
-	if len(hosts) < len(shards) {
-		return slabs.SlabPinParams{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
-	}
+		for _, host := range shuffle(s.dialer.Hosts()) {
+			if _, ok := seen[host]; ok {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case hostCh <- host:
+				seen[host] = struct{}{}
+			}
+		}
+	}()
 
 	errCh := make(chan error, len(shards))
-	nonce := make([]byte, 24)
 	sema := make(chan struct{}, maxInFlight)
 	for i := range shards {
-		// encrypt the shard before upload
-		nonce[0] = byte(i)
-		c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce)
-		c.XORKeyStream(shards[i], shards[i])
-
 		select {
 		case <-ctx.Done():
 			return slabs.SlabPinParams{}, ctx.Err()
@@ -153,6 +153,10 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 		}
 
 		go func(ctx context.Context, shard []byte, index int) {
+			nonce := [24]byte{byte(index)}
+			c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce[:])
+			c.XORKeyStream(shard, shard)
+
 			defer func() { <-sema }() // release semaphore
 			sector := (*[proto4.SectorSize]byte)(shard)
 			for {
@@ -162,16 +166,13 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 				default:
 				}
 
-				hostsMu.Lock()
-				if len(hosts) == 0 {
+				hostKey, ok := <-hostCh
+				if !ok {
 					errCh <- ErrNoMoreHosts
-					hostsMu.Unlock()
 					return
 				}
-				hostKey := hosts[0]
-				hosts = hosts[1:]
-				hostsMu.Unlock()
 
+				start := time.Now()
 				root, err := uploadShard(ctx, sector, hostKey, s.dialer, timeout) // error can be ignored, hosts will be retried until none are left and the upload fails.
 				if err == nil {
 					slab.Sectors[index] = slabs.SectorPinParams{
@@ -179,8 +180,10 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 						Root:    root,
 					}
 					errCh <- nil
+					s.log.Debug("shard uploaded", zap.Stringer("host", hostKey), zap.Stringer("root", root), zap.Duration("elapsed", time.Since(start)))
 					break
 				}
+				s.log.Debug("failed to upload shard", zap.Stringer("host", hostKey), zap.Error(err))
 			}
 		}(ctx, shards[i], i)
 	}
@@ -219,6 +222,7 @@ top:
 			defer wg.Done()
 			data, err := downloadShard(ctx, sector.Root, sector.HostKey, s.dialer, timeout)
 			if err != nil {
+				s.log.Debug("failed to download sector", zap.Stringer("host", sector.HostKey), zap.Error(err))
 				return
 			}
 			sectors[i] = data[:]
@@ -243,7 +247,7 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) ([]
 	uo := uploadOption{
 		dataShards:   10,
 		parityShards: 20,
-		hostTimeout:  4 * time.Second, // ~10 Mbps
+		hostTimeout:  4 * time.Second,
 		maxInflight:  30,
 	}
 	for _, opt := range opts {
@@ -254,20 +258,22 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) ([]
 		return nil, errors.New("redundancy must be at least 2x")
 	}
 
-	type work struct {
-		length        int
-		shards        [][]byte
-		encryptionKey [32]byte
-		err           error
+	type result struct {
+		slab  Slab
+		err   error
+		index int
 	}
-	workCh := make(chan work, 1)
+	resultCh := make(chan result, 1)
 	go func() {
+		defer close(resultCh) // signals done
 		enc, err := reedsolomon.New(int(uo.dataShards), int(uo.parityShards))
 		if err != nil {
-			workCh <- work{err: fmt.Errorf("failed to create erasure coder: %w", err)}
+			resultCh <- result{err: fmt.Errorf("failed to create erasure coder: %w", err)}
 			return
 		}
 		slabBuf := make([]byte, proto4.SectorSize*int(uo.dataShards))
+		sema := make(chan struct{}, 2)
+		var wg sync.WaitGroup
 		for i := 0; ; i++ {
 			select {
 			case <-ctx.Done():
@@ -276,10 +282,9 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) ([]
 			}
 			n, err := readAtMost(r, slabBuf)
 			if n == 0 && errors.Is(err, io.EOF) {
-				workCh <- work{err: io.EOF} // signal done with EOF
 				break
 			} else if err != nil && !errors.Is(err, io.EOF) {
-				workCh <- work{err: fmt.Errorf("failed to read slab %d: %w", i, err)}
+				resultCh <- result{err: fmt.Errorf("failed to read slab %d: %w", i, err)}
 				return
 			}
 			shards := make([][]byte, uo.dataShards+uo.parityShards)
@@ -288,45 +293,63 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) ([]
 			}
 			stripedSplit(slabBuf, shards[:uo.dataShards])
 			if err := enc.Encode(shards); err != nil {
-				workCh <- work{err: fmt.Errorf("failed to encode slab %d shards: %w", i, err)}
+				resultCh <- result{err: fmt.Errorf("failed to encode slab %d shards: %w", i, err)}
 				return
 			}
 			encryptionKey := types.HashBytes(append(s.appKey[:], slabBuf[:n]...))
-			workCh <- work{length: n, encryptionKey: encryptionKey, shards: shards}
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				select {
+				case <-ctx.Done():
+					return
+				case sema <- struct{}{}:
+					// acquire
+				}
+				defer func() { <-sema }() // release
+				params, err := s.uploadSlab(ctx, encryptionKey, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
+				if err != nil {
+					resultCh <- result{err: fmt.Errorf("failed to upload slab %d: %w", i, err)}
+					return
+				}
+
+				slabID, err := s.client.PinSlab(ctx, params)
+				if err != nil {
+					resultCh <- result{err: fmt.Errorf("failed to pin slab %d: %w", i, err)}
+					return
+				}
+				resultCh <- result{slab: Slab{
+					ID:     slabID,
+					Offset: 0,
+					Length: uint32(n),
+				}, err: err, index: i}
+			}(i)
 		}
+
+		wg.Wait()
 	}()
 
 	// TODO: cleanup on failure
 	var pinned []Slab
-	for i := 0; ; i++ {
+	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case work := <-workCh:
-			err := work.err
-			shards := work.shards
-			shardKey := work.encryptionKey
-
-			if errors.Is(err, io.EOF) {
-				// no more slabs to upload, return the pinned slabs
+		case result, ok := <-resultCh:
+			if !ok {
 				return pinned, nil
-			} else if work.err != nil {
-				return nil, work.err
-			}
-			params, err := s.uploadSlab(ctx, shardKey, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
-			if err != nil {
-				return nil, fmt.Errorf("failed to upload slab %d: %w", i, err)
+			} else if result.err != nil {
+				return nil, result.err
 			}
 
-			slabID, err := s.client.PinSlab(ctx, params)
-			if err != nil {
-				return nil, fmt.Errorf("failed to pin slab %d: %w", i, err)
+			if result.index == len(pinned) {
+				pinned = append(pinned, result.slab)
+			} else {
+				for len(pinned) <= result.index {
+					pinned = append(pinned, Slab{})
+				}
+				pinned[result.index] = result.slab
 			}
-			pinned = append(pinned, Slab{
-				ID:     slabID,
-				Offset: 0,
-				Length: uint32(work.length),
-			})
 		}
 	}
 }
@@ -340,7 +363,7 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata []Slab, opts .
 	}
 
 	do := downloadOption{
-		hostTimeout: 4 * time.Second, // ~10 Mbps
+		hostTimeout: 30 * time.Second,
 		maxInflight: 10,
 	}
 	for _, opt := range opts {
@@ -453,17 +476,9 @@ func uploadShard(ctx context.Context, sector *[proto4.SectorSize]byte, hostKey t
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	rootCh := make(chan types.Hash256, 1)
-	go func() {
-		root := proto4.SectorRoot(sector)
-		rootCh <- root
-	}()
-
 	uploaded, err := dialer.WriteSector(ctx, hostKey, sector)
 	if err != nil {
 		return types.Hash256{}, fmt.Errorf("failed to upload shard to host %s: %w", hostKey.String(), err)
-	} else if root := <-rootCh; uploaded != root {
-		return types.Hash256{}, fmt.Errorf("uploaded shard root %s does not match expected root %s", uploaded.String(), root.String())
 	}
 	return uploaded, nil
 }
@@ -542,7 +557,7 @@ func WithDownloadInflight(maxInflight int) DownloadOption {
 	}
 }
 
-func initSDK(client AppClient, dialer HostDialer, appKey types.PrivateKey) (*SDK, error) {
+func initSDK(client AppClient, dialer HostDialer, appKey types.PrivateKey, log *zap.Logger) (*SDK, error) {
 	if client == nil {
 		return nil, errors.New("app client is required")
 	} else if dialer == nil {
@@ -552,6 +567,7 @@ func initSDK(client AppClient, dialer HostDialer, appKey types.PrivateKey) (*SDK
 		appKey: appKey,
 		client: client,
 		dialer: dialer,
+		log:    log,
 	}, nil
 }
 
@@ -581,15 +597,13 @@ func NewSDK(baseURL string, appKey types.PrivateKey, opts ...Option) (*SDK, erro
 		opt(&options)
 	}
 
-	options.logger = options.logger.Named("sdk") // decorate logger
-
 	c, err := app.NewClient(baseURL, appKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create app client: %w", err)
 	}
-	dialer, err := NewDialer(c, appKey, options.logger)
+	dialer, err := NewDialer(c, appKey, options.logger.Named("dialer"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create host dialer: %w", err)
 	}
-	return initSDK(c, dialer, appKey)
+	return initSDK(c, dialer, appKey, options.logger)
 }

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -7,19 +7,26 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/klauspost/reedsolomon"
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/chacha20"
 	"lukechampine.com/frand"
 )
 
 func TestRoundtrip(t *testing.T) {
+	log := zap.NewNop()
 	dialer := newMockDialer(50)
 
 	appKey := types.GeneratePrivateKey()
 
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, appKey, log.Named("sdk"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,11 +63,12 @@ func (c *countWriter) Write(p []byte) (int, error) {
 }
 
 func TestRoundtripCount(t *testing.T) {
+	log := zap.NewNop()
 	dialer := newMockDialer(50)
 
 	appKey := types.GeneratePrivateKey()
 
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, appKey, log.Named("sdk"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,9 +97,10 @@ func TestRoundtripCount(t *testing.T) {
 }
 
 func TestUpload(t *testing.T) {
+	log := zap.NewNop()
 	dialer := newMockDialer(50)
 	appKey := types.GeneratePrivateKey()
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, appKey, log.Named("sdk"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,11 +131,12 @@ func TestUpload(t *testing.T) {
 }
 
 func TestDownload(t *testing.T) {
+	log := zap.NewNop()
 	dialer := newMockDialer(30)
 
 	appKey := types.GeneratePrivateKey()
 
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, appKey, log.Named("sdk"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +176,8 @@ func TestDownload(t *testing.T) {
 }
 
 func BenchmarkUpload(b *testing.B) {
-	const benchmarkSize = 256 * 1000 * 1000 // 256 MB
+	const benchmarkSize = 10 * proto.SectorSize
+	log := zaptest.NewLogger(b)
 	appKey := types.GeneratePrivateKey()
 	data := frand.Bytes(benchmarkSize)
 
@@ -178,7 +189,7 @@ func BenchmarkUpload(b *testing.B) {
 			dialer.SetSlowHosts(slow, time.Second)       // slow, but not too slow
 			dialer.SetSlowHosts(timeout, 30*time.Second) // longer than the default timeout
 
-			s, err := initSDK(newMockAppClient(), dialer, appKey)
+			s, err := initSDK(newMockAppClient(), dialer, appKey, log.Named("sdk"))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -195,10 +206,10 @@ func BenchmarkUpload(b *testing.B) {
 		})
 	}
 
-	inflight := []int{runtime.NumCPU(), 5, 10, 20, 30}
+	inflight := []int{10, 30}
 	// testing more variants is not particularly useful
-	slow := []int{0, 1, 3, 5}
-	timeout := []int{0, 1, 3, 5}
+	slow := []int{0, 1}
+	timeout := []int{0, 1}
 	for _, s := range slow {
 		for _, t := range timeout {
 			for _, i := range inflight {
@@ -208,13 +219,57 @@ func BenchmarkUpload(b *testing.B) {
 	}
 }
 
+func BenchmarkErasureCode(b *testing.B) {
+	const (
+		dataShards   = 10
+		parityShards = 20
+		dataSize     = proto.SectorSize * dataShards
+	)
+
+	encryptionKey := frand.Entropy256()
+	data := frand.Bytes(dataSize)
+	enc, err := reedsolomon.New(dataShards, parityShards)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.SetBytes(dataSize)
+	b.ResetTimer()
+	for b.Loop() {
+		shards := make([][]byte, dataShards+parityShards)
+		for i := range shards {
+			shards[i] = make([]byte, proto.SectorSize)
+		}
+
+		stripedSplit(data, shards[:dataShards])
+		if err := enc.Encode(shards); err != nil {
+			b.Fatal(err)
+		}
+
+		var wg sync.WaitGroup
+		for i := range shards {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				nonce := [24]byte{byte(i)}
+				c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce[:])
+				c.XORKeyStream(shards[i], shards[i])
+				time.Sleep(20 * time.Millisecond) // simulate network io for upload
+			}(i)
+		}
+
+		wg.Wait()
+	}
+}
+
 func BenchmarkDownload(b *testing.B) {
 	const benchmarkSize = 256 * 1000 * 1000 // 256 MB
+	log := zap.NewNop()
 	dialer := newMockDialer(30)
 
 	appKey := types.GeneratePrivateKey()
 
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, appKey, log.Named("sdk"))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -246,8 +301,8 @@ func BenchmarkDownload(b *testing.B) {
 
 	benchMatrix(b, 0, runtime.NumCPU())
 
-	inflight := []int{1, 3, 5, 10, 20, 30}
-	slow := []int{0, 1, 3, 5, 10, 20}
+	inflight := []int{10, 30}
+	slow := []int{0, 1}
 
 	for _, s := range slow {
 		for _, i := range inflight {

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -15,6 +15,33 @@ import (
 	"go.sia.tech/indexd/slabs"
 )
 
+type mockHost struct {
+	mu      sync.Mutex
+	sectors map[types.Hash256][proto4.SectorSize]byte
+}
+
+func (mh *mockHost) WriteSector(ctx context.Context, sector *[proto4.SectorSize]byte) (types.Hash256, error) {
+	root := proto4.SectorRoot(sector)
+
+	mh.mu.Lock()
+	defer mh.mu.Unlock()
+	if mh.sectors == nil {
+		mh.sectors = make(map[types.Hash256][proto4.SectorSize]byte)
+	}
+	mh.sectors[root] = *sector
+	return root, nil
+}
+
+func (mh *mockHost) ReadSector(ctx context.Context, root types.Hash256) (*[proto4.SectorSize]byte, error) {
+	mh.mu.Lock()
+	defer mh.mu.Unlock()
+	sector, ok := mh.sectors[root]
+	if !ok {
+		return nil, errors.New("sector not found")
+	}
+	return &sector, nil
+}
+
 type mockHostDialer struct {
 	hosts map[types.PublicKey]struct{}
 
@@ -22,7 +49,7 @@ type mockHostDialer struct {
 	slowHosts map[types.PublicKey]time.Duration
 
 	sectorsMu   sync.Mutex
-	hostSectors map[types.PublicKey]map[types.Hash256][proto4.SectorSize]byte
+	hostSectors map[types.PublicKey]*mockHost
 }
 
 // Hosts implements the [HostDialer] interface.
@@ -62,14 +89,13 @@ func (m *mockHostDialer) WriteSector(ctx context.Context, hostKey types.PublicKe
 	}
 
 	m.sectorsMu.Lock()
-	defer m.sectorsMu.Unlock()
-
-	root := proto4.SectorRoot(sector)
-	if _, ok := m.hostSectors[hostKey]; !ok {
-		m.hostSectors[hostKey] = make(map[types.Hash256][proto4.SectorSize]byte)
+	mh, ok := m.hostSectors[hostKey]
+	if !ok {
+		mh = &mockHost{}
+		m.hostSectors[hostKey] = mh
 	}
-	m.hostSectors[hostKey][root] = *sector
-	return root, nil
+	m.sectorsMu.Unlock()
+	return m.hostSectors[hostKey].WriteSector(ctx, sector)
 }
 
 // ReadSector implements the [HostDialer] interface.
@@ -80,18 +106,12 @@ func (m *mockHostDialer) ReadSector(ctx context.Context, hostKey types.PublicKey
 	}
 
 	m.sectorsMu.Lock()
-	defer m.sectorsMu.Unlock()
-
-	var sector [proto4.SectorSize]byte
-	sectors, ok := m.hostSectors[hostKey]
+	mh, ok := m.hostSectors[hostKey]
 	if !ok {
 		return nil, errors.New("host not found")
 	}
-	sector, ok = sectors[sectorRoot]
-	if !ok {
-		return nil, errors.New("sector not found")
-	}
-	return &sector, nil
+	m.sectorsMu.Unlock()
+	return mh.ReadSector(ctx, sectorRoot)
 }
 
 func (m *mockHostDialer) ResetSlowHosts() {
@@ -118,7 +138,7 @@ func newMockDialer(hosts int) *mockHostDialer {
 	m := &mockHostDialer{
 		hosts:       make(map[types.PublicKey]struct{}),
 		slowHosts:   make(map[types.PublicKey]time.Duration),
-		hostSectors: make(map[types.PublicKey]map[types.Hash256][proto4.SectorSize]byte),
+		hostSectors: make(map[types.PublicKey]*mockHost),
 	}
 	for range hosts {
 		sk := types.GeneratePrivateKey()


### PR DESCRIPTION
**Old**
```
goos: darwin
goarch: arm64
pkg: go.sia.tech/indexd/sdk
cpu: Apple M4 Max
BenchmarkUpload/slow_0_timeout_0_inflight_1-16         	       2	 700386833 ns/op	 365.51 MB/s	2057579816 B/op	   30899 allocs/op
BenchmarkUpload/slow_0_timeout_0_inflight_10-16        	       2	 638952438 ns/op	 400.66 MB/s	2038527384 B/op	   30497 allocs/op
BenchmarkUpload/slow_0_timeout_0_inflight_30-16        	       2	 627519667 ns/op	 407.96 MB/s	2046904592 B/op	   30482 allocs/op
BenchmarkUpload/slow_0_timeout_1_inflight_1-16         	       1	4692157791 ns/op	  54.56 MB/s	2061603112 B/op	   30549 allocs/op
BenchmarkUpload/slow_0_timeout_1_inflight_10-16        	       1	4579477709 ns/op	  55.90 MB/s	2061602336 B/op	   30534 allocs/op
BenchmarkUpload/slow_0_timeout_1_inflight_30-16        	       1	4626360958 ns/op	  55.34 MB/s	2061589968 B/op	   30543 allocs/op
BenchmarkUpload/slow_1_timeout_0_inflight_1-16         	       1	7825781958 ns/op	  32.71 MB/s	2061601536 B/op	   30503 allocs/op
BenchmarkUpload/slow_1_timeout_0_inflight_10-16        	       1	7571568291 ns/op	  33.81 MB/s	2061599360 B/op	   30501 allocs/op
BenchmarkUpload/slow_1_timeout_0_inflight_30-16        	       1	7479631666 ns/op	  34.23 MB/s	2061585472 B/op	   30489 allocs/op
BenchmarkUpload/slow_1_timeout_1_inflight_1-16         	       1	11866071209 ns/op	  21.57 MB/s	2061591776 B/op	   30569 allocs/op
BenchmarkUpload/slow_1_timeout_1_inflight_10-16        	       1	7382158708 ns/op	  34.68 MB/s	2061584960 B/op	   30490 allocs/op
BenchmarkUpload/slow_1_timeout_1_inflight_30-16        	       1	10525302083 ns/op	  24.32 MB/s	2061620720 B/op	   30580 allocs/op
```

**New**
```
BenchmarkUpload/slow_0_timeout_0_inflight_10-16         	       3	 443356222 ns/op	 577.41 MB/s	2028704773 B/op	   16524 allocs/op
BenchmarkUpload/slow_0_timeout_0_inflight_30-16         	       3	 445502819 ns/op	 574.63 MB/s	2039790845 B/op	   16283 allocs/op
BenchmarkUpload/slow_0_timeout_1_inflight_10-16         	       1	4329533750 ns/op	  59.13 MB/s	2060758176 B/op	   16376 allocs/op
BenchmarkUpload/slow_0_timeout_1_inflight_30-16         	       1	4332444459 ns/op	  59.09 MB/s	2060772776 B/op	   16370 allocs/op
BenchmarkUpload/slow_1_timeout_0_inflight_10-16         	       1	4163106042 ns/op	  61.49 MB/s	2060710624 B/op	   16250 allocs/op
BenchmarkUpload/slow_1_timeout_0_inflight_30-16         	       1	4130567333 ns/op	  61.98 MB/s	2060748096 B/op	   16281 allocs/op
BenchmarkUpload/slow_1_timeout_1_inflight_10-16         	       1	7187274750 ns/op	  35.62 MB/s	2060765064 B/op	   16360 allocs/op
BenchmarkUpload/slow_1_timeout_1_inflight_30-16         	       1	7114122292 ns/op	  35.98 MB/s	2060775840 B/op	   16381 allocs/op
```