### PR TITLE
Avoid unnecessary failures in log on shutdown

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -280,7 +280,10 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			hostLog.Debug("formed contract", zap.Stringer("contractID", contract.ID))
 			return nil
 		})
-		if errors.Is(err, hosts.ErrBadHost) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			formationLog.Warn("context cancelled, stopping contract formation")
+			break
+		} else if errors.Is(err, hosts.ErrBadHost) {
 			continue // ignore bad host
 		} else if err != nil {
 			hostLog.Error("failed to form contract", zap.Error(err))

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -150,24 +151,45 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 		case <-ticker.C:
 		}
 
-		if err := cm.performContractMaintenance(ctx, log); err != nil {
-			log.Error("contract maintenance failed", zap.Error(err))
+		if !performMaintenanceJob("contract maintenance", func() error {
+			return cm.performContractMaintenance(ctx, log)
+		}, log) {
+			return
 		}
 
-		if err := cm.performAccountFunding(ctx, false, log); err != nil {
-			log.Error("account funding failed", zap.Error(err))
+		if !performMaintenanceJob("account funding", func() error {
+			return cm.performAccountFunding(ctx, false, log)
+		}, log) {
+			return
 		}
 
-		if err := cm.performContractPruning(ctx, false, log); err != nil {
-			log.Error("contract pruning failed", zap.Error(err))
+		if !performMaintenanceJob("contract pruning", func() error {
+			return cm.performContractPruning(ctx, false, log)
+		}, log) {
+			return
 		}
 
-		if err := cm.performSectorPinning(ctx, log); err != nil {
-			log.Error("sector pinning failed", zap.Error(err))
+		if !performMaintenanceJob("sector pinning", func() error {
+			return cm.performSectorPinning(ctx, log)
+		}, log) {
+			return
 		}
 
-		if err := cm.store.PruneUnpinnableSectors(ctx, time.Now().Add(-pruneUnpinnableThreshold)); err != nil {
-			log.Error("failed to prune unpinnable sectors", zap.Error(err))
+		threshold := time.Now().Add(-pruneUnpinnableThreshold)
+		if !performMaintenanceJob("pruning unpinnable sectors", func() error {
+			return cm.store.PruneUnpinnableSectors(ctx, threshold)
+		}, log) {
+			return
 		}
 	}
+}
+
+func performMaintenanceJob(descr string, fn func() error, log *zap.Logger) bool {
+	if err := fn(); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false
+		}
+		log.Error(descr+" failed", zap.Error(err))
+	}
+	return true
 }

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -262,7 +262,7 @@ func (m *SlabManager) initServiceAccounts(migrationAccount, integrityAccount typ
 // perform on slabs
 func (m *SlabManager) maintenanceLoop(ctx context.Context) {
 	var wg sync.WaitGroup
-	launch := func(task func()) {
+	launch := func(descr string, task func(context.Context) error) {
 		healthTicker := time.NewTicker(m.healthCheckInterval)
 
 		wg.Add(1)
@@ -275,25 +275,15 @@ func (m *SlabManager) maintenanceLoop(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				}
-				task()
+				if err := task(ctx); err != nil && !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+					m.log.Error("failed to perform "+descr, zap.Error(err))
+				}
 			}
 		}()
 	}
 
-	launch(func() {
-		if err := m.performIntegrityChecks(ctx); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return
-		} else if err != nil {
-			m.log.Error("failed to perform integrity checks", zap.Error(err))
-		}
-	})
-	launch(func() {
-		if err := m.performSlabMigrations(ctx); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return
-		} else if err != nil {
-			m.log.Error("failed to perform slab migrations", zap.Error(err))
-		}
-	})
+	launch("integrity checks", m.performIntegrityChecks)
+	launch("slab migrations", m.performSlabMigrations)
 	wg.Wait()
 }
 

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -281,12 +281,16 @@ func (m *SlabManager) maintenanceLoop(ctx context.Context) {
 	}
 
 	launch(func() {
-		if err := m.performIntegrityChecks(ctx); err != nil {
+		if err := m.performIntegrityChecks(ctx); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		} else if err != nil {
 			m.log.Error("failed to perform integrity checks", zap.Error(err))
 		}
 	})
 	launch(func() {
-		if err := m.performSlabMigrations(ctx); err != nil {
+		if err := m.performSlabMigrations(ctx); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		} else if err != nil {
 			m.log.Error("failed to perform slab migrations", zap.Error(err))
 		}
 	})


