### PR TITLE
Simplify hosts in dialer

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -476,14 +476,6 @@ func uploadShard(ctx context.Context, sector *[proto4.SectorSize]byte, hostKey t
 	return uploaded, nil
 }
 
-// shuffle shuffles the elements of a slice in place and returns it.
-func shuffle[T any, S ~[]T](s S) S {
-	frand.Shuffle(len(s), func(i, j int) {
-		s[i], s[j] = s[j], s[i]
-	})
-	return s
-}
-
 // readAtMost reads from the reader until the buffer is filled,
 // no data is read, an error is returned, or EOF is reached.
 //

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -54,9 +54,6 @@ type (
 		// upload or download.
 		Hosts() []types.PublicKey
 
-		// ActiveHosts returns hosts that there is an active connection with.
-		ActiveHosts() []types.PublicKey
-
 		// WriteSector writes a sector to the host identified by the public key.
 		WriteSector(context.Context, types.PublicKey, *[proto4.SectorSize]byte) (types.Hash256, error)
 		// ReadSector reads a sector from the host identified by the public key.
@@ -119,22 +116,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 	}
 
 	var hostsMu sync.Mutex
-	activeHosts := shuffle(s.dialer.ActiveHosts())
-	allHosts := shuffle(s.dialer.Hosts())
-
-	hosts := make([]types.PublicKey, 0, len(allHosts))
-	seen := make(map[types.PublicKey]struct{}, len(activeHosts))
-	for _, pk := range activeHosts {
-		seen[pk] = struct{}{}
-		hosts = append(hosts, pk)
-	}
-	for _, pk := range allHosts {
-		if _, ok := seen[pk]; ok {
-			continue
-		}
-		hosts = append(hosts, pk)
-	}
-
+	hosts := s.dialer.Hosts()
 	if len(hosts) < len(shards) {
 		return slabs.SlabPinParams{}, fmt.Errorf("not enough hosts available: %d, required: %d", len(hosts), len(shards))
 	}

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -193,25 +193,30 @@ func (d *Dialer) clearHostConnection(hostKey types.PublicKey) {
 	entry.clear()
 }
 
-// ActiveHosts implements the [HostDialer] interface.
-func (d *Dialer) ActiveHosts() (hks []types.PublicKey) {
+// Hosts implements the [HostDialer] interface.
+func (d *Dialer) Hosts() (hks []types.PublicKey) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	// prioritize hosts we already have a connection with
+	seen := make(map[types.PublicKey]struct{})
 	for hk, entry := range d.conns {
 		if entry.tc != nil {
 			hks = append(hks, hk)
+			seen[hk] = struct{}{}
 		}
 	}
+	shuffle(hks)
+	length := len(hks)
+
+	for hk := range d.addrs {
+		if _, ok := seen[hk]; !ok {
+			hks = append(hks, hk)
+		}
+	}
+	shuffle(hks[length:])
+
 	return
-}
-
-// Hosts implements the [HostDialer] interface.
-func (d *Dialer) Hosts() []types.PublicKey {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	return slices.Collect(maps.Keys(d.addrs))
 }
 
 func (d *Dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, error) {

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -206,15 +206,12 @@ func (d *Dialer) Hosts() (hks []types.PublicKey) {
 			seen[hk] = struct{}{}
 		}
 	}
-	shuffle(hks)
-	length := len(hks)
 
 	for hk := range d.addrs {
 		if _, ok := seen[hk]; !ok {
 			hks = append(hks, hk)
 		}
 	}
-	shuffle(hks[length:])
 
 	return
 }

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -172,7 +172,7 @@ func TestHostDialerHosts(t *testing.T) {
 	if len(hks) != 3 {
 		t.Fatalf("expected 3 hosts, got %d", len(hks))
 	} else if hks[0] != hk {
-		t.Fatal("active host should be first:", err)
+		t.Fatal("active host should be first")
 	}
 
 	dialer.Close()

--- a/sdk/dialer_test.go
+++ b/sdk/dialer_test.go
@@ -139,7 +139,7 @@ func TestHostDialerParallel(t *testing.T) {
 
 func TestHostDialerHosts(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(2))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(3))
 	indexer := cluster.Indexer
 
 	// add an account
@@ -156,14 +156,9 @@ func TestHostDialerHosts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hks := dialer.ActiveHosts()
-	if len(hks) != 0 {
-		t.Fatalf("expected 0 active hosts, got %d", len(hks))
-	}
-
-	hks = dialer.Hosts()
-	if len(hks) != 2 {
-		t.Fatalf("expected 2 hosts, got %d", len(hks))
+	hks := dialer.Hosts()
+	if len(hks) != 3 {
+		t.Fatalf("expected 3 hosts, got %d", len(hks))
 	}
 
 	hk := hks[0]
@@ -173,22 +168,12 @@ func TestHostDialerHosts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hks = dialer.ActiveHosts()
-	if len(hks) != 1 {
-		t.Fatalf("expected 1 active hosts, got %d", len(hks))
-	} else if hks[0] != hk {
-		t.Fatal("wrong host was active")
-	}
-
 	hks = dialer.Hosts()
-	if len(hks) != 2 {
-		t.Fatalf("expected 2 hosts, got %d", len(hks))
+	if len(hks) != 3 {
+		t.Fatalf("expected 3 hosts, got %d", len(hks))
+	} else if hks[0] != hk {
+		t.Fatal("active host should be first:", err)
 	}
 
 	dialer.Close()
-
-	hks = dialer.ActiveHosts()
-	if len(hks) != 0 {
-		t.Fatalf("expected 0 active hosts after close, got %d", len(hks))
-	}
 }


### PR DESCRIPTION
Remove `ActiveHosts` method from interface and instead just ensure the list of public keys returned by `Hosts` begins with the active hosts' keys.