### PR TITLE
ci: publish doc site

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       slug: indexd-admin
       spec_path: openapi/admin.yml
+      docs_slug: sia
     secrets:
       SCALAR_API_KEY: ${{ secrets.SCALAR_API_KEY }}
 
@@ -24,5 +25,6 @@ jobs:
     with:
       slug: indexd-app
       spec_path: openapi/app.yml
+      docs_slug: sia
     secrets:
       SCALAR_API_KEY: ${{ secrets.SCALAR_API_KEY }}


### PR DESCRIPTION
- This parameter specifies which doc site to republish after the API registry is updated.