### PR TITLE
Ensure minimum distance between hosts using location

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -83,7 +83,7 @@ func (s *formContractSigner) SignV2Inputs(txn *types.V2Transaction, toSign []int
 }
 
 // performContractFormation makes sure that we have at least 'wanted' good
-// contracts with good hosts in unique CIDRs.
+// contracts with good hosts that are sufficiently spaced apart.
 func (cm *ContractManager) performContractFormation(ctx context.Context, period uint64, wanted int64, log *zap.Logger) error {
 	formationLog := log.Named("formation")
 	formationLog.Debug("started", zap.Uint64("period", period), zap.Int64("wanted", wanted))
@@ -118,7 +118,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 	formationLog.Debug("found candidates", zap.Uint64("n", uint64(len(candidates))))
 
 	// forceFormation is a map of hosts that we will always form a contract with
-	// regardless of how many we already have or what CIDR they are on
+	// regardless of how many we already have or where the host is located
 	forceFormation := make(map[types.PublicKey]bool)
 
 	// determine which hosts are 'full', meaning they have exclusively full
@@ -161,48 +161,16 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		forceFormation[hostKey] = true
 	}
 
-	// helpers for CIDR check
-	usedCidrs := make(map[string]types.PublicKey)
-	addHost := func(host hosts.Host) {
-		// NOTE: in testing CIDR checks are disabled because the hosts' network
-		// is an unspecified IPv6 address, in those cases we use the host's
-		// public key to ensure we don't keep forming contracts with the same
-		// host.
-		if cm.disableCIDRChecks {
-			usedCidrs[host.PublicKey.String()] = host.PublicKey
-		} else {
-			for _, network := range host.Networks {
-				usedCidrs[network] = host.PublicKey
-			}
-		}
-
-		wanted--
-	}
-	hasCidrConflict := func(host hosts.Host) (types.PublicKey, bool) {
-		if cm.disableCIDRChecks {
-			hk, known := usedCidrs[host.PublicKey.String()]
-			return hk, known
-		}
-		for _, cidr := range host.Networks {
-			if hk, known := usedCidrs[cidr]; known {
-				return hk, true
-			}
-		}
-		return types.PublicKey{}, false
-	}
-
 	// helper to check if a host is good to form a contract with
+	set := hosts.NewSpacedSet(cm.minHostDistance)
 	isGood := func(host hosts.Host, log *zap.Logger) bool {
 		force := forceFormation[host.PublicKey]
 		if good := host.Usability.Usable(); !good {
 			// host should be good
 			log.Debug("host is not usable due to bad usability", zap.String("reasons", host.Usability.FailedChecks()))
 			return false
-		} else if usedBy, used := hasCidrConflict(host); used && !force {
-			// host should be on a unique cidr unless 'full'
-			if host.PublicKey != usedBy {
-				log.Debug("host is not usable cidr is already in use", zap.Stringer("usedBy", usedBy))
-			}
+		} else if spaced := set.CanAddHost(host); !spaced && !force {
+			// host should be sufficiently spaced from other hosts
 			return false
 		} else if host.Settings.RemainingStorage < minRemainingStorage {
 			// host should at least have 10GB of storage left
@@ -236,7 +204,8 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		}
 
 		// contract is good
-		addHost(host)
+		set.Add(host)
+		wanted--
 	}
 
 	// randomize the candidate order to avoid preferring any host
@@ -292,7 +261,9 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			}
 
 			// contract formed successfully
-			addHost(host)
+			set.Add(host)
+			wanted--
+
 			hostLog.Debug("formed contract", zap.Stringer("contractID", contract.ID))
 			return nil
 		})

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -162,7 +162,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 	}
 
 	// helper to check if a host is good to form a contract with
