### PR TITLE
Fix migrations

### DIFF
--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -6,13 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/klauspost/reedsolomon"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
-	"lukechampine.com/frand"
 )
 
 func TestMigrations(t *testing.T) {
@@ -41,7 +39,7 @@ func TestMigrations(t *testing.T) {
 	}
 
 	// upload sectors to hosts
-	shards, roots := newTestShards(t, 2, 4)
+	encryptionKey, shards, roots := slabs.NewTestShards(t, 2, 4)
 	for i := range shards {
 		client := indexer.HostClient(t, hosts[i].PublicKey)
 		hs, err := client.Settings(context.Background())
@@ -55,7 +53,7 @@ func TestMigrations(t *testing.T) {
 
 	// pin the slab
 	slabID, err := app.PinSlab(context.Background(), slabs.SlabPinParams{
-		EncryptionKey: frand.Entropy256(),
+		EncryptionKey: encryptionKey,
 		MinShards:     2,
 		Sectors: []slabs.PinnedSector{
 			{Root: roots[0], HostKey: hosts[0].PublicKey},
@@ -96,42 +94,5 @@ func TestMigrations(t *testing.T) {
 		t.Fatalf("expected 6 pinned sectors, got %d", len(pinned.Sectors))
 	} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[6].PublicKey {
 		t.Fatalf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[6].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
-	}
-}
-
-func newTestShards(t *testing.T, dataShards, parityShards int) ([][]byte, []types.Hash256) {
-	enc, err := reedsolomon.New(dataShards, parityShards)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	shards := make([][]byte, dataShards+parityShards)
-	for i := range shards {
-		shards[i] = make([]byte, proto.SectorSize)
-	}
-
-	buf := make([]byte, proto.SectorSize*dataShards)
-	frand.Read(buf)
-
-	stripedSplit(buf, shards[:dataShards])
-	err = enc.Encode(shards)
-	if err != nil {
-		t.Fatalf("failed to encode shards: %v", err)
-	}
-
-	var roots []types.Hash256
-	for _, shard := range shards {
-		roots = append(roots, proto.SectorRoot((*[proto.SectorSize]byte)(shard)))
-	}
-
-	return shards, roots
-}
-
-func stripedSplit(data []byte, dataShards [][]byte) {
-	buf := bytes.NewBuffer(data)
-	for off := 0; buf.Len() > 0; off += proto.LeafSize {
-		for _, shard := range dataShards {
-			copy(shard[off:], buf.Next(proto.LeafSize))
-		}
 	}
 }

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -95,9 +95,11 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 	// decrypt the shards
 	nonce := make([]byte, 24)
 	for i := range shards {
-		nonce[0] = byte(i)
-		c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
-		c.XORKeyStream(shards[i], shards[i])
+		if len(shards[i]) > 0 {
+			nonce[0] = byte(i)
+			c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
+			c.XORKeyStream(shards[i], shards[i])
+		}
 	}
 
 	// indicate what shards are required
@@ -114,21 +116,19 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		return fmt.Errorf("failed to reconstruct shards for slab %s: %w", slab.ID, err)
 	}
 
-	// upload the missing shards
-	for i, missing := range required {
-		if !missing {
-			shards[i] = nil // nil shards that are not missing
+	// re-encrypt the shards that are required
+	for i, required := range required {
+		if !required {
+			shards[i] = nil
+			continue
 		}
-	}
 
-	// re-encrypt the shards
-	for i := range shards {
 		nonce[0] = byte(i)
 		c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
 		c.XORKeyStream(shards[i], shards[i])
 	}
 
-	// upload the missing shards
+	// migrate the shards
 	migratedShards, err := m.uploadShards(ctx, slab, shards, uploadCandidates, logger)
 
 	// update the database with the new locations for the migrated shards

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -11,6 +11,7 @@ import (
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/chacha20"
 	"lukechampine.com/frand"
 )
 
@@ -91,6 +92,14 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		return fmt.Errorf("failed to download slab %s: %w", slab.ID, err)
 	}
 
+	// decrypt the shards
+	nonce := make([]byte, 24)
+	for i := range shards {
+		nonce[0] = byte(i)
+		c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
+		c.XORKeyStream(shards[i], shards[i])
+	}
+
 	// indicate what shards are required
 	required := make([]bool, len(slab.Sectors))
 	for _, i := range indices {
@@ -110,6 +119,13 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		if !missing {
 			shards[i] = nil // nil shards that are not missing
 		}
+	}
+
+	// re-encrypt the shards
+	for i := range shards {
+		nonce[0] = byte(i)
+		c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
+		c.XORKeyStream(shards[i], shards[i])
 	}
 
 	// upload the missing shards

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -16,6 +16,7 @@ import (
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/chacha20"
 	"lukechampine.com/frand"
 )
 
@@ -72,7 +73,7 @@ func TestMigrateSlab(t *testing.T) {
 	db.contracts[h4.PublicKey] = c4
 
 	// prepare shards
-	shards, roots := newTestShards(t, 2, 2)
+	encryptionKey, shards, roots := NewTestShards(t, 2, 2)
 	r1 := roots[0]
 	r2 := roots[1]
 	r3 := roots[2]
@@ -84,7 +85,7 @@ func TestMigrateSlab(t *testing.T) {
 
 	// pin a slab
 	slabID, err := db.PinSlab(context.Background(), proto.Account(a1), time.Time{}, SlabPinParams{
-		EncryptionKey: [32]byte{},
+		EncryptionKey: encryptionKey,
 		MinShards:     2,
 		Sectors: []PinnedSector{
 			{Root: r1, HostKey: h1.PublicKey},
@@ -329,7 +330,9 @@ func newTestContract(hk types.PublicKey) contracts.Contract {
 	}
 }
 
-func newTestShards(t *testing.T, dataShards, parityShards int) ([][]byte, []types.Hash256) {
+// NewTestShards returns a new set of test shards along with their encryption
+// key and roots.
+func NewTestShards(t *testing.T, dataShards, parityShards int) ([32]byte, [][]byte, []types.Hash256) {
 	enc, err := reedsolomon.New(dataShards, parityShards)
 	if err != nil {
 		t.Fatal(err)
@@ -349,12 +352,21 @@ func newTestShards(t *testing.T, dataShards, parityShards int) ([][]byte, []type
 		t.Fatalf("failed to encode shards: %v", err)
 	}
 
+	var encryptionKey [32]byte
+	frand.Read(encryptionKey[:])
+	nonce := make([]byte, 24)
+	for i := range shards {
+		nonce[0] = byte(i)
+		c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce)
+		c.XORKeyStream(shards[i][:], shards[i][:])
+	}
+
 	var roots []types.Hash256
 	for _, shard := range shards {
 		roots = append(roots, proto.SectorRoot((*[proto.SectorSize]byte)(shard)))
 	}
 
-	return shards, roots
+	return encryptionKey, shards, roots
 }
 
 func stripedSplit(data []byte, dataShards [][]byte) {

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -358,7 +358,7 @@ func NewTestShards(t *testing.T, dataShards, parityShards int) ([32]byte, [][]by
 	for i := range shards {
 		nonce[0] = byte(i)
 		c, _ := chacha20.NewUnauthenticatedCipher(encryptionKey[:], nonce)
-		c.XORKeyStream(shards[i][:], shards[i][:])
+		c.XORKeyStream(shards[i], shards[i])
 	}
 
 	var roots []types.Hash256


### PR DESCRIPTION
Turns out we weren't decrypting the shards before reconstructing the data when migrating slabs. We have quite a bit of testing around migrations but the mistake was always the same, we were either mocking hosts and returning unencrypted data, or we weren't setting the slab's encryption key. Removing the decrypt/re-encrypt steps in the migration code makes the test fail now.