### PR TITLE
Fix SDK download

### DIFF
--- a/api/app/client.go
+++ b/api/app/client.go
@@ -147,6 +147,11 @@ func (c *Client) Hosts(ctx context.Context, opts ...api.URLQueryParameterOption)
 	return
 }
 
+// BaseURL returns the base URL of the indexer application API.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
 // PinSlab pins a slab to the indexer.
 func (c *Client) PinSlab(ctx context.Context, params slabs.SlabPinParams) (slabID slabs.SlabID, err error) {
 	err = c.signedRequestJSON(ctx, http.MethodPost, "/slabs", params, &slabID)

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -147,11 +147,6 @@ func (c *Client) Hosts(ctx context.Context, opts ...api.URLQueryParameterOption)
 	return
 }
 
-// BaseURL returns the base URL of the indexer application API.
-func (c *Client) BaseURL() string {
-	return c.baseURL
-}
-
 // PinSlab pins a slab to the indexer.
 func (c *Client) PinSlab(ctx context.Context, params slabs.SlabPinParams) (slabID slabs.SlabID, err error) {
 	err = c.signedRequestJSON(ctx, http.MethodPost, "/slabs", params, &slabID)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -348,7 +348,6 @@ func (s *SDK) Download(ctx context.Context, w io.Writer, obj Object, opts ...Dow
 	} else if obj.Key != nil {
 		w = decrypt(obj.Key, w, 0)
 	}
-
 	do := downloadOption{
 		hostTimeout: 4 * time.Second, // ~10 Mbps
 		maxInflight: 10,
@@ -443,15 +442,16 @@ func (s *SDK) downloadSlabs(ctx context.Context, w io.Writer, maxInflight int, h
 			if err != nil {
 				sendErr(fmt.Errorf("failed to download slab: %w", err))
 				return
-			} else if err := enc.ReconstructData(shards); err != nil {
-				sendErr(fmt.Errorf("failed to reconstruct slab data: %w", err))
-				return
 			}
 			nonce := make([]byte, 24)
 			for i := range shards {
 				nonce[0] = byte(i)
 				c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
 				c.XORKeyStream(shards[i], shards[i]) // decrypt shard in place
+			}
+			if err := enc.ReconstructData(shards); err != nil {
+				sendErr(fmt.Errorf("failed to reconstruct slab data: %w", err))
+				return
 			}
 			workCh <- work{
 				shards: shards[:slab.MinShards],

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -433,11 +433,6 @@ func (s *SDK) downloadSlabs(ctx context.Context, w io.Writer, maxInflight int, h
 				break
 			}
 
-			enc, err := reedsolomon.New(int(slab.MinShards), len(slab.Sectors)-int(slab.MinShards))
-			if err != nil {
-				sendErr(fmt.Errorf("failed to create erasure coder: %w", err))
-				return
-			}
 			shards, err := s.downloadSlab(ctx, slab.PinnedSlab, maxInflight, hostTimeout)
 			if err != nil {
 				sendErr(fmt.Errorf("failed to download slab: %w", err))
@@ -449,7 +444,11 @@ func (s *SDK) downloadSlabs(ctx context.Context, w io.Writer, maxInflight int, h
 				c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
 				c.XORKeyStream(shards[i], shards[i]) // decrypt shard in place
 			}
-			if err := enc.ReconstructData(shards); err != nil {
+
+			if enc, err := reedsolomon.New(int(slab.MinShards), len(slab.Sectors)-int(slab.MinShards)); err != nil {
+				sendErr(fmt.Errorf("failed to create erasure coder: %w", err))
+				return
+			} else if err := enc.ReconstructData(shards); err != nil {
 				sendErr(fmt.Errorf("failed to reconstruct slab data: %w", err))
 				return
 			}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/accounts"
+	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"lukechampine.com/frand"
 )
@@ -132,6 +135,46 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
+func TestRoundtripCluster(t *testing.T) {
+	logger := testutils.NewLogger(false)
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(6), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
+
+	indexer := cluster.Indexer
+	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 10)
+
+	a1 := types.GeneratePrivateKey()
+	err := indexer.Store().AddAccount(context.Background(), a1.PublicKey(), accounts.AccountMeta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_ = testutils.WaitForHosts(t, indexer.App(a1), 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := indexer.App(a1)
+	sdk_, err := NewSDK(client.BaseURL(), a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := frand.Bytes(proto.SectorSize)
+	r := bytes.NewReader(data)
+	obj, err := sdk_.Upload(t.Context(), r, WithRedundancy(2, 4))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err = sdk_.Download(t.Context(), &buf, obj)
+	if err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("data mismatch")
+	}
+}
+
 type countWriter struct {
 	count int
 
@@ -249,6 +292,8 @@ func TestDownload(t *testing.T) {
 		err = s.Download(context.Background(), buf, obj, WithDownloadHostTimeout(200*time.Millisecond))
 		if err != nil {
 			t.Fatal(err)
+		} else if !bytes.Equal(buf.Bytes(), data) {
+			t.Fatal("data mismatch")
 		}
 	})
 }

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -10,10 +10,7 @@ import (
 	"testing"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/accounts"
-	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"lukechampine.com/frand"
 )
@@ -122,8 +119,37 @@ func TestRoundtrip(t *testing.T) {
 	url, err := s.client.CreateSharedObjectURL(context.Background(), objKey, encryptionKey, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
+	} else if err := s.DownloadSharedObject(context.Background(), buf, url); err != nil {
+		t.Fatal("unexpected error", err)
+	} else if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("data mismatch")
 	}
 
+	// delete all data shards
+	sharedObj, _, err := s.client.SharedObject(context.Background(), url)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(sharedObj.Slabs) != 1 {
+		t.Fatalf("expected 1 slab, got %d", len(sharedObj.Slabs))
+	}
+	slab := sharedObj.Slabs[0]
+	for i, sector := range slab.Sectors {
+		delete(dialer.hostSectors[sector.HostKey], sector.Root)
+		if i == int(slab.MinShards) {
+			break
+		}
+	}
+
+	// ensure download still works
+	buf = bytes.NewBuffer(nil)
+	if err := s.Download(context.Background(), buf, obj); err != nil {
+		t.Fatal(err)
+	} else if !bytes.Equal(buf.Bytes(), data) {
+		t.Fatal("data mismatch")
+	}
+
+	// ensure download shared object still works
+	buf = bytes.NewBuffer(nil)
 	if err := s.DownloadSharedObject(context.Background(), buf, url); err != nil {
 		t.Fatal("unexpected error", err)
 	} else if !bytes.Equal(buf.Bytes(), data) {
@@ -132,46 +158,6 @@ func TestRoundtrip(t *testing.T) {
 
 	if _, err = s.Upload(context.Background(), bytes.NewReader(data), WithDisableEncryption(), WithXChaCha20Secret(encryptionKey)); err == nil {
 		t.Fatal("expected error when disabling encryption but still passing custom key")
-	}
-}
-
-func TestRoundtripCluster(t *testing.T) {
-	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(6), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
-
-	indexer := cluster.Indexer
-	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 10)
-
-	a1 := types.GeneratePrivateKey()
-	err := indexer.Store().AddAccount(context.Background(), a1.PublicKey(), accounts.AccountMeta{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_ = testutils.WaitForHosts(t, indexer.App(a1), 6)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	client := indexer.App(a1)
-	sdk_, err := NewSDK(client.BaseURL(), a1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data := frand.Bytes(proto.SectorSize)
-	r := bytes.NewReader(data)
-	obj, err := sdk_.Upload(t.Context(), r, WithRedundancy(2, 4))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var buf bytes.Buffer
-	err = sdk_.Download(t.Context(), &buf, obj)
-	if err != nil {
-		t.Fatal(err)
-	} else if !bytes.Equal(buf.Bytes(), data) {
-		t.Fatal("data mismatch")
 	}
 }
 


### PR DESCRIPTION
The SDK was decrypting after reconstructing the erasure coded data, it should do that before to match/mirror the behaviour on upload. We actually had a unit test that would've surfaced this issue, but we neglected to check whether the downloaded bytes matched the ones we uploaded in `TestDownload`.