### PR TITLE
Fix registered accounts count

### DIFF
--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -75,8 +75,6 @@ func (s *Store) AddAccount(ctx context.Context, ak types.PublicKey, meta account
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		if err := addAccount(ctx, tx, ak, false, meta, opts...); err != nil {
 			return fmt.Errorf("failed to add account: %w", err)
-		} else if err := s.incrementNumAccounts(ctx, tx, 1); err != nil {
-			return fmt.Errorf("failed to increment registered accounts: %w", err)
 		}
 		return nil
 	})
@@ -128,7 +126,7 @@ func (s *Store) DeleteAccount(ctx context.Context, ak types.PublicKey) error {
 			return fmt.Errorf("failed to delete account: %w", err)
 		} else if serviceAccount {
 			return accounts.ErrServiceAccount
-		} else if err := s.incrementNumAccounts(ctx, tx, -1); err != nil {
+		} else if err := incrementNumAccounts(ctx, tx, -1); err != nil {
 			return fmt.Errorf("failed to decrement registered accounts: %w", err)
 		}
 		return nil
@@ -316,6 +314,8 @@ func addAccount(ctx context.Context, tx *txn, account types.PublicKey, serviceAc
 		return fmt.Errorf("failed to add account: %w", err)
 	} else if res.RowsAffected() == 0 {
 		return accounts.ErrExists
+	} else if err := incrementNumAccounts(ctx, tx, 1); err != nil {
+		return fmt.Errorf("failed to increment registered accounts: %w", err)
 	}
 	return nil
 }

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -314,8 +314,11 @@ func addAccount(ctx context.Context, tx *txn, account types.PublicKey, serviceAc
 		return fmt.Errorf("failed to add account: %w", err)
 	} else if res.RowsAffected() == 0 {
 		return accounts.ErrExists
-	} else if err := incrementNumAccounts(ctx, tx, 1); err != nil {
-		return fmt.Errorf("failed to increment registered accounts: %w", err)
+	}
+	if !serviceAccount {
+		if err := incrementNumAccounts(ctx, tx, 1); err != nil {
+			return fmt.Errorf("failed to increment registered accounts: %w", err)
+		}
 	}
 	return nil
 }

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -114,6 +114,15 @@ func TestAppConnectKeys(t *testing.T) {
 	if _, err := store.ValidAppConnectKey(ctx, "foobar"); !errors.Is(err, accounts.ErrKeyNotFound) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
+
+	stats, err := store.AccountStats(ctx)
+	if err != nil {
+		t.Fatal(err)
+	} else if stats.Active != 1 {
+		t.Fatal("expected 1 active account, got", stats.Active)
+	} else if stats.Registered != 1 {
+		t.Fatal("expected 1 registered account, got", stats.Registered)
+	}
 }
 
 func TestAppConnectKey(t *testing.T) {

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -508,9 +508,9 @@ func (s *Store) PruneContractSectorsMap(ctx context.Context, maxBlocksSinceExpir
 		}
 		if err := res.Close(); err != nil {
 			return err
-		} else if err := s.incrementNumPinnedSectors(ctx, tx, -totalUnpinned); err != nil {
+		} else if err := incrementNumPinnedSectors(ctx, tx, -totalUnpinned); err != nil {
 			return fmt.Errorf("failed to update number of pinned sectors: %w", err)
-		} else if err := s.incrementUnpinnedSectors(ctx, tx, totalUnpinned); err != nil {
+		} else if err := incrementUnpinnedSectors(ctx, tx, totalUnpinned); err != nil {
 			return fmt.Errorf("failed to update number of unpinned sectors: %w", err)
 		}
 

--- a/persist/postgres/init.go
+++ b/persist/postgres/init.go
@@ -49,7 +49,7 @@ func (s *Store) initNewDatabase(ctx context.Context, target int64, ms contracts.
 			return err
 		} else if err := initSettings(ctx, tx, ms, us); err != nil {
 			return fmt.Errorf("failed to init settings: %w", err)
-		} else if err := s.initStats(ctx, tx); err != nil {
+		} else if err := initStats(ctx, tx); err != nil {
 			return fmt.Errorf("failed to init stats: %w", err)
 		} else if err := setDBVersion(ctx, tx, target); err != nil {
 			return fmt.Errorf("failed to set initial database version: %w", err)

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -237,4 +237,11 @@ CREATE INDEX object_slabs_object_id_slab_index_idx ON object_slabs(object_id, sl
 		}
 		return nil
 	},
+	// reset registered accounts
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		if _, err := tx.Exec(ctx, `UPDATE stats SET num_accounts_registered = (SELECT COUNT(*) FROM accounts);`); err != nil {
+			return fmt.Errorf("failed to reset num_accounts_registered: %w", err)
+		}
+		return nil
+	},
 }

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -239,7 +239,7 @@ CREATE INDEX object_slabs_object_id_slab_index_idx ON object_slabs(object_id, sl
 	},
 	// reset registered accounts
 	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
