### PR TITLE
Remove duplicate types

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -318,7 +318,7 @@ func (a *admin) handleGETAppConnectKeys(jc jape.Context) {
 }
 
 func (a *admin) handlePOSTAppConnectKeys(jc jape.Context) {
-	var req AddConnectKeyRequest
+	var req accounts.AddConnectKeyRequest
 	if jc.Decode(&req) != nil {
 		return
 	}

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -813,7 +813,7 @@ func TestSectorStatsAPI(t *testing.T) {
 	slabID, err := indexer.App(account).PinSlab(context.Background(), slabs.SlabPinParams{
 		EncryptionKey: [32]byte{1},
 		MinShards:     1,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{Root: frand.Entropy256(), HostKey: hk1},
 			{Root: frand.Entropy256(), HostKey: hk2},
 			{Root: frand.Entropy256(), HostKey: hk3},

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -49,7 +49,7 @@ func TestAppConnectKeys(t *testing.T) {
 	for i := range 100 {
 		description := fmt.Sprintf("key %d", i)
 		uses := frand.Intn(1000) + 1
-		created, err := adminClient.AddAppConnectKey(context.Background(), admin.AddConnectKeyRequest{
+		created, err := adminClient.AddAppConnectKey(context.Background(), accounts.AddConnectKeyRequest{
 			Description:   description,
 			RemainingUses: uses,
 		})

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -53,7 +53,7 @@ func (c *Client) DeleteAppConnectKey(ctx context.Context, key string) (err error
 }
 
 // AddAppConnectKey adds a new application connection key.
-func (c *Client) AddAppConnectKey(ctx context.Context, req AddConnectKeyRequest) (key accounts.ConnectKey, err error) {
+func (c *Client) AddAppConnectKey(ctx context.Context, req accounts.AddConnectKeyRequest) (key accounts.ConnectKey, err error) {
 	err = c.c.POST(ctx, "/apps/connect/keys", req, &key)
 	return
 }

--- a/api/admin/types.go
+++ b/api/admin/types.go
@@ -8,13 +8,6 @@ import (
 )
 
 type (
-	// AddConnectKeyRequest is the request body for adding a new application connection key.
-	AddConnectKeyRequest struct {
-		Description   string `json:"description"`
-		MaxPinnedData int64  `json:"maxPinnedData,omitempty"`
-		RemainingUses int    `json:"remainingUses"`
-	}
-
 	// BuildState contains static information about the build.
 	BuildState struct {
 		Version   string    `json:"version"`

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -132,7 +132,7 @@ func TestApplicationAPI(t *testing.T) {
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),
 			MinShards:     1,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{
 					Root:    frand.Entropy256(),
 					HostKey: h1.PublicKey,
@@ -543,7 +543,7 @@ func TestSharedObjects(t *testing.T) {
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),
 			MinShards:     1,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{
 					Root:    frand.Entropy256(),
 					HostKey: h1.PublicKey,

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -15,8 +15,8 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4/quic"
+	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
-	"go.sia.tech/indexd/api/admin"
 	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/internal/testutils"
@@ -76,7 +76,7 @@ func TestApplicationAPI(t *testing.T) {
 	sk := types.GeneratePrivateKey()
 	client := indexer.App(sk)
 
-	key, err := adminClient.AddAppConnectKey(ctx, admin.AddConnectKeyRequest{
+	key, err := adminClient.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
 		RemainingUses: 1,
 	})
 	if err != nil {
@@ -412,7 +412,7 @@ func TestAppConnect(t *testing.T) {
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
 
-	connectKey, err := adminClient.AddAppConnectKey(ctx, admin.AddConnectKeyRequest{
+	connectKey, err := adminClient.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
 		Description:   "hello world",
 		RemainingUses: 1,
 	})
@@ -510,7 +510,7 @@ func TestSharedObjects(t *testing.T) {
 		sk := types.GeneratePrivateKey()
 		client := indexer.App(sk)
 
-		key, err := adminClient.AddAppConnectKey(ctx, admin.AddConnectKeyRequest{
+		key, err := adminClient.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
 			RemainingUses: 1,
 		})
 		if err != nil {

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -58,7 +58,7 @@ func TestContractPruning(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		params.Sectors = append(params.Sectors, slabs.SectorPinParams{Root: proto.SectorRoot(&sector), HostKey: host.PublicKey})
+		params.Sectors = append(params.Sectors, slabs.PinnedSector{Root: proto.SectorRoot(&sector), HostKey: host.PublicKey})
 	}
 
 	// pin the slab
@@ -161,7 +161,7 @@ func TestSectorPinning(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		params.Sectors = append(params.Sectors, slabs.SectorPinParams{Root: proto.SectorRoot(&sector), HostKey: host.PublicKey})
+		params.Sectors = append(params.Sectors, slabs.PinnedSector{Root: proto.SectorRoot(&sector), HostKey: host.PublicKey})
 	}
 
 	// pin the slab

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -485,7 +485,7 @@ func TestPrunableContractRoots(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, time.Now(), slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     11,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{Root: roots[0], HostKey: hk1},
 			{Root: roots[2], HostKey: hk2},
 		},
@@ -496,7 +496,7 @@ func TestPrunableContractRoots(t *testing.T) {
 	slabID, err := store.PinSlab(context.Background(), account, time.Now(), slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     11,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{Root: roots[1], HostKey: hk1},
 			{Root: roots[3], HostKey: hk2},
 		},
@@ -1535,11 +1535,11 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
 			hk := hks[hostIdx]
 			root := frand.Entropy256()
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    root,
 				HostKey: hks[hostIdx],
 			})

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -130,7 +130,7 @@ func TestHost(t *testing.T) {
 	} else if _, err := db.PinSlab(context.Background(), proto4.Account(hk), time.Now(), slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     1,
-		Sectors:       []slabs.SectorPinParams{{Root: r1, HostKey: hk}},
+		Sectors:       []slabs.PinnedSector{{Root: r1, HostKey: hk}},
 	}); err != nil {
 		t.Fatal(err)
 	} else if err := db.MarkSectorsLost(context.Background(), hk, []types.Hash256{r1}); err != nil {
@@ -776,7 +776,7 @@ func TestHostsWithLostSectors(t *testing.T) {
 	_, err := db.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    root1,
 				HostKey: hk1,
@@ -870,7 +870,7 @@ func TestHostsWithUnpinnableSectors(t *testing.T) {
 	_, err := db.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     1,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    types.Hash256(hk3),
 				HostKey: hk3,
@@ -1387,7 +1387,7 @@ func TestHostsForPinning(t *testing.T) {
 	if _, err := db.PinSlab(context.Background(), acc, time.Now(), slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     1,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    r1,
 				HostKey: hk1,
@@ -1614,7 +1614,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		_, err := db.PinSlab(context.Background(), acc, nextCheck, slabs.SlabPinParams{
 			EncryptionKey: [32]byte{},
 			MinShards:     1,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{
 					Root:    root,
 					HostKey: hk,
@@ -1770,11 +1770,11 @@ func BenchmarkHostsForPinning(b *testing.B) {
 		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
 			batchSize := min(remainingSectors, 10000)
 			remainingSectors -= batchSize
-			var sectors []slabs.SectorPinParams
+			var sectors []slabs.PinnedSector
 			var roots []types.Hash256
 			for range batchSize {
 				root := frand.Entropy256()
-				sectors = append(sectors, slabs.SectorPinParams{
+				sectors = append(sectors, slabs.PinnedSector{
 					Root:    root,
 					HostKey: hk,
 				})
@@ -1829,10 +1829,10 @@ func BenchmarkHostsForIntegrityCheck(b *testing.B) {
 		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
 			batchSize := min(remainingSectors, 10000)
 			remainingSectors -= batchSize
-			var sectors []slabs.SectorPinParams
+			var sectors []slabs.PinnedSector
 			for range batchSize {
 				root := frand.Entropy256()
-				sectors = append(sectors, slabs.SectorPinParams{
+				sectors = append(sectors, slabs.PinnedSector{
 					Root:    root,
 					HostKey: hk,
 				})
@@ -1892,10 +1892,10 @@ func BenchmarkHostsWithLostSectors(b *testing.B) {
 		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
 			batchSize := min(remainingSectors, 10000)
 			remainingSectors -= batchSize
-			var sectors []slabs.SectorPinParams
+			var sectors []slabs.PinnedSector
 			for range batchSize {
 				root := frand.Entropy256()
-				sectors = append(sectors, slabs.SectorPinParams{
+				sectors = append(sectors, slabs.PinnedSector{
 					Root:    root,
 					HostKey: hk,
 				})
@@ -1948,10 +1948,10 @@ func BenchmarkHostsWithUnpinnableSectors(b *testing.B) {
 		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
 			batchSize := min(remainingSectors, 10000)
 			remainingSectors -= batchSize
-			var sectors []slabs.SectorPinParams
+			var sectors []slabs.PinnedSector
 			for range batchSize {
 				root := frand.Entropy256()
-				sectors = append(sectors, slabs.SectorPinParams{
+				sectors = append(sectors, slabs.PinnedSector{
 					Root:    root,
 					HostKey: hk,
 				})

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -257,7 +257,7 @@ func TestSharedObjects(t *testing.T) {
 		s := slabs.SlabPinParams{
 			MinShards:     uint(frand.Intn(255)),
 			EncryptionKey: frand.Entropy256(),
-			Sectors:       make([]slabs.SectorPinParams, 30),
+			Sectors:       make([]slabs.PinnedSector, 30),
 		}
 		for i := range s.Sectors {
 			s.Sectors[i].HostKey = hostKeys[i%len(hostKeys)]
@@ -323,10 +323,10 @@ func TestSharedObjects(t *testing.T) {
 	for _, slab := range expectedSharedObj.Slabs {
 		_, err := store.PinSlab(t.Context(), acc2, time.Time{}, slabs.SlabPinParams{
 			MinShards: slab.MinShards,
-			Sectors: func() []slabs.SectorPinParams {
-				sps := make([]slabs.SectorPinParams, len(slab.Sectors))
+			Sectors: func() []slabs.PinnedSector {
+				sps := make([]slabs.PinnedSector, len(slab.Sectors))
 				for i := range slab.Sectors {
-					sps[i] = slabs.SectorPinParams{
+					sps[i] = slabs.PinnedSector{
 						Root:    slab.Sectors[i].Root,
 						HostKey: slab.Sectors[i].HostKey,
 					}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -43,7 +43,7 @@ func TestMigrateSector(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, pinTime, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    root1,
 				HostKey: hk1,
@@ -167,7 +167,7 @@ func TestRecordIntegrityCheck(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, pinTime, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    root1,
 				HostKey: hk,
@@ -312,7 +312,7 @@ func TestSectorsForIntegrityCheck(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    root1,
 				HostKey: hk,
@@ -398,7 +398,7 @@ func TestSlabIDs(t *testing.T) {
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),
 			MinShards:     10,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{
 					Root:    frand.Entropy256(),
 					HostKey: hk1,
@@ -489,7 +489,7 @@ func TestPinSlabs(t *testing.T) {
 		slab := slabs.SlabPinParams{
 			EncryptionKey: [32]byte{i},
 			MinShards:     10,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{
 					Root:    frand.Entropy256(),
 					HostKey: hk1,
@@ -738,7 +738,7 @@ func TestUnpinSlab(t *testing.T) {
 		params = append(params, slabs.SlabPinParams{
 			EncryptionKey: [32]byte{},
 			MinShards:     2,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{Root: frand.Entropy256(), HostKey: hk},
 				{Root: frand.Entropy256(), HostKey: hk},
 			},
@@ -864,7 +864,7 @@ func TestPinSectors(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				HostKey: hk,
 				Root:    types.Hash256{1},
@@ -1146,7 +1146,7 @@ func TestPruneUnpinnableSectors(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    root1,
 				HostKey: hk,
@@ -1223,7 +1223,7 @@ func TestUnpinnedSectors(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				HostKey: hk,
 				Root:    types.Hash256{1},
@@ -1307,9 +1307,9 @@ func BenchmarkSlabs(b *testing.B) {
 
 	// helper to create slabs
 	newSlab := func() slabs.SlabPinParams {
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for i := range hks {
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hks[i],
 			})
@@ -1448,9 +1448,9 @@ func BenchmarkUnpinnedSectors(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hk,
 			})
@@ -1533,9 +1533,9 @@ func BenchmarkSectorsForIntegrityCheck(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hk,
 			})
@@ -1596,9 +1596,9 @@ func BenchmarkPinSectors(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hk,
 			})
@@ -1693,9 +1693,9 @@ func BenchmarkUnhealthySlabs(b *testing.B) {
 
 	// helper to create slabs
 	newSlab := func() slabs.SlabPinParams {
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for i := range hks {
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hks[i],
 			})
@@ -1801,10 +1801,10 @@ func BenchmarkUnpinSlab(b *testing.B) {
 
 	// insert slabs
 	slabIDs := make([]slabs.SlabID, nSlabs)
-	sectors := make([]slabs.SectorPinParams, 30)
+	sectors := make([]slabs.PinnedSector, 30)
 	for i := range nSlabs {
 		for j := range 30 {
-			sectors[j] = slabs.SectorPinParams{
+			sectors[j] = slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hk,
 			}
@@ -1862,10 +1862,10 @@ func BenchmarkRecordIntegrityChecks(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
 			root := frand.Entropy256()
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    root,
 				HostKey: hk,
 			})
@@ -1925,10 +1925,10 @@ func BenchmarkMarkFailingSectorsLost(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
 			root := frand.Entropy256()
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    root,
 				HostKey: hk,
 			})
@@ -1989,10 +1989,10 @@ func BenchmarkPruneUnpinnableSectors(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
 			root := frand.Entropy256()
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    root,
 				HostKey: hk,
 			})
@@ -2065,7 +2065,7 @@ func TestMarkSectorsLost(t *testing.T) {
 	_, err := store.PinSlab(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     10,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{
 				Root:    root1,
 				HostKey: hk1,
@@ -2169,9 +2169,9 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    frand.Entropy256(),
 				HostKey: hk,
 			})
@@ -2292,11 +2292,11 @@ func BenchmarkMigrateSector(b *testing.B) {
 	for remainingSectors := nSectors; remainingSectors > 0; {
 		batchSize := min(remainingSectors, 10000)
 		remainingSectors -= batchSize
-		var sectors []slabs.SectorPinParams
+		var sectors []slabs.PinnedSector
 		for range batchSize {
 			hk := hks[hostIdx]
 			root := frand.Entropy256()
-			sectors = append(sectors, slabs.SectorPinParams{
+			sectors = append(sectors, slabs.PinnedSector{
 				Root:    root,
 				HostKey: hks[hostIdx],
 			})
@@ -2340,11 +2340,11 @@ func (s *Store) pinTestSlab(t testing.TB, account proto.Account, minShards uint,
 	params := slabs.SlabPinParams{
 		EncryptionKey: [32]byte(types.GeneratePrivateKey()),
 		MinShards:     minShards,
-		Sectors:       make([]slabs.SectorPinParams, len(hks)),
+		Sectors:       make([]slabs.PinnedSector, len(hks)),
 	}
 
 	for i, hk := range hks {
-		params.Sectors[i] = slabs.SectorPinParams{
+		params.Sectors[i] = slabs.PinnedSector{
 			Root:    frand.Entropy256(),
 			HostKey: hk,
 		}

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -34,12 +34,12 @@ func TestSlab(t *testing.T) {
 	params := slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     10,
-		Sectors:       make([]slabs.SectorPinParams, 0, len(hosts)),
+		Sectors:       make([]slabs.PinnedSector, 0, len(hosts)),
 	}
 	var expectedSectors []slabs.Sector
 	for _, host := range hosts {
 		root := frand.Entropy256()
-		params.Sectors = append(params.Sectors, slabs.SectorPinParams{
+		params.Sectors = append(params.Sectors, slabs.PinnedSector{
 			Root:    root,
 			HostKey: host,
 		})
@@ -120,10 +120,10 @@ func TestPinnedSlab(t *testing.T) {
 	pinned := slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     10,
-		Sectors:       make([]slabs.SectorPinParams, 0, len(hosts)),
+		Sectors:       make([]slabs.PinnedSector, 0, len(hosts)),
 	}
 	for _, host := range hosts {
-		pinned.Sectors = append(pinned.Sectors, slabs.SectorPinParams{
+		pinned.Sectors = append(pinned.Sectors, slabs.PinnedSector{
 			Root:    frand.Entropy256(),
 			HostKey: host,
 		})

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -28,7 +28,7 @@ func TestSectorStatsNumSlabs(t *testing.T) {
 		slab := slabs.SlabPinParams{
 			EncryptionKey: [32]byte{i},
 			MinShards:     10,
-			Sectors: []slabs.SectorPinParams{
+			Sectors: []slabs.PinnedSector{
 				{
 					Root:    frand.Entropy256(),
 					HostKey: hk,

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -112,7 +112,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 	slab := slabs.SlabPinParams{
 		EncryptionKey: encryptionKey,
 		MinShards:     uint(dataShards),
-		Sectors:       make([]slabs.SectorPinParams, len(shards)),
+		Sectors:       make([]slabs.PinnedSector, len(shards)),
 	}
 
 	var hostsMu sync.Mutex
@@ -159,7 +159,7 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 
 				root, err := uploadShard(ctx, sector, hostKey, s.dialer, timeout) // error can be ignored, hosts will be retried until none are left and the upload fails.
 				if err == nil {
-					slab.Sectors[index] = slabs.SectorPinParams{
+					slab.Sectors[index] = slabs.PinnedSector{
 						HostKey: hostKey,
 						Root:    root,
 					}

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -57,7 +57,7 @@ func TestMigrations(t *testing.T) {
 	slabID, err := app.PinSlab(context.Background(), slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     2,
-		Sectors: []slabs.SectorPinParams{
+		Sectors: []slabs.PinnedSector{
 			{Root: roots[0], HostKey: hosts[0].PublicKey},
 			{Root: roots[1], HostKey: hosts[1].PublicKey},
 			{Root: roots[2], HostKey: hosts[2].PublicKey},

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -86,7 +86,7 @@ func TestMigrateSlab(t *testing.T) {
 	slabID, err := db.PinSlab(context.Background(), proto.Account(a1), time.Time{}, SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     2,
-		Sectors: []SectorPinParams{
+		Sectors: []PinnedSector{
 			{Root: r1, HostKey: h1.PublicKey},
 			{Root: r2, HostKey: h2.PublicKey}, // migrate
 			{Root: r3, HostKey: h3.PublicKey},

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -54,23 +54,17 @@ type (
 		PinnedAt      time.Time `json:"pinnedAt"`
 	}
 
-	// SectorPinParams describes an uploaded sector to be pinned.
-	SectorPinParams struct {
+	// A PinnedSector is a sector that has been pinned to a host.
+	PinnedSector struct {
 		Root    types.Hash256   `json:"root"`
 		HostKey types.PublicKey `json:"hostKey"`
 	}
 
 	// SlabPinParams is the input to PinSlabs
 	SlabPinParams struct {
-		EncryptionKey [32]byte          `json:"encryptionKey"`
-		MinShards     uint              `json:"minShards"`
-		Sectors       []SectorPinParams `json:"sectors"`
-	}
-
-	// A PinnedSector is a sector that has been pinned to a host.
-	PinnedSector struct {
-		Root    types.Hash256   `json:"root"`
-		HostKey types.PublicKey `json:"hostKey"`
+		EncryptionKey [32]byte       `json:"encryptionKey"`
+		MinShards     uint           `json:"minShards"`
+		Sectors       []PinnedSector `json:"sectors"`
 	}
 
 	// A PinnedSlab is a slab that has been pinned to hosts.

--- a/slabs/slabs_test.go
+++ b/slabs/slabs_test.go
@@ -12,7 +12,7 @@ func TestSlabPinParamsValidate(t *testing.T) {
 	params := SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     1,
-		Sectors: []SectorPinParams{
+		Sectors: []PinnedSector{
 			{
 				Root:    frand.Entropy256(),
 				HostKey: frand.Entropy256(),
@@ -56,7 +56,7 @@ func TestSlabPinParamsDigest(t *testing.T) {
 	params := SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     10,
-		Sectors: []SectorPinParams{
+		Sectors: []PinnedSector{
 			{
 				Root:    frand.Entropy256(),
 				HostKey: frand.Entropy256(),


### PR DESCRIPTION
Remove `admin.ConnectKeyRequest` which is identical to `accounts.ConnectKeyRequest`, and `slabs.SectorPinParams` which is identical to `slabs.PinnedSector`.