### PR TITLE
Add host metrics

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -72,6 +72,8 @@ type (
 
 		UsabilitySettings(ctx context.Context) (hosts.UsabilitySettings, error)
 		UpdateUsabilitySettings(ctx context.Context, us hosts.UsabilitySettings) error
+
+		Stats(ctx context.Context, offset, limit int) ([]hosts.HostStats, error)
 	}
 
 	// PinManager defines an interface for managing pinned settings.
@@ -103,6 +105,7 @@ type (
 	Store interface {
 		AccountStats(ctx context.Context) (AccountStatsResponse, error)
 		ContractsStats(ctx context.Context) (ContractsStatsResponse, error)
+		HostStats(ctx context.Context, offset, limit int) ([]hosts.HostStats, error)
 		SectorStats(ctx context.Context) (SectorsStatsResponse, error)
 
 		LastScannedIndex(context.Context) (types.ChainIndex, error)
@@ -243,6 +246,7 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 		// stats endpoints
 		"GET /stats/accounts":  a.handleGETStatsAccounts,
 		"GET /stats/contracts": a.handleGETStatsContracts,
+		"GET /stats/hosts":     a.handleGETStatsHosts,
 		"GET /stats/sectors":   a.handleGETStatsSectors,
 	}
 
@@ -866,6 +870,24 @@ func (a *admin) handleGETStatsContracts(jc jape.Context) {
 		return
 	}
 	writeResponse(jc, stats)
+}
+
+func (a *admin) handleGETStatsHosts(jc jape.Context) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	stats, err := a.hosts.Stats(jc.Request.Context(), offset, limit)
+	if jc.Check("failed to retrieve host stats", err) != nil {
+		return
+	}
+
+	var res HostStatsResponse
+	for _, s := range stats {
+		res.Hosts = append(res.Hosts, HostStats(s))
+	}
+	writeResponse(jc, res)
 }
 
 func (a *admin) handleGETStatsSectors(jc jape.Context) {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -800,6 +800,37 @@ func TestContractsStatsAPI(t *testing.T) {
 	t.Fatalf("expected some contracts, got %d", stats.Contracts)
 }
 
+func TestHostsStatsAPI(t *testing.T) {
+	// create cluster with two hosts
+	cluster := testutils.NewCluster(t, testutils.WithHosts(2))
+	admin := cluster.Indexer.Admin
+	time.Sleep(time.Second)
+
+	res, err := admin.StatsHosts(t.Context(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(res.Hosts) != 2 {
+		t.Fatal("expected 2 hosts", len(res.Hosts))
+	} else if res.Hosts[0].PublicKey == res.Hosts[1].PublicKey {
+		t.Fatal("expected hosts to have different public keys")
+	}
+
+	// assert offset and limit are being applied
+	res, err = admin.StatsHosts(t.Context(), 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(res.Hosts) != 1 {
+		t.Fatal("expected 1 host", len(res.Hosts))
+	}
+
+	res, err = admin.StatsHosts(t.Context(), 2, 1)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(res.Hosts) != 0 {
+		t.Fatal("expected 0 hosts", len(res.Hosts))
+	}
+}
+
 func TestSectorStatsAPI(t *testing.T) {
 	// create cluster with three hosts
 	logger := newTestLogger(false)

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -293,6 +293,15 @@ func (c *Client) StatsContracts(ctx context.Context) (resp ContractsStatsRespons
 	return
 }
 
+// StatsHosts returns statistics about the hosts managed by the indexer.
+func (c *Client) StatsHosts(ctx context.Context, offset, limit int) (resp HostStatsResponse, err error) {
+	values := url.Values{}
+	values.Set("offset", fmt.Sprintf("%d", offset))
+	values.Set("limit", fmt.Sprintf("%d", limit))
+	err = c.c.GET(ctx, "/stats/hosts?"+values.Encode(), &resp)
+	return
+}
+
 // StatsSectors returns statistics about the sectors managed by the indexer.
 func (c *Client) StatsSectors(ctx context.Context) (resp SectorsStatsResponse, err error) {
 	err = c.c.GET(ctx, "/stats/sectors", &resp)

--- a/api/admin/prometheus.go
+++ b/api/admin/prometheus.go
@@ -49,6 +49,43 @@ func (s ContractsStatsResponse) PrometheusMetric() (metrics []prometheus.Metric)
 }
 
 // PrometheusMetric implements the prometheus.Marshaller interface for the
+// host stats response.
+func (h HostStatsResponse) PrometheusMetric() (metrics []prometheus.Metric) {
+	metrics = prometheus.Slice(h.Hosts).PrometheusMetric()
+	return
+}
+
+// PrometheusMetric implements the prometheus.Marshaller interface for a single
+// host's stats.
+func (h HostStats) PrometheusMetric() (metrics []prometheus.Metric) {
+	labels := map[string]any{
+		"public_key": h.PublicKey.String(),
+	}
+	return []prometheus.Metric{
+		{
+			Name:   "indexd_host_account_usage",
+			Labels: labels,
+			Value:  float64(h.AccountUsage.Siacoins()),
+		},
+		{
+			Name:   "indexd_host_total_usage",
+			Labels: labels,
+			Value:  float64(h.TotalUsage.Siacoins()),
+		},
+		{
+			Name:   "indexd_host_lost_sectors",
+			Labels: labels,
+			Value:  float64(h.LostSectors),
+		},
+		{
+			Name:   "indexd_host_active_contracts_size",
+			Labels: labels,
+			Value:  float64(h.ActiveContractsSize),
+		},
+	}
+}
+
+// PrometheusMetric implements the prometheus.Marshaller interface for the
 // sector stats response.
 func (s SectorsStatsResponse) PrometheusMetric() (metrics []prometheus.Metric) {
 	return []prometheus.Metric{

--- a/api/admin/types.go
+++ b/api/admin/types.go
@@ -5,6 +5,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/wallet"
+	"go.sia.tech/indexd/hosts"
 )
 
 type (
@@ -52,6 +53,14 @@ type (
 		Registered uint64 `json:"registered"`
 		Active     uint64 `json:"active"`
 	}
+
+	// HostStatsResponse is the response body for the [GET] /stats/hosts.
+	HostStatsResponse struct {
+		Hosts []HostStats `json:"hosts"`
+	}
+
+	// HostStats wraps hosts.HostStats to provide a custom PrometheusMetric method.
+	HostStats hosts.HostStats
 
 	// State is the response body for the [GET] /state endpoint.
 	State struct {

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -62,6 +62,15 @@ type (
 		log *zap.Logger
 	}
 
+	// HostStats contains various statistics about a single host.
+	HostStats struct {
+		AccountUsage        types.Currency  `json:"accountUsage"`
+		ActiveContractsSize int64           `json:"activeContractsSize"`
+		PublicKey           types.PublicKey `json:"publicKey"`
+		LostSectors         int64           `json:"lostSectors"`
+		TotalUsage          types.Currency  `json:"totalUsage"`
+	}
+
 	// OnlineChecker defines an interface to check whether the indexer is online. It's
 	// used to ensure hosts aren't punished for failing a scan if the indexer is
 	// offline.
@@ -84,6 +93,7 @@ type (
 	Store interface {
 		Host(ctx context.Context, hk types.PublicKey) (Host, error)
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...HostQueryOpt) ([]Host, error)
+		HostStats(ctx context.Context, offset, limit int) ([]HostStats, error)
 
 		HostsForScanning(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPruning(ctx context.Context) ([]types.PublicKey, error)
@@ -380,6 +390,11 @@ func (m *HostManager) UpdateChainState(tx UpdateTx, applied []chain.ApplyUpdate)
 		}
 	}
 	return nil
+}
+
+// Stats returns statistics about the hosts in the database.
+func (m *HostManager) Stats(ctx context.Context, offset, limit int) ([]HostStats, error) {
+	return m.store.HostStats(ctx, offset, limit)
 }
 
 // hostsForScanning returns the public keys of the hosts that need to be

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -48,6 +48,10 @@ func (s *mockStore) Hosts(ctx context.Context, offset, limit int, opts ...HostQu
 
 func (s *mockStore) HostsForScanning(ctx context.Context) ([]types.PublicKey, error) { return nil, nil }
 
+func (s *mockStore) HostStats(ctx context.Context, offset, limit int) ([]HostStats, error) {
+	return nil, nil
+}
+
 func (s *mockStore) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reason string) error {
 	return nil
 }

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -1241,6 +1241,36 @@ paths:
               schema:
                 $ref: "#/components/schemas/ContractsStatsResponse"
 
+  /stats/hosts:
+    get:
+      tags:
+        - stats
+      summary: Get stats about hosts
+      operationId: getStatsHosts
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of host stats to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: The number of host stats to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: Stats about used hosts on this instance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HostsStatsResponse"
+
   /stats/sectors:
     get:
       tags:
@@ -1253,7 +1283,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SectorsStatsResponse"
+                $ref: "#/components/schemas/SectorStatsResponse"
 
   /txpool/recommendedfee:
     get:
@@ -1580,9 +1610,11 @@ components:
     AddConnectKeyRequest:
       $ref: "./components.yml#/components/schemas/AddConnectKeyRequest"
     ContractsStatsResponse:
-      $ref: "./components.yml#/components/schemas/ContractssStatsResponse"
+      $ref: "./components.yml#/components/schemas/ContractsStatsResponse"
+    HostsStatsResponse:
+      $ref: "./components.yml#/components/schemas/HostsStatsResponse"
     SectorStatsResponse:
-      $ref: "./components.yml#/components/schemas/SectorsStatsResponse"
+      $ref: "./components.yml#/components/schemas/SectorStatsResponse"
     AuthConnectStatusResponse:
       $ref: "./components.yml#/components/schemas/AuthConnectStatusResponse"
     RegisterAppResponse:

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -806,6 +806,35 @@ components:
           format: int64
           description: Total size of all active contracts
 
+    HostsStatsResponse:
+      type: object
+      properties:
+        hosts:
+          type: array
+          items:
+            type: object
+            properties:
+              accountUsage:
+                allOf:
+                  - $ref: "#/components/schemas/Currency"
+                  - description: Total amount spent on ephemeral accounts
+              activeContractsSize:
+                type: integer
+                format: int64
+                description: Total size of all active contracts on this host
+              publicKey:
+                allOf:
+                  - $ref: "#/components/schemas/PublicKey"
+                  - description: The public key of the host
+              lostSectors:
+                type: integer
+                format: int64
+                description: Total number of sectors lost on this host
+              totalUsage:
+                allOf:
+                  - $ref: "#/components/schemas/Currency"
+                  - description: Total amount spent on this host
+
     SectorStatsResponse:
       type: object
       properties:

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1480,29 +1480,7 @@ func BenchmarkContracts(b *testing.B) {
 
 			hostContractIDs := make([]types.FileContractID, numContractsPerHost)
 			for i := range numContractsPerHost {
-				revision := newTestRevision(hk)
-				frand.Read(hostContractIDs[i][:])
-				revision.Filesize = frand.Uint64n(1e9)                                                            // random size
-				revision.Capacity = revision.Filesize + frand.Uint64n(1e3)                                        // random capacity
-				revision.RenterOutput.Value = types.Siacoins(100).Add(types.Siacoins(uint32(frand.Uint64n(100)))) // random allowance
-				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, next_prune) VALUES ($1, $2, $3, 0, 0, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`,
-					hostID,
-					sqlHash256(hostContractIDs[i][:]),
-					sqlFileContract(revision),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(revision.RemainingAllowance().Add(types.Siacoins(1))), // 1SC more than initial allowance
-					sqlCurrency(revision.RemainingAllowance()),
-					sqlContractState(uint8(frand.Uint64n(5))), // random contract state (40% active)
-					frand.Uint64n(2) == 0,                     // random good state (50% good)
-					revision.Filesize,
-					revision.Capacity,
-					randomTime(), // random last_broadcast_attempt
-					randomTime(), // random next_prune
-				); err != nil {
-					return err
-				}
+				hostContractIDs[i] = insertRandomContract(b, tx, hostID, hk)
 			}
 			for i := 1; i < len(hostContractIDs)-1; i++ {
 				if _, err := tx.Exec(ctx, `UPDATE contracts SET renewed_from = $1, renewed_to = $2 WHERE contract_id = $3;`, hostContractIDs[i-1], hostContractIDs[i+1], hostContractIDs[i]); err != nil {
@@ -1791,4 +1769,42 @@ func newTestRevision(hk types.PublicKey) types.V2FileContract {
 		RevisionNumber:   1,
 		TotalCollateral:  types.Siacoins(100),
 	}
+}
+
+func insertRandomContract(b *testing.B, tx *txn, hostID int64, hostKey types.PublicKey) (fcid types.FileContractID) {
+	frand.Read(fcid[:])
+
+	randomTime := func() time.Time {
+		maxOneHour := time.Duration(frand.Uint64n(60*60)) * time.Second
+		return time.Now().Add(-30 * time.Minute).Add(maxOneHour)
+	}
+
+	revision := newTestRevision(hostKey)
+	revision.Filesize = frand.Uint64n(1e9)                                                            // random size
+	revision.Capacity = revision.Filesize + frand.Uint64n(1e3)                                        // random capacity
+	revision.RenterOutput.Value = types.Siacoins(100).Add(types.Siacoins(uint32(frand.Uint64n(100)))) // random allowance
+
+	if _, err := tx.Exec(b.Context(), `
+		INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, next_prune) VALUES ($1, $2, $3, 1, 2, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`,
+		hostID,
+		sqlHash256(fcid),
+		sqlFileContract(revision),
+		sqlCurrency(types.ZeroCurrency),
+		sqlCurrency(types.ZeroCurrency),
+		sqlCurrency(types.ZeroCurrency),
+		sqlCurrency(revision.RemainingAllowance().Add(types.Siacoins(1))), // 1SC more than initial allowance
+		sqlCurrency(revision.RemainingAllowance()),
+		sqlContractState(uint8(frand.Uint64n(5))), // random contract state (40% active)
+		frand.Uint64n(2) == 0,                     // random good state (50% good)
+		revision.Filesize,
+		revision.Capacity,
+		randomTime(), // random last_broadcast_attempt
+		randomTime(), // random next_prune
+	); err != nil {
+		b.Fatal(err)
+	} else if _, err := tx.Exec(b.Context(), `INSERT INTO contract_sectors_map (contract_id) VALUES ($1)`, sqlHash256(fcid)); err != nil {
+		b.Fatal(err)
+	}
+
+	return
 }

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1267,7 +1267,8 @@ func BenchmarkHosts(b *testing.B) {
 	// define parameters
 	const (
 		numHosts     = 10_000
-		numBlocklist = 1000
+		numBlocklist = 1_000
+		numContracts = 25 // ~40% is active
 	)
 
 	// prepare database
@@ -1277,7 +1278,12 @@ func BenchmarkHosts(b *testing.B) {
 		for i := range numHosts {
 			var hostID int64
 			hk := types.GeneratePrivateKey().PublicKey()
-			err := tx.QueryRow(context.Background(), `INSERT INTO hosts (public_key, last_announcement) VALUES ($1, NOW()) RETURNING id;`, sqlPublicKey(hk)).Scan(&hostID)
+			err := tx.QueryRow(context.Background(), `INSERT INTO hosts (public_key, lost_sectors, usage_account_funding, usage_total_spent, last_announcement) VALUES ($1, $2, $3, $4, NOW()) RETURNING id;`,
+				sqlPublicKey(hk),
+				frand.Uint64n(1e3), // random lost sectors
+				sqlCurrency(types.NewCurrency64(frand.Uint64n(1e6))), // random account funding
+				sqlCurrency(types.NewCurrency64(frand.Uint64n(1e6))), // random total spent
+			).Scan(&hostID)
 			if err != nil {
 				return err
 			}
@@ -1287,6 +1293,10 @@ func BenchmarkHosts(b *testing.B) {
 			_, err = tx.Exec(ctx, `INSERT INTO host_addresses (host_id, net_address, protocol) VALUES ($1, $2, $3)`, hostID, na.Address, sqlNetworkProtocol(na.Protocol))
 			if err != nil {
 				return fmt.Errorf("failed to insert host address: %w", err)
+			}
+
+			for range numContracts {
+				insertRandomContract(b, tx, hostID, hk)
 			}
 		}
 
@@ -1299,6 +1309,13 @@ func BenchmarkHosts(b *testing.B) {
 		}
 		return nil
 	}); err != nil {
+		b.Fatal(err)
+	}
+
+	// analyze tables to ensure query planner has up-to-date statistics
+	if _, err := store.pool.Exec(b.Context(), `VACUUM (ANALYZE) hosts;`); err != nil {
+		b.Fatal(err)
+	} else if _, err := store.pool.Exec(b.Context(), `VACUUM (ANALYZE) contracts;`); err != nil {
 		b.Fatal(err)
 	}
 
@@ -1322,6 +1339,20 @@ func BenchmarkHosts(b *testing.B) {
 					b.Fatal(err)
 				} else if len(hosts) != limit {
 					b.Fatalf("expected %d hosts, got %d", limit, len(hosts)) // sanity check
+				}
+			}
+		})
+	}
+
+	for _, limit := range []int{100, 500} {
+		b.Run(fmt.Sprintf("HostStats_%d", limit), func(b *testing.B) {
+			for b.Loop() {
+				offset := frand.Intn(numHosts - limit)
+				stats, err := store.HostStats(context.Background(), offset, limit)
+				if err != nil {
+					b.Fatal(err)
+				} else if len(stats) != limit {
+					b.Fatalf("expected %d host stats, got %d", limit, len(stats)) // sanity check
 				}
 			}
 		})
@@ -1404,11 +1435,6 @@ func BenchmarkUsableHosts(b *testing.B) {
 	randomProtocol := func() chain.Protocol {
 		protocols := []chain.Protocol{siamux.Protocol, quic.Protocol}
 		return protocols[frand.Intn(len(protocols))]
-	}
-
-	randomTime := func() time.Time {
-		maxOneHour := time.Duration(frand.Uint64n(60*60)) * time.Second
-		return time.Now().Add(-30 * time.Minute).Add(maxOneHour)
 	}
 
 	// define parameters
@@ -1498,28 +1524,7 @@ func BenchmarkUsableHosts(b *testing.B) {
 			}
 
 			// add contract
-			revision := newTestRevision(hk)
-			revision.Filesize = frand.Uint64n(1e9)                                                            // random size
-			revision.Capacity = revision.Filesize + frand.Uint64n(1e3)                                        // random capacity
-			revision.RenterOutput.Value = types.Siacoins(100).Add(types.Siacoins(uint32(frand.Uint64n(100)))) // random allowance
-			if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, next_prune) VALUES ($1, $2, $3, 0, 0, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`,
-				hostID,
-				sqlHash256(types.FileContractID(hk)),
-				sqlFileContract(revision),
-				sqlCurrency(types.ZeroCurrency),
-				sqlCurrency(types.ZeroCurrency),
-				sqlCurrency(types.ZeroCurrency),
-				sqlCurrency(revision.RemainingAllowance().Add(types.Siacoins(1))), // 1SC more than initial allowance
-				sqlCurrency(revision.RemainingAllowance()),
-				sqlContractState(uint8(frand.Uint64n(5))), // random contract state (40% active)
-				frand.Uint64n(2) == 0,                     // random good state (50% good)
-				revision.Filesize,
-				revision.Capacity,
-				randomTime(), // random last_broadcast_attempt
-				randomTime(), // random next_prune
-			); err != nil {
-				return err
-			}
+			insertRandomContract(b, tx, hostID, hk)
 		}
 		return nil
 	}); err != nil {
@@ -1765,13 +1770,7 @@ func BenchmarkHostsForPruning(b *testing.B) {
 		nBlocklistHosts   = 1000
 	)
 
-	randomTime := func() time.Time {
-		maxOneHour := time.Duration(frand.Uint64n(60*60)) * time.Second
-		return time.Now().Add(-30 * time.Minute).Add(maxOneHour)
-	}
-
 	// prepare database
-	hostToContractID := make(map[types.PublicKey]types.FileContractID, nHosts)
 	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 		for range nHosts {
 			// add host
@@ -1783,27 +1782,9 @@ func BenchmarkHostsForPruning(b *testing.B) {
 			}
 
 			// add contracts
-			var fcid types.FileContractID
 			for range nContractsPerHost {
-				frand.Read(fcid[:])
-				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, next_prune) VALUES ($1, $2, $3, 0, 0, $4, $5, $6, $7, $8, $9, $10, $11);`,
-					hostID,
-					sqlHash256(fcid[:]),
-					sqlFileContract(newTestRevision(hk)),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlContractState(uint8(frand.Uint64n(5))), // random contract state (40% active)
-					frand.Uint64n(2) == 0,                     // random good state (50% good)
-					randomTime(),                              // random next prune time
-
-				); err != nil {
-					return err
-				}
+				insertRandomContract(b, tx, hostID, hk)
 			}
-			hostToContractID[hk] = fcid
 		}
 
 		// we LEFT JOIN the blocklist so we populate it with random entries
@@ -1952,7 +1933,7 @@ func BenchmarkHostsForPinning(b *testing.B) {
 	)
 
 	// prepare database
-	hostToContractID := make(map[types.PublicKey]types.FileContractID, nHosts)
+	hostToContractIDs := make(map[types.PublicKey][]types.FileContractID, nHosts)
 	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 		for range nHosts {
 			// add host
@@ -1964,30 +1945,9 @@ func BenchmarkHostsForPinning(b *testing.B) {
 			}
 
 			// add contracts
-			var fcid types.FileContractID
 			for range nContractsPerHost {
-				frand.Read(fcid[:])
-				size := frand.Uint64n(1e9)
-				if _, err := tx.Exec(ctx, `INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity) VALUES ($1, $2, $3, 0, 0, $4, $5, $6, $7, $8, $9, $10, $11, $12);`,
-					hostID,
-					sqlHash256(fcid),
-					sqlFileContract(newTestRevision(hk)),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.ZeroCurrency),
-					sqlCurrency(types.NewCurrency64(frand.Uint64n(5))), // random remaining allowance
-					sqlContractState(uint8(frand.Uint64n(5))),          // random contract state (40% active)
-					frand.Uint64n(2) == 0,                              // random good state (50% good)
-					size,                                               // random size
-					size+frand.Uint64n(1e3),                            // random capacity
-				); err != nil {
-					return err
-				} else if _, err := tx.Exec(ctx, `INSERT INTO contract_sectors_map (contract_id) VALUES ($1)`, sqlHash256(fcid)); err != nil {
-					return err
-				}
+				hostToContractIDs[hk] = append(hostToContractIDs[hk], insertRandomContract(b, tx, hostID, hk))
 			}
-			hostToContractID[hk] = fcid
 		}
 
 		// we LEFT JOIN the blocklist so we populate it with random entries
@@ -2004,8 +1964,12 @@ func BenchmarkHostsForPinning(b *testing.B) {
 	}
 
 	// add sectors
-	for hk, fcid := range hostToContractID {
+	for hk, fcids := range hostToContractIDs {
+		var idx int
 		for remainingSectors := nSectorsPerHost; remainingSectors > 0; {
+			fcid := fcids[idx%len(fcids)]
+			idx++
+
 			batchSize := min(remainingSectors, 10000)
 			remainingSectors -= batchSize
 			var sectors []slabs.PinnedSector

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -61,6 +61,7 @@ CREATE INDEX hosts_next_scan_idx ON hosts(next_scan);
 
 CREATE INDEX hosts_last_integrity_check_idx ON hosts(last_integrity_check ASC);
 CREATE INDEX hosts_lost_sectors_idx ON hosts(lost_sectors);
+CREATE INDEX hosts_usage_total_spent_idx ON hosts(usage_total_spent DESC);
 
 -- speed up querying by country
 CREATE INDEX hosts_country_code_idx ON hosts(country_code);
@@ -228,6 +229,7 @@ CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (capacity DESC
 -- stats indices
 CREATE INDEX contracts_proof_height_idx ON contracts (proof_height);
 CREATE INDEX contracts_state_active_idx ON contracts(state) WHERE state = 0 OR state = 1;
+CREATE INDEX contracts_active_host_size_idx ON contracts(proof_height, host_id) INCLUDE (size) WHERE (state = 0 OR state = 1) AND renewed_to IS NULL;
 
 -- foreign key constraint index
 CREATE INDEX contracts_host_id_idx ON contracts(host_id);

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -272,4 +272,16 @@ ALTER TABLE objects ADD COLUMN signature BYTEA UNIQUE NOT NULL CHECK (LENGTH(sig
 		_, err := tx.Exec(ctx, query)
 		return err
 	},
+	// add indices to support host stats
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `CREATE INDEX hosts_usage_total_spent_idx ON hosts(usage_total_spent DESC);`)
+		if err != nil {
+			return fmt.Errorf("failed to create hosts_usage_total_spent_idx index: %w", err)
+		}
+		_, err = tx.Exec(ctx, `CREATE INDEX contracts_active_host_size_idx ON contracts(proof_height, host_id) INCLUDE (size) WHERE (state = 0 OR state = 1) AND renewed_to IS NULL;`)
+		if err != nil {
+			return fmt.Errorf("failed to create contracts_active_host_size_idx index: %w", err)
+		}
+		return nil
+	},
 }

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.sia.tech/indexd/api/admin"
+	"go.sia.tech/indexd/hosts"
 )
 
 func incrementNumAccounts(ctx context.Context, tx *txn, delta int64) error {
@@ -69,6 +70,57 @@ func (s *Store) AccountStats(ctx context.Context) (admin.AccountStatsResponse, e
 			return fmt.Errorf("failed to get active accounts: %w", err)
 		}
 		return nil
+	})
+	return stats, err
+}
+
+// HostStats reports statistics about used hosts. We consider a host to be used
+// as soon as we spent any funds on it.
+func (s *Store) HostStats(ctx context.Context, offset, limit int) ([]hosts.HostStats, error) {
+	var stats []hosts.HostStats
+	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			WITH globals AS (
+				SELECT scanned_height FROM global_settings
+			),
+			selected_hosts AS (
+				SELECT id, public_key, lost_sectors, usage_account_funding, usage_total_spent
+				FROM hosts
+				WHERE usage_total_spent > 0
+				ORDER BY usage_total_spent DESC
+				OFFSET $1
+				LIMIT $2
+			)
+			SELECT
+				h.public_key,
+				h.lost_sectors,
+				COALESCE(cs.total_contracts_size, 0) AS total_contracts_size,
+				h.usage_account_funding,
+				h.usage_total_spent
+			FROM selected_hosts h
+			LEFT JOIN LATERAL (
+			SELECT SUM(size) AS total_contracts_size
+			FROM contracts
+			WHERE host_id = h.id
+				AND (state = 0 OR state = 1)
+				AND renewed_to IS NULL
+				AND proof_height > (SELECT scanned_height FROM globals)
+			) cs ON TRUE
+			ORDER BY h.usage_total_spent DESC;
+		`, offset, limit)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var hs hosts.HostStats
+			if err := rows.Scan((*sqlPublicKey)(&hs.PublicKey), &hs.LostSectors, &hs.ActiveContractsSize, (*sqlCurrency)(&hs.AccountUsage), (*sqlCurrency)(&hs.TotalUsage)); err != nil {
+				return err
+			}
+			stats = append(stats, hs)
+		}
+		return rows.Err()
 	})
 	return stats, err
 }

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/slabs"
+	"go.sia.tech/indexd/subscriber"
 	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
@@ -105,5 +106,123 @@ func TestAccountStatsRegistered(t *testing.T) {
 		} else if expected := uint64(len(accs)) - uint64(i) - 1; stats.Registered != expected {
 			t.Fatalf("expected %d accounts, got %d", expected, stats.Registered)
 		}
+	}
+}
+
+func TestHostStats(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	updateUsageTotalSpent := func(hk types.PublicKey, spent types.Currency) {
+		t.Helper()
+		if _, err := store.pool.Exec(
+			t.Context(),
+			"UPDATE hosts SET usage_total_spent = $1 WHERE public_key = $2", sqlCurrency(spent), sqlPublicKey(hk)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// add three hosts
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	hk3 := store.addTestHost(t)
+
+	// assert empty stats
+	stats, err := store.HostStats(t.Context(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(stats))
+	}
+
+	// add test contracts
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID(hk1))
+	store.addTestContract(t, hk2, types.FileContractID(hk2))
+	store.addTestContract(t, hk3, types.FileContractID(hk3))
+
+	// assert empty stats - no usage
+	stats, err = store.HostStats(t.Context(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(stats))
+	}
+
+	// update usage spent
+	updateUsageTotalSpent(hk1, types.NewCurrency64(10))
+	updateUsageTotalSpent(hk2, types.NewCurrency64(20))
+	// hk3 remains at 0
+
+	testRevision := newTestRevision(types.PublicKey{})
+
+	// assert updated stats
+
+	stats, err = store.HostStats(t.Context(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(stats))
+	} else if stats[0].PublicKey != hk2 {
+		t.Fatalf("expected first host to be hk2, got %s", stats[0].PublicKey.String())
+	} else if stats[1].PublicKey != hk1 {
+		t.Fatalf("expected second host to be hk1, got %s", stats[1].PublicKey.String())
+	} else if stats[0].ActiveContractsSize != int64(testRevision.Filesize) {
+		t.Fatalf("expected first host to have %d active contract size, got %d", testRevision.Filesize, stats[0].ActiveContractsSize)
+	} else if stats[1].ActiveContractsSize != int64(testRevision.Filesize) {
+		t.Fatalf("expected second host to have %d active contract size, got %d", testRevision.Filesize, stats[1].ActiveContractsSize)
+	}
+
+	// resolve first contract manually - should exclude it from total_contract_size
+	_, err = store.pool.Exec(t.Context(), "UPDATE contracts SET state = $1 WHERE contract_id = $2", sqlContractState(2), sqlHash256(fcid1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assert updated stats
+	stats, err = store.HostStats(t.Context(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(stats))
+	} else if stats[0].PublicKey != hk2 {
+		t.Fatalf("expected first host to be hk2, got %s", stats[0].PublicKey.String())
+	} else if stats[1].PublicKey != hk1 {
+		t.Fatalf("expected second host to be hk1, got %s", stats[1].PublicKey.String())
+	} else if stats[0].ActiveContractsSize != int64(testRevision.Filesize) {
+		t.Fatalf("expected first host to have %d active contract size, got %d", testRevision.Filesize, stats[0].ActiveContractsSize)
+	} else if stats[1].ActiveContractsSize != 0 {
+		t.Fatalf("expected second host to have 0 active contract size, got %d", stats[1].ActiveContractsSize)
+	}
+
+	// set scanned height to the proof height - should exclude it
+	proofHeight := testRevision.ProofHeight
+	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+		return tx.UpdateLastScannedIndex(context.Background(), types.ChainIndex{Height: proofHeight})
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert updated stats
+	stats, err = store.HostStats(t.Context(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(stats))
+	} else if stats[0].ActiveContractsSize != 0 {
+		t.Fatalf("expected first host to have 0 active contract size, got %d", stats[0].ActiveContractsSize)
+	} else if stats[1].ActiveContractsSize != 0 {
+		t.Fatalf("expected second host to have 0 active contract size, got %d", stats[1].ActiveContractsSize)
+	}
+
+	// assert limit and offset are applied
+	if stats, err := store.HostStats(t.Context(), 1, 1); err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(stats))
+	} else if stats[0].PublicKey != hk1 {
+		t.Fatalf("expected host to be hk1, got %s", stats[0].PublicKey.String())
+	} else if stats, err := store.HostStats(t.Context(), 2, 1); err != nil {
+		t.Fatal(err)
+	} else if len(stats) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(stats))
 	}
 }