-	set := hosts.NewSpacedSet(cm.minHostDistance)
+	set := hosts.NewSpacedSet(cm.minHostDistanceKm)
 	isGood := func(host hosts.Host, log *zap.Logger) bool {
 		force := forceFormation[host.PublicKey]
 		if good := host.Usability.Usable(); !good {

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -202,9 +202,13 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 
 	// helper to create a good host
 	goodHost := func(i int) hosts.Host {
+		countries := []string{"US", "DE", "FR", "CN", "JP", "IN", "BR", "RU", "GB", "IT", "ES", "CA", "AU"}
 		return hosts.Host{
-			PublicKey: types.PublicKey{byte(i)},
-			Networks:  []string{fmt.Sprintf("127.0.0.%d/24", i)},
+			PublicKey:   types.PublicKey{byte(i)},
+			CountryCode: countries[frand.Intn(len(countries))],
+			Latitude:    frand.Float64()*180 - 90,
+			Longitude:   frand.Float64()*360 - 180,
+			Networks:    []string{fmt.Sprintf("127.0.0.%d/24", i)},
 			Addresses: []chain.NetAddress{
 				{
 					Protocol: siamux.Protocol,
@@ -225,15 +229,14 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 	good1 := goodHost(1)
 	hm.settings[good1.PublicKey] = goodSettings
 
-	// second one is bad since the network overlaps with the first one
+	// second one is bad since the location matches the first one
 	bad1 := goodHost(2)
-	bad1.Networks = append(bad1.Networks, good1.Networks[0])
+	bad1.Latitude = good1.Latitude
+	bad1.Longitude = good1.Longitude
 	hm.settings[bad1.PublicKey] = goodSettings
 
-	// third one is good even though it overlaps with the second one which
-	// didn't get picked
+	// third one is good again
 	good2 := goodHost(3)
-	good2.Networks = append(good2.Networks, bad1.Networks[0])
 	hm.settings[good2.PublicKey] = goodSettings
 
 	// fourth one is bad due to bad usability
@@ -357,9 +360,13 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	// helper to create a good host
 	goodHost := func(i int) hosts.Host {
+		countries := []string{"US", "DE", "FR", "CN", "JP", "IN", "BR", "RU", "GB", "IT", "ES", "CA", "AU"}
 		return hosts.Host{
-			PublicKey: types.PublicKey{byte(i)},
-			Networks:  []string{fmt.Sprintf("127.0.0.%d/24", i)},
+			PublicKey:   types.PublicKey{byte(i)},
+			CountryCode: countries[frand.Intn(len(countries))],
+			Latitude:    frand.Float64()*180 - 90,
+			Longitude:   frand.Float64()*360 - 180,
+			Networks:    []string{fmt.Sprintf("127.0.0.%d/24", i)},
 			Addresses: []chain.NetAddress{
 				{
 					Protocol: siamux.Protocol,
@@ -369,6 +376,13 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 			Settings:  goodSettings, // default to good settings to consider every host
 			Usability: hosts.GoodUsability,
 		}
+	}
+
+	badHost := func(i int) hosts.Host {
+		h := goodHost(i)
+		h.Usability.AcceptingContracts = false
+		h.Settings.AcceptingContracts = false
+		return h
 	}
 
 	store := newStoreMock()
@@ -394,42 +408,35 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	// first one is good and has a good contract already -> no formation
 	good1 := goodHost(1)
-	hm.settings[good1.PublicKey] = goodSettings
 	formContract(good1.PublicKey, true)
 
 	// second one is bad with a good contract that shouldn't count -> no formation
-	bad1 := goodHost(2)
-	bad1.Networks = append(bad1.Networks, good1.Networks[0])
-	hm.settings[bad1.PublicKey] = goodSettings
+	bad1 := badHost(2)
 	formContract(bad1.PublicKey, true)
 
-	// third one is good, but shares the subnet with the first one -> no formation
+	// third one is good, but has the same location as the first one -> no formation
 	good2 := goodHost(3)
-	good2.Networks = append(good2.Networks, good1.Networks[0])
-	hm.settings[good2.PublicKey] = goodSettings
+	good2.Latitude = good1.Latitude
+	good2.Longitude = good1.Longitude
 
-	// fourth one is good and shares a subnet with bad1 which is ok since bad1
-	// is bad -> forms a contract
+	// fourth one is good and has the same location as bad1 which is ok since
+	// bad1 is bad -> forms a contract
 	good3 := goodHost(4)
-	good3.Networks = append(good3.Networks, bad1.Networks[0])
-	hm.settings[good3.PublicKey] = goodSettings
+	good3.Latitude = bad1.Latitude
+	good3.Longitude = bad1.Longitude
 
 	// fifth one is good -> forms a contract
 	good4 := goodHost(5)
-	hm.settings[good4.PublicKey] = goodSettings
 
 	// sixth one is a good host with a bad contract which won't count -> forms a contract
 	good5 := goodHost(6)
-	hm.settings[good5.PublicKey] = goodSettings
 	formContract(good5.PublicKey, false)
 
 	// seventh one is good but full host takes priority -> no formation
 	good6 := goodHost(7)
-	hm.settings[good6.PublicKey] = goodSettings
 
 	// eighth one is good and has a full contract
 	good7 := goodHost(8)
-	hm.settings[good7.PublicKey] = goodSettings
 	formContract(good7.PublicKey, true)
 	for i := range store.contracts {
 		if store.contracts[i].ID == types.FileContractID(good7.PublicKey) {
@@ -438,10 +445,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	}
 
 	// ninth one is bad and has an unpinned sector
-	bad2 := goodHost(9)
-	badSettings := goodSettings
-	badSettings.AcceptingContracts = false
-	hm.settings[bad2.PublicKey] = badSettings
+	bad2 := badHost(9)
 	store.sectors[bad2.PublicKey] = []sector{
 		{
 			root:       frand.Entropy256(),
@@ -451,7 +455,6 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 
 	// tenth one is good and has an unpinned sector
 	good8 := goodHost(10)
-	hm.settings[good8.PublicKey] = goodSettings
 	store.sectors[good8.PublicKey] = []sector{
 		{
 			root:       frand.Entropy256(),
@@ -462,13 +465,11 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	// eleventh one is good and has a contract that is close to the max
 	// collateral
 	good9 := goodHost(11)
-	maxCollSettings := goodSettings
-	maxCollSettings.MaxCollateral = types.Siacoins(1000)
-	hm.settings[good9.PublicKey] = maxCollSettings
+	good9.Settings.MaxCollateral = types.Siacoins(1000)
 	formContract(good9.PublicKey, true)
 	for i := range store.contracts {
 		if store.contracts[i].ID == types.FileContractID(good9.PublicKey) {
-			store.contracts[i].UsedCollateral = maxCollSettings.MaxCollateral.Sub(minHostCollateral)
+			store.contracts[i].UsedCollateral = good9.Settings.MaxCollateral.Sub(minHostCollateral)
 		}
 	}
 
@@ -485,6 +486,11 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 		bad2.PublicKey:  bad2,
 		good8.PublicKey: good8,
 		good9.PublicKey: good9,
+	}
+
+	// populate host settings
+	for hk := range store.hosts {
+		hm.settings[hk] = store.hosts[hk].Settings
 	}
 
 	dialer := newDialerMock()
@@ -530,7 +536,7 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 	// settings and params
 	nCalls := dialer.TotalFormations()
 	if nCalls != wanted-1 {
-		t.Fatalf("expected %v calls, got %v", wanted-1, nCalls)
+		t.Fatalf("expected %v formations, got %v", wanted-1, nCalls)
 	}
 	assertFormation(good3)
 	assertFormation(good4)

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -13,7 +13,6 @@ import (
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/client"
-	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
@@ -196,7 +195,7 @@ type (
 		expiredContractPruneBuffer        uint64
 		expiredContractSectorsPruneBuffer uint64
 		maintenanceFrequency              time.Duration
-		minHostDistance                   geoip.Distance
+		minHostDistanceKm                 float64
 		pruneIntervalSuccess              time.Duration
 		pruneIntervalFailure              time.Duration
 		syncPollInterval                  time.Duration
@@ -220,11 +219,11 @@ func WithMaintenanceFrequency(frequency time.Duration) ContractManagerOpt {
 }
 
 // WithMinHostDistance sets the minimum geographic separation required between
-// hosts for the contract manager. The default is 10km (6.2 miles), when set to
+// hosts for the contract manager. The default is 10km, when set to
 // 0, the distance check is disabled.
-func WithMinHostDistance(d geoip.Distance) ContractManagerOpt {
+func WithMinHostDistance(km float64) ContractManagerOpt {
 	return func(cm *ContractManager) {
-		cm.minHostDistance = d
+		cm.minHostDistanceKm = km
 	}
 }
 
@@ -419,7 +418,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, chai
 		expiredContractPruneBuffer:        144,           // 144 blocks after broadcast
 		expiredContractSectorsPruneBuffer: 36,            // 36 blocks (~6 hours) after expiration
 		maintenanceFrequency:              10 * time.Minute,
-		minHostDistance:                   geoip.Km(10),       // 10km
+		minHostDistanceKm:                 10,                 // 10km
 		pruneIntervalSuccess:              24 * time.Hour,     // 1 day
 		pruneIntervalFailure:              3 * time.Hour,      // 3 hours
 		revisionBroadcastInterval:         7 * 24 * time.Hour, // 1 week,

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -13,6 +13,7 @@ import (
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/client"
+	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
@@ -191,11 +192,11 @@ type (
 		tg      *threadgroup.ThreadGroup
 
 		contractRejectBuffer              time.Duration
-		disableCIDRChecks                 bool
 		expiredContractBroadcastBuffer    uint64
 		expiredContractPruneBuffer        uint64
 		expiredContractSectorsPruneBuffer uint64
 		maintenanceFrequency              time.Duration
+		minHostDistance                   geoip.Distance
 		pruneIntervalSuccess              time.Duration
 		pruneIntervalFailure              time.Duration
 		syncPollInterval                  time.Duration
@@ -210,18 +211,20 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 	}
 }
 
-// WithDisabledCIDRChecks disables the CIDR checks for the contract manager.
-func WithDisabledCIDRChecks() ContractManagerOpt {
-	return func(cm *ContractManager) {
-		cm.disableCIDRChecks = true
-	}
-}
-
 // WithMaintenanceFrequency sets the frequency at which the contract manager
 // performs maintenance tasks. The default is 10 minutes.
 func WithMaintenanceFrequency(frequency time.Duration) ContractManagerOpt {
 	return func(cm *ContractManager) {
 		cm.maintenanceFrequency = frequency
+	}
+}
+
+// WithMinHostDistance sets the minimum geographic separation required between
+// hosts for the contract manager. The default is 10km (6.2 miles), when set to
+// 0, the distance check is disabled.
+func WithMinHostDistance(d geoip.Distance) ContractManagerOpt {
+	return func(cm *ContractManager) {
+		cm.minHostDistance = d
 	}
 }
 
@@ -416,6 +419,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, chai
 		expiredContractPruneBuffer:        144,           // 144 blocks after broadcast
 		expiredContractSectorsPruneBuffer: 36,            // 36 blocks (~6 hours) after expiration
 		maintenanceFrequency:              10 * time.Minute,
+		minHostDistance:                   geoip.Km(10),       // 10km
 		pruneIntervalSuccess:              24 * time.Hour,     // 1 day
 		pruneIntervalFailure:              3 * time.Hour,      // 3 hours
 		revisionBroadcastInterval:         7 * 24 * time.Hour, // 1 week,

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -2,6 +2,7 @@ package geoip
 
 import (
 	_ "embed" // needed for geolocation database
+	"math"
 	"net"
 	"sync"
 
@@ -11,6 +12,69 @@ import (
 //go:embed GeoLite2-City.mmdb
 var maxMindCityDB []byte
 
+const radiusKm = 6371.0088
+
+type distanceUnit int
+
+const (
+	// Kilometers is a distance unit in kilometers.
+	Kilometers distanceUnit = iota
+	// Miles is a distance unit in miles.
+	Miles
+)
+
+type (
+	// Distance represents a distance measurement in a specific unit.
+	Distance struct {
+		value float64
+		unit  distanceUnit
+	}
+)
+
+// Km returns a Distance representing the provided number of kilometers.
+func Km(v float64) Distance { return Distance{value: v, unit: Kilometers} }
+
+// MilesD returns a Distance representing the provided number of miles.
+func MilesD(v float64) Distance { return Distance{value: v, unit: Miles} }
+
+// Compare compares two distances, returning -1 if d < other, 1 if d > other, and
+// 0 if they are equal.
+func (d Distance) Compare(other Distance) int {
+	dKm := d.ToKm()
+	otherKm := other.ToKm()
+
+	switch {
+	case dKm < otherKm:
+		return -1
+	case dKm > otherKm:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// LessThan returns true if the receiver is smaller than the other.
+func (d Distance) LessThan(other Distance) bool {
+	return d.Compare(other) < 0
+}
+
+// IsZero returns true if the distance is zero.
+func (d Distance) IsZero() bool {
+	return d.value == 0
+}
+
+// ToKm converts the distance to kilometers.
+func (d Distance) ToKm() float64 {
+	switch d.unit {
+	case Kilometers:
+		return d.value
+	case Miles:
+		return d.value * 1.60934
+	default:
+		panic("unknown distance unit")
+	}
+}
+
 // A Location represents an ISO 3166-1 A-2 country codes and an approximate
 // latitude/longitude.
 type Location struct {
@@ -18,6 +82,21 @@ type Location struct {
 
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
+}
+
+// HaversineDistance returns the great-circle distance between the location and
+// the other location in kilometers.
+func (l Location) HaversineDistance(other Location) Distance {
+	φ1 := l.Latitude * math.Pi / 180
+	φ2 := other.Latitude * math.Pi / 180
+	dφ := (other.Latitude - l.Latitude) * math.Pi / 180
+	dλ := (other.Longitude - l.Longitude) * math.Pi / 180
+
+	sinDφ := math.Sin(dφ / 2)
+	sinDλ := math.Sin(dλ / 2)
+	a := sinDφ*sinDφ + math.Cos(φ1)*math.Cos(φ2)*sinDλ*sinDλ
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	return Km(radiusKm * c)
 }
 
 // A Locator maps IP addresses to their location.

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -14,67 +14,6 @@ var maxMindCityDB []byte
 
 const radiusKm = 6371.0088
 
-type distanceUnit int
-
-const (
-	// Kilometers is a distance unit in kilometers.
-	Kilometers distanceUnit = iota
-	// Miles is a distance unit in miles.
-	Miles
-)
-
-type (
-	// Distance represents a distance measurement in a specific unit.
-	Distance struct {
-		value float64
-		unit  distanceUnit
-	}
-)
-
-// Km returns a Distance representing the provided number of kilometers.
-func Km(v float64) Distance { return Distance{value: v, unit: Kilometers} }
-
-// MilesD returns a Distance representing the provided number of miles.
-func MilesD(v float64) Distance { return Distance{value: v, unit: Miles} }
-
-// Compare compares two distances, returning -1 if d < other, 1 if d > other, and
-// 0 if they are equal.
-func (d Distance) Compare(other Distance) int {
-	dKm := d.ToKm()
-	otherKm := other.ToKm()
-
-	switch {
-	case dKm < otherKm:
-		return -1
-	case dKm > otherKm:
-		return 1
-	default:
-		return 0
-	}
-}
-
-// LessThan returns true if the receiver is smaller than the other.
-func (d Distance) LessThan(other Distance) bool {
-	return d.Compare(other) < 0
-}
-
-// IsZero returns true if the distance is zero.
-func (d Distance) IsZero() bool {
-	return d.value == 0
-}
-
-// ToKm converts the distance to kilometers.
-func (d Distance) ToKm() float64 {
-	switch d.unit {
-	case Kilometers:
-		return d.value
-	case Miles:
-		return d.value * 1.60934
-	default:
-		panic("unknown distance unit")
-	}
-}
-
 // A Location represents an ISO 3166-1 A-2 country codes and an approximate
 // latitude/longitude.
 type Location struct {
@@ -84,9 +23,9 @@ type Location struct {
 	Longitude float64 `json:"longitude"`
 }
 
-// HaversineDistance returns the great-circle distance between the location and
+// HaversineDistanceKm returns the great-circle distance between the location and
 // the other location in kilometers.
-func (l Location) HaversineDistance(other Location) Distance {
+func (l Location) HaversineDistanceKm(other Location) float64 {
 	φ1 := l.Latitude * math.Pi / 180
 	φ2 := other.Latitude * math.Pi / 180
 	dφ := (other.Latitude - l.Latitude) * math.Pi / 180
@@ -96,7 +35,7 @@ func (l Location) HaversineDistance(other Location) Distance {
 	sinDλ := math.Sin(dλ / 2)
 	a := sinDφ*sinDφ + math.Cos(φ1)*math.Cos(φ2)*sinDλ*sinDλ
 	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
-	return Km(radiusKm * c)
+	return radiusKm * c
 }
 
 // A Locator maps IP addresses to their location.

--- a/geoip/geoip_test.go
+++ b/geoip/geoip_test.go
@@ -1,0 +1,64 @@
+package geoip
+
+import (
+	"math"
+	"testing"
+)
+
+func TestHaversineDistance(t *testing.T) {
+	almostEqual := func(a, b, tol float64) bool {
+		return math.Abs(a-b) <= tol
+	}
+
+	tests := []struct {
+		name      string
+		a, b      Location
+		expected  float64
+		tolerance float64
+	}{
+		{
+			name:      "same point is zero",
+			a:         Location{Latitude: 50.8503, Longitude: 4.3517}, // Brussels
+			b:         Location{Latitude: 50.8503, Longitude: 4.3517},
+			expected:  0,
+			tolerance: 1e-9, // zero tolerance
+		},
+		{
+			name:      "1 degree of longitude at equator ≈ 111.19508 km",
+			a:         Location{Latitude: 0, Longitude: 0},
+			b:         Location{Latitude: 0, Longitude: 1},
+			expected:  111.1950802335329,
+			tolerance: 1e-4, // ~0.1 meters for 1° at equator
+		},
+		{
+			name:      "Brussels ↔ Antwerp ≈ 41.1955 km",
+			a:         Location{Latitude: 50.8503, Longitude: 4.3517},
+			b:         Location{Latitude: 51.2194, Longitude: 4.4025},
+			expected:  41.19553412569231,
+			tolerance: 1e-4, // ~50 meters tolerance for city pair
+		},
+		{
+			name:      "antipodes (0,0) ↔ (0,180) = πR",
+			a:         Location{Latitude: 0, Longitude: 0},
+			b:         Location{Latitude: 0, Longitude: 180},
+			expected:  math.Pi * radiusKm,
+			tolerance: 1e-9, // zero tolerance
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.a.HaversineDistance(tc.b).ToKm()
+			if !almostEqual(got, tc.expected, tc.tolerance) {
+				t.Fatalf("HaversineDistance(%+v, %+v) = %.12f km, want %.12f km (±%.6f)",
+					tc.a, tc.b, got, tc.expected, tc.tolerance)
+			}
+			// Symmetry check: d(a,b) == d(b,a)
+			gotBA := tc.b.HaversineDistance(tc.a).ToKm()
+			if !almostEqual(got, gotBA, tc.tolerance) {
+				t.Fatalf("distance not symmetric: d(a,b)=%.12f, d(b,a)=%.12f (±%.6f)",
+					got, gotBA, tc.tolerance)
+			}
+		})
+	}
+}

--- a/geoip/geoip_test.go
+++ b/geoip/geoip_test.go
@@ -48,13 +48,13 @@ func TestHaversineDistance(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.a.HaversineDistance(tc.b).ToKm()
+			got := tc.a.HaversineDistanceKm(tc.b)
 			if !almostEqual(got, tc.expected, tc.tolerance) {
 				t.Fatalf("HaversineDistance(%+v, %+v) = %.12f km, want %.12f km (±%.6f)",
 					tc.a, tc.b, got, tc.expected, tc.tolerance)
 			}
 			// Symmetry check: d(a,b) == d(b,a)
-			gotBA := tc.b.HaversineDistance(tc.a).ToKm()
+			gotBA := tc.b.HaversineDistanceKm(tc.a)
 			if !almostEqual(got, gotBA, tc.tolerance) {
 				t.Fatalf("distance not symmetric: d(a,b)=%.12f, d(b,a)=%.12f (±%.6f)",
 					got, gotBA, tc.tolerance)

--- a/hosts/distance.go
+++ b/hosts/distance.go
@@ -1,0 +1,55 @@
+package hosts
+
+import (
+	"go.sia.tech/indexd/geoip"
+)
+
+// SpacedSet is a set of hosts that are sufficiently spaced apart based on a
+// minimum distance. A spaced set is not thread-safe.
+type SpacedSet struct {
+	minDistance geoip.Distance
+	selected    []Host
+}
+
+// NewSpacedSet creates a new SpacedSet with the given minimum distance.
+func NewSpacedSet(minDistance geoip.Distance) *SpacedSet {
+	return &SpacedSet{minDistance: minDistance}
+}
+
+// Add adds the host to the set if it is sufficiently spaced apart from the
+// existing hosts. It returns true if the host was added, false otherwise.
+func (s *SpacedSet) Add(h Host) bool {
+	if s.CanAddHost(h) {
+		s.selected = append(s.selected, h)
+		return true
+	}
+	return false
+}
+
+// CanAddHost returns true if the host is sufficiently far removed from the
+// existing hosts in the set. If the minimum distance is zero, it only checks
+// for uniqueness.
+func (s *SpacedSet) CanAddHost(h Host) bool {
+	if s.minDistance.IsZero() {
+		return !s.contains(h)
+	}
+
+	location := h.Location()
+	for _, other := range s.selected {
+		distance := location.HaversineDistance(other.Location())
+		if distance.LessThan(s.minDistance) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *SpacedSet) contains(h Host) bool {
+	for _, other := range s.selected {
+		if h.PublicKey == other.PublicKey {
+			return true
+		}
+	}
+	return false
+}

--- a/hosts/distance.go
+++ b/hosts/distance.go
@@ -8,15 +8,15 @@ import (
 // SpacedSet is a set of hosts that are sufficiently spaced apart based on a
 // minimum distance. A spaced set is not thread-safe.
 type SpacedSet struct {
-	minDistance geoip.Distance
-	selected    map[types.PublicKey]geoip.Location
+	minDistanceKm float64
+	selected      map[types.PublicKey]geoip.Location
 }
 
 // NewSpacedSet creates a new SpacedSet with the given minimum distance.
-func NewSpacedSet(minDistance geoip.Distance) *SpacedSet {
+func NewSpacedSet(minDistanceKm float64) *SpacedSet {
 	return &SpacedSet{
-		minDistance: minDistance,
-		selected:    make(map[types.PublicKey]geoip.Location),
+		minDistanceKm: minDistanceKm,
+		selected:      make(map[types.PublicKey]geoip.Location),
 	}
 }
 
@@ -34,15 +34,15 @@ func (s *SpacedSet) Add(h Host) bool {
 // existing hosts in the set. If the minimum distance is zero, it only checks
 // for uniqueness.
 func (s *SpacedSet) CanAddHost(h Host) bool {
-	if s.minDistance.IsZero() {
+	if s.minDistanceKm == 0 {
 		_, exists := s.selected[h.PublicKey]
 		return !exists
 	}
 
 	location := h.Location()
 	for _, other := range s.selected {
-		distance := location.HaversineDistance(other)
-		if distance.LessThan(s.minDistance) {
+		distance := location.HaversineDistanceKm(other)
+		if distance < s.minDistanceKm {
 			return false
 		}
 	}

--- a/hosts/distance.go
+++ b/hosts/distance.go
@@ -1,6 +1,7 @@
 package hosts
 
 import (
+	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/geoip"
 )
 
@@ -8,19 +9,22 @@ import (
 // minimum distance. A spaced set is not thread-safe.
 type SpacedSet struct {
 	minDistance geoip.Distance
-	selected    []Host
+	selected    map[types.PublicKey]geoip.Location
 }
 
 // NewSpacedSet creates a new SpacedSet with the given minimum distance.
 func NewSpacedSet(minDistance geoip.Distance) *SpacedSet {
-	return &SpacedSet{minDistance: minDistance}
+	return &SpacedSet{
+		minDistance: minDistance,
+		selected:    make(map[types.PublicKey]geoip.Location),
+	}
 }
 
 // Add adds the host to the set if it is sufficiently spaced apart from the
 // existing hosts. It returns true if the host was added, false otherwise.
 func (s *SpacedSet) Add(h Host) bool {
 	if s.CanAddHost(h) {
-		s.selected = append(s.selected, h)
+		s.selected[h.PublicKey] = h.Location()
 		return true
 	}
 	return false
@@ -31,25 +35,17 @@ func (s *SpacedSet) Add(h Host) bool {
 // for uniqueness.
 func (s *SpacedSet) CanAddHost(h Host) bool {
 	if s.minDistance.IsZero() {
-		return !s.contains(h)
+		_, exists := s.selected[h.PublicKey]
+		return !exists
 	}
 
 	location := h.Location()
 	for _, other := range s.selected {
-		distance := location.HaversineDistance(other.Location())
+		distance := location.HaversineDistance(other)
 		if distance.LessThan(s.minDistance) {
 			return false
 		}
 	}
 
 	return true
-}
-
-func (s *SpacedSet) contains(h Host) bool {
-	for _, other := range s.selected {
-		if h.PublicKey == other.PublicKey {
-			return true
-		}
-	}
-	return false
 }

--- a/hosts/distance_test.go
+++ b/hosts/distance_test.go
@@ -1,0 +1,67 @@
+package hosts
+
+import (
+	"testing"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/geoip"
+)
+
+func TestSpacedSet(t *testing.T) {
+	// Distances (approx):
+	// Brussels–Ghent: ~50 km
+	// Brussels–Liège: ~90 km
+	// Ghent–Liège: ~125 km
+
+	brussels := Host{
+		PublicKey:   types.PublicKey{1},
+		CountryCode: "BE",
+		Latitude:    50.8503,
+		Longitude:   4.3517,
+	} // Brussels
+
+	ghent := Host{
+		PublicKey:   types.PublicKey{2},
+		CountryCode: "BE",
+		Latitude:    51.0543,
+		Longitude:   3.7174,
+	} // Ghent
+	liege := Host{
+		PublicKey:   types.PublicKey{3},
+		CountryCode: "BE",
+		Latitude:    50.6326,
+		Longitude:   5.5797,
+	} // Liège
+
+	// assert behaviour of the spaced set with a min distance of 100 km
+	s := NewSpacedSet(geoip.Km(100))
+	if !s.Add(brussels) {
+		t.Fatal("expected to add Brussels")
+	} else if s.Add(ghent) {
+		t.Fatal("expected Ghent to be rejected (<100 km from Brussels)")
+	} else if s.Add(liege) {
+		t.Fatal("expected Liège to be rejected (<100 km from Brussels)")
+	}
+
+	// lower threshold to 45km
+	s2 := NewSpacedSet(geoip.Km(45))
+	if !s2.Add(brussels) {
+		t.Fatal("expected to add Brussels")
+	} else if !s2.Add(ghent) {
+		t.Fatal("expected Ghent to be accepted (~50 km from Brussels)")
+	} else if !s2.Add(liege) {
+		t.Fatal("expected Liège to be accepted (~90–125 km from others)")
+	}
+
+	// assert behaviour of the spaced set with a min distance of 0 km (only uniqueness)
+	s3 := NewSpacedSet(geoip.Km(0))
+	if !s3.Add(brussels) {
+		t.Fatal("expected to add Brussels")
+	} else if !s3.Add(ghent) {
+		t.Fatal("expected to add Ghent (0 km min distance)")
+	} else if !s3.Add(liege) {
+		t.Fatal("expected to add Liège (0 km min distance)")
+	} else if s3.Add(brussels) {
+		t.Fatal("expected Brussels to be rejected (duplicate)")
+	}
+}

--- a/hosts/distance_test.go
+++ b/hosts/distance_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/geoip"
 )
 
 func TestSpacedSet(t *testing.T) {
@@ -34,7 +33,7 @@ func TestSpacedSet(t *testing.T) {
 	} // Liège
 
 	// assert behaviour of the spaced set with a min distance of 100 km
-	s := NewSpacedSet(geoip.Km(100))
+	s := NewSpacedSet(100)
 	if !s.Add(brussels) {
 		t.Fatal("expected to add Brussels")
 	} else if s.Add(ghent) {
@@ -44,7 +43,7 @@ func TestSpacedSet(t *testing.T) {
 	}
 
 	// lower threshold to 45km
-	s2 := NewSpacedSet(geoip.Km(45))
+	s2 := NewSpacedSet(45)
 	if !s2.Add(brussels) {
 		t.Fatal("expected to add Brussels")
 	} else if !s2.Add(ghent) {
@@ -54,7 +53,7 @@ func TestSpacedSet(t *testing.T) {
 	}
 
 	// assert behaviour of the spaced set with a min distance of 0 km (only uniqueness)
-	s3 := NewSpacedSet(geoip.Km(0))
+	s3 := NewSpacedSet(0)
 	if !s3.Add(brussels) {
 		t.Fatal("expected to add Brussels")
 	} else if !s3.Add(ghent) {

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -9,6 +9,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/geoip"
 )
 
 const (
@@ -167,6 +168,15 @@ type (
 // IsGood returns true if the host is considered good for storing data.
 func (h *Host) IsGood() bool {
 	return h.Usability.Usable() && !h.Blocked && len(h.Networks) > 0
+}
+
+// Location returns the geoip.Location of the host.
+func (h *Host) Location() geoip.Location {
+	return geoip.Location{
+		CountryCode: h.CountryCode,
+		Latitude:    h.Latitude,
+		Longitude:   h.Longitude,
+	}
 }
 
 // GoodUsability is the usability struct indicating that all checks passed.

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -78,7 +78,7 @@ type (
 func defaultIndexerCfg() *indexerCfg {
 	return &indexerCfg{
 		maintenanceSettings: MaintenanceSettings,
-		slabOpts:            []slabs.Option{slabs.WithDisabledCIDRChecks()},
+		slabOpts:            []slabs.Option{slabs.WithMinHostDistance(geoip.Km(0))}, // disable distance checks in tests
 	}
 }
 
@@ -143,7 +143,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 
 	contractOpts := []contracts.ContractManagerOpt{
-		contracts.WithDisabledCIDRChecks(),
+		contracts.WithMinHostDistance(geoip.Km(0)), // disable location checks in tests
 		contracts.WithLogger(log.Named("contracts")),
 		contracts.WithMaintenanceFrequency(200 * time.Millisecond),
 		contracts.WithSyncPollInterval(100 * time.Millisecond),

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -78,7 +78,7 @@ type (
 func defaultIndexerCfg() *indexerCfg {
 	return &indexerCfg{
 		maintenanceSettings: MaintenanceSettings,
-		slabOpts:            []slabs.Option{slabs.WithMinHostDistance(geoip.Km(0))}, // disable distance checks in tests
+		slabOpts:            []slabs.Option{slabs.WithMinHostDistance(0)}, // disable distance checks in tests
 	}
 }
 
@@ -143,7 +143,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 
 	contractOpts := []contracts.ContractManagerOpt{
-		contracts.WithMinHostDistance(geoip.Km(0)), // disable location checks in tests
+		contracts.WithMinHostDistance(0), // disable location checks in tests
 		contracts.WithLogger(log.Named("contracts")),
 		contracts.WithMaintenanceFrequency(200 * time.Millisecond),
 		contracts.WithSyncPollInterval(100 * time.Millisecond),

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -16,6 +16,7 @@ import (
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -25,13 +26,12 @@ type (
 	// checking their integrity on the network and migrating their sectors if
 	// necessary.
 	SlabManager struct {
-		disableCIDRChecks bool
-
 		healthCheckInterval time.Duration
 
 		integrityCheckInterval       time.Duration
 		failedIntegrityCheckInterval time.Duration
 		maxFailedIntegrityChecks     uint
+		minHostDistance              geoip.Distance
 
 		migrationAccount    proto.Account
 		migrationAccountKey types.PrivateKey
@@ -123,13 +123,6 @@ var (
 // An Option is a functional option for the SlabManager.
 type Option func(*SlabManager)
 
-// WithDisabledCIDRChecks disables the CIDR checks for the slab manager.
-func WithDisabledCIDRChecks() Option {
-	return func(m *SlabManager) {
-		m.disableCIDRChecks = true
-	}
-}
-
 // WithHealthCheckInterval sets the interval for health checks.
 func WithHealthCheckInterval(interval time.Duration) Option {
 	return func(m *SlabManager) {
@@ -142,6 +135,15 @@ func WithIntegrityCheckIntervals(success, failure time.Duration) Option {
 	return func(m *SlabManager) {
 		m.integrityCheckInterval = success
 		m.failedIntegrityCheckInterval = failure
+	}
+}
+
+// WithMinHostDistance sets the minimum distance between hosts used for storing
+// sectors of the same slab. The default is 10km, if set to 0, the distance
+// check is disabled.
+func WithMinHostDistance(d geoip.Distance) Option {
+	return func(m *SlabManager) {
+		m.minHostDistance = d
 	}
 }
 
@@ -192,6 +194,7 @@ func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Diale
 		integrityCheckInterval:       7 * 24 * time.Hour,
 		failedIntegrityCheckInterval: 6 * time.Hour,
 		maxFailedIntegrityChecks:     5,
+		minHostDistance:              geoip.Km(10),
 
 		migrationAccount:    proto.Account(migrationAccount.PublicKey()),
 		migrationAccountKey: migrationAccount,

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -16,7 +16,6 @@ import (
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/client"
 	"go.sia.tech/indexd/contracts"
-	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -31,7 +30,7 @@ type (
 		integrityCheckInterval       time.Duration
 		failedIntegrityCheckInterval time.Duration
 		maxFailedIntegrityChecks     uint
-		minHostDistance              geoip.Distance
+		minHostDistanceKm            float64
 
 		migrationAccount    proto.Account
 		migrationAccountKey types.PrivateKey
@@ -141,9 +140,9 @@ func WithIntegrityCheckIntervals(success, failure time.Duration) Option {
 // WithMinHostDistance sets the minimum distance between hosts used for storing
 // sectors of the same slab. The default is 10km, if set to 0, the distance
 // check is disabled.
-func WithMinHostDistance(d geoip.Distance) Option {
+func WithMinHostDistance(km float64) Option {
 	return func(m *SlabManager) {
-		m.minHostDistance = d
+		m.minHostDistanceKm = km
 	}
 }
 
@@ -194,7 +193,7 @@ func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Diale
 		integrityCheckInterval:       7 * 24 * time.Hour,
 		failedIntegrityCheckInterval: 6 * time.Hour,
 		maxFailedIntegrityChecks:     5,
-		minHostDistance:              geoip.Km(10),
+		minHostDistanceKm:            10,
 
 		migrationAccount:    proto.Account(migrationAccount.PublicKey()),
 		migrationAccountKey: migrationAccount,

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -9,6 +9,7 @@ import (
 	"github.com/klauspost/reedsolomon"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/chacha20"
@@ -74,7 +75,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		return fmt.Errorf("failed to fetch slab %s: %w", slabID, err)
 	}
 
-	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, period, m.disableCIDRChecks)
+	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, period, m.minHostDistance)
 	if len(indices) == 0 {
 		logger.Debug("tried to migrate slab but no indices require migration")
 		return nil
@@ -154,9 +155,9 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 
 // sectorsToMigrate filters the sectors of a slab and returns the indices of the
 // sectors that require migration together with hosts that can be used to
-// migrate bad sectors to. These hosts are guaranteed to not have overlapping
-// CIDRs and are returned in random order.
-func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, period uint64, disableCIDRChecks bool) ([]int, []hosts.Host) {
+// migrate bad sectors to. These hosts are guaranteed to be at least
+// minHostDistance apart from each other and are returned in random order.
+func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, period uint64, minHostDistance geoip.Distance) ([]int, []hosts.Host) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range allHosts {
@@ -174,10 +175,11 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 		}
 	}
 
-	// remember the CIDRs of the hosts that good sectors are stored on. We don't
-	// care if two good sectors are stored on the same CIDR but we don't want to
-	// migrate bad sectors to the same CIDR.
-	usedCIDRs := make(map[string]struct{})
+	// keep track of hosts in a spaced set, ensuring we store sectors on hosts
+	// that are sufficiently far apart. We don't care if two good sectors on
+	// hosts that are too close to one another, but we don't want to migrate bad
+	// sectors to hosts that are too close to those same hosts
+	set := hosts.NewSpacedSet(minHostDistance)
 
 	// determine whether the sector needs to be migrated. That's the case if
 	// one of the following is true:
@@ -195,47 +197,21 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 		// remove contract from the map since we don't want to use it again
 		delete(goodContractMap, *sector.ContractID)
 
-		// NOTE: in testing CIDR checks are disabled because the hosts' network
-		// is an unspecified IPv6 address, in those cases we use the host's
-		// public key to ensure we don't migrate the bad sector to a used host
-		if disableCIDRChecks {
-			usedCIDRs[sector.HostKey.String()] = struct{}{}
-			continue
-		}
-
-		for _, network := range hostsMap[*sector.HostKey].Networks {
-			usedCIDRs[network] = struct{}{}
+		// add the host to the spaced set to ensure we don't use hosts that are
+		// too close to existing hosts
+		if host, ok := hostsMap[*sector.HostKey]; ok {
+			set.Add(host)
 		}
 	}
 
 	// return all hosts with contracts that are good, currently not in use and
-	// don't have overlapping CIDRs, if CIDR checks are disabled we only check
-	// against the host key to ensure unique hosts are used
+	// are sufficiently far apart
 	var candidates []hosts.Host
-	if disableCIDRChecks {
-		for _, contract := range goodContractMap {
-			if _, used := usedCIDRs[contract.HostKey.String()]; used {
-				continue
-			}
-			usedCIDRs[contract.HostKey.String()] = struct{}{}
-			candidates = append(candidates, hostsMap[contract.HostKey])
-		}
-		return toMigrate, candidates
-	}
-
-LOOP:
 	for _, contract := range goodContractMap {
-		host := hostsMap[contract.HostKey]
-		for _, network := range host.Networks {
-			if _, ok := usedCIDRs[network]; ok {
-				continue LOOP
-			}
+		if host, ok := hostsMap[contract.HostKey]; ok && set.CanAddHost(host) {
+			set.Add(host)
+			candidates = append(candidates, host)
 		}
-
-		for _, network := range host.Networks {
-			usedCIDRs[network] = struct{}{}
-		}
-		candidates = append(candidates, host)
 	}
 
 	return toMigrate, candidates

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -9,7 +9,6 @@ import (
 	"github.com/klauspost/reedsolomon"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/contracts"
-	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/chacha20"
@@ -75,7 +74,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		return fmt.Errorf("failed to fetch slab %s: %w", slabID, err)
 	}
 
-	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, period, m.minHostDistance)
+	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, period, m.minHostDistanceKm)
 	if len(indices) == 0 {
 		logger.Debug("tried to migrate slab but no indices require migration")
 		return nil
@@ -157,7 +156,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 // sectors that require migration together with hosts that can be used to
 // migrate bad sectors to. These hosts are guaranteed to be at least
 // minHostDistance apart from each other and are returned in random order.
-func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, period uint64, minHostDistance geoip.Distance) ([]int, []hosts.Host) {
+func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, period uint64, minHostDistanceKm float64) ([]int, []hosts.Host) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range allHosts {
@@ -179,7 +178,7 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 	// that are sufficiently far apart. We don't care if two good sectors on
 	// hosts that are too close to one another, but we don't want to migrate bad
 	// sectors to hosts that are too close to those same hosts
-	set := hosts.NewSpacedSet(minHostDistance)
+	set := hosts.NewSpacedSet(minHostDistanceKm)
 
 	// determine whether the sector needs to be migrated. That's the case if
 	// one of the following is true:
@@ -208,8 +207,7 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 	// are sufficiently far apart
 	var candidates []hosts.Host
 	for _, contract := range goodContractMap {
-		if host, ok := hostsMap[contract.HostKey]; ok && set.CanAddHost(host) {
-			set.Add(host)
+		if host, ok := hostsMap[contract.HostKey]; ok && set.Add(host) {
 			candidates = append(candidates, host)
 		}
 	}

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -14,6 +14,7 @@ import (
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/chacha20"
@@ -46,7 +47,8 @@ func TestMigrateSlab(t *testing.T) {
 	h1 := newTestHost(types.PublicKey{1})
 	h2 := newTestHost(types.PublicKey{2})
 	h3 := newTestHost(types.PublicKey{3})
-	h3.Networks = h1.Networks // redundant CIDR
+	h3.Latitude = h1.Latitude   // same location as h1
+	h3.Longitude = h1.Longitude // same location as h1
 	h4 := newTestHost(types.PublicKey{4})
 	dialer := newMockDialer([]hosts.Host{h1, h2, h3, h4})
 
@@ -185,6 +187,8 @@ func TestSectorsToMigrate(t *testing.T) {
 			Blocked:   blocked,
 			PublicKey: types.PublicKey{i},
 			Settings:  goodSettings,
+			Latitude:  frand.Float64()*180 - 90,
+			Longitude: frand.Float64()*360 - 180,
 		}
 		if usable {
 			h.Usability = hosts.GoodUsability
@@ -217,10 +221,11 @@ func TestSectorsToMigrate(t *testing.T) {
 	// good host with bad contract
 	badContract := newContract(2, goodHost.PublicKey, false)
 
-	// good host with redundant CIDR
-	redundantCIDRHost := newHost(2, true, false, true)
-	redundantCIDRHost.Networks = goodHost.Networks
-	redundantCIDRContract := newContract(3, redundantCIDRHost.PublicKey, true)
+	// good host with identical location as the good host
+	sameLocationHost := newHost(2, true, false, true)
+	sameLocationHost.Latitude = goodHost.Latitude
+	sameLocationHost.Longitude = goodHost.Longitude
+	sameLocationContract := newContract(3, sameLocationHost.PublicKey, true)
 
 	// prepare a slab that has one good sector and multiple bad sectors for
 	// various reasons
@@ -247,8 +252,8 @@ func TestSectorsToMigrate(t *testing.T) {
 			// good contract with host on redundant CIDR -> don't migrate
 			{
 				Root:       types.Hash256{4},
-				ContractID: &redundantCIDRContract.ID,
-				HostKey:    &redundantCIDRContract.HostKey,
+				ContractID: &sameLocationContract.ID,
+				HostKey:    &sameLocationContract.HostKey,
 			},
 		},
 	}
@@ -256,7 +261,7 @@ func TestSectorsToMigrate(t *testing.T) {
 	// helper to assert result of contractsForRepair
 	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots, expectedHosts []int) {
 		t.Helper()
-		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 100, false)
+		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 100, geoip.Km(10))
 		if len(toRepair) != len(expectedRoots) {
 			t.Fatalf("expected %d roots to repair, got %d: %v", len(expectedRoots), len(toRepair), toRepair)
 		} else if len(toUse) != len(expectedHosts) {
@@ -284,8 +289,8 @@ func TestSectorsToMigrate(t *testing.T) {
 
 	// calling contractsForRepair with just the hosts and contracts the slab is stored on should
 	// return the missing sectors and no contracts
-	allHosts := []hosts.Host{goodHost, redundantCIDRHost}
-	allContracts := []contracts.Contract{goodContract, badContract, redundantCIDRContract}
+	allHosts := []hosts.Host{goodHost, sameLocationHost}
+	allContracts := []contracts.Contract{goodContract, badContract, sameLocationContract}
 	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
 
 	// prepare a bunch of hosts and contracts which can't be used for repairs
@@ -298,13 +303,14 @@ func TestSectorsToMigrate(t *testing.T) {
 	blockedHost := newHost(5, true, true, false)
 	cBlockedHost := newContract(6, blockedHost.PublicKey, true)
 
-	redundantCIDRHost2 := newHost(6, true, false, true)
-	redundantCIDRHost2.Networks = goodHost.Networks
-	cRedundantCIDRHost2 := newContract(7, redundantCIDRHost2.PublicKey, true)
+	sameLocationHost2 := newHost(6, true, false, true)
+	sameLocationHost2.Latitude = goodHost.Latitude
+	sameLocationHost2.Longitude = goodHost.Longitude
+	cSameLocationHost2 := newContract(7, sameLocationHost2.PublicKey, true)
 
 	// add the bad hosts+contracts and try again - expect same result
-	allHosts = append(allHosts, badHost2, hostWithoutNetworks, blockedHost, redundantCIDRHost2)
-	allContracts = append(allContracts, cBadHost2, cHostWithoutNetworks, cBlockedHost, cRedundantCIDRHost2)
+	allHosts = append(allHosts, badHost2, hostWithoutNetworks, blockedHost, sameLocationHost2)
+	allContracts = append(allContracts, cBadHost2, cHostWithoutNetworks, cBlockedHost, cSameLocationHost2)
 	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
 
 	// prepare 2 good hosts

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -14,7 +14,6 @@ import (
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/contracts"
-	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/chacha20"
@@ -261,7 +260,7 @@ func TestSectorsToMigrate(t *testing.T) {
 	// helper to assert result of contractsForRepair
 	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots, expectedHosts []int) {
 		t.Helper()
-		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 100, geoip.Km(10))
+		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 100, 10)
 		if len(toRepair) != len(expectedRoots) {
 			t.Fatalf("expected %d roots to repair, got %d: %v", len(expectedRoots), len(toRepair), toRepair)
 		} else if len(toUse) != len(expectedHosts) {

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -29,7 +29,7 @@ type (
 // uploadShards uploads the shards to the given hosts. If not all shards were
 // migrated, an error is returned but any finished shards will still be returned
 // and should be tracked in the database. The given shards must not be nil and
-// the given hosts must all be good and not have overlapping CIDRs.
+// the given hosts must all be good and be sufficiently spaced apart.
 func (m *SlabManager) uploadShards(ctx context.Context, slab Slab, shards [][]byte, uploadCandidates []hosts.Host, logger *zap.Logger) ([]Shard, error) {
 	uploaded := make([]Shard, 0, len(shards))
 

--- a/slabs/uploads_test.go
+++ b/slabs/uploads_test.go
@@ -144,11 +144,16 @@ func TestUploadShards(t *testing.T) {
 }
 
 func newTestHost(hk types.PublicKey) hosts.Host {
+	countries := []string{"US", "DE", "FR", "CN", "JP", "IN", "BR", "RU", "GB", "IT", "ES", "CA", "AU"}
 	return hosts.Host{
-		Networks:  []string{fmt.Sprintf("127.0.0.%d/24", hk[0])},
 		PublicKey: hk,
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,
+
+		CountryCode: countries[frand.Intn(len(countries))],
+		Latitude:    frand.Float64()*180 - 90,
+		Longitude:   frand.Float64()*360 - 180,
+		Networks:    []string{fmt.Sprintf("127.0.0.%d/24", hk[0])},
 	}
 }
 


### PR DESCRIPTION
This PR replaces our CIDR checks with a min. distance check using the host's location. I'm planning to F/U with a PR that gets rid of `host_resolved_cidrs` in the database. Note that I updated the geoip database to the latest version.

References https://github.com/SiaFoundation/indexd/issues/473