-		if _, err := tx.Exec(ctx, `UPDATE stats SET num_accounts_registered = (SELECT COUNT(*) FROM accounts);`); err != nil {
+		if _, err := tx.Exec(ctx, `UPDATE stats SET num_accounts_registered = (SELECT COUNT(*) FROM accounts WHERE service_account != TRUE);`); err != nil {
 			return fmt.Errorf("failed to reset num_accounts_registered: %w", err)
 		}
 		return nil

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -56,9 +56,9 @@ func (s *Store) MarkSectorsLost(ctx context.Context, hostKey types.PublicKey, ro
 			return fmt.Errorf("failed to mark sectors as lost: %w", err)
 		} else if _, err := tx.Exec(ctx, `UPDATE hosts SET lost_sectors = lost_sectors + $1 WHERE id = $2`, len(sectorIDs), hostID); err != nil {
 			return fmt.Errorf("failed to increment host's lost sectors: %w", err)
-		} else if err := s.incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
+		} else if err := incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
 			return fmt.Errorf("failed to update pinned sectors: %w", err)
-		} else if err := s.incrementUnpinnedSectors(ctx, tx, pinned); err != nil {
+		} else if err := incrementUnpinnedSectors(ctx, tx, pinned); err != nil {
 			return fmt.Errorf("failed to update unpinned sectors: %w", err)
 		} else {
 			return nil
@@ -178,9 +178,9 @@ func (s *Store) markFailingSectorsLostBatch(ctx context.Context, hostKey types.P
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
 		} else if _, err := tx.Exec(ctx, `UPDATE hosts SET lost_sectors = lost_sectors + $1 WHERE id = $2`, totalUpdated, hostID); err != nil {
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
-		} else if err := s.incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
+		} else if err := incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
 			return fmt.Errorf("failed to update pinned sectors: %w", err)
