### PR TITLE
Add path to signed url

### DIFF
--- a/api/app/app.go
+++ b/api/app/app.go
@@ -345,7 +345,7 @@ func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 
 func (a *app) handleAuthRegister(jc jape.Context) {
 	// check whether the request is properly signed
-	pk, ok := validateURLSignature(jc, a.hostname)
+	pk, ok := validateURLSignature(jc, a.hostname, jc.Request.URL.Path)
 	if !ok {
 		return
 	}
@@ -403,7 +403,7 @@ func (a *app) handleGETAuthCheck(jc jape.Context, _ types.PublicKey) {
 }
 
 func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
-	pk, ok := validateURLSignature(jc, a.hostname)
+	pk, ok := validateURLSignature(jc, a.hostname, jc.Request.URL.Path)
 	if !ok {
 		return
 	}
@@ -548,7 +548,7 @@ func NewAPI(advertiseURL string, store Store, am Accounts, contracts Contracts, 
 
 	wrapSignedAuth := func(h authedHandler) jape.Handler {
 		return func(jc jape.Context) {
-			pk, ok := validateSignedURLAuth(jc, a.hostname, am)
+			pk, ok := validateSignedURLAuth(jc, a.hostname, jc.Request.URL.Path, am)
 			if !ok {
 				return
 			}

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -405,6 +405,9 @@ func TestAppConnect(t *testing.T) {
 		Description:   "hello world",
 		RemainingUses: 1,
 	})
+	if err != nil {
+		t.Fatal("failed to add app connect key:", err)
+	}
 
 	sk := types.GeneratePrivateKey()
 	appClient := indexer.App(sk)

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -49,7 +50,7 @@ const (
 // and verifies the signature and expiration. If successful, it returns the
 // public key and true, otherwise it writes an error to the context and returns
 // an empty public key and false.
-func validateURLSignature(jc jape.Context, hostname string) (types.PublicKey, bool) {
+func validateURLSignature(jc jape.Context, hostname, path string) (types.PublicKey, bool) {
 	req := jc.Request
 	defer req.Body.Close()
 
@@ -88,8 +89,8 @@ func validateURLSignature(jc jape.Context, hostname string) (types.PublicKey, bo
 	if ts.Before(time.Now().UTC()) {
 		jc.Error(ErrSignatureExpired, http.StatusUnauthorized)
 		return types.PublicKey{}, false
-	} else if !pk.VerifyHash(requestHash(req.Method, hostname, ts, buf), sig) {
-		jc.Error(fmt.Errorf("failed to authenticate for %q host %q: %w", req.Method, hostname, ErrSignatureInvalid), http.StatusUnauthorized)
+	} else if !pk.VerifyHash(requestHash(req.Method, hostname, path, ts, buf), sig) {
+		jc.Error(fmt.Errorf("failed to authenticate for %q host %q: %w", req.Method, filepath.Join(hostname, path), ErrSignatureInvalid), http.StatusUnauthorized)
 		return types.PublicKey{}, false
 	}
 	return pk, true
@@ -99,10 +100,10 @@ func validateURLSignature(jc jape.Context, hostname string) (types.PublicKey, bo
 // parameters, verifying the signature and expiration, and confirming the
 // account exists. If any check fails, it writes an HTTP error and returns
 // false, otherwise it returns the public key and true.
-func validateSignedURLAuth(jc jape.Context, hostname string, store Accounts) (types.PublicKey, bool) {
+func validateSignedURLAuth(jc jape.Context, hostname, path string, store Accounts) (types.PublicKey, bool) {
 	req := jc.Request
 
-	pk, ok := validateURLSignature(jc, hostname)
+	pk, ok := validateURLSignature(jc, hostname, path)
 	if !ok {
 		return types.PublicKey{}, false
 	}
@@ -158,10 +159,11 @@ func isSignedRequest(req *http.Request) bool {
 		req.URL.Query().Has(queryParamValidUntil)
 }
 
-func requestHash(method string, hostname string, validUntil time.Time, body []byte) types.Hash256 {
+func requestHash(method string, hostname, path string, validUntil time.Time, body []byte) types.Hash256 {
 	h := types.NewHasher()
 	h.E.Write([]byte(method))
 	h.E.Write([]byte(hostname))
+	h.E.Write([]byte(path))
 	h.E.WriteUint64(uint64(validUntil.Unix()))
 	if body != nil {
 		h.E.Write(body)

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -34,17 +34,18 @@ func (s *mockAccounts) UseAppConnectKey(ctx context.Context, connectKey string, 
 
 func TestAuth(t *testing.T) {
 	const hostname = "indexer.sia.tech"
+	const path = "/foo"
 	sk := types.GeneratePrivateKey()
 	s := &mockAccounts{tokens: map[types.PublicKey]struct{}{sk.PublicKey(): {}}}
 
 	server := httptest.NewServer(jape.Mux(map[string]jape.Handler{
 		"GET /foo": func(jc jape.Context) {
-			if _, ok := validateSignedURLAuth(jc, hostname, s); ok {
+			if _, ok := validateSignedURLAuth(jc, hostname, path, s); ok {
 				jc.ResponseWriter.WriteHeader(http.StatusOK)
 			}
 		},
 		"POST /foo": func(jc jape.Context) {
-			if _, ok := validateSignedURLAuth(jc, hostname, s); ok {
+			if _, ok := validateSignedURLAuth(jc, hostname, path, s); ok {
 				jc.ResponseWriter.WriteHeader(http.StatusOK)
 			}
 		},
@@ -85,7 +86,7 @@ func TestAuth(t *testing.T) {
 		val := url.Values{}
 		val.Set(queryParamValidUntil, fmt.Sprint(validUntil.Unix()))
 		val.Set(queryParamCredential, sk.PublicKey().String())
-		val.Set(queryParamSignature, sk.SignHash(requestHash(method, hostname, validUntil, body)).String())
+		val.Set(queryParamSignature, sk.SignHash(requestHash(method, hostname, path, validUntil, body)).String())
 		return val
 	}
 
@@ -98,7 +99,9 @@ func TestAuth(t *testing.T) {
 	// assert authorized if the body does match
 	params := goodParams(http.MethodPost, []byte("hello, world!"))
 	status, errorMsg = doRequest(http.MethodPost, params, []byte("hello, world!"))
-	if status != http.StatusOK {
+	if errorMsg != "" {
+		t.Fatal("unexpected", errorMsg)
+	} else if status != http.StatusOK {
 		t.Fatal("unexpected", status)
 	}
 

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -33,9 +33,9 @@ type Client struct {
 	validity time.Duration
 }
 
-// Sign signs the request with the appropriate headers and returns the signed URL
+// sign signs the request with the appropriate headers and returns the signed URL
 // and request body.
-func Sign(appKey types.PrivateKey, validity time.Duration, method, endpointURL string, req any) (string, io.Reader, error) {
+func sign(appKey types.PrivateKey, validUntil time.Time, method, endpointURL string, req any) (string, io.Reader, error) {
 	u, err := url.Parse(endpointURL)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to parse URL: %w", err)
@@ -50,8 +50,7 @@ func Sign(appKey types.PrivateKey, validity time.Duration, method, endpointURL s
 		}
 	}
 	// prepare request hash
-	validUntil := time.Now().Add(validity)
-	sigHash := requestHash(method, u.Host, validUntil, buf)
+	sigHash := requestHash(method, u.Host, u.Path, validUntil, buf)
 
 	// prepare query parameters
 	val := url.Values{}
@@ -75,7 +74,7 @@ func Sign(appKey types.PrivateKey, validity time.Duration, method, endpointURL s
 }
 
 func (c *Client) signedRequestCustom(ctx context.Context, accept, method, route string, data any) (io.ReadCloser, error) {
-	u, body, err := Sign(c.appkey, c.validity, method, fmt.Sprintf("%s%s", c.baseURL, route), data)
+	u, body, err := sign(c.appkey, time.Now().Add(c.validity), method, fmt.Sprintf("%s%s", c.baseURL, route), data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign request: %w", err)
 	}
@@ -200,6 +199,16 @@ func (c *Client) DeleteObject(ctx context.Context, key types.Hash256) (err error
 	return
 }
 
+// ObjectShareURL generates a signed URL for accessing the object with the given
+// key. The URL is valid until the specified validUntil time.
+func (c *Client) ObjectShareURL(ctx context.Context, key types.Hash256, validUntil time.Time) (string, error) {
+	u, _, err := sign(c.appkey, validUntil, http.MethodGet, fmt.Sprintf("%s/objects/%s", c.baseURL, key), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign request: %w", err)
+	}
+	return u, nil
+}
+
 // RequestAppConnection requests an application connection to the indexer.
 func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
 	err = c.signedRequestJSON(ctx, http.MethodPost, "/auth/connect", request, &resp)
@@ -209,7 +218,7 @@ func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRe
 // CheckRequestStatus checks if an auth request has been approved.
 // If the auth request is still pending, it returns false.
 func (c *Client) CheckRequestStatus(ctx context.Context, statusURL string) (bool, error) {
-	requestURL, body, err := Sign(c.appkey, c.validity, http.MethodGet, statusURL, nil)
+	requestURL, body, err := sign(c.appkey, time.Now().Add(c.validity), http.MethodGet, statusURL, nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to sign request: %w", err)
 	}
@@ -242,7 +251,7 @@ func (c *Client) CheckRequestStatus(ctx context.Context, statusURL string) (bool
 // CheckAppAuth checks if the application is authenticated with the indexer.
 // It returns true if authenticated, false if not, and an error if the request fails.
 func (c *Client) CheckAppAuth(ctx context.Context) (bool, error) {
-	u, body, err := Sign(c.appkey, c.validity, http.MethodGet, fmt.Sprintf("%s/auth/check", c.baseURL), nil)
+	u, body, err := sign(c.appkey, time.Now().Add(c.validity), http.MethodGet, fmt.Sprintf("%s/auth/check", c.baseURL), nil)
 	if err != nil {
 		return false, fmt.Errorf("failed to sign request: %w", err)
 	}


### PR DESCRIPTION
Currently signed URLs can be used on any request matching the HTTP host and method. Sharing an object URL GET request would allow the "sharee" to access any other GET endpoint using the url query parameters.