### PR DESCRIPTION
If we shutdown indexd during one of our maintenance loops, it unnecessarily logs a lot of failures. This PR should tackle most (if not all) of them.

```
{"level":"info","ts":"2025-09-26T02:23:14Z","caller":"indexd/run.go:242","msg":"shutdown signal received...attempting graceful shutdown..."}
{"level":"info","ts":"2025-09-26T02:23:14Z","caller":"indexd/run.go:266","msg":"...shutdown complete"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.bdeb677172f96a729a22da974c2a151d8e1ac9fa82c94a017e0cf50d0a23037b","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.344eb0f6e936e901b52cfa1db912a2ef80ca3f5f00a2e85d3df500e4476daa3b","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:1b473a2239c5290d45680ed1699795d94481a7a22b981d2c9a1456d1dd2dd699","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.1e6bf2bbcc99c462f3c1d62569d74f03072d81b3f1d6021b7ec20f8cceb1a285","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:9964b230d134bcb1e8f6a08a545684375c27b49f1ea48768116baf9a74bd89ff","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.344eb0f6e936e901b52cfa1db912a2ef80ca3f5f00a2e85d3df500e4476daa3b","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.4082211f58047d844de69c847ead24b9465a792238e5785ce7e0b95e2ff2e260","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.7b288b9425086ff34ec63cda6a7292522728fe3d6aa44aa5c7dfac457b535410","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.3dc88ca366ba3d1ea1686e23a91f6f93299b4c239bc0099dcca36d79cf58e32e","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:ec3331abf7d0a0bc4c0ad073644cdc5eca19c445e2939c2e7ab19ba82230c9db","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.0ac41ff4ce54c13831e39f227b17905926725993c29d2634b4f4fe0a85ba8cb6","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:ce1ad06650d66a7a7552d79ef812558d2881b15f75317eb78d9c296c9699c311","error":"failed to read sector: failed to read response: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.bdeb677172f96a729a22da974c2a151d8e1ac9fa82c94a017e0cf50d0a23037b","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:92282dfa2cb8e962b07f6d2f78ff0a78f336b75d810844c5104bb054595a21ff","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.7b288b9425086ff34ec63cda6a7292522728fe3d6aa44aa5c7dfac457b535410","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:50bca4be99b3131d80eb674566db67ba95f3251e2f29265ac2e8acc640e24444","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.3dc88ca366ba3d1ea1686e23a91f6f93299b4c239bc0099dcca36d79cf58e32e","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 7b288b9425086ff34ec63cda6a7292522728fe3d6aa44aa5c7dfac457b535410: downloaded 0 out of 2 shards: context canceled"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.11dbc4930bc3d3b67e1a4fddfa6fe41fb0c73c3f077ca55b90af97fd1124209f","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:5423b9f522f8e14b3dea4da09631b6c8c641132c797c897f5e87077b5920e495","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.0ac41ff4ce54c13831e39f227b17905926725993c29d2634b4f4fe0a85ba8cb6","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.1e6bf2bbcc99c462f3c1d62569d74f03072d81b3f1d6021b7ec20f8cceb1a285","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.d7545524ceac068fce4ae124f06073e32675d127d15173f0e0df3d6a3650c651","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:8b0c1316745b21e12c2b10128f2b1db0da18ed2b45e6994e7f7310b6876a3294","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 1e6bf2bbcc99c462f3c1d62569d74f03072d81b3f1d6021b7ec20f8cceb1a285: downloaded 0 out of 2 shards: context canceled"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.d55e60b29de1fdaa20437661434fc63cfd1a5b7ca9f41806b0da1f8df4fdc5ea","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 344eb0f6e936e901b52cfa1db912a2ef80ca3f5f00a2e85d3df500e4476daa3b: downloaded 0 out of 2 shards: context canceled"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.d55e60b29de1fdaa20437661434fc63cfd1a5b7ca9f41806b0da1f8df4fdc5ea","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:e249be0fb3d1ddbb36b06f1407928c60195686aca89882267349c78f144ca8ce","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.11dbc4930bc3d3b67e1a4fddfa6fe41fb0c73c3f077ca55b90af97fd1124209f","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.4082211f58047d844de69c847ead24b9465a792238e5785ce7e0b95e2ff2e260","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:5423b9f522f8e14b3dea4da09631b6c8c641132c797c897f5e87077b5920e495","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3.d7545524ceac068fce4ae124f06073e32675d127d15173f0e0df3d6a3650c651","caller":"slabs/downloads.go:123","msg":"failed to download shard","hostKey":"ed25519:75615c81f6de6506050bedb42d121b30761dc2fe6a45f0c02ad665c2df68294a","error":"failed to read sector: failed to read data: stream was gracefully closed"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab bdeb677172f96a729a22da974c2a151d8e1ac9fa82c94a017e0cf50d0a23037b: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 3dc88ca366ba3d1ea1686e23a91f6f93299b4c239bc0099dcca36d79cf58e32e: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 0ac41ff4ce54c13831e39f227b17905926725993c29d2634b4f4fe0a85ba8cb6: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab d55e60b29de1fdaa20437661434fc63cfd1a5b7ca9f41806b0da1f8df4fdc5ea: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 11dbc4930bc3d3b67e1a4fddfa6fe41fb0c73c3f077ca55b90af97fd1124209f: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab 4082211f58047d844de69c847ead24b9465a792238e5785ce7e0b95e2ff2e260: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations.e9cf19b2cee939836c5dc8fcaeee85e3","caller":"slabs/migrations.go:60","msg":"failed to migrate slab","error":"failed to download slab d7545524ceac068fce4ae124f06073e32675d127d15173f0e0df3d6a3650c651: downloaded 0 out of 2 shards: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs","caller":"slabs/manager.go:290","msg":"failed to perform slab migrations","error":"failed to begin transaction: context canceled"}
{"level":"debug","ts":"2025-09-26T02:23:14Z","logger":"slabs.migrations","caller":"slabs/manager.go:363","msg":"starting slab migrations","start":"2025-09-26T02:23:14Z"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"slabs","caller":"slabs/manager.go:290","msg":"failed to perform slab migrations","error":"failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:3128aca726a83738c089369fd4dbda1dd73d7c96113b90bd381ba69e1738fa48","force":false,"error":"failed to scan host, failed to fetch settings, failed to upgrade connection: failed to connect to \"entroducing.tplinkdns.com:9984\": dial tcp 49.245.70.118:9984: operation was canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:f166b306fbbcc6a774aead9605e2e9187ed660254a513d68f282a722a4c6b74c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:d2d24b4bf3958fc484d8b0fec9792a401a178f56d527dfd0a94afa4a6777f399","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:38bf1b2f626a172eaac16ed44b602f623b0ee23616ee1dc478c1a2bdeb42913c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:e249be0fb3d1ddbb36b06f1407928c60195686aca89882267349c78f144ca8ce","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:7f7000041cd55d9ca4f8be9c7e587bb4e4a79b320b699a05b723eed9b1104b64","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:cb807bf0edbd86b865aedbf9948ea46949c090a74ce0e1effb5343b0c44f6df6","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:97da923688f0ba983321697904ecb3649712c390a69fd662f70659c63981a06d","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:586e049fd9e1324030b75698064db804e1ef83c0083da6ecd6e32744890e5966","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:d5bfc8fcf4976b1b17f8ddcd843afc50ce52f144a2dbcff75bd75b0fdbe41249","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:0fb2ddfd2bd81142b03a3db01258292c0ce541f946463348cdb1c1547dae73f9","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:0cda28bdbee364da451ee71c1dcae856c35daf5f0d91a8371932442dec6374af","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:cd428930c1455d5aba6e9c964d1b53b258a07dafd872033f7514f484b068596e","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:f88fc66c25a9635afc6d6e7c653551ac6af4ea0a54650dd973f64517af90b8e7","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:ec3331abf7d0a0bc4c0ad073644cdc5eca19c445e2939c2e7ab19ba82230c9db","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:4298a298dd84bc48028f7bcf267e8b779a41fa671df3924cf47199fc7d344e2c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:3794d9438e79cbfa16c419c367e4c18ee6b34f5f8a7670e2c3dd485c16787297","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:f54367610e7917b51e9a731bba11f68a4570415e3518901d6e89c6912e1b2278","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:cfc3034e2270ebf2f55683b5ff485b6678186417d2f8def08e4e2c25912af321","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:45699ce33ed8161894e315d40fa9c8da85e815a2b8be1f1169a03bd098fe7a3c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:3f39e8be4206ef20cb346602feba81d366fcd7ce64a225f4b44c7e6c73be1075","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:cee586ac30b5051228fe730c599d6783a1f8ceabd3d99bd77e66b32288842543","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:01d14791302b9d8e9037cc70c5e7e4d670e276af875c2db9eefec9385620f6b6","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:9c8cd0a6ec26a5c7362861aaf2ad63d506d29914b6c2849b5737becaef4fd9ec","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c5751343decc773389e6744a69effb5cf0c2576c2af874bb69d4643eb678aade","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:3e19a46061f373e8548700876316201e315e69e6ee48b00c8d79f307c5cddbfc","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c8100e62d9bf5de75ce874ef9b23e23da5afbab1d988e25dd7c528b09f1522fb","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:ae98dd8194d7ffba2cae18e4315c5a9fc61a5123eaf1872516ebba953bc49ac5","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c96f0b378b7c7f141c33df2d3625d40f5a338136409fbaeacc0f6d0871ac127d","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:7b249f6a8fd5b9563f5e668ebe40a432130d6d1c588b6e793ec1439c88101621","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:97541e985d72fb9151bcb9f50f413138803c0a1adb899d2064bdaa91f1011c3a","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:ce8272efd45f1f6e6d1c7a20ee43eabad83284983ae530f7d162ea654dccca9c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:baf4061d9865f509722327ff5ca85203523b2a71afd50806c1322b5ca1ac6fcc","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:167052f289b38d926260ad8190baff9e0353a745e8a40c77795e1054e0df1a46","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:1bdf513521b27bed0fc278acf40d7e0a43c6f1556fe3789aa89601505d061756","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:5b34cd8e05a47fbce60778a328baa0265124f48d15ed9ed3775ae8f88a6ca8de","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:a8544ee30760baa192a0dd32a34be3cba62f73d9b6562904f4d681491c8b1606","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:9e12f3cbd436d5d1fd037a159c28c7265a0cd327fd63a64dac7d0fbad6d3d582","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:e6ae8d565dd974eb7e25026bcad55a41a6bcd3e046cc4df150424683e77c92ca","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:d624c6db542ca8be19f4f51b05896b081ff801c18785443eec9a3357866d195c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:eb5172fb6e1644d9308ca55caf1ffcafccd4ff1542918daeb69b024ed602409e","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:5423b9f522f8e14b3dea4da09631b6c8c641132c797c897f5e87077b5920e495","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c761cce8a6a7c0ed4f3824ac5d71076a515152bf234d936a22a1734fb4445bcf","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:1d43801aa499b76b9cae3f2117c1c5734f7812c1b9ecb3e7ee810fc0888e6b9f","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:6f6b07c8206d7077b559fcd65652ac3c106cd457317ee7bcfdfce8e022fd1fae","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:3bfefda3e91d724e02a74c95830eade6441a565d50ac762f93c625cc5a529a2c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:8ce562d3c19bf1f060cd0ca7c8428586e2e1906591d17a592c207e18c2e042ba","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:9e5bd3690c2cde02d8b0d6c84c081b018424cc566244a7a7e1f25a7e5c686d4b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:381423994909daf6cbd1a779fb73f40b1b034adaf64fb9da62a0f797ecdc624b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:fd9090f5973fc92410e141d2ca7112f266a5f9e5aca9a7024f4116b5a3504274","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:da2e16500a5413f31170a37334e91eeccf38af620861991bad21a9e9eb9061e7","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:365c507e918960b3b73be218384ed61d58b2e8e6d5ed86242b23e5312e04c280","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:58c13a5bb97cdd9f42fa475f97e531bfae4dfe2f142bf9ae50cf8cd075819872","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:f291371aedfd74fd8a7f2a42b56ff46ecda298bc72bfd2dd7618408d75a8fc26","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:382c7ea2a45e11fda3b3fa7318f56690763e1be7a6451cc3f055010f171bfdaa","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:05f83ae1236c063fc6a14ba8c6771f7ea1e326f96ec69b6b49e09157ee602121","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:aa0321bef5823e24662ecceddc475041fd0c52ff0e4a9258af563cf9b8c100c4","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:0eb6fb00c40cc94f72f8ee59a49665c3d4d202bd18f6feb3d41bb912da4e7bac","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:6ca72d775f21931df582314fb7df0c56066cd96ace322f3ea97f2a1171bf936b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:a45e96c7019be76a7aa57f508b683cf7da2dff603d7b3fda63009016a53b0ca1","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:1b7913f49d5410a99dc184a7c88e2a638eee94c87b6b3af5cb61c3e9a4c13212","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:1effbcd6411c6a305c9f6bb43c42e4f2da1d674e3f179259777beb259faaa194","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:e291c871b48213c0e697877455cf70daf31f2e04b206b8fa3c607e1df0fc497b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:0796bc73d9c1d60e4f5c6678435b324bf849dc979088d1f577efd2e4429ed4db","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:b2c62d20263e370dd98c35c176d775424f353e580629c4202da2aa4d348e8e03","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:b7f7eefb28aac62139ad1aa3f5eca696fc27100ba99fc6e58d38d2c43eccd659","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:5f575c9371c049e1da69524f0561a6be19096494af3f26f3365b8275e182ad50","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c44ba129e35fc5ed63412b3348a5df5deaec0a402a88ae20084c67c846291f9a","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:1b8647e7583f76befdd1d772ec53b86f33d8978682052b003b00e176c094f264","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:b273cf91f18d9ff574cd3e10fa6619c80f5db27fc4c5cbf6aa70cf73991145f5","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:a2d26f8dd2f55781f967a5ca179d3655437895535ff29d0924d246f3a82b2004","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:62ea72d1b258a67ed7b6b7e4064153c8f8e0e40f88466ff1bcb134a8ca435232","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:6e96f7f3c0d70a33a0a4b5dd5fdec883acb834b5cc3667d7dbfa8134be9bb2c7","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:5457df80d247691e51778642d7c93bd7a3aeb0025c5f0d3ee174904265fcd94d","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:7cb55846ba1d271a384d50585d52003e5b766f32cebc87841d841845c2ee2c10","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:40b145f1e6a7f8294386a333c70f10456de19bdf892c0a181f0e18f225e54afa","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:0247d704dd9140c40243ec2e18344a7d5b62069ef4c062bc2928e74112aa90a3","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:327c8542bcff02d7bc2a6021cffc694bfa1b441eff80110f0819deabc7810344","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:fba406818f558676e117323f45665f3affbb10bb025f74548fafe66df0dd5274","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:ae9e41bd163373ce6977680951a2b97e4317523ec770acb349cf94af1d52d315","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:9167094dc19fc706ce10405baacc8072c1d35fd8433e9e4be93158d15d776183","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c382eb06d719d7720549e8073c0aafa94658f58945bb6771aa73a6f7426565a5","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:4074d176be9fe4d4a1ab46abf6102651ac39166eeb93061c09536b488fe49080","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:949819f0b2969395385b0f079df17829d86a02725bb6e21218e6a3208a970cb3","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c7a0b59262eca12e213d86ab1c4252e76b7b5bc3a7fe5e6c6affeb4bf15cc423","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:2fa891ec9c60730f06ab74c581d9f4419210f219555e822ac7609ed348995d28","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:6fa5984496eb525092ea60b2cad14d191337e1d7868eb2c72523830992abff22","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:3f05e711c6fb414555b3957fdcb74643bb6dd34ce4f94442ffa2f5eeff90922c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:890c504b73f58f81f98abad9c41f27a75732bb98269fe032f6962b9ff776bfba","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:557a715045b824e5ec3a71fb417bd3921829cfb1fdcaf32b1c9a0cc0eeb15483","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:e684675abef9fc14909965331441c9ff3c6ac270666736d1335ed8820a33e75b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:dbc344464fbde26e3ae5b6243c0d5d23d0272465dd778b9a6a1b4a95ec6247a6","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:6410baa4fd1b68d61df0430024e563e345d9adc37b12ba7a03cc80ace31d5bfc","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:21ede3a88ef16924b2abd8c7d5c00b085c33e17a11e4a8611df8715714ef4650","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:547b6bca84f90d05827d42f7f49ca6bfad678b51e84956fa0d57e164fcf3d2a1","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:ea6fa149022d645714927c2ac577afb748ee5efb55cbd8ae5b833a6eb15fc3fb","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:14abb9d376abdc3e3920e76cd27d8d4271fa2ea0fe08b74df897adf22329d235","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:fd59e75632bf88c6e52bcc1df3b88ea04b1cf9c25f92a343c05d10e3656b949f","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:d8ab5fdc4aa3c7ba47526d565b318dbad98f25fdfc1934e995ccdb266b05d0d6","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:154bee9ca48de47704da0c839418e803d467f861147a4e7e43dffe5b97d3c7b2","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:6d1b26661f3866e089a6372bc97152a583b20c9ad9c802fff5818afc411c3d7b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:4d313deb5e26cb8a527901861684a9af7c04a14e18ac8d8234168a6333307dcd","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:50bca4be99b3131d80eb674566db67ba95f3251e2f29265ac2e8acc640e24444","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:02962bac82e57747793c09d54f356c23a0698d09f2f0cc332522b2dba63161e9","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:54292cfed80d5bbd5dc9f0986ead13c6d46f35817639756fecb87e8d3ecda4f1","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:4720a1d2127ef1236fc53ae32d034864bd8ce47c336cd9ff23f92d471fd373d6","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:7971523cc2c04b93c30a7017fba0f78c6375754d5277f1ae8ac1adb5478be1fc","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:ee932313dd43de576b50991638891f4dfa146fefce3754b3632746f49320d96e","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:b7cbc560e8f389eb91702cc18ff38d4434d4e91ef03f201b5521dbf415a092bf","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:39e40667db6bd5c781aee104caae0ed8216d544bfd348e6f365cf30c846a5365","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:96e2b58d8235b031ed3b4fa684ae08020eb4039ed3c106891301bad101a447c7","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:5979173b6e7f96a56624f49c175737a87e7c0adc1f7412ac5120e9dc0cab139b","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:35e4a78314ccc770a99309b50ba3e58405aa4b9ba346b484c79a1dbc97282fe3","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:1dcaeab5f47c506a6947cf7f532b52b25f6ea82919e5724be88275457e6a3057","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:783c49d3a116c694bcbf2c88323f9bf4f5a444a3866bd327182e3a6a92a446b3","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:c1c6aa1407b52f418bf611ee6867e79e7a0a4bb1b110681bb09b41f370f0334c","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:e6428965f42d90c62c487663a0346440c6648c456928f8105dcdf5e0d6fdd70f","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:01217be817bce1d3aa8137ede6a7572c6260d5b1c4351c335b3e686ac2cd8241","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:36f84c5e6a52d44d2bfa51a84bdb5f2c5b7522a70c1b9e106b7ec84f10476c72","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance.formation","caller":"contracts/form.go:286","msg":"failed to form contract","hostKey":"ed25519:db869af21e4547e974b47db63bcf7d40740051dde472661cdc7e320d71dd9770","force":false,"error":"failed to get host, failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance","caller":"contracts/maintenance.go:154","msg":"contract maintenance failed","error":"failed to broadcast contract revisions: failed to fetch contracts for broadcasting: failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance","caller":"contracts/maintenance.go:158","msg":"account funding failed","error":"failed to fetch hosts for account funding: failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance","caller":"contracts/maintenance.go:162","msg":"contract pruning failed","error":"failed to fetch hosts for pruning: failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance","caller":"contracts/maintenance.go:166","msg":"sector pinning failed","error":"failed to fetch hosts for pinning: failed to begin transaction: context canceled"}
{"level":"error","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance","caller":"contracts/maintenance.go:170","msg":"failed to prune unpinnable sectors","error":"failed to begin transaction: context canceled"}
{"level":"info","ts":"2025-09-26T02:23:14Z","logger":"contracts.maintenance","caller":"contracts/manager.go:275","msg":"waiting for wallet to be scanned before doing contract maintenance"}
```