### PR TITLE
Efficiently pin sectors across contracts

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -113,7 +113,7 @@ func (c *HostClient) AccountBalance(ctx context.Context, account proto.Account) 
 // The integer returned does not indicate the number of sectors that were
 // appended, but rather the number of sectors that were attempted. Check the
 // result for the actual number of sectors that were appended.
-func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (res rhp.RPCAppendSectorsResult, remaining int, err error) {
+func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (res rhp.RPCAppendSectorsResult, attempted int, err error) {
 	// sanity check
 	if len(sectors) > proto.MaxSectorBatchSize {
 		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
@@ -142,7 +142,7 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 		// only attempt to append up to the calculated maximum number of sectors
 		if uint64(len(sectors)) > maxAppendSectors {
 			sectors = sectors[:maxAppendSectors]
-			remaining = len(sectors)
+			attempted = len(sectors)
 		}
 
 		res, err = rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, contract, sectors)

--- a/client/client.go
+++ b/client/client.go
@@ -106,29 +106,53 @@ func (c *HostClient) AccountBalance(ctx context.Context, account proto.Account) 
 	return rhp.RPCAccountBalance(ctx, c.client, account)
 }
 
-// AppendSectors appends the given sectors to the contract.
-func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
+// AppendSectors appends the given sectors to the contract. If the contract
+// cannot fit all sectors, as many as possible will be appended and the number of
+// sectors attempted will be returned.
+//
+// The integer returned does not indicate the number of sectors that were
+// appended, but rather the number of sectors that were attempted. Check the
+// result for the actual number of sectors that were appended.
+func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (res rhp.RPCAppendSectorsResult, remaining int, err error) {
 	// sanity check
 	if len(sectors) > proto.MaxSectorBatchSize {
-		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
+		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
 	}
 
 	// append sectors
-	var res rhp.RPCAppendSectorsResult
-	if err := c.withRevision(ctx, contractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
+	err = c.withRevision(ctx, contractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
 		if contract.Revision.Filesize > maxContractSize {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d", contract.Revision.Filesize, maxContractSize)
 		}
+		// calculate the maximum number of sectors we can append based on the
+		// contract's remaining capacity and collateral
+		maxRemainingSectors := (maxContractSize - contract.Revision.Filesize) / proto.SectorSize
+		var maxAppendSectors uint64
+		if contract.Revision.Filesize < contract.Revision.Capacity {
+			maxAppendSectors = (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
+		}
+		sectorCollateralCost := hostPrices.RPCAppendSectorsCost(1, contract.Revision.ExpirationHeight-hostPrices.TipHeight).RiskedCollateral
+		if sectorCollateralCost.IsZero() {
+			sectorCollateralCost = types.NewCurrency64(1) // avoid division by zero
+		}
+		maxAppendSectors += contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
+		// ensure the maximum contract size is not exceeded
+		maxAppendSectors = min(maxAppendSectors, maxRemainingSectors)
+
+		// only attempt to append up to the calculated maximum number of sectors
+		if uint64(len(sectors)) > maxAppendSectors {
+			sectors = sectors[:maxAppendSectors]
+			remaining = len(sectors)
+		}
+
 		res, err = rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, contract, sectors)
 		if err != nil {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("failed to append sectors: %w", err)
 		}
 		contract.Revision = res.Revision
 		return contract, res.Usage, nil
-	}); err != nil {
-		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("failed to append sectors: %w", err)
-	}
-	return res, nil
+	})
+	return
 }
 
 // Close closes the underlying transport client.

