### PR TITLE
Fix integrity checks

### DIFF
--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -278,9 +278,15 @@ func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, f
 		return fmt.Errorf("%w: blocked=%t, usable=%t, networks=%d", ErrBadHost, host.Blocked, host.Usability.Usable(), len(host.Networks))
 	}
 
-	// optimistically call the function
-	if err := fn(host); err != nil && !errors.Is(err, proto4.ErrPricesExpired) {
-		return err
+	// optimistically call the function if the prices are still valid for a
+	// bit
+	const validPriceBuf = 5 * time.Minute
+	if host.Settings.Prices.ValidUntil.After(time.Now().Add(validPriceBuf)) {
+		if err := fn(host); err != nil && !errors.Is(err, proto4.ErrPricesExpired) {
+			return err
+		} else if err == nil {
+			return nil // 'fn' succeeded so we're done
+		}
 	}
 	logger.Debug("host has outdated prices, rescan")
 

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -12,13 +12,13 @@ import (
 )
 
 func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey types.PublicKey, logger *zap.Logger) {
-	hostLogger := logger.With(zap.Stringer("hostKey", hostKey))
+	logger = logger.With(zap.Stringer("hostKey", hostKey))
 
 	const batchSize = 1000 // batch size for sector retrieval
 	for interrupt := false; !interrupt; {
 		toCheck, err := m.store.SectorsForIntegrityCheck(ctx, hostKey, batchSize)
 		if err != nil {
-			hostLogger.Error("failed to fetch sectors for integrity check", zap.Error(err))
+			logger.Error("failed to fetch sectors for integrity check", zap.Error(err))
 			return
 		} else if len(toCheck) == 0 {
 			return
@@ -27,17 +27,23 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 
 		// perform integrity checks
 		var results []CheckSectorsResult
-		err = m.hm.WithScannedHost(ctx, hostKey, func(host hosts.Host) error {
-			results, err = m.verifier.VerifySectors(ctx, host, toCheck)
-			return err
-		})
-		if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
-			interrupt = true
+		for len(results) < len(toCheck) {
+			var batch []CheckSectorsResult
+			err = m.hm.WithScannedHost(ctx, hostKey, func(host hosts.Host) error {
+				batch, err = m.verifier.VerifySectors(ctx, host, toCheck[len(results):])
+				return err
+			})
+			if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
+				interrupt = true
+				break
+			}
+			if err != nil {
+				logger.Error("failed to check sectors", zap.Error(err))
+				return
+			}
+			results = append(results, batch...)
 		}
-		if err != nil {
-			hostLogger.Error("failed to check sectors", zap.Error(err))
-			return
-		}
+
 		var lost, failed, success []types.Hash256
 		for i, result := range results {
 			switch result {
@@ -48,10 +54,10 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 			case SectorSuccess:
 				success = append(success, toCheck[i])
 			default:
-				hostLogger.Fatal("unknown result", zap.Int("result", int(result)))
+				logger.Fatal("unknown result", zap.Int("result", int(result)))
 			}
 		}
-		hostLogger.Debug("performed integrity checks", zap.Int("lost", len(lost)), zap.Int("failed", len(failed)), zap.Int("successful", len(success)))
+		logger.Debug("performed integrity checks", zap.Int("lost", len(lost)), zap.Int("failed", len(failed)), zap.Int("successful", len(success)))
 
 		// starting from here, we use a background context with a
 		// timeout, to make sure even when the integrity checks are
@@ -62,15 +68,15 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 
 			// update lost, failed and successful sectors
 			if err := m.store.MarkSectorsLost(ctx, hostKey, lost); err != nil {
-				hostLogger.Error("failed to mark sectors as lost", zap.Error(err))
+				logger.Error("failed to mark sectors as lost", zap.Error(err))
 				return fmt.Errorf("failed to mark sectors as lost: %w", err)
 			}
 			if err := m.store.RecordIntegrityCheck(ctx, false, time.Now().Add(m.failedIntegrityCheckInterval), hostKey, failed); err != nil {
-				hostLogger.Error("failed to record integrity check for failed sectors", zap.Error(err))
+				logger.Error("failed to record integrity check for failed sectors", zap.Error(err))
 				return fmt.Errorf("failed to record integrity check for failed sectors: %w", err)
 			}
 			if err := m.store.RecordIntegrityCheck(ctx, true, time.Now().Add(m.integrityCheckInterval), hostKey, success); err != nil {
-				hostLogger.Error("failed to record integrity check for successful sectors", zap.Error(err))
+				logger.Error("failed to record integrity check for successful sectors", zap.Error(err))
 				return fmt.Errorf("failed to record integrity check for successful sectors: %w", err)
 			}
 
@@ -78,13 +84,13 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 			// times and mark them lost as well
 			err := m.store.MarkFailingSectorsLost(ctx, hostKey, m.maxFailedIntegrityChecks)
 			if err != nil {
-				hostLogger.Error("failed to mark failing sectors as lost", zap.Error(err))
+				logger.Error("failed to mark failing sectors as lost", zap.Error(err))
 				return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
 			}
 			return nil
 		}()
 		if err != nil {
-			hostLogger.Error("failed to persist integrity check results", zap.Error(err))
+			logger.Error("failed to persist integrity check results", zap.Error(err))
 			return
 		}
 	}

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -11,12 +11,12 @@ import (
 	"go.uber.org/zap"
 )
 
