### PR TITLE
Fix ScanHost not updating store when context is timed out

### DIFF
--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -61,6 +61,7 @@ loop:
 			}()
 
 			if err := cm.hosts.WithScannedHost(ctx, hostKey, func(host hosts.Host) error {
+				hostLog = hostLog.With(zap.Stringer("protocolVersion", host.Settings.ProtocolVersion))
 				return cm.performContractPruningOnHost(ctx, host, hostLog)
 			}); err != nil {
 				hostLog.Debug("failed to prune contracts", zap.Error(err))

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -337,7 +337,12 @@ func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (Host, e
 		scanExponentialBackoffMaxHours,
 	)
 
-	err = m.store.UpdateHost(ctx, hk, networks, settings, loc, success, nextScan)
+	// derive a context from the background context for persisting the scan
+	// results to prevent a scan that timed out from not being recorded
+	updateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = m.store.UpdateHost(updateCtx, hk, networks, settings, loc, success, nextScan)
 	if err != nil {
 		return Host{}, fmt.Errorf("failed to update host, %w", err)
 	}

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -404,7 +404,7 @@ type blockingScanner struct {
 }
 
 func (bs *blockingScanner) Settings(ctx context.Context, _ types.PublicKey, _ string) (proto4.HostSettings, error) {
-	<-time.After(bs.delay)
+	time.Sleep(bs.delay)
 	return bs.settings, nil
 }
 

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -65,6 +65,16 @@ func (s *mockStore) PruneHosts(ctx context.Context, lastSuccessfulScanCutoff tim
 }
 
 func (s *mockStore) UpdateHost(ctx context.Context, hk types.PublicKey, networks []string, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	host := s.hosts[hk]
+	if scanSucceeded {
+		host.Settings = hs
+		s.hosts[hk] = host
+	}
 	return nil
 }
 
@@ -385,6 +395,57 @@ func TestResolveHost(t *testing.T) {
 		t.Fatal("unexpected", len(networks))
 	} else if loc != mockLocation {
 		t.Fatalf("expected location %v, got %v", mockLocation, loc)
+	}
+}
+
+type blockingScanner struct {
+	delay    time.Duration
+	settings proto4.HostSettings
+}
+
+func (bs *blockingScanner) Settings(ctx context.Context, _ types.PublicKey, _ string) (proto4.HostSettings, error) {
+	<-time.After(bs.delay)
+	return bs.settings, nil
+}
+
+func TestScanTimeout(t *testing.T) {
+	r := &mockResolver{
+		ips: map[string][]net.IPAddr{
+			"1.1.1.1": {{IP: net.IPv4(1, 1, 1, 1)}},
+		},
+	}
+
+	hostKey := types.PublicKey{1}
+	db := &mockStore{hosts: map[types.PublicKey]Host{
+		hostKey: Host{
+			Addresses: []chain.NetAddress{
+				testMuxAddr("1.1.1.1:1111"),
+			},
+		},
+	}}
+
+	// create host manager
+	mgr, err := NewManager(&mockSyncer{peers: []*syncer.Peer{{}}}, &mockLocator{}, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mgr.resolver = r
+	mgr.scanner = &blockingScanner{
+		delay: 500 * time.Millisecond,
+		settings: proto4.HostSettings{
+			Release: "delayedScan",
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	host, err := mgr.ScanHost(ctx, hostKey)
+	if err != nil {
+		t.Fatal(err)
+	} else if host.Settings.Release != "delayedScan" {
+		t.Fatal("unexpected", host.Settings)
 	}
 }
 

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -417,7 +417,7 @@ func TestScanTimeout(t *testing.T) {
 
 	hostKey := types.PublicKey{1}
 	db := &mockStore{hosts: map[types.PublicKey]Host{
-		hostKey: Host{
+		hostKey: {
 			Addresses: []chain.NetAddress{
 				testMuxAddr("1.1.1.1:1111"),
 			},


### PR DESCRIPTION
At least one of the hosts on Zeus keeps timing out during scans with the following error.
```
indexd-1  | DEBUG	contracts.maintenance.contractpruning	failed to prune contracts	{"hostKey": "ed25519:389258107290842af1f14d29f853695d71d621a51022e3322d5673e6c6519888", "error": "failed to scan host, failed to update host, failed to begin transaction: context deadline exceeded"}
```

This PR fixes this by putting the `UpdateHost` call on a separate context.