### PR TITLE
Remove spammy logging

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -140,7 +140,6 @@ func (m *AccountManager) FundAccounts(ctx context.Context, host hosts.Host, cont
 		}
 	}
 
-	log.Debug("funding successful")
 	return nil
 }
 

--- a/contracts/chain.go
+++ b/contracts/chain.go
@@ -206,6 +206,9 @@ func (m *ContractManager) broadcastExpiredContracts(ctx context.Context) error {
 		return fmt.Errorf("failed to get expired contracts for broadcast: %w", err)
 	}
 	for _, fce := range expiredFCEs {
+		log := m.log.With(zap.Stringer("contractID", fce.ID)).
+			With(zap.Uint64("expirationHeight", fce.V2FileContract.ExpirationHeight))
+
 		const contractResolutionTxnWeight = 1000
 		txn := types.V2Transaction{
 			MinerFee: m.wallet.RecommendedFee().Mul64(contractResolutionTxnWeight),
@@ -220,7 +223,7 @@ func (m *ContractManager) broadcastExpiredContracts(ctx context.Context) error {
 		// fund and sign txn
 		basis, toSign, err := m.wallet.FundV2Transaction(&txn, txn.MinerFee, true)
 		if err != nil {
-			m.log.Error("failed to fund contract expiration txn", zap.Error(err))
+			log.Error("failed to fund contract expiration txn", zap.Error(err))
 			continue
 		}
 		m.wallet.SignV2Inputs(&txn, toSign)
@@ -228,7 +231,7 @@ func (m *ContractManager) broadcastExpiredContracts(ctx context.Context) error {
 		// fetch potential parents and basis for broadcasting the txn set
 		basis, txnSet, err := m.chain.V2TransactionSet(basis, txn)
 		if err != nil {
-			m.log.Error("failed to retrieve txn set for broadcasting", zap.Error(err))
+			log.Error("failed to retrieve txn set for broadcasting", zap.Error(err))
 			m.wallet.ReleaseInputs(nil, []types.V2Transaction{txn})
 			continue
 		}
@@ -236,7 +239,7 @@ func (m *ContractManager) broadcastExpiredContracts(ctx context.Context) error {
 		// verify txn and broadcast it
 		if err = m.wallet.BroadcastV2TransactionSet(basis, txnSet); err != nil {
 			m.wallet.ReleaseInputs(nil, []types.V2Transaction{txn})
-			m.log.Error("failed to broadcast contract expiration txn", zap.Error(err))
+			log.Error("failed to broadcast contract expiration txn", zap.Error(err))
 			continue
 		}
 	}

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -200,7 +200,9 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			return false
 		} else if usedBy, used := hasCidrConflict(host); used && !force {
 			// host should be on a unique cidr unless 'full'
-			log.Debug("host is not usable cidr is already in use", zap.Stringer("usedBy", usedBy))
+			if host.PublicKey != usedBy {
+				log.Debug("host is not usable cidr is already in use", zap.Stringer("usedBy", usedBy))
+			}
 			return false
 		} else if host.Settings.RemainingStorage < minRemainingStorage {
 			// host should at least have 10GB of storage left

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -34,6 +34,7 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 				return err
 			})
 			if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
+				logger.Debug("integrity checks got interrupted", zap.Error(err))
 				interrupt = true
 				break
 			}
@@ -42,6 +43,9 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 				return
 			}
 			results = append(results, batch...)
+		}
+		if len(results) == 0 {
+			return
 		}
 
 		var lost, failed, success []types.Hash256


### PR DESCRIPTION
This PR removes some unnecessary logging that I see quite a lot in the spirit of avoiding 100GB renterd logs.

Also adds some logging in case integrity checks get interrupted since that seems to be the case quite a lot with a lot of 
```
indexd-1  | 2025-09-18T10:54:49Z	DEBUG	slabs.integrity	performed integrity checks	{"hostKey": "ed25519:5bb5d3380a5af9014f0d08632446fcc3e532d5d366b14f82568b22a22911cc03", "lost": 0, "failed": 0, "successful": 0}
```
in the logs which currently lack the context to figure out why