### PR TITLE
Add dockerfile for junkd

### DIFF
--- a/cmd/junkd/Dockerfile
+++ b/cmd/junkd/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /junkd
+
+# get dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# copy source
+COPY . .
+# build
+RUN go build -o bin/ -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w'  ./cmd/junkd
+
+FROM debian:bookworm-slim
+
+LABEL maintainer="The Sia Foundation <info@sia.tech>" \
+    org.opencontainers.image.description.vendor="The Sia Foundation" \
+    org.opencontainers.image.description="A test container for uploading random data to the Sia network" \
+    org.opencontainers.image.source="https://github.com/SiaFoundation/indexd/cmd/junkd" \
+    org.opencontainers.image.licenses=MIT
+
+# copy binary and certificates
+COPY --from=builder /junkd/bin/* /usr/bin/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENTRYPOINT [ "junkd" ]
+CMD [ "--help" ]


### PR DESCRIPTION
This is the Dockerfile of the image currently deployed on Zeus. 
I manually pushed it to `ghcr.io/siafoundation/junkd:master`

Fixes https://github.com/SiaFoundation/indexd/issues/221