-func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, host hosts.Host, logger *zap.Logger) {
-	hostLogger := logger.With(zap.Stringer("hostKey", host.PublicKey))
+func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey types.PublicKey, logger *zap.Logger) {
+	hostLogger := logger.With(zap.Stringer("hostKey", hostKey))
 
-	const batchSize = 100 // batch size for sector retrieval
+	const batchSize = 1000 // batch size for sector retrieval
 	for interrupt := false; !interrupt; {
-		toCheck, err := m.store.SectorsForIntegrityCheck(ctx, host.PublicKey, batchSize)
+		toCheck, err := m.store.SectorsForIntegrityCheck(ctx, hostKey, batchSize)
 		if err != nil {
 			hostLogger.Error("failed to fetch sectors for integrity check", zap.Error(err))
 			return
@@ -26,7 +26,11 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, host ho
 		interrupt = len(toCheck) < batchSize
 
 		// perform integrity checks
-		results, err := m.verifier.VerifySectors(ctx, host, toCheck)
+		var results []CheckSectorsResult
+		err = m.hm.WithScannedHost(ctx, hostKey, func(host hosts.Host) error {
+			results, err = m.verifier.VerifySectors(ctx, host, toCheck)
+			return err
+		})
 		if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
 			interrupt = true
 		}
@@ -57,22 +61,22 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, host ho
 			defer cancel()
 
 			// update lost, failed and successful sectors
-			if err := m.store.MarkSectorsLost(ctx, host.PublicKey, lost); err != nil {
+			if err := m.store.MarkSectorsLost(ctx, hostKey, lost); err != nil {
 				hostLogger.Error("failed to mark sectors as lost", zap.Error(err))
 				return fmt.Errorf("failed to mark sectors as lost: %w", err)
 			}
-			if err := m.store.RecordIntegrityCheck(ctx, false, time.Now().Add(m.failedIntegrityCheckInterval), host.PublicKey, failed); err != nil {
+			if err := m.store.RecordIntegrityCheck(ctx, false, time.Now().Add(m.failedIntegrityCheckInterval), hostKey, failed); err != nil {
 				hostLogger.Error("failed to record integrity check for failed sectors", zap.Error(err))
 				return fmt.Errorf("failed to record integrity check for failed sectors: %w", err)
 			}
-			if err := m.store.RecordIntegrityCheck(ctx, true, time.Now().Add(m.integrityCheckInterval), host.PublicKey, success); err != nil {
+			if err := m.store.RecordIntegrityCheck(ctx, true, time.Now().Add(m.integrityCheckInterval), hostKey, success); err != nil {
 				hostLogger.Error("failed to record integrity check for successful sectors", zap.Error(err))
 				return fmt.Errorf("failed to record integrity check for successful sectors: %w", err)
 			}
 
 			// fetch sector roots for sectors that have now failed the check 5+
 			// times and mark them lost as well
-			err := m.store.MarkFailingSectorsLost(ctx, host.PublicKey, m.maxFailedIntegrityChecks)
+			err := m.store.MarkFailingSectorsLost(ctx, hostKey, m.maxFailedIntegrityChecks)
 			if err != nil {
 				hostLogger.Error("failed to mark failing sectors as lost", zap.Error(err))
 				return fmt.Errorf("failed to mark failing sectors as lost: %w", err)

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -158,8 +158,8 @@ func TestPerformIntegrityChecksForHostExpiredPrices(t *testing.T) {
 	sm.performIntegrityChecksForHost(context.Background(), host.PublicKey, zap.NewNop())
 
 	// no checks should have failed
-	if len(store.failedChecks) != 0 {
-		t.Fatal("expected 0 failed checks, got", len(store.failedChecks))
+	if store.failedChecks[host.PublicKey][r1] != 0 || store.failedChecks[host.PublicKey][r2] != 0 {
+		t.Fatal("expected 0 failed checks")
 	}
 }
 

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"testing"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -103,6 +104,61 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 		t.Fatalf("expected lost sector %v, got %v", r2, store.lostSectors)
 	} else if _, exists := store.lostSectors[host.PublicKey][r3]; !exists {
 		t.Fatalf("expected lost sector %v, got %v", r3, store.lostSectors)
+	}
+}
+
+func TestPerformIntegrityChecksForHostExpiredPrices(t *testing.T) {
+	// prepare host
+	hk := types.PublicKey{1}
+	host := hosts.Host{
+		Networks:  []string{"1.1.1.1"},
+		PublicKey: hk,
+		Settings: proto.HostSettings{
+			Prices: proto.HostPrices{
+				EgressPrice: types.Siacoins(1).Div64(proto.SectorSize), // 1SC per sector
+				ValidUntil:  time.Time{},                               // prices are initially expired
+			},
+		},
+	}
+	dialer := newMockDialer([]hosts.Host{host})
+
+	// prepare managers
+	store := newMockStore()
+	am := newMockAccountManager(store)
+	hm := newMockHostManager()
+	hm.refreshPrices = true // refresh prices after first scan
+	host.Usability = hosts.GoodUsability
+	hm.hosts[host.PublicKey] = host // make host scannable to get valid prices
+
+	// prepare account
+	sk := types.GeneratePrivateKey()
+	acc := proto.Account(sk.PublicKey())
+
+	// prepare slab manager
+	sm, err := newSlabManager(am, hm, store, dialer, nil, sk, sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// prepare 2 roots for checking
+	r1 := types.Hash256{1}
+	r2 := types.Hash256{2}
+	dialer.clients[host.PublicKey].integrity[r1] = nil
+	dialer.clients[host.PublicKey].integrity[r2] = nil
+	store.sectorsForCheck = []types.Hash256{r1, r2}
+
+	// fund service account
+	err = am.UpdateServiceAccountBalance(context.Background(), hk, acc, types.MaxCurrency)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// perform the checks once
+	sm.performIntegrityChecksForHost(context.Background(), host.PublicKey, zap.NewNop())
+
+	// no checks should have failed
+	if len(store.failedChecks) != 0 {
+		t.Fatal("expected 0 failed checks, got", len(store.failedChecks))
 	}
 }
 

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -19,6 +19,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 	// prepare host
 	hk := types.PublicKey{1}
 	host := hosts.Host{
+		Networks:  []string{"1.1.1.1"},
 		PublicKey: hk,
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{
@@ -32,6 +33,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 	store := newMockStore()
 	am := newMockAccountManager(store)
 	hm := newMockHostManager()
+	host.Usability = hosts.GoodUsability
 	hm.hosts[host.PublicKey] = host // make host scannable
 
 	// prepare account
@@ -64,7 +66,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 
 	// perform the checks once
 	resetBalance()
-	sm.performIntegrityChecksForHost(context.Background(), host, zap.NewNop())
+	sm.performIntegrityChecksForHost(context.Background(), host.PublicKey, zap.NewNop())
 
 	// the lost sector should be marked as lost
 	if len(store.lostSectors[host.PublicKey]) != 1 {
@@ -84,7 +86,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 	// checks before a bad sector gets removed
 	for i := uint(1); i < sm.maxFailedIntegrityChecks; i++ {
 		resetBalance()
-		sm.performIntegrityChecksForHost(context.Background(), host, zap.NewNop())
+		sm.performIntegrityChecksForHost(context.Background(), host.PublicKey, zap.NewNop())
 	}
 
 	// the failed sector should be marked as failed 5 times

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -25,6 +25,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{
 				EgressPrice: types.Siacoins(1).Div64(proto.SectorSize), // 1SC per sector
+				ValidUntil:  time.Now().Add(time.Hour),
 			},
 		},
 	}

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -318,7 +318,7 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 					<-sem
 					wg.Done()
 				}()
-				m.performIntegrityChecksForHost(ctx, host, logger)
+				m.performIntegrityChecksForHost(ctx, hostKey, logger)
 			}(host)
 		}
 		wg.Wait()

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -318,13 +318,7 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 					<-sem
 					wg.Done()
 				}()
-
-				if err := m.hm.WithScannedHost(ctx, host, func(host hosts.Host) error {
-					m.performIntegrityChecksForHost(ctx, host, logger)
-					return nil
-				}); err != nil {
-					logger.With(zap.Stringer("hostKey", hostKey)).Error("failed to perform integrity checks for host", zap.Error(err))
-				}
+				m.performIntegrityChecksForHost(ctx, host, logger)
 			}(host)
 		}
 		wg.Wait()

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -340,6 +340,8 @@ func (m *mockAccountManager) DebitServiceAccount(ctx context.Context, hostKey ty
 
 type mockhostManager struct {
 	hosts map[types.PublicKey]hosts.Host
+
+	refreshPrices bool // reset prices.ValidUntil after each call to WithScannedHost
 }
 
 func newMockHostManager() *mockhostManager {
@@ -355,7 +357,12 @@ func (mock *mockhostManager) WithScannedHost(ctx context.Context, hk types.Publi
 	} else if !host.IsGood() {
 		return hosts.ErrBadHost
 	}
-	return fn(host)
+	err := fn(host)
+	if mock.refreshPrices {
+		host.Settings.Prices.ValidUntil = time.Now().Add(time.Hour)
+		mock.hosts[hk] = host
+	}
+	return err
 }
 
 type mockDialer struct {

--- a/slabs/sectorverifier.go
+++ b/slabs/sectorverifier.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -115,6 +116,11 @@ func (v *SectorVerifier) VerifySectors(ctx context.Context, host hosts.Host, roo
 		// check our budget before verifying the sector
 		if budget.Cmp(cost) < 0 {
 			return results, errInsufficientServiceAccountBalance
+		}
+
+		// check host prices are still valid
+		if !host.Settings.Prices.ValidUntil.After(time.Now().Add(30 * time.Second)) {
+			return results, nil // interrupt integrity checks to rescan host
 		}
 
 		// verify the sector

--- a/slabs/sectorverifier.go
+++ b/slabs/sectorverifier.go
@@ -109,7 +109,7 @@ func (v *SectorVerifier) VerifySectors(ctx context.Context, host hosts.Host, roo
 	for _, root := range roots {
 		select {
 		case <-ctx.Done():
-			return results, nil
+			return results, ctx.Err()
 		default:
 		}
 

--- a/slabs/sectorverifier_test.go
+++ b/slabs/sectorverifier_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -43,6 +44,7 @@ func TestSectorVerifier(t *testing.T) {
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{
 				EgressPrice: oneSC.Div64(proto.SectorSize), // 1SC per sector
+				ValidUntil:  time.Now().Add(time.Hour),
 			},
 		},
 	}
@@ -74,7 +76,7 @@ func TestSectorVerifier(t *testing.T) {
 		if err != nil && expectedErr == nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(got, want) {
+		if (len(want) != 0 || len(got) != 0) && !reflect.DeepEqual(got, want) {
 			t.Fatalf("expected results %v, got %v", want, got)
 		}
 		if !errors.Is(err, expectedErr) {
@@ -126,4 +128,10 @@ func TestSectorVerifier(t *testing.T) {
 	dialer.clients[host.PublicKey].integrity[r1] = nil              // good sector
 	dialer.clients[host.PublicKey].integrity[r2] = context.Canceled // verification interrupted
 	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{SectorSuccess}, context.Canceled)
+
+	// case 5: interruption via expired prices
+	updateBalance(types.Siacoins(10))
+	dialer.clients[host.PublicKey].integrity[r1] = nil // good sector
+	host.Settings.Prices.ValidUntil = time.Time{}
+	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{}, nil)
 }


### PR DESCRIPTION
Almost all integrity checks failed on zeus due to expired prices. This PR fixes that and a few other things by changing the following:

- `WithScannedHost` doesn't execute the closure when the prices are obviously outdated
- `WithScannedHost` doesn't execute the closure twice upon successful execution
- `performIntegrityChecksForHost` calls `WithScannedHost` per batch to guarantee every batch has up-to-date prices

After deploying this on Zeus, things are looking a lot better
```
indexd-1  | DEBUG	slabs.integrity	performed integrity checks	{"hostKey": "ed25519:c6e4c0b5d05b561c0d6b7718baf2841c6ecd3c5e2bcdb2c6a40bdc7a48e88a0a", "lost": 0, "failed": 0, "successful": 1000}
indexd-1  | DEBUG	slabs.integrity	performed integrity checks	{"hostKey": "ed25519:92282dfa2cb8e962b07f6d2f78ff0a78f336b75d810844c5104bb054595a21ff", "lost": 0, "failed": 0, "successful": 1000}
```