--- a/client/client.go
+++ b/client/client.go
@@ -121,23 +121,26 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 
 	// append sectors
 	err = c.withRevision(ctx, contractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
-		if contract.Revision.Filesize > maxContractSize {
+		if contract.Revision.Filesize >= maxContractSize {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d", contract.Revision.Filesize, maxContractSize)
+		} else if contract.Revision.ExpirationHeight <= hostPrices.TipHeight {
+			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract has expired at height %d, current height is %d", contract.Revision.ExpirationHeight, hostPrices.TipHeight)
 		}
 		// calculate the maximum number of sectors we can append based on the
 		// contract's remaining capacity and collateral
 		maxRemainingSectors := (maxContractSize - contract.Revision.Filesize) / proto.SectorSize
-		var maxAppendSectors uint64
-		if contract.Revision.Filesize < contract.Revision.Capacity {
-			maxAppendSectors = (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
-		}
-		sectorCollateralCost := hostPrices.RPCAppendSectorsCost(1, contract.Revision.ExpirationHeight-hostPrices.TipHeight).RiskedCollateral
+		maxAppendSectors := (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
+		duration := contract.Revision.ExpirationHeight - hostPrices.TipHeight
+		sectorCollateralCost := hostPrices.RPCAppendSectorsCost(1, duration).RiskedCollateral
 		if sectorCollateralCost.IsZero() {
 			sectorCollateralCost = types.NewCurrency64(1) // avoid division by zero
 		}
 		maxAppendSectors += contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
 		// ensure the maximum contract size is not exceeded
 		maxAppendSectors = min(maxAppendSectors, maxRemainingSectors)
+		if maxAppendSectors == 0 {
+			return rhp.ContractRevision{}, proto.Usage{}, ErrContractOutOfFunds
+		}
 
 		// only attempt to append up to the calculated maximum number of sectors
 		if uint64(len(sectors)) > maxAppendSectors {

--- a/client/client.go
+++ b/client/client.go
@@ -142,9 +142,8 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 		// only attempt to append up to the calculated maximum number of sectors
 		if uint64(len(sectors)) > maxAppendSectors {
 			sectors = sectors[:maxAppendSectors]
-			attempted = len(sectors)
 		}
-
+		attempted = len(sectors)
 		res, err = rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, contract, sectors)
 		if err != nil {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("failed to append sectors: %w", err)

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -79,8 +79,9 @@ type hostClientMock struct {
 	renewCalls        []renewContractCall
 	sectorRootsCalls  []sectorRootsCall
 
-	sectorRoots    map[types.FileContractID][]types.Hash256
-	missingSectors map[types.Hash256]struct{}
+	maxPinnedPerAppend int
+	sectorRoots        map[types.FileContractID][]types.Hash256
+	missingSectors     map[types.Hash256]struct{}
 }
 
 func newHostClientMock() *hostClientMock {

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -62,7 +62,14 @@ type (
 	// contracts.
 	HostClient interface {
 		io.Closer
-		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error)
+		// AppendSectors appends the given sectors to the contract. If the contract
+		// cannot fit all sectors, as many as possible will be appended and the number of
+		// sectors attempted will be returned.
+		//
+		// The integer returned does not indicate the number of sectors that were
+		// appended, but rather the number of sectors that were attempted. Check the
+		// result for the actual number of sectors that were appended.
+		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, int, error)
 		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
 		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
 		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -99,9 +99,10 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 	return ctx.Err()
 }
 
-// pinSectors pins a set of sectors using the given set of contracts The
-// contracts are tried in order, the contract ID that ends up being used is
-// returned, alongside with a list of missing sectors if any.
+// pinSectors pins a set of sectors using the given set of contracts. It will
+// attempt to pin all sectors, but may not be able to if the contracts run out of
+// space. It will try to pin sectors using the contracts in the order they are
+// provided. If the host refuses to pin a sector, it will be marked as lost.
 func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, hostKey types.PublicKey, hostPrices proto.HostPrices, contractIDs []types.FileContractID, sectors []types.Hash256, log *zap.Logger) error {
 	for _, contractID := range contractIDs {
 		if len(sectors) == 0 {
@@ -119,26 +120,25 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 			continue
 		}
 
-		// TODO: this should be atomic with where the contract revision is updated.
-		// Any time a revision is saved the sectors that were added or removed should
-		// be updated in the same transaction.
+		// TODO: this should be atomic with the contract revision. Any time a
+		// revision is saved the sectors that were added or removed should
+		// be updated in the same transaction for consistency.
 		if err := cm.store.PinSectors(ctx, contractID, res.Sectors); err != nil {
 			return fmt.Errorf("failed to pin sectors: %w", err)
 		}
 
-		// if a contract didn't have enough space to pin all the sectors,
-		// it may have pinned some of them. Only the sectors that were
-		// attempted should be marked as missing.
+		// Only the sectors that were attempted should be marked
+		// as missing. So sectors that were not part of the append
+		// call can be pinned to other contracts.
 		if len(res.Sectors) != len(sectors[:attempted]) {
-			missing := sectors[:attempted]
 			lookup := make(map[types.Hash256]struct{}, attempted)
-			for _, sector := range missing {
+			for _, sector := range sectors[:attempted] {
 				lookup[sector] = struct{}{}
 			}
 			for _, sector := range res.Sectors {
 				delete(lookup, sector)
 			}
-			missing = missing[:0]
+			missing := make([]types.Hash256, 0, len(lookup))
 			for sector := range lookup {
 				missing = append(missing, sector)
 			}
@@ -148,8 +148,8 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 			}
 			log = log.With(zap.Int("missing", len(missing)))
 		}
+		sectors = sectors[attempted:] // pin the remaining sectors
 		log.Debug("pinned sectors", zap.Int("pinned", len(res.Sectors)), zap.Int("attempted", attempted))
-		sectors = sectors[attempted:]
 	}
 	return nil
 }

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -61,7 +61,7 @@ loop:
 	return ctx.Err()
 }
 
-func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host hosts.Host, hostLog *zap.Logger) error {
+func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host hosts.Host, log *zap.Logger) error {
 	// check host is good
 	if !host.IsGood() {
 		return fmt.Errorf("host is bad: blocked=%t, usable=%t", host.Blocked, host.Usability.Usable())
@@ -82,19 +82,6 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 		return errors.New("no contracts for pinning")
 	}
 
-	var nPinned, nMissing uint64
-	defer func() {
-		if nPinned+nMissing > 0 {
-			hostLog.Debug(
-				"pinned sectors",
-				zap.Uint64("bytesPinned", nPinned*proto.SectorSize),
-				zap.Uint64("sectorsMissing", nMissing),
-			)
-		}
-	}()
-
-	const updateDBBatchSize = 1000
-
 	var exhausted bool
 	for !exhausted && ctx.Err() == nil {
 		roots, err := cm.store.UnpinnedSectors(ctx, host.PublicKey, proto.MaxSectorBatchSize)
@@ -104,40 +91,9 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 			exhausted = true
 		}
 
-		contractID, missing, err := pinSectors(ctx, client, host.Settings.Prices, contractIDs, roots, hostLog)
-		if err != nil {
+		if err := cm.pinSectors(ctx, client, host.PublicKey, host.Settings.Prices, contractIDs, roots, log); err != nil {
 			return fmt.Errorf("failed to pin sectors: %w", err)
 		}
-
-		if len(missing) > 0 {
-			for i := 0; i < len(missing); i += updateDBBatchSize {
-				end := min(i+updateDBBatchSize, len(missing))
-				if err := cm.store.MarkSectorsLost(ctx, host.PublicKey, missing[i:end]); err != nil {
-					return fmt.Errorf("failed to mark sectors as lost: %w", err)
-				}
-			}
-
-			isMissing := make(map[types.Hash256]struct{}, len(missing))
-			for _, sector := range missing {
-				isMissing[sector] = struct{}{}
-			}
-
-			filtered := roots[:0]
-			for _, root := range roots {
-				if _, missing := isMissing[root]; !missing {
-					filtered = append(filtered, root)
-				}
-			}
-			roots = filtered
-		}
-
-		err = cm.store.PinSectors(ctx, contractID, roots)
-		if err != nil {
-			return fmt.Errorf("failed to pin sectors: %w", err)
-		}
-
-		nMissing += uint64(len(missing))
-		nPinned += uint64(len(roots))
 	}
 
 	return ctx.Err()
@@ -146,40 +102,54 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 // pinSectors pins a set of sectors using the given set of contracts The
 // contracts are tried in order, the contract ID that ends up being used is
 // returned, alongside with a list of missing sectors if any.
-func pinSectors(ctx context.Context, client HostClient, hostPrices proto.HostPrices, contractIDs []types.FileContractID, sectors []types.Hash256, log *zap.Logger) (usedContractID types.FileContractID, missing []types.Hash256, _ error) {
+func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, hostKey types.PublicKey, hostPrices proto.HostPrices, contractIDs []types.FileContractID, sectors []types.Hash256, log *zap.Logger) error {
 	for _, contractID := range contractIDs {
-		contractLog := log.With(zap.Stringer("contractID", contractID))
+		if len(sectors) == 0 {
+			break
+		}
+		log := log.With(zap.Stringer("contractID", contractID))
 
 		// try to pin sectors to the contract
-		res, err := client.AppendSectors(ctx, hostPrices, contractID, sectors)
+		res, attempted, err := client.AppendSectors(ctx, hostPrices, contractID, sectors)
 		if err != nil {
-			contractLog.Debug("failed to pin sectors", zap.Error(err))
+			log.Debug("failed to pin sectors", zap.Error(err))
 			continue
 		} else if len(res.Sectors) == 0 {
-			contractLog.Debug("no sectors were pinned")
+			log.Debug("no sectors were pinned")
 			continue
 		}
 
-		// figure out which sectors were missing if necessary
-		if len(res.Sectors) != len(sectors) {
-			lookup := make(map[types.Hash256]struct{}, len(sectors))
-			for _, sector := range sectors {
+		// TODO: this should be atomic with where the contract revision is updated.
+		// Any time a revision is saved the sectors that were added or removed should
+		// be updated in the same transaction.
+		if err := cm.store.PinSectors(ctx, contractID, res.Sectors); err != nil {
+			return fmt.Errorf("failed to pin sectors: %w", err)
+		}
+
+		// if a contract didn't have enough space to pin all the sectors,
+		// it may have pinned some of them. Only the sectors that were
+		// attempted should be marked as missing.
+		missing := sectors[:attempted]
+		// figure out which sectors were missing
+		if len(res.Sectors) != len(missing) {
+			lookup := make(map[types.Hash256]struct{}, attempted)
+			for _, sector := range missing {
 				lookup[sector] = struct{}{}
 			}
 			for _, sector := range res.Sectors {
 				delete(lookup, sector)
 			}
+			missing = missing[:0]
 			for sector := range lookup {
 				missing = append(missing, sector)
 			}
 
-			contractLog.Debug("some sectors were not pinned", zap.Int("pinned", len(res.Sectors)), zap.Int("missing", len(missing)))
+			if err := cm.store.MarkSectorsLost(ctx, hostKey, missing); err != nil {
+				return fmt.Errorf("failed to mark sectors as lost: %w", err)
+			}
 		}
-
-		// TODO: handle usage
-
-		usedContractID = contractID
-		return
+		log.Debug("pinned sectors", zap.Int("pinned", len(res.Sectors)), zap.Int("attempted", attempted), zap.Int("missing", len(missing)))
+		sectors = sectors[attempted:]
 	}
-	return types.FileContractID{}, nil, errors.New("no usable contract found")
+	return nil
 }

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -129,9 +129,8 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 		// if a contract didn't have enough space to pin all the sectors,
 		// it may have pinned some of them. Only the sectors that were
 		// attempted should be marked as missing.
-		missing := sectors[:attempted]
-		// figure out which sectors were missing
-		if len(res.Sectors) != len(missing) {
+		if len(res.Sectors) != len(sectors[:attempted]) {
+			missing := sectors[:attempted]
 			lookup := make(map[types.Hash256]struct{}, attempted)
 			for _, sector := range missing {
 				lookup[sector] = struct{}{}
@@ -147,8 +146,9 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 			if err := cm.store.MarkSectorsLost(ctx, hostKey, missing); err != nil {
 				return fmt.Errorf("failed to mark sectors as lost: %w", err)
 			}
+			log = log.With(zap.Int("missing", len(missing)))
 		}
-		log.Debug("pinned sectors", zap.Int("pinned", len(res.Sectors)), zap.Int("attempted", attempted), zap.Int("missing", len(missing)))
+		log.Debug("pinned sectors", zap.Int("pinned", len(res.Sectors)), zap.Int("attempted", attempted))
 		sectors = sectors[attempted:]
 	}
 	return nil

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -120,9 +120,6 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 			continue
 		}
 
-		// TODO: this should be atomic with the contract revision. Any time a
-		// revision is saved the sectors that were added or removed should
-		// be updated in the same transaction for consistency.
 		if err := cm.store.PinSectors(ctx, contractID, res.Sectors); err != nil {
 			return fmt.Errorf("failed to pin sectors: %w", err)
 		}
@@ -130,7 +127,7 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 		// Only the sectors that were attempted should be marked
 		// as missing. So sectors that were not part of the append
 		// call can be pinned to other contracts.
-		if len(res.Sectors) != len(sectors[:attempted]) {
+		if len(res.Sectors) != attempted {
 			lookup := make(map[types.Hash256]struct{}, attempted)
 			for _, sector := range sectors[:attempted] {
 				lookup[sector] = struct{}{}

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -194,7 +194,7 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// contracts with more
+	// contracts with greater capacity are preferred
 	for i, c := range store.contracts {
 		switch c.ID {
 		case fcid1:

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
@@ -12,7 +13,7 @@ import (
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/indexd/hosts"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
 
@@ -22,25 +23,29 @@ type appendSectorCall struct {
 	sectors    []types.Hash256
 }
 
-func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, error) {
+func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, int, error) {
 	if c.failsRPCs {
-		return rhp.RPCAppendSectorsResult{}, fmt.Errorf("mocked error")
+		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("mocked error")
 	}
 
 	c.appendSectorCalls = append(c.appendSectorCalls, appendSectorCall{
 		hostPrices: hostPrices,
 		contractID: contractID,
-		sectors:    sectors,
+		sectors:    slices.Clone(sectors),
 	})
 
+	n := len(sectors)
+	if c.maxPinnedPerAppend != 0 {
+		n = min(c.maxPinnedPerAppend, n)
+	}
 	appended := make([]types.Hash256, 0, len(sectors))
-	for _, sector := range sectors {
+	for _, sector := range sectors[:n] {
 		if _, ok := c.missingSectors[sector]; !ok {
-			appended = append(appended, sector)
+			appended = append(appended, sector) // skip missing sectors
 		}
 	}
 
-	return rhp.RPCAppendSectorsResult{Sectors: appended}, nil
+	return rhp.RPCAppendSectorsResult{Sectors: appended}, n, nil
 }
 
 func (c *hostClientMock) Settings(ctx context.Context) (proto.HostSettings, error) {
@@ -153,6 +158,7 @@ func (s *storeMock) UnpinnedSectors(ctx context.Context, hostKey types.PublicKey
 }
 
 func TestPerformSectorPinningOnHost(t *testing.T) {
+	log := zaptest.NewLogger(t)
 	store := newStoreMock()
 
 	// prepare two hosts
@@ -205,35 +211,25 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 	}
 
 	// prepare roots
-	r1 := types.Hash256{1}
-	r2 := types.Hash256{2}
-	r3 := types.Hash256{3}
-	r4 := types.Hash256{4}
-	r5 := types.Hash256{5}
-	r6 := types.Hash256{6}
-	r7 := types.Hash256{7}
-	r8 := types.Hash256{8}
+	roots := make([]types.Hash256, 8)
+	for i := range roots {
+		roots[i] = frand.Entropy256()
+	}
 
 	// prepare sectors for h1
 	store.sectors[hk1] = []sector{
-		{root: r1},
-		{root: r2},
-		{root: r3},
-		{root: r4},
-		{root: r5},
-		{root: r6},
+		{root: roots[0]},
+		{root: roots[1]},
+		{root: roots[2]},
+		{root: roots[3]},
+		{root: roots[4]},
+		{root: roots[5]},
 	}
 
 	// prepare sectors for h2
 	store.sectors[hk2] = []sector{
-		{root: r7},
-		{root: r8},
-	}
-
-	// prepare sectors for h3 - these will remain unpinned
-	store.sectors[types.PublicKey{3}] = []sector{
-		{root: frand.Entropy256()},
-		{root: frand.Entropy256()},
+		{root: roots[6]},
+		{root: roots[7]},
 	}
 
 	// prepare dialer
@@ -245,7 +241,7 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 	dialer.clients[hk2] = h2Mock
 
 	// indicate that root 4 is missing
-	dialer.clients[hk1].missingSectors[r4] = struct{}{}
+	dialer.clients[hk1].missingSectors[roots[3]] = struct{}{}
 
 	// prepare hm
 	hm := newHostManagerMock(store)
@@ -254,88 +250,184 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 
 	// prepare contract manager
 	cm := newContractManager(types.PublicKey{}, nil, nil, store, dialer, hm, nil, nil)
+	assertSectorsContract := func(hostKey types.PublicKey, roots []types.Hash256, contractID *types.FileContractID) {
+		t.Helper()
+
+		sectors, ok := store.sectors[hostKey]
+		if !ok {
+			t.Fatalf("expected sectors for host %v", hostKey)
+		}
+		for _, sector := range sectors {
+			if !slices.Contains(roots, sector.root) || sector.contractID == nil && contractID == nil {
+				// sector not part of the check, or both unpinned
+				continue
+			} else if contractID == nil && sector.contractID != nil {
+				t.Fatalf("expected sector %v to be unpinned, got %v", sector.root, *sector.contractID)
+			} else if contractID != nil && sector.contractID == nil {
+				t.Fatalf("expected sector %v to be pinned to contract %v, got unpinned", sector.root, *contractID)
+			} else if *sector.contractID != *contractID {
+				t.Fatalf("expected sector %v to be pinned to contract %v, got %v", sector.root, *contractID, *sector.contractID)
+			}
+		}
+	}
+
+	assertAppendSectorCalled := func(call appendSectorCall, contractID types.FileContractID, prices proto.HostPrices, expectedRoots []types.Hash256) {
+		t.Helper()
+
+		if call.contractID != contractID {
+			t.Fatalf("expected contract ID %v, got %v", contractID, call.contractID)
+		} else if call.hostPrices != prices {
+			t.Fatalf("expected host prices %v, got %v", prices, call.hostPrices)
+		} else if len(call.sectors) != len(expectedRoots) {
+			t.Fatalf("expected %v sectors, got %v", len(expectedRoots), len(call.sectors))
+		}
+		for _, root := range expectedRoots {
+			if !slices.Contains(call.sectors, root) {
+				t.Fatalf("expected sector %v to be pinned, got %v", root, call.sectors)
+			}
+		}
+	}
 
 	// pin sectors on h1
 	h1Prices := h1.Settings.Prices
-	err := cm.performSectorPinningOnHost(context.Background(), h1, zap.NewNop())
+	err := cm.performSectorPinningOnHost(context.Background(), h1, log.Named("pin"))
 	if err != nil {
 		t.Fatal(err)
+	} else if len(h1Mock.appendSectorCalls) != 1 {
+		t.Fatalf("expected one call, got %v", len(h1Mock.appendSectorCalls))
 	}
 
 	// assert sector pinning on h1
-	if len(h1Mock.appendSectorCalls) != 1 {
-		t.Fatalf("expected one call, got %v", len(h1Mock.appendSectorCalls))
-	} else if call := h1Mock.appendSectorCalls[0]; call.hostPrices != h1Prices {
-		t.Fatalf("unexpected host prices %v, expected %v", call.hostPrices, h1Prices)
-	} else if call.contractID != fcid2 {
-		t.Fatalf("unexpected contract ID %v, expected %v", call.contractID, fcid2)
-	} else if len(call.sectors) != 6 {
-		t.Fatalf("expected 6 sectors, got %v", call.sectors)
-	}
+	// both contracts should be attempted, but only fcid2 should have sectors pinned
+	assertAppendSectorCalled(h1Mock.appendSectorCalls[0], fcid2, h1Prices, roots[:6]) // called with all stored roots
+	h1Pinned := append(slices.Clone(roots[:3]), roots[4:7]...)
+	assertSectorsContract(hk1, h1Pinned, &fcid2) // all but the missing root pinned to fcid2
+	assertSectorsContract(hk1, roots[3:4], nil)  // missing root remains unpinned
 
 	// pin sectors on h2
 	h2Prices := h2.Settings.Prices
-	err = cm.performSectorPinningOnHost(context.Background(), h2, zap.NewNop())
+	err = cm.performSectorPinningOnHost(context.Background(), h2, log.Named("pin"))
 	if err != nil {
+		t.Fatal(err)
+	} else if len(h2Mock.appendSectorCalls) != 1 {
+		t.Fatalf("expected one calls, got %v", len(h2Mock.appendSectorCalls))
+	}
+	// all h2 sectors pinned to fcid3
+	assertAppendSectorCalled(h2Mock.appendSectorCalls[0], fcid3, h2Prices, roots[6:8])
+	assertSectorsContract(hk2, roots[6:8], &fcid3)
+}
+
+func TestPerformSectorPinningOnHostOverflow(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	store := newStoreMock()
+
+	// prepare a host with two contracts
+	hk1 := types.PublicKey{1}
+	h1 := hosts.Host{
+		PublicKey: hk1,
+		Addresses: []chain.NetAddress{{Protocol: siamux.Protocol, Address: "host1.com"}},
+		Settings:  goodSettings,
+		Usability: hosts.GoodUsability,
+	}
+	h1.Settings.Prices.StoragePrice = types.NewCurrency64(123)
+	h1.Settings.Prices.TipHeight = 111
+	store.hosts[hk1] = h1
+
+	// add two contracts for h1
+	fcid1 := types.FileContractID{1}
+	if err := store.AddFormedContract(context.Background(), hk1, fcid1, newTestRevision(hk1), types.ZeroCurrency, types.NewCurrency64(1), types.ZeroCurrency); err != nil {
+		t.Fatal(err)
+	}
+	fcid2 := types.FileContractID{2}
+	if err := store.AddFormedContract(context.Background(), hk1, fcid2, newTestRevision(hk1), types.ZeroCurrency, types.NewCurrency64(1), types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
 
-	// assert sector pinning on h2
-	if len(h2Mock.appendSectorCalls) != 1 {
-		t.Fatalf("expected one calls, got %v", len(h2Mock.appendSectorCalls))
-	} else if call := h2Mock.appendSectorCalls[0]; call.hostPrices != h2Prices {
-		t.Fatalf("unexpected host prices %v, got %v", call.hostPrices, h2Prices)
-	} else if call.contractID != fcid3 {
-		t.Fatalf("expected contract ID %v, got %v", call.contractID, fcid3)
-	} else if len(call.sectors) != 2 {
-		t.Fatalf("expected 2 sectors, got %v", len(call.sectors))
+	// make fcid2 the better contract for pinning
+	for i, c := range store.contracts {
+		switch c.ID {
+		case fcid1:
+			store.contracts[i].Capacity = 100
+		case fcid2:
+			store.contracts[i].Capacity = 200
+		}
 	}
 
-	// assert sectors are pinned in the store
-	if h1Sectors, ok := store.sectors[hk1]; !ok {
-		t.Fatalf("expected sectors for host %v", hk1)
-	} else {
-		for _, sector := range h1Sectors {
-			switch sector.root {
-			case r1, r2, r3, r5, r6:
-				if *sector.contractID != fcid2 {
-					t.Fatalf("expected contract ID %v, got %v", fcid2, *sector.contractID)
-				}
-			case r4:
-				if sector.contractID != nil {
-					t.Fatalf("expected unpinned sector, got %v", *sector.contractID)
-				}
-			default:
-				t.Fatalf("unexpected root %v", sector.root)
+	// prepare roots
+	roots := make([]types.Hash256, 8)
+	for i := range roots {
+		roots[i] = frand.Entropy256()
+		store.sectors[hk1] = append(store.sectors[hk1], sector{root: roots[i]})
+	}
+
+	// prepare dialer
+	h1Mock := newHostClientMock()
+	h1Mock.missingSectors[roots[3]] = struct{}{}
+	h1Mock.maxPinnedPerAppend = 4 // only allow 4 sectors to be pinned per call
+
+	dialer := newDialerMock()
+	dialer.clients[hk1] = h1Mock
+
+	// prepare hm
+	hm := newHostManagerMock(store)
+	hm.settings[hk1] = h1.Settings
+
+	// prepare contract manager
+	cm := newContractManager(types.PublicKey{}, nil, nil, store, dialer, hm, nil, nil)
+	assertSectorsContract := func(hostKey types.PublicKey, roots []types.Hash256, contractID *types.FileContractID) {
+		t.Helper()
+
+		sectors, ok := store.sectors[hostKey]
+		if !ok {
+			t.Fatalf("expected sectors for host %v", hostKey)
+		}
+		for _, sector := range sectors {
+			if !slices.Contains(roots, sector.root) || sector.contractID == nil && contractID == nil {
+				// sector not part of the check, or both unpinned
+				continue
+			} else if contractID == nil && sector.contractID != nil {
+				t.Fatalf("expected sector %v to be unpinned, got %v", sector.root, *sector.contractID)
+			} else if contractID != nil && sector.contractID == nil {
+				t.Fatalf("expected sector %v to be pinned to contract %v, got unpinned", sector.root, *contractID)
+			} else if *sector.contractID != *contractID {
+				t.Fatalf("expected sector %v to be pinned to contract %v, got %v", sector.root, *contractID, *sector.contractID)
 			}
 		}
 	}
 
-	if h2Sectors, ok := store.sectors[hk2]; !ok {
-		t.Fatalf("expected sectors for host %v", hk2)
-	} else {
-		for _, sector := range h2Sectors {
-			switch sector.root {
-			case r7, r8:
-				if *sector.contractID != fcid3 {
-					t.Fatalf("expected contract ID %v, got %v", fcid3, *sector.contractID)
-				}
-			default:
-				t.Fatalf("unexpected root %v", sector.root)
+	assertAppendSectorCalled := func(call appendSectorCall, contractID types.FileContractID, prices proto.HostPrices, expectedRoots []types.Hash256) {
+		t.Helper()
+
+		if call.contractID != contractID {
+			t.Fatalf("expected contract ID %v, got %v", contractID, call.contractID)
+		} else if call.hostPrices != prices {
+			t.Fatalf("expected host prices %v, got %v", prices, call.hostPrices)
+		} else if len(call.sectors) != len(expectedRoots) {
+			t.Fatalf("expected %v sectors, got %v", len(expectedRoots), len(call.sectors))
+		}
+		for _, root := range expectedRoots {
+			if !slices.Contains(call.sectors, root) {
+				t.Fatalf("expected sector %v to be pinned, got %v", root, call.sectors)
 			}
 		}
 	}
 
-	if h3Sectors, ok := store.sectors[types.PublicKey{3}]; !ok {
-		t.Fatalf("expected sectors for host %v", types.PublicKey{3})
-	} else {
-		if len(h3Sectors) != 2 {
-			t.Fatalf("expected 2 sectors, got %v", len(h3Sectors))
-		}
-		for _, sector := range h3Sectors {
-			if sector.contractID != nil {
-				t.Fatalf("expected unpinned sector, got %v", *sector.contractID)
-			}
-		}
+	// pin sectors on h1
+	h1Prices := h1.Settings.Prices
+	err := cm.performSectorPinningOnHost(context.Background(), h1, log.Named("pin"))
+	if err != nil {
+		t.Fatal(err)
+	} else if len(h1Mock.appendSectorCalls) != 2 {
+		t.Fatalf("expected two calls, got %v", len(h1Mock.appendSectorCalls))
 	}
+
+	// assert sector pinning on h1
+	// both contracts should be attempted, but only fcid2 should have sectors pinned
+	assertAppendSectorCalled(h1Mock.appendSectorCalls[0], fcid2, h1Prices, roots)     // called with all stored roots
+	assertAppendSectorCalled(h1Mock.appendSectorCalls[1], fcid1, h1Prices, roots[4:]) // called again with remaining unpinned roots
+
+	// the missing sector should not be pinned
+	assertSectorsContract(hk1, slices.Clone(roots[:3]), &fcid2) // the first half minus the missing root pinned to fcid2
+	assertSectorsContract(hk1, roots[4:], &fcid1)               // the second half pinned to fcid1
+	assertSectorsContract(hk1, roots[3:4], nil)                 // missing root remains unpinned
 }

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -258,7 +258,7 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 			t.Fatalf("expected sectors for host %v", hostKey)
 		}
 		for _, sector := range sectors {
-			if !slices.Contains(roots, sector.root) || sector.contractID == nil && contractID == nil {
+			if !slices.Contains(roots, sector.root) || (sector.contractID == nil && contractID == nil) {
 				// sector not part of the check, or both unpinned
 				continue
 			} else if contractID == nil && sector.contractID != nil {

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -60,10 +60,10 @@ func (s *storeMock) ContractsForPinning(ctx context.Context, hk types.PublicKey,
 		}
 	}
 	sort.Slice(contracts, func(i, j int) bool {
-		if contracts[i].Capacity == contracts[j].Capacity {
-			return contracts[i].Size > contracts[j].Size
-		}
-		return contracts[i].Capacity > contracts[j].Capacity
+		// prefer contracts with more empty capacity
+		remainingI := contracts[i].Capacity - contracts[i].Size
+		remainingJ := contracts[j].Capacity - contracts[j].Size
+		return remainingI > remainingJ
 	})
 
 	out := make([]types.FileContractID, len(contracts))
@@ -194,7 +194,7 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// make fcid2 the better contract for pinning
+	// contracts with more
 	for i, c := range store.contracts {
 		switch c.ID {
 		case fcid1:

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -318,6 +318,7 @@ LIMIT $3
 func (s *Store) ContractsForPinning(ctx context.Context, hk types.PublicKey, maxContractSize uint64) ([]types.FileContractID, error) {
 	var fcids []types.FileContractID
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		// covered by index contracts_capacity_size_contract_id_idx
 		rows, err := tx.Query(ctx, `
 SELECT c.contract_id
 FROM contracts c

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -323,7 +323,8 @@ SELECT c.contract_id
 FROM contracts c
 INNER JOIN hosts h ON c.host_id = h.id
 WHERE h.public_key = $1 AND c.good = TRUE AND c.state <= $2 AND c.remaining_allowance > 0 AND c.size < $3
-ORDER BY c.capacity DESC, c.size DESC`, sqlPublicKey(hk), sqlContractState(contracts.ContractStateActive), maxContractSize)
+-- sort by empty capacity desc to prefer heavily pruned contracts 
+ORDER BY (c.capacity - c.size) DESC`, sqlPublicKey(hk), sqlContractState(contracts.ContractStateActive), maxContractSize)
 		if err != nil {
 			return fmt.Errorf("failed to fetch contracts for pinning: %w", err)
 		}

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -384,10 +384,10 @@ func TestContractsForPinning(t *testing.T) {
 		t.Fatal(err)
 	} else if len(contractIDs) != 3 {
 		t.Fatalf("expected 3 contracts, got %d", len(contractIDs))
-	} else if contractIDs[0] != (types.FileContractID{6}) {
-		t.Fatalf("expected contract %v, got %v", types.FileContractID{6}, contractIDs[0])
-	} else if contractIDs[1] != (types.FileContractID{7}) {
-		t.Fatalf("expected contract %v, got %v", types.FileContractID{7}, contractIDs[1])
+	} else if contractIDs[0] != (types.FileContractID{7}) {
+		t.Fatalf("expected contract %v, got %v", types.FileContractID{7}, contractIDs[0])
+	} else if contractIDs[1] != (types.FileContractID{6}) {
+		t.Fatalf("expected contract %v, got %v", types.FileContractID{6}, contractIDs[1])
 	} else if contractIDs[2] != (types.FileContractID{5}) {
 		t.Fatalf("expected contract %v, got %v", types.FileContractID{5}, contractIDs[2])
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -224,7 +224,7 @@ CREATE INDEX contracts_state_formation_idx ON contracts(state, formation); -- fo
 CREATE INDEX contracts_state_good_idx ON contracts(state) WHERE state <= 1 AND good; -- for filtering contracts
 CREATE INDEX contracts_last_broadcast_attempt_contract_id_idx ON contracts (last_broadcast_attempt ASC, contract_id) WHERE renewed_to IS NULL; -- for fetching contracts for broadcasting
 CREATE INDEX contracts_host_id_remaining_allowance_contract_id_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for funding
-CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (contract_id, size, capacity - size DESC) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for pinning
+CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, (capacity - size) DESC, size) WHERE good = true AND state <= 1 AND remaining_allowance > 0; -- for fetching contracts for pinning
 
 -- stats indices
 CREATE INDEX contracts_proof_height_idx ON contracts (proof_height);

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -224,7 +224,7 @@ CREATE INDEX contracts_state_formation_idx ON contracts(state, formation); -- fo
 CREATE INDEX contracts_state_good_idx ON contracts(state) WHERE state <= 1 AND good; -- for filtering contracts
 CREATE INDEX contracts_last_broadcast_attempt_contract_id_idx ON contracts (last_broadcast_attempt ASC, contract_id) WHERE renewed_to IS NULL; -- for fetching contracts for broadcasting
 CREATE INDEX contracts_host_id_remaining_allowance_contract_id_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for funding
-CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (capacity DESC, size DESC, contract_id) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for pinning
+CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (contract_id, size, capacity - size DESC) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for pinning
 
 -- stats indices
 CREATE INDEX contracts_proof_height_idx ON contracts (proof_height);

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -305,7 +305,7 @@ ALTER TABLE objects ADD COLUMN signature BYTEA UNIQUE NOT NULL CHECK (LENGTH(sig
 	func(ctx context.Context, t *txn, _ *zap.Logger) error {
 		const query = `
 DROP INDEX IF EXISTS contracts_state_active_idx;
-CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (contract_id, size, capacity - size DESC) WHERE good = true AND remaining_allowance > 0;`
+CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, (capacity - size) DESC, size) WHERE good = true AND state <= 1 AND remaining_allowance > 0;`
 
 		_, err := t.Exec(ctx, query)
 		return err

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -304,7 +304,7 @@ ALTER TABLE objects ADD COLUMN signature BYTEA UNIQUE NOT NULL CHECK (LENGTH(sig
 	// changes the pinning ordering to prefer contracts with available capacity
 	func(ctx context.Context, t *txn, _ *zap.Logger) error {
 		const query = `
-DROP INDEX IF EXISTS contracts_state_active_idx;
+DROP INDEX IF EXISTS contracts_capacity_size_contract_id_idx;
 CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, (capacity - size) DESC, size) WHERE good = true AND state <= 1 AND remaining_allowance > 0;`
 
 		_, err := t.Exec(ctx, query)

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -301,4 +301,13 @@ ALTER TABLE objects ADD COLUMN signature BYTEA UNIQUE NOT NULL CHECK (LENGTH(sig
 		}
 		return nil
 	},
+	// changes the pinning ordering to prefer contracts with available capacity
+	func(ctx context.Context, t *txn, _ *zap.Logger) error {
+		const query = `
+DROP INDEX IF EXISTS contracts_state_active_idx;
+CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (contract_id, size, capacity - size DESC) WHERE good = true AND remaining_allowance > 0;`
+
+		_, err := t.Exec(ctx, query)
+		return err
+	},
 }


### PR DESCRIPTION
Changes the pin sectors function to determine the maximum number of sectors that can be pinned given the current revision of a contract instead of attempting to pin all sectors and failing to the next contract. Also changes the sort to prefer contracts with more empty capacity to "refill" contracts that have been pruned.

This should be a more efficient use of space when pinning large numbers of sectors or for contracts that have been pruned.

```
BenchmarkContracts/contracts_for_pinning-16           	    3490	    325186 ns/op	    5589 B/op	     132 allocs/op
```