### PR TITLE
More context when logging drained contract

### DIFF
--- a/accounts/funder.go
+++ b/accounts/funder.go
@@ -100,8 +100,10 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 		} else if err != nil {
 			contractLog.Debug("failed to replenish accounts", zap.Error(err))
 			continue
-		} else if res.Revision.RenterOutput.Value.Cmp(target) < 0 {
-			contractLog.Debug("contract was drained by replenish RPC")
+		} else if res.Revision.RemainingAllowance().Cmp(target) < 0 {
+			contractLog.Debug("contract was drained by replenish RPC",
+				zap.Stringer("remainingAllowance", res.Revision.RemainingAllowance()),
+				zap.Stringer("target", target))
 			drained++
 		}
 


### PR DESCRIPTION
Some contract repeatedly reported getting drained for funding accounts. 

e.g.
```
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
indexd-1  | DEBUG	contracts.maintenance.accounts	contract was drained by replenish RPC	{"hostKey": "ed25519:887e01c621e7fc68514fd6c0c991aba961ad73066219eb3bcbb784bc1653c056", "contractID": "46cce0b46468735ebd16b5dbbd40899dfe4d918ed1f1c5dc8255c78faf7dc10d"}
```

The same contract never seems to get refreshed. This PR adds some context to figure out why that might be the case and why replenishing accounts using that contract still succeeds with a seemingly empty contract.