### PR TITLE
Random encryption key

### DIFF
--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -685,8 +685,7 @@ func TestSharedObjects(t *testing.T) {
 	}
 
 	// generate a random encryption key
-	var encryptionKey [32]byte
-	frand.Read(encryptionKey[:])
+	encryptionKey := frand.Entropy256()
 
 	// create a shared URL for the object
 	shareURL, err := client1.CreateSharedObjectURL(ctx, obj.Key, encryptionKey, time.Now().Add(time.Second))

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -113,11 +113,8 @@ func (s *SDK) uploadSlab(ctx context.Context, shards [][]byte, dataShards uint8,
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	var encryptionKey [32]byte
-	frand.Read(encryptionKey[:])
-
 	slab := slabs.SlabPinParams{
-		EncryptionKey: encryptionKey,
+		EncryptionKey: frand.Entropy256(),
 		MinShards:     uint(dataShards),
 		Sectors:       make([]slabs.PinnedSector, len(shards)),
 	}
@@ -134,7 +131,7 @@ func (s *SDK) uploadSlab(ctx context.Context, shards [][]byte, dataShards uint8,
 	for i := range shards {
 		// encrypt the shard before upload
 		nonce[0] = byte(i)
-		c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce)
+		c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
 		c.XORKeyStream(shards[i], shards[i])
 
 		select {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -103,7 +103,7 @@ var (
 	ErrNoMoreHosts = errors.New("no more hosts available")
 )
 
-func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][]byte, dataShards uint8, maxInFlight int, timeout time.Duration) (slabs.SlabPinParams, error) {
+func (s *SDK) uploadSlab(ctx context.Context, shards [][]byte, dataShards uint8, maxInFlight int, timeout time.Duration) (slabs.SlabPinParams, error) {
 	if len(shards) == 0 {
 		return slabs.SlabPinParams{}, errors.New("no shards to upload")
 	} else if len(shards) < int(dataShards) {
@@ -112,6 +112,9 @@ func (s *SDK) uploadSlab(ctx context.Context, encryptionKey [32]byte, shards [][
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	var encryptionKey [32]byte
+	frand.Read(encryptionKey[:])
 
 	slab := slabs.SlabPinParams{
 		EncryptionKey: encryptionKey,
@@ -258,10 +261,9 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 	}
 
 	type work struct {
-		length        int
-		shards        [][]byte
-		encryptionKey [32]byte
-		err           error
+		length int
+		shards [][]byte
+		err    error
 	}
 	workCh := make(chan work, 1)
 	go func() {
@@ -294,8 +296,7 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 				workCh <- work{err: fmt.Errorf("failed to encode slab %d shards: %w", i, err)}
 				return
 			}
-			encryptionKey := types.HashBytes(append(s.appKey[:], slabBuf[:n]...))
-			workCh <- work{length: n, encryptionKey: encryptionKey, shards: shards}
+			workCh <- work{length: n, shards: shards}
 		}
 	}()
 
@@ -307,7 +308,6 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 		case work := <-workCh:
 			err := work.err
 			shards := work.shards
-			shardKey := work.encryptionKey
 
 			if errors.Is(err, io.EOF) {
 				// no more slabs to upload, return the pinned slabs
@@ -315,7 +315,7 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 			} else if work.err != nil {
 				return Object{}, work.err
 			}
-			params, err := s.uploadSlab(ctx, shardKey, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
+			params, err := s.uploadSlab(ctx, shards, uo.dataShards, uo.maxInflight, uo.hostTimeout)
 			if err != nil {
 				return Object{}, fmt.Errorf("failed to upload slab %d: %w", i, err)
 			}


### PR DESCRIPTION
Right now the upload code derives the slab encryption key from the slab data. Which unnecessarily introduces determinism in our key derivation and since we use the shard index as the nonce, also introduces a security concern for any slabs that are uploaded multiple times.

e.g. when the same shard is uploaded to the same host twice with only a subset of it changing, a host will be able to tell since the remaining data will still match. By xor'ing the the part that differs they can then get access to the key and even decrypt the changed part. 

This PR changes the SDK to use randomly generated keys for each slab which makes this impossible.

NOTE: This also matches our Rust SDK now.