### PR TITLE
Add active accounts to account stats

### DIFF
--- a/api/admin/prometheus.go
+++ b/api/admin/prometheus.go
@@ -14,6 +14,10 @@ func (s AccountStatsResponse) PrometheusMetric() (metrics []prometheus.Metric) {
 			Name:  "indexd_num_registered_accounts",
 			Value: float64(s.Registered),
 		},
+		{
+			Name:  "indexd_num_active_accounts",
+			Value: float64(s.Active),
+		},
 	}
 }
 

--- a/api/admin/types.go
+++ b/api/admin/types.go
@@ -49,7 +49,8 @@ type (
 
 	// AccountStatsResponse is the response body for the [GET] /stats/accounts.
 	AccountStatsResponse struct {
-		Registered int64 `json:"registered"`
+		Registered uint64 `json:"registered"`
+		Active     uint64 `json:"active"`
 	}
 
 	// State is the response body for the [GET] /state endpoint.

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -775,8 +775,12 @@ components:
       properties:
         registered:
           type: integer
-          format: int64
+          format: uint64
           description: Number of accounts currently registered on the indexer
+        active:
+          type: integer
+          format: uint64
+          description: Number of accounts active in the last week.
 
     ContractsStatsResponse:
       type: object

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -102,11 +102,17 @@ func (s *Store) HasAccount(ctx context.Context, ak types.PublicKey) (bool, error
 	return exists, nil
 }
 
+func activeAccounts(ctx context.Context, tx *txn, threshold time.Time) (count uint64, err error) {
+	err = tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE last_used >= $1;`, threshold).Scan(&count)
+	return
+}
+
 // ActiveAccounts returns the number of accounts that have been used since the threshold
 // time.
 func (s *Store) ActiveAccounts(ctx context.Context, threshold time.Time) (count uint64, err error) {
-	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		return tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE last_used >= $1;`, threshold).Scan(&count)
+	err = s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
+		count, err = activeAccounts(ctx, tx, threshold)
+		return
 	})
 	return
 }

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -62,7 +62,9 @@ func (s *Store) AccountStats(ctx context.Context) (admin.AccountStatsResponse, e
 		if err != nil {
 			return fmt.Errorf("failed to get number of registered accounts: %w", err)
 		}
-		stats.Active, err = activeAccounts(ctx, tx, time.Now().Add(-24*7*time.Hour))
+
+		const activeAccountThreshold = 7 * 24 * time.Hour
+		stats.Active, err = activeAccounts(ctx, tx, time.Now().Add(-activeAccountThreshold))
 		if err != nil {
 			return fmt.Errorf("failed to get active accounts: %w", err)
 		}

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"go.sia.tech/indexd/api/admin"
 )
@@ -56,7 +58,15 @@ func (s *Store) incrementNumAccounts(ctx context.Context, tx *txn, delta int64) 
 func (s *Store) AccountStats(ctx context.Context) (admin.AccountStatsResponse, error) {
 	var stats admin.AccountStatsResponse
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		return tx.QueryRow(ctx, "SELECT num_accounts_registered FROM stats").Scan(&stats.Registered)
+		err := tx.QueryRow(ctx, "SELECT num_accounts_registered FROM stats").Scan(&stats.Registered)
+		if err != nil {
+			return fmt.Errorf("failed to get number of registered accounts: %w", err)
+		}
+		stats.Active, err = activeAccounts(ctx, tx, time.Now().Add(-24*7*time.Hour))
+		if err != nil {
+			return fmt.Errorf("failed to get active accounts: %w", err)
+		}
+		return nil
 	})
 	return stats, err
 }

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -84,7 +84,7 @@ func TestAccountStatsRegistered(t *testing.T) {
 	for i := range 5 {
 		if stats, err := store.AccountStats(t.Context()); err != nil {
 			t.Fatal(err)
-		} else if stats.Registered != int64(i) {
+		} else if stats.Registered != uint64(i) {
 			t.Fatalf("expected %d accounts, got %d", i, stats.Registered)
 		}
 
@@ -102,7 +102,7 @@ func TestAccountStatsRegistered(t *testing.T) {
 
 		if stats, err := store.AccountStats(t.Context()); err != nil {
 			t.Fatal(err)
-		} else if expected := int64(len(accs)) - int64(i) - 1; stats.Registered != expected {
+		} else if expected := uint64(len(accs)) - uint64(i) - 1; stats.Registered != expected {
 			t.Fatalf("expected %d accounts, got %d", expected, stats.Registered)
 		}
 	}


### PR DESCRIPTION
Close #459 
Close #470

This will count service accounts as active.  Do we want to do that?  It could result in confusion if the active number is greater than the registered number.