### PR TITLE
Update SDK Upload/Download signature

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/cipher"
 	"errors"
 	"fmt"
 	"io"
@@ -20,7 +21,6 @@ import (
 	"go.sia.tech/indexd/slabs"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/chacha20"
-	"lukechampine.com/frand"
 )
 
 type (
@@ -29,9 +29,6 @@ type (
 		parityShards uint8
 		hostTimeout  time.Duration
 		maxInflight  int
-
-		customKey         *[32]byte
-		disableEncryption bool
 	}
 
 	downloadOption struct {
@@ -224,7 +221,7 @@ top:
 // Upload uploads the data to hosts and pins it to the indexer.
 //
 // Returns the metadata of the slabs that were pinned
-func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Object, error) {
+func (s *SDK) Upload(ctx context.Context, r cipher.StreamReader, opts ...UploadOption) (uploaded []Slab, _ error) {
 	uo := uploadOption{
 		dataShards:   10,
 		parityShards: 20,
@@ -235,22 +232,8 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 		opt(&uo)
 	}
 
-	if (uo.parityShards+uo.dataShards)/uo.dataShards < 2 {
-		return Object{}, errors.New("redundancy must be at least 2x")
-	} else if uo.disableEncryption && uo.customKey != nil {
-		return Object{}, errors.New("custom key provided but encryption disabled ")
-	}
-
-	var obj Object
-	if !uo.disableEncryption {
-		if uo.customKey != nil {
-			obj.Key = uo.customKey
-		} else {
-			obj.Key = new([32]byte)
-			frand.Read(obj.Key[:])
-		}
-
-		r = encrypt(obj.Key, r, 0)
+	if uo.parityShards+uo.dataShards < uo.dataShards*slabs.DefaultRedundancy {
+		return nil, errors.New("redundancy must be at least 3x")
 	}
 
 	type work struct {
@@ -299,7 +282,7 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 	for i := 0; ; i++ {
 		select {
 		case <-ctx.Done():
-			return Object{}, ctx.Err()
+			return nil, ctx.Err()
 		case work := <-workCh:
 			err := work.err
 			shards := work.shards
@@ -307,26 +290,26 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 
 			if errors.Is(err, io.EOF) {
 				// no more slabs to upload, return the pinned slabs
-				return obj, nil
+				return uploaded, nil
 			} else if work.err != nil {
-				return Object{}, work.err
+				return nil, work.err
 			}
 			params, err := s.uploadSlab(ctx, shardKey, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
 			if err != nil {
-				return Object{}, fmt.Errorf("failed to upload slab %d: %w", i, err)
+				return nil, fmt.Errorf("failed to upload slab %d: %w", i, err)
 			}
 			expectedSlabID, err := params.Digest()
 			if err != nil {
-				return Object{}, fmt.Errorf("failed to compute slab id for slab %d: %w", i, err)
+				return nil, fmt.Errorf("failed to compute slab id for slab %d: %w", i, err)
 			}
 
 			slabID, err := s.client.PinSlab(ctx, params)
 			if err != nil {
-				return Object{}, fmt.Errorf("failed to pin slab %d: %w", i, err)
+				return nil, fmt.Errorf("failed to pin slab %d: %w", i, err)
 			} else if slabID != expectedSlabID {
-				return Object{}, fmt.Errorf("pinned slab %d id %s does not match expected id %s", i, slabID.String(), expectedSlabID.String())
+				return nil, fmt.Errorf("pinned slab %d id %s does not match expected id %s", i, slabID.String(), expectedSlabID.String())
 			}
-			obj.Slabs = append(obj.Slabs, Slab{
+			uploaded = append(uploaded, Slab{
 				ID:     slabID,
 				Offset: 0,
 				Length: uint32(work.length),
@@ -338,13 +321,9 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 // Download downloads object metadata
 //
 // TODO: support seeks
-func (s *SDK) Download(ctx context.Context, w io.Writer, metadata Object, opts ...DownloadOption) error {
-	if len(metadata.Slabs) == 0 {
+func (s *SDK) Download(ctx context.Context, w cipher.StreamWriter, slabs []Slab, opts ...DownloadOption) error {
+	if len(slabs) == 0 {
 		return errors.New("no slabs to download")
-	}
-
-	if metadata.Key != nil {
-		w = decrypt(metadata.Key, w, 0)
 	}
 
 	do := downloadOption{
@@ -361,7 +340,7 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata Object, opts .
 	}
 	workCh := make(chan work, 1)
 	go func() {
-		for i, meta := range metadata.Slabs {
+		for i, meta := range slabs {
 			pinned, err := s.client.Slab(ctx, meta.ID)
 			if err != nil {
 				workCh <- work{err: fmt.Errorf("failed to get slab %d metadata: %w", i, err)}
@@ -407,8 +386,7 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, metadata Object, opts .
 			} else if err != nil {
 				return err
 			}
-			slab := metadata.Slabs[i]
-			if err := stripedJoin(bw, work.shards, int(slab.Length)); err != nil {
+			if err := stripedJoin(bw, work.shards, int(slabs[i].Length)); err != nil {
 				return fmt.Errorf("failed to write slab %d: %w", i, err)
 			}
 		}
@@ -496,9 +474,9 @@ func readAtMost(r io.Reader, buf []byte) (int, error) {
 	return n, nil
 }
 
-// WithRedundancy sets the number of data and parity shards for the upload.
-// The number of shards must be at least 2x redundancy:
-// `(dataShards + parityShards) / dataShards >= 2`.
+// WithRedundancy sets the number of data and parity shards for the upload. The
+// number of shards must be at least 3x redundancy: `(dataShards + parityShards)
+// / dataShards >= 3`.
 func WithRedundancy(dataShards, parityShards uint8) UploadOption {
 	return func(uo *uploadOption) {
 		uo.dataShards = dataShards
@@ -521,23 +499,6 @@ func WithUploadHostTimeout(timeout time.Duration) UploadOption {
 func WithUploadInflight(maxInflight int) UploadOption {
 	return func(uo *uploadOption) {
 		uo.maxInflight = maxInflight
-	}
-}
-
-// WithDisableEncryption disables client side encryption for uploads.  By
-// default client side encryption is enabled.
-func WithDisableEncryption() UploadOption {
-	return func(uo *uploadOption) {
-		uo.disableEncryption = true
-	}
-}
-
-// WithXChaCha20Secret sets a custom key for client side encryption.  By
-// default a randomly generated key is used.  In both cases, the key will be
-// returned alongside the slabs in the Object.
-func WithXChaCha20Secret(key [32]byte) UploadOption {
-	return func(uo *uploadOption) {
-		uo.customKey = &key
 	}
 }
 

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -17,90 +17,44 @@ import (
 
 func TestRoundtrip(t *testing.T) {
 	dialer := newMockDialer(50)
-
-	appKey := types.GeneratePrivateKey()
-
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, types.GeneratePrivateKey())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// each upload has varying encryption configurations so we should get
-	// different slab IDs every time
+	data := frand.Bytes(4096)
+
+	// assertRoundtrip uploads the data and asserts download matches the original data
 	seen := make(map[slabs.SlabID]struct{})
-	checkSlabIDs := func(slabs []Slab) {
+	assertRoundtrip := func(encryptionKey *[32]byte) {
 		t.Helper()
+
+		buf := bytes.NewBuffer(nil)
+		slabs, err := s.Upload(context.Background(), EncryptStream(encryptionKey, bytes.NewReader(data), 0))
+		if err != nil {
+			t.Fatal(err)
+		} else if len(slabs) != 1 {
+			t.Fatal("expected 1 slab, got", len(slabs))
+		} else if slabs[0].Length != uint32(len(data)) {
+			t.Fatal("expected slab length", len(data), "got", slabs[0].Length)
+		} else if err := s.Download(context.Background(), DecryptStream(encryptionKey, buf, 0), slabs); err != nil {
+			t.Fatal(err)
+		} else if !bytes.Equal(buf.Bytes(), data) {
+			t.Fatal("data mismatch")
+		}
 
 		for _, slab := range slabs {
 			if _, ok := seen[slab.ID]; ok {
-				t.Fatal("slab ID seen twice")
+				t.Fatal("duplicate slabID")
 			}
 			seen[slab.ID] = struct{}{}
 		}
 	}
 
-	// without client side encryption
-	data := frand.Bytes(4096)
-	obj, err := s.Upload(context.Background(), bytes.NewReader(data), WithDisableEncryption())
-	if err != nil {
-		t.Fatalf("failed to upload: %v", err)
-	} else if len(obj.Slabs) != 1 {
-		t.Fatalf("expected 1 slab, got %d", len(obj.Slabs))
-	} else if obj.Slabs[0].Length != uint32(len(data)) {
-		t.Fatalf("expected slab length %d, got %d", len(data), obj.Slabs[0].Length)
-	}
-	checkSlabIDs(obj.Slabs)
-
-	buf := bytes.NewBuffer(nil)
-	if err := s.Download(context.Background(), buf, obj); err != nil {
-		t.Fatal(err)
-	}
-
-	// with client side encryption
-	obj, err = s.Upload(context.Background(), bytes.NewReader(data))
-	if err != nil {
-		t.Fatalf("failed to upload: %v", err)
-	} else if len(obj.Slabs) != 1 {
-		t.Fatalf("expected 1 slab, got %d", len(obj.Slabs))
-	} else if obj.Slabs[0].Length != uint32(len(data)) {
-		t.Fatalf("expected slab length %d, got %d", len(data), obj.Slabs[0].Length)
-	}
-	checkSlabIDs(obj.Slabs)
-
-	buf = bytes.NewBuffer(nil)
-	if err := s.Download(context.Background(), buf, obj); err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(buf.Bytes(), data) {
-		t.Fatal("data mismatch")
-	}
-
-	// with client side encryption, custom key
-	var key [32]byte
-	frand.Read(key[:])
-	obj, err = s.Upload(context.Background(), bytes.NewReader(data), WithXChaCha20Secret(key))
-	if err != nil {
-		t.Fatalf("failed to upload: %v", err)
-	} else if len(obj.Slabs) != 1 {
-		t.Fatalf("expected 1 slab, got %d", len(obj.Slabs))
-	} else if obj.Slabs[0].Length != uint32(len(data)) {
-		t.Fatalf("expected slab length %d, got %d", len(data), obj.Slabs[0].Length)
-	}
-	checkSlabIDs(obj.Slabs)
-
-	buf = bytes.NewBuffer(nil)
-	if err := s.Download(context.Background(), buf, obj); err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(buf.Bytes(), data) {
-		t.Fatal("data mismatch")
-	}
-
-	if _, err = s.Upload(context.Background(), bytes.NewReader(data), WithDisableEncryption(), WithXChaCha20Secret(key)); err == nil {
-		t.Fatal("expected error when disabling encryption but still passing custom key")
-	}
+	var encryptionKey [32]byte
+	assertRoundtrip(&encryptionKey) // passthrough encryption
+	frand.Read(encryptionKey[:])
+	assertRoundtrip(&encryptionKey) // random encryption key
 }
 
 type countWriter struct {
@@ -115,52 +69,50 @@ func (c *countWriter) Write(p []byte) (int, error) {
 }
 
 func TestRoundtripCount(t *testing.T) {
-	dialer := newMockDialer(50)
-
-	appKey := types.GeneratePrivateKey()
-
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), newMockDialer(50), types.GeneratePrivateKey())
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	ek := randomEncryptionKey()
+
 	// 1 MB
 	data := frand.Bytes(1 << 20)
-	obj, err := s.Upload(context.Background(), bytes.NewReader(data))
+	slabs, err := s.Upload(context.Background(), EncryptStream(ek, bytes.NewReader(data), 0))
 	if err != nil {
 		t.Fatalf("failed to upload: %v", err)
-	} else if len(obj.Slabs) != 1 {
-		t.Fatalf("expected 1 slab, got %d", len(obj.Slabs))
-	} else if obj.Slabs[0].Length != uint32(len(data)) {
-		t.Fatalf("expected slab length %d, got %d", len(data), obj.Slabs[0].Length)
+	} else if len(slabs) != 1 {
+		t.Fatalf("expected 1 slab, got %d", len(slabs))
+	} else if slabs[0].Length != uint32(len(data)) {
+		t.Fatalf("expected slab length %d, got %d", len(data), slabs[0].Length)
 	}
 
 	buf := bytes.NewBuffer(nil)
 	cw := &countWriter{w: buf}
-	if err := s.Download(context.Background(), cw, obj); err != nil {
+	if err := s.Download(context.Background(), DecryptStream(ek, cw, 0), slabs); err != nil {
 		t.Fatal(err)
-	}
-
-	if !bytes.Equal(buf.Bytes(), data) {
+	} else if !bytes.Equal(buf.Bytes(), data) {
 		t.Fatal("data mismatch")
 	}
+
 	t.Logf("Downloaded: %d bytes, Write calls: %d", buf.Len(), cw.count)
 }
 
 func TestUpload(t *testing.T) {
 	dialer := newMockDialer(50)
-	appKey := types.GeneratePrivateKey()
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, types.GeneratePrivateKey())
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	sk := randomEncryptionKey()
 	data := frand.Bytes(4096)
 
 	t.Run("timeout", func(t *testing.T) {
 		dialer.ResetSlowHosts()
 		// make enough hosts timeout to fail
 		dialer.SetSlowHosts(30, time.Second)
-		_, err := s.Upload(context.Background(), bytes.NewReader(data), WithUploadHostTimeout(100*time.Millisecond))
+		_, err := s.Upload(context.Background(), EncryptStream(sk, bytes.NewReader(data), 0), WithUploadHostTimeout(100*time.Millisecond))
 		if !errors.Is(err, ErrNoMoreHosts) {
 			t.Fatalf("expected ErrNoMoreHosts, got %v", err)
 		}
@@ -168,56 +120,55 @@ func TestUpload(t *testing.T) {
 
 	t.Run("slow", func(t *testing.T) {
 		dialer.ResetSlowHosts()
-		// make most of the hosts slow,
-		// but not enough to fail to upload
+		// make most of the hosts slow, but not enough to fail to upload
 		dialer.SetSlowHosts(20, time.Second)
-		obj, err := s.Upload(context.Background(), bytes.NewReader(data), WithUploadHostTimeout(100*time.Millisecond))
+		slabs, err := s.Upload(context.Background(), EncryptStream(sk, bytes.NewReader(data), 0), WithUploadHostTimeout(100*time.Millisecond))
 		if err != nil {
 			t.Fatal(err)
-		} else if len(obj.Slabs) != 1 {
-			t.Fatalf("expected 1 slab, got %d", len(obj.Slabs))
+		} else if len(slabs) != 1 {
+			t.Fatalf("expected 1 slab, got %d", len(slabs))
 		}
 	})
 }
 
 func TestDownload(t *testing.T) {
 	dialer := newMockDialer(30)
-
-	appKey := types.GeneratePrivateKey()
-
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, types.GeneratePrivateKey())
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	ek := randomEncryptionKey()
 	data := frand.Bytes(4096)
-	obj, err := s.Upload(context.Background(), bytes.NewReader(data))
+	slabs, err := s.Upload(context.Background(), EncryptStream(ek, bytes.NewReader(data), 0))
 	if err != nil {
 		t.Fatalf("failed to upload: %v", err)
 	}
 
 	buf := bytes.NewBuffer(nil)
-	if err = s.Download(context.Background(), buf, obj); err != nil {
+	if err = s.Download(context.Background(), DecryptStream(ek, buf, 0), slabs); err != nil {
 		t.Fatalf("failed to download: %v", err)
+	} else if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("data mismatch")
 	}
 
+	// make enough hosts timeout to fail to download
 	t.Run("timeout", func(t *testing.T) {
 		dialer.ResetSlowHosts()
-		// make enough hosts timeout to fail to download
 		dialer.SetSlowHosts(21, time.Second)
 		buf := bytes.NewBuffer(nil)
-		err = s.Download(context.Background(), buf, obj, WithDownloadHostTimeout(200*time.Millisecond))
+		err = s.Download(context.Background(), DecryptStream(ek, buf, 0), slabs, WithDownloadHostTimeout(200*time.Millisecond))
 		if !errors.Is(err, ErrNotEnoughShards) {
 			t.Fatalf("expected ErrNotEnoughShards, got %v", err)
 		}
 	})
 
+	// make most of the hosts timeout
 	t.Run("slow", func(t *testing.T) {
 		dialer.ResetSlowHosts()
-		// make most of the hosts timeout
 		dialer.SetSlowHosts(20, time.Second)
 		buf := bytes.NewBuffer(nil)
-		err = s.Download(context.Background(), buf, obj, WithDownloadHostTimeout(200*time.Millisecond))
+		err = s.Download(context.Background(), DecryptStream(ek, buf, 0), slabs, WithDownloadHostTimeout(200*time.Millisecond))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -227,6 +178,8 @@ func TestDownload(t *testing.T) {
 func BenchmarkUpload(b *testing.B) {
 	const benchmarkSize = 256 * 1000 * 1000 // 256 MB
 	appKey := types.GeneratePrivateKey()
+
+	sk := randomEncryptionKey()
 	data := frand.Bytes(benchmarkSize)
 
 	benchMatrix := func(b *testing.B, slow, timeout, inflight int) {
@@ -247,7 +200,7 @@ func BenchmarkUpload(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				r.Reset(data)
-				if _, err := s.Upload(context.Background(), r, WithUploadInflight(inflight)); err != nil {
+				if _, err := s.Upload(context.Background(), EncryptStream(sk, r, 0), WithUploadInflight(inflight)); err != nil {
 					b.Fatalf("failed to upload: %v", err)
 				}
 			}
@@ -269,17 +222,17 @@ func BenchmarkUpload(b *testing.B) {
 
 func BenchmarkDownload(b *testing.B) {
 	const benchmarkSize = 256 * 1000 * 1000 // 256 MB
+
 	dialer := newMockDialer(30)
-
-	appKey := types.GeneratePrivateKey()
-
-	s, err := initSDK(newMockAppClient(), dialer, appKey)
+	s, err := initSDK(newMockAppClient(), dialer, types.GeneratePrivateKey())
 	if err != nil {
 		b.Fatal(err)
 	}
 
+	sk := randomEncryptionKey()
 	data := frand.Bytes(benchmarkSize)
-	obj, err := s.Upload(context.Background(), bytes.NewReader(data))
+
+	slabs, err := s.Upload(context.Background(), EncryptStream(sk, bytes.NewReader(data), 0))
 	if err != nil {
 		b.Fatalf("failed to upload: %v", err)
 	}
@@ -295,7 +248,7 @@ func BenchmarkDownload(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				buf.Reset()
-				err = s.Download(context.Background(), buf, obj, WithDownloadInflight(inflight))
+				err = s.Download(context.Background(), DecryptStream(sk, buf, 0), slabs, WithDownloadInflight(inflight))
 				if err != nil {
 					b.Fatalf("failed to download: %v", err)
 				}
@@ -313,4 +266,10 @@ func BenchmarkDownload(b *testing.B) {
 			benchMatrix(b, s, i)
 		}
 	}
+}
+
+func randomEncryptionKey() *[32]byte {
+	var encryptionKey [32]byte
+	frand.Read(encryptionKey[:])
+	return &encryptionKey
 }

--- a/sdk/encrypt.go
+++ b/sdk/encrypt.go
@@ -81,9 +81,9 @@ func nonce(offset uint64) (nonce [24]byte, nonce64 uint64) {
 	return
 }
 
-// encrypt returns a cipher.StreamReader that encrypts r with k starting at the
-// given offset.
-func encrypt(key *[32]byte, r io.Reader, offset uint64) cipher.StreamReader {
+// EncryptStream returns a cipher.StreamReader that encrypts r with k starting
+// at the given offset.
+func EncryptStream(key *[32]byte, r io.Reader, offset uint64) cipher.StreamReader {
 	n, n64 := nonce(offset)
 	offset %= maxBytesPerNonce
 	skip := int(offset % 64)
@@ -94,9 +94,9 @@ func encrypt(key *[32]byte, r io.Reader, offset uint64) cipher.StreamReader {
 	return cipher.StreamReader{S: rs, R: r}
 }
 
-// decrypt returns a cipher.StreamWriter that decrypts w with k, starting at the
-// specified offset.
-func decrypt(key *[32]byte, w io.Writer, offset uint64) cipher.StreamWriter {
+// DecryptStream returns a cipher.StreamWriter that decrypts w with k, starting
+// at the specified offset.
+func DecryptStream(key *[32]byte, w io.Writer, offset uint64) cipher.StreamWriter {
 	n, n64 := nonce(offset)
 	offset %= maxBytesPerNonce
 	skip := int(offset % 64)

--- a/sdk/encrypt_test.go
+++ b/sdk/encrypt_test.go
@@ -18,7 +18,7 @@ func TestEncryptRoundtrip(t *testing.T) {
 
 	for _, offset := range []uint64{0, 16, 31, 63, 64, 96, 128, 2048, 4096, maxBytesPerNonce - 127, maxBytesPerNonce - 128, maxBytesPerNonce - 63, maxBytesPerNonce - 64, maxBytesPerNonce, 2 * maxBytesPerNonce} {
 		t.Run(fmt.Sprint(offset), func(t *testing.T) {
-			r := encrypt(&key, bytes.NewReader(data[:]), offset)
+			r := EncryptStream(&key, bytes.NewReader(data[:]), offset)
 
 			read, err := io.ReadAll(r)
 			if err != nil {
@@ -26,7 +26,7 @@ func TestEncryptRoundtrip(t *testing.T) {
 			}
 
 			var buf bytes.Buffer
-			decrypted := decrypt(&key, &buf, offset)
+			decrypted := DecryptStream(&key, &buf, offset)
 			if _, err := decrypted.Write(read); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR updates the SDK to have upload/download receive a cipher reader/writer and return slabs. This sets us up to get rid of the `Object` and `Slab` types in the `sdk` package.