### PR TITLE
Limit max number of shards to 256

### DIFF
--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -13,6 +13,9 @@ import (
 const (
 	// DefaultRedundancy is the default minimum redundancy for slabs.
 	DefaultRedundancy = 3
+
+	// MaxTotalShards is the maximum number of total shards (data + parity) allowed in a slab.
+	MaxTotalShards = 256
 )
 
 var (
@@ -121,6 +124,8 @@ func (s SlabPinParams) Validate() error {
 		return errors.New("encryption key is empty")
 	} else if len(s.Sectors) < int(s.MinShards*DefaultRedundancy) {
 		return fmt.Errorf("%w: minimum redundancy of %dx is not met", ErrInsufficientRedundancy, DefaultRedundancy)
+	} else if len(s.Sectors) > MaxTotalShards {
+		return fmt.Errorf("total number of shards %d exceeds maximum of %d", len(s.Sectors), MaxTotalShards)
 	}
 
 	hks := make(map[types.PublicKey]struct{}, len(s.Sectors))

--- a/slabs/slabs_test.go
+++ b/slabs/slabs_test.go
@@ -49,6 +49,12 @@ func TestSlabPinParamsValidate(t *testing.T) {
 	if err := params.Validate(); err == nil || !strings.Contains(err.Error(), "minimum redundancy of 3x is not met") {
 		t.Fatal("unexpected", err)
 	}
+
+	// assert exceeding max total shards is illegal
+	params.Sectors = make([]PinnedSector, MaxTotalShards+1)
+	if err := params.Validate(); err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatal("unexpected", err)
+	}
 }
 
 // TestSlabPinParamsDigest is a unit test for the SlabPinParams.Digest method.


### PR DESCRIPTION
I considered moving it to the store or even on schema level but considering we enforce the other rules in `params.Validate()` I figured it'd probably be fine. Especially since we might allow slabs with more shards in the future.

Fixes https://github.com/SiaFoundation/indexd/issues/461