### PR DESCRIPTION
This PR adds hosts stats. Took me quite some time to get the benchmark down to a reasonable performance, considering the amount of hosts and contracts I feel it's actually quite fast. This is the query plan for 10k hosts (all usable) and 25 contracts per host (~half are active).

```
Sort  (cost=4783.43..4808.47 rows=10017 width=81) (actual time=20.362..20.730 rows=10000 loops=1)
  Sort Key: h.usage_total_spent DESC
  Sort Method: quicksort  Memory: 1166kB
  ->  Hash Right Join  (cost=667.28..4117.79 rows=10017 width=81) (actual time=3.344..18.117 rows=10000 loops=1)
        Hash Cond: (contracts.host_id = h.id)
        ->  GroupAggregate  (cost=0.29..3324.32 rows=10018 width=36) (actual time=0.023..13.333 rows=10000 loops=1)
              Group Key: contracts.host_id
              ->  Index Only Scan using contracts_active_host_size_idx on contracts  
                    (cost=0.29..2746.39 rows=90540 width=12) 
                    (actual time=0.015..6.453 rows=99770 loops=1)
                    Heap Fetches: 0
        ->  Hash  (cost=542.00..542.00 rows=9999 width=53) (actual time=3.316..3.316 rows=10000 loops=1)
              Buckets: 16384  Batches: 1  Memory Usage: 1026kB
              ->  Seq Scan on hosts h  
                    (cost=0.00..542.00 rows=9999 width=53) 
                    (actual time=0.006..2.231 rows=10000 loops=1)
                    Filter: (usage_total_spent > '0'::numeric)
Planning Time: 0.541 ms
Execution Time: 20.970 ms
```

Fixes #471 