### PR TITLE
Run maintenance loops in parallel

### DIFF
--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -256,24 +256,36 @@ func (m *SlabManager) initServiceAccounts(migrationAccount, integrityAccount typ
 // maintenanceLoop performs any background tasks that the slab manager needs to
 // perform on slabs
 func (m *SlabManager) maintenanceLoop(ctx context.Context) {
-	healthTicker := time.NewTicker(m.healthCheckInterval)
-	defer healthTicker.Stop()
+	var wg sync.WaitGroup
+	launch := func(task func()) {
+		healthTicker := time.NewTicker(m.healthCheckInterval)
 
-	for {
-		select {
-		case <-healthTicker.C:
-		case <-ctx.Done():
-			return
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer healthTicker.Stop()
+			for {
+				select {
+				case <-healthTicker.C:
+				case <-ctx.Done():
+					return
+				}
+				task()
+			}
+		}()
+	}
 
+	launch(func() {
 		if err := m.performIntegrityChecks(ctx); err != nil {
 			m.log.Error("failed to perform integrity checks", zap.Error(err))
 		}
-
+	})
+	launch(func() {
 		if err := m.performSlabMigrations(ctx); err != nil {
 			m.log.Error("failed to perform slab migrations", zap.Error(err))
 		}
-	}
+	})
+	wg.Wait()
 }
 
 func newLostSectorsAlert(hks []types.PublicKey) alerts.Alert {
@@ -281,7 +293,7 @@ func newLostSectorsAlert(hks []types.PublicKey) alerts.Alert {
 		ID:       alertLostSectorsID,
 		Severity: alerts.SeverityWarning,
 		Message:  "Host(s) have lost sectors",
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"hostKeys": hks,
 			"hint":     "Host(s) have reported that it can't serve at least one sector. Consider blocking these hosts through the blocklist feature.",
 		},


### PR DESCRIPTION
Data integrity checks can take a long time for slow hosts. e.g. on Zeus we have 2 hosts for which a batch of 1000 sectors takes about 5 minutes to complete. 

Since migrations and integrity checks can happen in parallel, this PR updates the maintenance loop to actually run each of those tasks in their own loop to allow migrations to happen even when slow hosts block the integrity checks.