### PR TITLE
Remove `host_resolved_cidrs` table

### DIFF
--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -211,11 +211,11 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// set h1 to US
-	if err := indexer.Store().UpdateHost(context.Background(), h1.PublicKey, h1.Networks, h1.Settings, locationUS, true, h1.LastSuccessfulScan); err != nil {
+	if err := indexer.Store().UpdateHost(context.Background(), h1.PublicKey, h1.Settings, locationUS, true, h1.LastSuccessfulScan); err != nil {
 		t.Fatal(err)
 	}
 	// set h2 to AU
-	if err := indexer.Store().UpdateHost(context.Background(), h2.PublicKey, h2.Networks, h2.Settings, locationAU, true, h2.LastSuccessfulScan); err != nil {
+	if err := indexer.Store().UpdateHost(context.Background(), h2.PublicKey, h2.Settings, locationAU, true, h2.LastSuccessfulScan); err != nil {
 		t.Fatal(err)
 	}
 

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -28,7 +28,6 @@ func TestBroadcastContractRevisions(t *testing.T) {
 	store.hosts = map[types.PublicKey]hosts.Host{
 		hk: {
 			PublicKey: hk,
-			Networks:  []string{"127.0.0.1/24"},
 			Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host.com"}},
 			Settings:  goodSettings,
 			Usability: hosts.GoodUsability,

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -208,7 +208,6 @@ func TestPerformContractFormationWithoutContracts(t *testing.T) {
 			CountryCode: countries[frand.Intn(len(countries))],
 			Latitude:    frand.Float64()*180 - 90,
 			Longitude:   frand.Float64()*360 - 180,
-			Networks:    []string{fmt.Sprintf("127.0.0.%d/24", i)},
 			Addresses: []chain.NetAddress{
 				{
 					Protocol: siamux.Protocol,
@@ -366,7 +365,6 @@ func TestPerformContractFormationWithContracts(t *testing.T) {
 			CountryCode: countries[frand.Intn(len(countries))],
 			Latitude:    frand.Float64()*180 - 90,
 			Longitude:   frand.Float64()*360 - 180,
-			Networks:    []string{fmt.Sprintf("127.0.0.%d/24", i)},
 			Addresses: []chain.NetAddress{
 				{
 					Protocol: siamux.Protocol,

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -64,7 +64,7 @@ loop:
 func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host hosts.Host, hostLog *zap.Logger) error {
 	// check host is good
 	if !host.IsGood() {
-		return fmt.Errorf("host is bad: blocked=%t, usable=%t, networks=%d", host.Blocked, host.Usability.Usable(), len(host.Networks))
+		return fmt.Errorf("host is bad: blocked=%t, usable=%t", host.Blocked, host.Usability.Usable())
 	}
 
 	// dial the host

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -159,7 +159,6 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 	hk1 := types.PublicKey{1}
 	h1 := hosts.Host{
 		PublicKey: hk1,
-		Networks:  []string{"127.0.0.1/24"},
 		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host1.com"}},
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,
@@ -171,7 +170,6 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 	hk2 := types.PublicKey{2}
 	h2 := hosts.Host{
 		PublicKey: hk2,
-		Networks:  []string{"127.0.0.2/24"},
 		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host2.com"}},
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,

--- a/contracts/pruning_test.go
+++ b/contracts/pruning_test.go
@@ -140,7 +140,6 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 	hk1 := types.PublicKey{1}
 	h1 := hosts.Host{
 		PublicKey: hk1,
-		Networks:  []string{"127.0.0.1/24"},
 		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host1.com"}},
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,
@@ -153,7 +152,6 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 	hk2 := types.PublicKey{2}
 	h2 := hosts.Host{
 		PublicKey: hk2,
-		Networks:  []string{"127.0.0.2/24"},
 		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host2.com"}},
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,
@@ -176,7 +174,6 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 	hk4 := types.PublicKey{4}
 	h4 := hosts.Host{
 		PublicKey: hk4,
-		Networks:  []string{"127.0.0.2/24"},
 		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host4.com"}},
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,
@@ -187,7 +184,6 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 	hk5 := types.PublicKey{5}
 	h5 := hosts.Host{
 		PublicKey: hk5,
-		Networks:  []string{"127.0.0.1/24"},
 		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host5.com"}},
 		Settings:  goodSettings,
 		Usability: hosts.GoodUsability,

--- a/contracts/refresh_test.go
+++ b/contracts/refresh_test.go
@@ -65,7 +65,6 @@ func TestPerformContractRefreshes(t *testing.T) {
 			PublicKey: types.PublicKey{byte(i)},
 			Settings:  goodSettings,
 			Usability: hosts.GoodUsability,
-			Networks:  []string{""},
 		}
 	}
 

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -57,7 +57,6 @@ func TestPerformContractRenewals(t *testing.T) {
 			PublicKey: types.PublicKey{byte(i)},
 			Settings:  badSettings, // will be updated by scan to good settings
 			Usability: hosts.GoodUsability,
-			Networks:  []string{""},
 		}
 	}
 

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -21,10 +21,6 @@ var (
 	// ErrNotFound is returned by database operations that fail due to a host
 	// not being found.
 	ErrNotFound = errors.New("host not found")
-
-	// ErrNoNetworks is returned when a host has no networks even though it
-	// should.
-	ErrNoNetworks = errors.New("host has no networks")
 )
 var (
 	// DefaultHostsQueryOpts re the default options applied when querying hosts. By
@@ -92,7 +88,6 @@ type (
 		ConsecutiveFailedScans int                 `json:"consecutiveFailedScans"`
 		RecentUptime           float64             `json:"recentUptime"`
 		Addresses              []chain.NetAddress  `json:"addresses"`
-		Networks               []string            `json:"networks"`
 		CountryCode            string              `json:"countryCode"`
 		Latitude               float64             `json:"latitude"`
 		Longitude              float64             `json:"longitude"`
@@ -167,7 +162,7 @@ type (
 
 // IsGood returns true if the host is considered good for storing data.
 func (h *Host) IsGood() bool {
-	return h.Usability.Usable() && !h.Blocked && len(h.Networks) > 0
+	return h.Usability.Usable() && !h.Blocked
 }
 
 // Location returns the geoip.Location of the host.

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -24,9 +24,6 @@ import (
 const (
 	announcementMaxAddressesPerProtocol = 2
 
-	ipv4FilterRange = 24
-	ipv6FilterRange = 32
-
 	pruneFrequency                  = time.Hour * 24
 	pruneMinConsecutiveScanFailures = 10
 	pruneMinDowntime                = time.Hour * 24 * 365 // 1 year
@@ -98,7 +95,7 @@ type (
 		UnblockHost(ctx context.Context, hk types.PublicKey) error
 
 		PruneHosts(ctx context.Context, lastSuccessfulScanCutoff time.Time, minConsecutiveFailedScans int) (int64, error)
-		UpdateHost(ctx context.Context, hk types.PublicKey, networks []string, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error
+		UpdateHost(ctx context.Context, hk types.PublicKey, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error
 
 		UsabilitySettings(ctx context.Context) (UsabilitySettings, error)
 		UpdateUsabilitySettings(ctx context.Context, us UsabilitySettings) error
@@ -275,7 +272,7 @@ func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, f
 	if err != nil {
 		return fmt.Errorf("failed to get host, %w", err)
 	} else if !host.IsGood() {
-		return fmt.Errorf("%w: blocked=%t, usable=%t, networks=%d", ErrBadHost, host.Blocked, host.Usability.Usable(), len(host.Networks))
+		return fmt.Errorf("%w: blocked=%t, usable=%t", ErrBadHost, host.Blocked, host.Usability.Usable())
 	}
 
 	// optimistically call the function if the prices are still valid for a
@@ -295,7 +292,7 @@ func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, f
 	if err != nil {
 		return fmt.Errorf("failed to scan host, %w", err)
 	} else if !host.IsGood() {
-		return fmt.Errorf("%w: blocked=%t, usable=%t, networks=%d", ErrBadHost, host.Blocked, host.Usability.Usable(), len(host.Networks))
+		return fmt.Errorf("%w: blocked=%t, usable=%t", ErrBadHost, host.Blocked, host.Usability.Usable())
 	}
 
 	// try again
@@ -315,7 +312,7 @@ func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (Host, e
 		return Host{}, fmt.Errorf("failed to get host, %w", err)
 	}
 
-	addrs, networks, loc, err := resolveHost(ctx, m.resolver, m.locator, host.Addresses, logger)
+	addrs, loc, err := resolveHost(ctx, m.resolver, m.locator, host.Addresses, logger)
 	if err != nil {
 		return Host{}, fmt.Errorf("failed to resolve host, %w", err)
 	}
@@ -348,7 +345,7 @@ func (m *HostManager) ScanHost(ctx context.Context, hk types.PublicKey) (Host, e
 	updateCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	err = m.store.UpdateHost(updateCtx, hk, networks, settings, loc, success, nextScan)
+	err = m.store.UpdateHost(updateCtx, hk, settings, loc, success, nextScan)
 	if err != nil {
 		return Host{}, fmt.Errorf("failed to update host, %w", err)
 	}
@@ -537,9 +534,8 @@ func calculateNextScanTime(lastScan time.Time, success bool, consecScanFailures 
 // and/or private addresses, and a list of networks in CIDR notation. The only
 // error this function returns is [context.Canceled], other errors that occur
 // during the resolving and parsing are debug logged but otherwise ignored.
-func resolveHost(ctx context.Context, resolver Resolver, locator Locator, addresses []chain.NetAddress, log *zap.Logger) ([]chain.NetAddress, []string, geoip.Location, error) {
+func resolveHost(ctx context.Context, resolver Resolver, locator Locator, addresses []chain.NetAddress, log *zap.Logger) ([]chain.NetAddress, geoip.Location, error) {
 	var filtered []chain.NetAddress
-	var networks []string
 	var loc geoip.Location
 	for _, na := range addresses {
 		host, _, err := net.SplitHostPort(na.Address)
@@ -550,9 +546,12 @@ func resolveHost(ctx context.Context, resolver Resolver, locator Locator, addres
 
 		ips, err := resolver.LookupIPAddr(ctx, host)
 		if errors.Is(err, context.Canceled) {
-			return nil, nil, geoip.Location{}, err
+			return nil, geoip.Location{}, err
 		} else if err != nil {
 			log.Debug("failed to resolve host", zap.String("host", host), zap.Error(err))
+			continue
+		} else if len(ips) == 0 {
+			log.Debug("no IPs found for host", zap.String("host", host))
 			continue
 		}
 
@@ -568,37 +567,17 @@ func resolveHost(ctx context.Context, resolver Resolver, locator Locator, addres
 			continue
 		}
 
-		var ipnets []net.IPNet
-		for _, ip := range ips {
-			ipRange := ipv6FilterRange
-			if ip.IP.To4() != nil {
-				ipRange = ipv4FilterRange
-			}
-
-			cidr := fmt.Sprintf("%s/%d", ip.IP.String(), ipRange)
-			_, ipnet, err := net.ParseCIDR(cidr)
-			if err != nil {
-				log.Debug("failed to parse CIDR", zap.String("CIDR", cidr), zap.Error(err))
-				continue
-			}
-			ipnets = append(ipnets, *ipnet)
-		}
-
-		if len(ipnets) > 0 {
-			for _, ipnet := range ipnets {
-				networks = append(networks, ipnet.String())
-			}
-			filtered = append(filtered, na)
-		}
-
-		if len(ips) > 0 && loc.CountryCode == "" {
+		if loc.CountryCode == "" {
 			loc, err = locator.Locate(ips[0].IP)
 			if err != nil {
 				log.Debug("failed to locate IP address", zap.Error(err))
 			}
 		}
+
+		filtered = append(filtered, na)
 	}
-	return filtered, networks, loc, nil
+
+	return filtered, loc, nil
 }
 
 func isPrivateIP(ip net.IP) bool {

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -64,7 +64,7 @@ func (s *mockStore) PruneHosts(ctx context.Context, lastSuccessfulScanCutoff tim
 	return 0, nil
 }
 
-func (s *mockStore) UpdateHost(ctx context.Context, hk types.PublicKey, networks []string, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error {
+func (s *mockStore) UpdateHost(ctx context.Context, hk types.PublicKey, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -364,13 +364,13 @@ func TestResolveHost(t *testing.T) {
 	locator := &mockLocator{}
 
 	// assert [context.Cancelled] is returned when context is cancelled
-	_, _, _, err := resolveHost(cancelledCtx, r, locator, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
+	_, _, err := resolveHost(cancelledCtx, r, locator, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
 
 	// assert incorrect addresses are filtered out
-	addrs, _, _, err := resolveHost(context.Background(), r, locator, []chain.NetAddress{testMuxAddr("h1.com")}, zap.NewNop())
+	addrs, _, err := resolveHost(context.Background(), r, locator, []chain.NetAddress{testMuxAddr("h1.com")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 0 {
@@ -378,21 +378,19 @@ func TestResolveHost(t *testing.T) {
 	}
 
 	// assert net addresses with private IPs are filtered out
-	addrs, _, _, err = resolveHost(context.Background(), r, locator, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
+	addrs, _, err = resolveHost(context.Background(), r, locator, []chain.NetAddress{testMuxAddr("h1.com:1234")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 0 {
 		t.Fatal("unexpected", len(addrs))
 	}
 
-	// assert net addresses get resolved and networks are returned
-	addrs, networks, loc, err := resolveHost(context.Background(), r, locator, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
+	// assert net addresses get resolved
+	addrs, loc, err := resolveHost(context.Background(), r, locator, []chain.NetAddress{testMuxAddr("h2.com:1234")}, zap.NewNop())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(addrs) != 1 {
 		t.Fatal("unexpected", len(addrs))
-	} else if len(networks) != 1 {
-		t.Fatal("unexpected", len(networks))
 	} else if loc != mockLocation {
 		t.Fatalf("expected location %v, got %v", mockLocation, loc)
 	}

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -569,10 +569,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/NetAddress"
-        networks:
-          type: array
-          items:
-            $ref: "#/components/schemas/IPNet"
         settings:
           $ref: "#/components/schemas/HostSettings"
         usability:

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -106,12 +105,8 @@ FROM hosts CROSS JOIN globals;`, sqlPublicKey(hk)))
 			return fmt.Errorf("host %q: %w", hk, hosts.ErrNotFound)
 		} else if err != nil {
 			return fmt.Errorf("failed to query host: %w", err)
-		}
-
-		if err := decorateHostAddresses(ctx, tx, &dbHost); err != nil {
+		} else if err := decorateHostAddresses(ctx, tx, &dbHost); err != nil {
 			return fmt.Errorf("failed to decorate host addresses: %w", err)
-		} else if err := decorateHostNetworks(ctx, tx, &dbHost); err != nil {
-			return fmt.Errorf("failed to decorate host networks: %w", err)
 		}
 
 		host = dbHost.Host
@@ -221,12 +216,8 @@ WHERE
 			return err
 		} else if len(dbHosts) == 0 {
 			return nil
-		}
-
-		if err := decorateHostAddresses(ctx, tx, dbHosts...); err != nil {
+		} else if err := decorateHostAddresses(ctx, tx, dbHosts...); err != nil {
 			return fmt.Errorf("failed to decorate host addresses: %w", err)
-		} else if err := decorateHostNetworks(ctx, tx, dbHosts...); err != nil {
-			return fmt.Errorf("failed to decorate host networks: %w", err)
 		}
 
 		for _, h := range dbHosts {
@@ -398,10 +389,7 @@ func (s *Store) PruneHosts(ctx context.Context, minLastSuccessfulScan time.Time,
 }
 
 // UpdateHost updates a host in the database, the given parameters are the result of scanning the host.
-func (s *Store) UpdateHost(ctx context.Context, hk types.PublicKey, networks []string, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error {
-	if len(networks) == 0 && scanSucceeded {
-		return hosts.ErrNoNetworks
-	}
+func (s *Store) UpdateHost(ctx context.Context, hk types.PublicKey, hs proto4.HostSettings, loc geoip.Location, scanSucceeded bool, nextScan time.Time) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		if !scanSucceeded {
 			if res, err := tx.Exec(ctx, `
@@ -519,26 +507,6 @@ WHERE hosts.id = computed.id RETURNING hosts.id`,
 		} else if hostID == 0 {
 			return errors.New("failed to return host id after successful update") // sanity check
 		}
-
-		if scanSucceeded {
-			_, err = tx.Exec(ctx, `DELETE FROM host_resolved_cidrs WHERE host_id = $1`, hostID)
-			if err != nil {
-				return err
-			}
-
-			for _, cidr := range networks {
-				_, ipnet, err := net.ParseCIDR(cidr)
-				if err != nil {
-					return fmt.Errorf("failed to parse CIDR: %w", err)
-				}
-
-				_, err = tx.Exec(ctx, `INSERT INTO host_resolved_cidrs (host_id, cidr) VALUES ($1, $2)`, hostID, ipnet)
-				if err != nil {
-					return fmt.Errorf("failed to insert host resolved CIDR: %w", err)
-				}
-			}
-		}
-
 		return nil
 	})
 }
@@ -705,32 +673,6 @@ func decorateHostAddresses(ctx context.Context, tx *txn, hosts ...*dbHost) error
 			return fmt.Errorf("failed to scan host address: %w", err)
 		}
 		hosts[idToIdx[hostID]].Addresses = append(hosts[idToIdx[hostID]].Addresses, na)
-	}
-
-	return rows.Err()
-}
-
-func decorateHostNetworks(ctx context.Context, tx *txn, hosts ...*dbHost) error {
-	hostIDs := make([]int64, 0, len(hosts))
-	idToIdx := make(map[int64]int64, len(hosts))
-	for i := range hosts {
-		idToIdx[hosts[i].id] = int64(i)
-		hostIDs = append(hostIDs, hosts[i].id)
-	}
-
-	rows, err := tx.Query(ctx, `SELECT host_id, cidr FROM host_resolved_cidrs WHERE host_id = ANY($1)`, hostIDs)
-	if err != nil {
-		return fmt.Errorf("failed to query host networks: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var hostID int64
-		var cidr net.IPNet
-		if err := rows.Scan(&hostID, &cidr); err != nil {
-			return fmt.Errorf("failed to scan host network: %w", err)
-		}
-		hosts[idToIdx[hostID]].Networks = append(hosts[idToIdx[hostID]].Networks, cidr.String())
 	}
 
 	return rows.Err()

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -27,8 +27,6 @@ import (
 	"lukechampine.com/frand"
 )
 
-var testNetworks = []string{"1.2.3.4/32"}
-
 func TestAddHostAnnouncement(t *testing.T) {
 	// create database
 	log := zaptest.NewLogger(t)
@@ -105,21 +103,18 @@ func TestHost(t *testing.T) {
 	db.addTestHost(t, hk)
 
 	// update the host
-	networks := []string{"1.2.3.4/32"}
-	err = db.UpdateHost(context.Background(), hk, networks, hs, geoip.Location{}, true, time.Now())
+	err = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// assert host is found and address, networks and settings are populated
+	// assert host is found and addresses and settings are populated
 	if h, err := db.Host(context.Background(), hk); err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(h.Settings, hs) {
 		t.Fatal("expected settings to match", h.Settings)
 	} else if len(h.Addresses) != 1 {
 		t.Fatal("unexpected", len(h.Addresses))
-	} else if len(h.Networks) != 1 {
-		t.Fatal("unexpected networks", h.Networks)
 	} else if h.LostSectors != 0 {
 		t.Fatal("expected lost sectors to be 0, got", h.LostSectors)
 	}
@@ -222,7 +217,7 @@ func TestHostChecks(t *testing.T) {
 	}
 
 	// update host with settings that fail all checks
-	err := db.UpdateHost(context.Background(), hk, testNetworks, proto4.HostSettings{
+	err := db.UpdateHost(context.Background(), hk, proto4.HostSettings{
 		Release:             "test",
 		ProtocolVersion:     proto4.ProtocolVersion{0, 0, 0},
 		AcceptingContracts:  false,
@@ -247,7 +242,7 @@ func TestHostChecks(t *testing.T) {
 	}
 
 	// fail scan to ensure we fail on uptime
-	err = db.UpdateHost(context.Background(), hk, nil, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
+	err = db.UpdateHost(context.Background(), hk, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,58 +269,58 @@ func TestHostChecks(t *testing.T) {
 
 	// adjust max duration so we pass the check
 	hs.MaxContractDuration = settingPeriod
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("MaxContractDuration")
 
 	// adjust max collateral so we pass the check
 	hs.MaxCollateral = hs.Prices.Collateral.Mul64(oneTB).Mul64(settingPeriod)
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("MaxCollateral")
 
 	// adjust protocol to pass the check
 	hs.ProtocolVersion = rhp.ProtocolVersion400
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("ProtocolVersion")
 
 	// adjust price validity so we pass the check
 	hs.Prices.ValidUntil = time.Now().Add(time.Second * 1801)
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("PriceValidity")
 
 	// adjust accepting contracts so we pass the check
 	hs.AcceptingContracts = true
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("AcceptingContracts")
 
 	// adjust contract price so we pass the check
 	hs.Prices.ContractPrice = oneSC.Sub(oneH)
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("ContractPrice")
 
 	// adjust collateral so we pass the check
 	hs.Prices.Collateral = hs.Prices.StoragePrice.Mul64(2)
 	hs.MaxCollateral = hs.Prices.Collateral.Mul64(oneTB).Mul64(settingPeriod)
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("Collateral")
 
 	// adjust storage price so we pass the check
 	hs.Prices.StoragePrice = settingMaxStoragePrice
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("StoragePrice")
 
 	// adjust egress price so we pass the check
 	hs.Prices.EgressPrice = settingMaxEgressPrice
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("EgressPrice")
 
 	// adjust ingress price so we pass the check
 	hs.Prices.IngressPrice = settingMaxIngressPrice
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("IngressPrice")
 
 	// adjust free sector price so we pass the check
 	hs.Prices.FreeSectorPrice = oneSC.Div64(sectorsPerTB)
-	_ = db.UpdateHost(context.Background(), hk, testNetworks, hs, geoip.Location{}, true, time.Now())
+	_ = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, time.Now())
 	assertCheckOK("FreeSectorPrice")
 
 	// assert host is usable
@@ -405,11 +400,11 @@ func TestHosts(t *testing.T) {
 		if !usable {
 			settings.AcceptingContracts = false
 		}
-		err := db.UpdateHost(context.Background(), hk, []string{"127.0.0.1/24"}, settings, geoip.Location{}, false, time.Now().Add(time.Hour))
+		err := db.UpdateHost(context.Background(), hk, settings, geoip.Location{}, false, time.Now().Add(time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = db.UpdateHost(context.Background(), hk, []string{"127.0.0.1/24"}, settings, geoip.Location{}, true, time.Now().Add(time.Hour))
+		err = db.UpdateHost(context.Background(), hk, settings, geoip.Location{}, true, time.Now().Add(time.Hour))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -460,8 +455,6 @@ func TestHosts(t *testing.T) {
 				t.Fatal("host should have uptime")
 			} else if host.Addresses == nil {
 				t.Fatal("host should have an address")
-			} else if host.Networks == nil {
-				t.Fatal("host should have a network")
 			}
 
 			blocked := false
@@ -576,7 +569,7 @@ func TestUsableHosts(t *testing.T) {
 		if !usable {
 			settings.AcceptingContracts = false
 		}
-		if err := db.UpdateHost(context.Background(), hk, []string{"127.0.0.1/24"}, settings, loc, true, time.Now().Add(time.Hour)); err != nil {
+		if err := db.UpdateHost(context.Background(), hk, settings, loc, true, time.Now().Add(time.Hour)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -769,7 +762,7 @@ func TestHostsForScanning(t *testing.T) {
 
 	// simulate scanning h1 successfully
 	nextScan := time.Now().Round(time.Microsecond).Add(time.Minute)
-	err = db.UpdateHost(context.Background(), hk1, testNetworks, proto4.HostSettings{}, geoip.Location{}, true, nextScan)
+	err = db.UpdateHost(context.Background(), hk1, proto4.HostSettings{}, geoip.Location{}, true, nextScan)
 	if err != nil {
 		t.Fatal("unexpected", err)
 	}
@@ -785,7 +778,7 @@ func TestHostsForScanning(t *testing.T) {
 	}
 
 	// simulate scanning h2 successfully
-	err = db.UpdateHost(context.Background(), hk2, testNetworks, proto4.HostSettings{}, geoip.Location{}, true, nextScan)
+	err = db.UpdateHost(context.Background(), hk2, proto4.HostSettings{}, geoip.Location{}, true, nextScan)
 	if err != nil {
 		t.Fatal("unexpected", err)
 	}
@@ -971,14 +964,14 @@ func TestHostsRecentUptime(t *testing.T) {
 		if up {
 			for range n {
 				_, err1 := db.pool.Exec(context.Background(), `UPDATE hosts SET last_failed_scan = '0001-01-01 00:00:00+00'::timestamptz, last_successful_scan = NOW() - INTERVAL '24 hours'`)
-				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, testNetworks, newTestHostSettings(hk), geoip.Location{}, true, time.Time{})); err != nil {
+				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, newTestHostSettings(hk), geoip.Location{}, true, time.Time{})); err != nil {
 					t.Fatal(err)
 				}
 			}
 		} else {
 			for range n {
 				_, err1 := db.pool.Exec(context.Background(), `UPDATE hosts SET last_successful_scan = '0001-01-01 00:00:00+00'::timestamptz, last_failed_scan = NOW() - INTERVAL '24 hours'`)
-				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, testNetworks, proto4.HostSettings{}, geoip.Location{}, false, time.Time{})); err != nil {
+				if err := errors.Join(err1, db.UpdateHost(context.Background(), hk, proto4.HostSettings{}, geoip.Location{}, false, time.Time{})); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -1082,7 +1075,7 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// simulate failed scan for h1
-	err = db.UpdateHost(context.Background(), h1, nil, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
+	err = db.UpdateHost(context.Background(), h1, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
 	if err != nil {
 		t.Fatal("unexpected", err)
 	}
@@ -1098,7 +1091,7 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// simulate failed scan for h2
-	err = db.UpdateHost(context.Background(), h2, nil, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
+	err = db.UpdateHost(context.Background(), h2, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
 	if err != nil {
 		t.Fatal("unexpected", err)
 	}
@@ -1115,10 +1108,10 @@ func TestPruneHosts(t *testing.T) {
 	h1 = db.addTestHost(t)
 	h2 = db.addTestHost(t)
 	err = errors.Join(
-		db.UpdateHost(context.Background(), h1, testNetworks, proto4.HostSettings{}, geoip.Location{}, true, time.Now()),
-		db.UpdateHost(context.Background(), h1, testNetworks, proto4.HostSettings{}, geoip.Location{}, false, time.Now()),
-		db.UpdateHost(context.Background(), h2, testNetworks, proto4.HostSettings{}, geoip.Location{}, true, time.Now()),
-		db.UpdateHost(context.Background(), h2, testNetworks, proto4.HostSettings{}, geoip.Location{}, false, time.Now()),
+		db.UpdateHost(context.Background(), h1, proto4.HostSettings{}, geoip.Location{}, true, time.Now()),
+		db.UpdateHost(context.Background(), h1, proto4.HostSettings{}, geoip.Location{}, false, time.Now()),
+		db.UpdateHost(context.Background(), h2, proto4.HostSettings{}, geoip.Location{}, true, time.Now()),
+		db.UpdateHost(context.Background(), h2, proto4.HostSettings{}, geoip.Location{}, false, time.Now()),
 	)
 	if err != nil {
 		t.Fatal("unexpected", err)
@@ -1166,7 +1159,7 @@ func TestUpdateHost(t *testing.T) {
 
 	// assert [hosts.ErrNotFound] is returned
 	hk := types.GeneratePrivateKey().PublicKey()
-	err := db.UpdateHost(context.Background(), hk, nil, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
+	err := db.UpdateHost(context.Background(), hk, proto4.HostSettings{}, geoip.Location{}, false, time.Now())
 	if !errors.Is(err, hosts.ErrNotFound) {
 		t.Fatal("expected [hosts.ErrNotFound], got", err)
 	}
@@ -1176,7 +1169,7 @@ func TestUpdateHost(t *testing.T) {
 
 	// assert host settings are not inserted if the scan failed
 	hs := newTestHostSettings(hk)
-	err = db.UpdateHost(context.Background(), hk, nil, hs, geoip.Location{}, false, time.Now())
+	err = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, false, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	} else if h, err := db.Host(context.Background(), hk); err != nil {
@@ -1190,7 +1183,7 @@ func TestUpdateHost(t *testing.T) {
 	}
 
 	// assert consecutive failed scans are incremented
-	err = db.UpdateHost(context.Background(), hk, nil, hs, geoip.Location{}, false, time.Now())
+	err = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, false, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	} else if h, err := db.Host(context.Background(), hk); err != nil {
@@ -1201,7 +1194,6 @@ func TestUpdateHost(t *testing.T) {
 
 	now := time.Now().Round(time.Minute)
 	nextScan := now.Add(time.Hour)
-	networks := []string{"1.2.3.4/32"}
 
 	location := geoip.Location{
 		CountryCode: "US",
@@ -1209,7 +1201,7 @@ func TestUpdateHost(t *testing.T) {
 		Longitude:   -20,
 	}
 	// assert host is properly updated on successful scan
-	err = db.UpdateHost(context.Background(), hk, networks, hs, location, true, nextScan)
+	err = db.UpdateHost(context.Background(), hk, hs, location, true, nextScan)
 	if err != nil {
 		t.Fatal(err)
 	} else if h, err := db.Host(context.Background(), hk); err != nil {
@@ -1224,10 +1216,6 @@ func TestUpdateHost(t *testing.T) {
 		t.Fatal("unexpected next scan", h.NextScan)
 	} else if h.RecentUptime == 0.895 {
 		t.Fatal("expected recent uptime to be updated")
-	} else if len(h.Networks) != 1 {
-		t.Fatal("unexpected networks", h.Networks)
-	} else if h.Networks[0] != networks[0] {
-		t.Fatal("unexpected network", h.Networks)
 	} else if h.CountryCode != location.CountryCode {
 		t.Fatal("unexpected country code", h.CountryCode)
 	} else if h.Latitude != location.Latitude {
@@ -1236,36 +1224,13 @@ func TestUpdateHost(t *testing.T) {
 		t.Fatal("unexpected Longitude", h.Longitude)
 	}
 
-	// assert networks are overwritten
-	networks = []string{"4.3.2.1/32"}
-	err = db.UpdateHost(context.Background(), hk, networks, hs, location, true, nextScan)
+	// assert updating with a failed scan doesn't affect the host's location or
+	// country code
+	err = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, false, nextScan)
 	if err != nil {
 		t.Fatal(err)
 	} else if h, err := db.Host(context.Background(), hk); err != nil {
 		t.Fatal(err)
-	} else if len(h.Networks) != 1 {
-		t.Fatal("unexpected networks", h.Networks)
-	} else if h.Networks[0] != networks[0] {
-		t.Fatal("unexpected network", h.Networks)
-	}
-
-	// assert successful scan needs networks
-	err = db.UpdateHost(context.Background(), hk, nil, hs, location, true, nextScan)
-	if !errors.Is(err, hosts.ErrNoNetworks) {
-		t.Fatalf("expected hosts.ErrNoNetworks, got %v", err)
-	}
-
-	// assert updating with a failed scan doesn't affect the host's networks
-	// or geolocation
-	err = db.UpdateHost(context.Background(), hk, []string{"9.9.9.9"}, hs, geoip.Location{}, false, nextScan)
-	if err != nil {
-		t.Fatal(err)
-	} else if h, err := db.Host(context.Background(), hk); err != nil {
-		t.Fatal(err)
-	} else if len(h.Networks) != 1 {
-		t.Fatal("unexpected networks", h.Networks)
-	} else if h.Networks[0] != networks[0] {
-		t.Fatal("unexpected network", h.Networks)
 	} else if h.CountryCode != location.CountryCode {
 		t.Fatal("unexpected country code", h.CountryCode)
 	} else if h.Latitude != location.Latitude {
@@ -1274,15 +1239,13 @@ func TestUpdateHost(t *testing.T) {
 		t.Fatal("unexpected Longitude", h.Longitude)
 	}
 
-	// assert updating with an empty location doesn't affect the host's
-	// geolocation
-	err = db.UpdateHost(context.Background(), hk, networks, hs, geoip.Location{}, true, nextScan)
+	// assert updating with a null location doesn't affect the host's location
+	// or country code
+	err = db.UpdateHost(context.Background(), hk, hs, geoip.Location{}, true, nextScan)
 	if err != nil {
 		t.Fatal(err)
 	} else if h, err := db.Host(context.Background(), hk); err != nil {
 		t.Fatal(err)
-	} else if len(h.Networks) != 1 {
-		t.Fatal("unexpected networks", h.Networks)
 	} else if h.CountryCode != location.CountryCode {
 		t.Fatal("unexpected country code", h.CountryCode)
 	} else if h.Latitude != location.Latitude {
@@ -1307,12 +1270,6 @@ func BenchmarkHosts(b *testing.B) {
 		numBlocklist = 1000
 	)
 
-	// prepare test variables
-	networks := []string{
-		"1.2.3.4/32",
-		"2.3.4.5/32",
-	}
-
 	// prepare database
 	hosts := make([]types.PublicKey, numHosts)
 	store := initPostgres(b, zap.NewNop())
@@ -1330,11 +1287,6 @@ func BenchmarkHosts(b *testing.B) {
 			_, err = tx.Exec(ctx, `INSERT INTO host_addresses (host_id, net_address, protocol) VALUES ($1, $2, $3)`, hostID, na.Address, sqlNetworkProtocol(na.Protocol))
 			if err != nil {
 				return fmt.Errorf("failed to insert host address: %w", err)
-			}
-
-			_, err = tx.Exec(ctx, `INSERT INTO host_resolved_cidrs (host_id, cidr) VALUES ($1, $2), ($1, $3)`, hostID, networks[0], networks[1])
-			if err != nil {
-				return err
 			}
 		}
 
@@ -1402,7 +1354,7 @@ func BenchmarkHosts(b *testing.B) {
 		for b.Loop() {
 			hk := hosts[i%numHosts]
 			succeeded := frand.Intn(2) == 0
-			err := store.UpdateHost(context.Background(), hk, networks, hs, geoip.Location{}, succeeded, ts)
+			err := store.UpdateHost(context.Background(), hk, hs, geoip.Location{}, succeeded, ts)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -1543,13 +1495,6 @@ func BenchmarkUsableHosts(b *testing.B) {
 				INSERT INTO host_addresses (host_id, net_address, protocol) 
 				VALUES ($1, $2, $3)`, hostID, "foo.com", sqlNetworkProtocol(randomProtocol())); err != nil {
 				return fmt.Errorf("failed to insert host address: %w", err)
-			}
-
-			// add CIDRs
-			if _, err := tx.Exec(ctx, `
-				INSERT INTO host_resolved_cidrs (host_id, cidr) 
-				VALUES ($1, $2), ($1, $3)`, hostID, "1.2.3.4/32", "2.3.4.5/32"); err != nil {
-				return err
 			}
 
 			// add contract

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -99,13 +99,6 @@ CREATE TABLE host_addresses (
 );
 CREATE INDEX host_addresses_host_id_idx ON host_addresses (host_id);
 
-CREATE TABLE host_resolved_cidrs (
-    id SERIAL PRIMARY KEY,
-    host_id INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
-    cidr CIDR NOT NULL
-);
-CREATE INDEX host_resolved_cidrs_host_id_idx ON host_resolved_cidrs (host_id);
-
 CREATE TABLE syncer_peers (
     ip_address INET NOT NULL,
     port INTEGER NOT NULL CHECK (port BETWEEN 1 AND 65535),

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -237,4 +237,9 @@ CREATE INDEX object_slabs_object_id_slab_index_idx ON object_slabs(object_id, sl
 		}
 		return nil
 	},
+	// drop host_resolved_cidrs table
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `DROP TABLE IF EXISTS host_resolved_cidrs;`)
+		return err
+	},
 }

--- a/persist/postgres/migrations_test.go
+++ b/persist/postgres/migrations_test.go
@@ -85,13 +85,6 @@ CREATE TABLE host_addresses (
 );
 CREATE INDEX host_addresses_host_id_idx ON host_addresses (host_id);
 
-CREATE TABLE host_resolved_cidrs (
-    id SERIAL PRIMARY KEY,
-    host_id INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
-    cidr CIDR NOT NULL
-);
-CREATE INDEX host_resolved_cidrs_host_id_idx ON host_resolved_cidrs (host_id);
-
 CREATE TABLE syncer_peers (
     ip_address INET NOT NULL,
     port INTEGER NOT NULL CHECK (port BETWEEN 1 AND 65535),

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -20,7 +20,6 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 	// prepare host
 	hk := types.PublicKey{1}
 	host := hosts.Host{
-		Networks:  []string{"1.1.1.1"},
 		PublicKey: hk,
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{
@@ -112,7 +111,6 @@ func TestPerformIntegrityChecksForHostExpiredPrices(t *testing.T) {
 	// prepare host
 	hk := types.PublicKey{1}
 	host := hosts.Host{
-		Networks:  []string{"1.1.1.1"},
 		PublicKey: hk,
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -3,7 +3,6 @@ package slabs
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -181,7 +180,7 @@ func TestMigrateSlab(t *testing.T) {
 }
 
 func TestSectorsToMigrate(t *testing.T) {
-	newHost := func(i byte, usable, blocked, networks bool) hosts.Host {
+	newHost := func(i byte, usable, blocked bool) hosts.Host {
 		h := hosts.Host{
 			Blocked:   blocked,
 			PublicKey: types.PublicKey{i},
@@ -191,9 +190,6 @@ func TestSectorsToMigrate(t *testing.T) {
 		}
 		if usable {
 			h.Usability = hosts.GoodUsability
-		}
-		if networks {
-			h.Networks = []string{fmt.Sprintf("1.1.1.%d/24", i)}
 		}
 		return h
 	}
@@ -214,14 +210,14 @@ func TestSectorsToMigrate(t *testing.T) {
 	}
 
 	// good host with good contract
-	goodHost := newHost(1, true, false, true)
+	goodHost := newHost(1, true, false)
 	goodContract := newContract(1, goodHost.PublicKey, true)
 
 	// good host with bad contract
 	badContract := newContract(2, goodHost.PublicKey, false)
 
 	// good host with identical location as the good host
-	sameLocationHost := newHost(2, true, false, true)
+	sameLocationHost := newHost(2, true, false)
 	sameLocationHost.Latitude = goodHost.Latitude
 	sameLocationHost.Longitude = goodHost.Longitude
 	sameLocationContract := newContract(3, sameLocationHost.PublicKey, true)
@@ -248,7 +244,7 @@ func TestSectorsToMigrate(t *testing.T) {
 				ContractID: &badContract.ID,
 				HostKey:    &badContract.HostKey,
 			},
-			// good contract with host on redundant CIDR -> don't migrate
+			// good contract with host on same location -> don't migrate
 			{
 				Root:       types.Hash256{4},
 				ContractID: &sameLocationContract.ID,
@@ -293,36 +289,33 @@ func TestSectorsToMigrate(t *testing.T) {
 	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
 
 	// prepare a bunch of hosts and contracts which can't be used for repairs
-	badHost2 := newHost(3, false, false, true)
+	badHost2 := newHost(3, false, false)
 	cBadHost2 := newContract(4, badHost2.PublicKey, true)
 
-	hostWithoutNetworks := newHost(4, true, false, false)
-	cHostWithoutNetworks := newContract(5, hostWithoutNetworks.PublicKey, true)
+	blockedHost := newHost(4, true, true)
+	cBlockedHost := newContract(5, blockedHost.PublicKey, true)
 
-	blockedHost := newHost(5, true, true, false)
-	cBlockedHost := newContract(6, blockedHost.PublicKey, true)
-
-	sameLocationHost2 := newHost(6, true, false, true)
+	sameLocationHost2 := newHost(5, true, false)
 	sameLocationHost2.Latitude = goodHost.Latitude
 	sameLocationHost2.Longitude = goodHost.Longitude
-	cSameLocationHost2 := newContract(7, sameLocationHost2.PublicKey, true)
+	cSameLocationHost2 := newContract(6, sameLocationHost2.PublicKey, true)
 
 	// add the bad hosts+contracts and try again - expect same result
-	allHosts = append(allHosts, badHost2, hostWithoutNetworks, blockedHost, sameLocationHost2)
-	allContracts = append(allContracts, cBadHost2, cHostWithoutNetworks, cBlockedHost, cSameLocationHost2)
+	allHosts = append(allHosts, badHost2, blockedHost, sameLocationHost2)
+	allContracts = append(allContracts, cBadHost2, cBlockedHost, cSameLocationHost2)
 	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
 
 	// prepare 2 good hosts
-	goodHost2 := newHost(7, true, false, true)
-	cGoodHost2 := newContract(8, goodHost2.PublicKey, true)
+	goodHost2 := newHost(6, true, false)
+	cGoodHost2 := newContract(7, goodHost2.PublicKey, true)
 
-	goodHost3 := newHost(8, true, false, true)
-	cGoodHost3 := newContract(9, goodHost3.PublicKey, true)
+	goodHost3 := newHost(7, true, false)
+	cGoodHost3 := newContract(8, goodHost3.PublicKey, true)
 
 	// should use them
 	allHosts = append(allHosts, goodHost2, goodHost3)
 	allContracts = append(allContracts, cGoodHost2, cGoodHost3)
-	assertResult(allHosts, allContracts, []int{1, 2}, []int{7, 8})
+	assertResult(allHosts, allContracts, []int{1, 2}, []int{6, 7})
 }
 
 func newTestContract(hk types.PublicKey) contracts.Contract {

--- a/slabs/uploads_test.go
+++ b/slabs/uploads_test.go
@@ -3,7 +3,6 @@ package slabs
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -153,7 +152,6 @@ func newTestHost(hk types.PublicKey) hosts.Host {
 		CountryCode: countries[frand.Intn(len(countries))],
 		Latitude:    frand.Float64()*180 - 90,
 		Longitude:   frand.Float64()*360 - 180,
-		Networks:    []string{fmt.Sprintf("127.0.0.%d/24", hk[0])},
 	}
 }
 


### PR DESCRIPTION
We can get rid of the table in the database now that we distribute shards to hosts based on their location.

Fixes https://github.com/SiaFoundation/indexd/issues/473