### PR TITLE
Update min protocol version and fix spammy logging for bad hosts

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -242,7 +242,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		err := cm.hosts.WithScannedHost(ctx, hostKey, func(host hosts.Host) error {
 			// make sure host is still good
 			if !isGood(host, hostLog) {
-				return fmt.Errorf("host is not good: %s", host.PublicKey)
+				return fmt.Errorf("%w: %s", hosts.ErrBadHost, host.PublicKey)
 			}
 
 			allowance, collateral := contractFunding(host.Settings, 0, minAllowance.Mul64(activeAccounts), minHostCollateral, period)

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -38,7 +38,7 @@ var (
 		MaxIngressPrice:    types.Siacoins(3000).Div64(oneTB),                       // 3000 SC / TB
 		MaxStoragePrice:    types.Siacoins(3000).Div64(oneTB).Div64(blocksPerMonth), // 3000 SC / TB / month
 		MinCollateral:      types.Siacoins(100).Div64(oneTB).Div64(blocksPerMonth),  // 100 SC / TB / month
-		MinProtocolVersion: rhp.ProtocolVersion400,
+		MinProtocolVersion: rhp.ProtocolVersion501,
 	}
 )
 

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -265,8 +265,6 @@ func (m *HostManager) UpdateUsabilitySettings(ctx context.Context, us UsabilityS
 // NOTE: It's important that the function passed to WithScannedHost can be
 // called twice.
 func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, fn func(h Host) error) error {
-	logger := m.log.With(zap.Stringer("hk", hk))
-
 	// fetch host
 	host, err := m.store.Host(ctx, hk)
 	if err != nil {

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -285,7 +285,6 @@ func (m *HostManager) WithScannedHost(ctx context.Context, hk types.PublicKey, f
 			return nil // 'fn' succeeded so we're done
 		}
 	}
-	logger.Debug("host has outdated prices, rescan")
 
 	// scan the host if the prices were outdated
 	host, err = m.ScanHost(ctx, hk)


### PR DESCRIPTION
This PR makes sure that we don't log every bad host we attempt to form a contract with as an error anymore by wrapping `hosts.ErrBadHost` like we do in other places. Must have been an oversight.

Also bumps the min protocol version to be 5.0.1 by default since we now have more than 400 hosts on that version according to the indexer's database. This gets rid of all the issues during pruning and pinning related to the max sector batch size. It also means we consistently use the new refresh RPC.