-		} else if err := s.incrementUnpinnedSectors(ctx, tx, pinned); err != nil {
+		} else if err := incrementUnpinnedSectors(ctx, tx, pinned); err != nil {
 			return fmt.Errorf("failed to update unpinned sectors: %w", err)
 		} else {
 			return nil
@@ -258,7 +258,7 @@ func (s *Store) PinSlab(ctx context.Context, account proto.Account, nextIntegrit
 		}
 
 		// update slab stats
-		if err := s.incrementNumSlabs(ctx, tx, 1); err != nil {
+		if err := incrementNumSlabs(ctx, tx, 1); err != nil {
 			return fmt.Errorf("failed to increment number of slabs: %w", err)
 		}
 
@@ -296,7 +296,7 @@ func (s *Store) PinSlab(ctx context.Context, account proto.Account, nextIntegrit
 
 		// update number of unpinned sectors
 		if unpinned > 0 {
-			if err := s.incrementUnpinnedSectors(ctx, tx, unpinned); err != nil {
+			if err := incrementUnpinnedSectors(ctx, tx, unpinned); err != nil {
 				return fmt.Errorf("failed to increment number of unpinned sectors: %w", err)
 			}
 		}
@@ -380,7 +380,7 @@ func (s *Store) UnpinSlab(ctx context.Context, account proto.Account, slabID sla
 		}
 
 		// update slab stats
-		if err := s.incrementNumSlabs(ctx, tx, -1); err != nil {
+		if err := incrementNumSlabs(ctx, tx, -1); err != nil {
 			return fmt.Errorf("failed to decrement number of slabs: %w", err)
 		}
 
@@ -547,9 +547,9 @@ func (s *Store) PinSectors(ctx context.Context, contractID types.FileContractID,
 		if _, err := tx.Exec(ctx, `UPDATE sectors SET host_id = $1, contract_sectors_map_id = $2 WHERE id = ANY($3)`, hostID, contractMapID, sectorIDs); err != nil {
 			return fmt.Errorf("failed to pin sectors: %w", err)
 		} else if unpinned > 0 {
-			if err := s.incrementNumPinnedSectors(ctx, tx, unpinned); err != nil {
+			if err := incrementNumPinnedSectors(ctx, tx, unpinned); err != nil {
 				return fmt.Errorf("failed to update number of pinned sectors: %w", err)
-			} else if err := s.incrementUnpinnedSectors(ctx, tx, -unpinned); err != nil {
+			} else if err := incrementUnpinnedSectors(ctx, tx, -unpinned); err != nil {
 				return fmt.Errorf("failed to update number of unpinned sectors: %w", err)
 			}
 		}
@@ -571,7 +571,7 @@ func (s *Store) PruneUnpinnableSectors(ctx context.Context, threshold time.Time)
 		if err != nil {
 			return fmt.Errorf("failed to prune unpinnable sectors: %w", err)
 		} else if res.RowsAffected() > 0 {
-			if err := s.incrementNumUnpinnableSlabs(ctx, tx, uint64(res.RowsAffected())); err != nil {
+			if err := incrementNumUnpinnableSlabs(ctx, tx, uint64(res.RowsAffected())); err != nil {
 				return fmt.Errorf("failed to increment unpinnable sectors: %w", err)
 			}
 		}
@@ -696,13 +696,13 @@ func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey t
 		}
 
 		migrated = true
-		if err := s.incrementNumMigratedSectors(ctx, tx); err != nil {
+		if err := incrementNumMigratedSectors(ctx, tx); err != nil {
 			return fmt.Errorf("failed to increment number of migrated sectors: %w", err)
 		} else if contractMapID.Valid {
 			// sector was pinned before, update stats
-			if err := s.incrementNumPinnedSectors(ctx, tx, -1); err != nil {
+			if err := incrementNumPinnedSectors(ctx, tx, -1); err != nil {
 				return fmt.Errorf("failed to decrement pinned sectors: %w", err)
-			} else if err := s.incrementUnpinnedSectors(ctx, tx, 1); err != nil {
+			} else if err := incrementUnpinnedSectors(ctx, tx, 1); err != nil {
 				return fmt.Errorf("failed to increment unpinned sectors: %w", err)
 			}
 		}

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -8,32 +8,37 @@ import (
 	"go.sia.tech/indexd/api/admin"
 )
 
-func (s *Store) incrementNumSlabs(ctx context.Context, tx *txn, delta int64) error {
+func incrementNumAccounts(ctx context.Context, tx *txn, delta int64) error {
+	_, err := tx.Exec(ctx, "UPDATE stats SET num_accounts_registered = num_accounts_registered + $1", delta)
+	return err
+}
+
+func incrementNumSlabs(ctx context.Context, tx *txn, delta int64) error {
 	_, err := tx.Exec(ctx, "UPDATE stats SET num_slabs = num_slabs + $1", delta)
 	return err
 }
 
-func (s *Store) incrementNumMigratedSectors(ctx context.Context, tx *txn) error {
+func incrementNumMigratedSectors(ctx context.Context, tx *txn) error {
 	_, err := tx.Exec(ctx, `UPDATE stats SET num_migrated_sectors = num_migrated_sectors + 1`)
 	return err
 }
 
-func (s *Store) incrementNumPinnedSectors(ctx context.Context, tx *txn, delta int64) error {
+func incrementNumPinnedSectors(ctx context.Context, tx *txn, delta int64) error {
 	_, err := tx.Exec(ctx, `UPDATE stats SET num_pinned_sectors = num_pinned_sectors + $1`, delta)
 	return err
 }
 
-func (s *Store) incrementNumUnpinnableSlabs(ctx context.Context, tx *txn, incr uint64) error {
+func incrementNumUnpinnableSlabs(ctx context.Context, tx *txn, incr uint64) error {
 	_, err := tx.Exec(ctx, "UPDATE stats SET num_unpinnable_sectors = num_unpinnable_sectors + $1", incr)
 	return err
 }
 
-func (s *Store) incrementUnpinnedSectors(ctx context.Context, tx *txn, delta int64) error {
+func incrementUnpinnedSectors(ctx context.Context, tx *txn, delta int64) error {
 	_, err := tx.Exec(ctx, "UPDATE stats SET num_unpinned_sectors = num_unpinned_sectors + $1", delta)
 	return err
 }
 
-func (s *Store) initStats(ctx context.Context, tx *txn) error {
+func initStats(ctx context.Context, tx *txn) error {
 	_, err := tx.Exec(ctx, "INSERT INTO stats (id) VALUES (0) ON CONFLICT(id) DO NOTHING")
 	return err
 }
@@ -47,11 +52,6 @@ func (s *Store) SectorStats(ctx context.Context) (admin.SectorsStatsResponse, er
 		return row.Scan(&stats.Slabs, &stats.Migrated, &stats.Pinned, &stats.Unpinnable, &stats.Unpinned)
 	})
 	return stats, err
-}
-
-func (s *Store) incrementNumAccounts(ctx context.Context, tx *txn, delta int64) error {
-	_, err := tx.Exec(ctx, "UPDATE stats SET num_accounts_registered = num_accounts_registered + $1", delta)
-	return err
 }
 
 // AccountStats reports statistics about the accounts stored in the database.


### PR DESCRIPTION
This PR moves `incrementNumAccounts` into `addAccount` to fix our counting of registered accounts. Since we were missing accounts created from app keys. 
Since that requires getting rid of the receiver I also got rid of all the unnecessary receivers for the other increment methods.
A little migration fixes the count upon the next startup.