### PR TITLE
Don't timeout database transaction

### DIFF
--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -72,6 +72,9 @@ func (dc *downloadCandidates) next() (hosts.Host, bool) {
 // downloadShards downloads at least the minimum number of shards required to
 // recover the slab.
 func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []hosts.Host, logger *zap.Logger) ([][]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, m.slabTimeout)
+	defer cancel()
+
 	shards := make([][]byte, len(slab.Sectors))
 	var downloaded atomic.Uint32
 
@@ -79,9 +82,6 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []
 	if uint(len(candidates.indices)) < slab.MinShards {
 		return nil, fmt.Errorf("%w: only %d sectors available, minimum required: %d", errNotEnoughShards, len(candidates.indices), slab.MinShards)
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	var wg sync.WaitGroup
 	sema := make(chan struct{}, slab.MinShards)

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -83,10 +83,9 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, m.slabTimeout)
-	defer cancel()
-
 	// download enough shards to reconstruct the slab's shards
+	// note: timeouts are set within downloadShards to avoid timing
+	// out the database
 	shards, err := m.downloadShards(ctx, slab, allHosts, logger)
 	if err != nil {
 		return fmt.Errorf("failed to download slab %s: %w", slab.ID, err)
@@ -129,6 +128,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 	}
 
 	// migrate the shards
+	// note: timeouts are set within uploadShards to avoid timing out the database
 	migratedShards, err := m.uploadShards(ctx, slab, shards, uploadCandidates, logger)
 
 	// update the database with the new locations for the migrated shards

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -31,6 +31,9 @@ type (
 // and should be tracked in the database. The given shards must not be nil and
 // the given hosts must all be good and be sufficiently spaced apart.
 func (m *SlabManager) uploadShards(ctx context.Context, slab Slab, shards [][]byte, uploadCandidates []hosts.Host, logger *zap.Logger) ([]Shard, error) {
+	ctx, cancel := context.WithTimeout(ctx, m.slabTimeout)
+	defer cancel()
+
 	uploaded := make([]Shard, 0, len(shards))
 
 	if len(slab.Sectors) != len(shards) {


### PR DESCRIPTION
```
2025-09-30T19:55:28.340542939Z 2025-09-30T19:55:28Z	ERROR	slabs.migrations.a64401f98bcd06ca1a8358bb112064fd	failed to migrate slab	{"error": "failed to migrate sector 3217295c7ad93fc601242e518a569b57907bbf1c73170602d02555dccd1713de: failed to begin transaction: context deadline exceeded"}
2025-09-30T19:55:28.340565830Z 2025-09-30T19:55:28Z	ERROR	slabs.migrations.a64401f98bcd06ca1a8358bb112064fd	failed to migrate slab	{"error": "failed to migrate sector d29817132f07ac5895e83e551f56f3a0b0bcfa00dcfcc95e68fa1d248d9f992c: failed to begin transaction: context deadline exceeded"}
2025-09-30T19:55:28.340590611Z 2025-09-30T19:55:28Z	ERROR	slabs.migrations.a64401f98bcd06ca1a8358bb112064fd	failed to migrate slab	{"error": "failed to migrate sector 1208206ffa3b7a0b90dd531d16d6a0529515ba27604b656838974421d8d53fb2: failed to begin transaction: context deadline exceeded"}
2025-09-30T19:55:28.340655573Z 2025-09-30T19:55:28Z	ERROR	slabs.migrations.a64401f98bcd06ca1a8358bb112064fd	failed to migrate slab	{"error": "failed to migrate sector fca81fbaa78abcabed6785e026420c36aab53e1fc5c823064aeedcd38ceeb10c: failed to begin transaction: context deadline exceeded"}
2025-09-30T19:55:28.340729796Z 2025-09-30T19:55:28Z	ERROR	slabs.migrations.a64401f98bcd06ca1a8358bb112064fd	failed to migrate slab	{"error": "failed to migrate sector c1ba87a10c5db05c411689bcd0eb2aaf3e919282fd427dc164fec61682e9e416: failed to begin transaction: context deadline exceeded"}
2025-09-30T19:55:28.340785908Z 2025-09-30T19:55:28Z	ERROR	slabs.migrations.a64401f98bcd06ca1a8358bb112064fd	failed to migrate slab	{"error": "failed to migrate sector ed6d18261193a29604d8c432fbcbb8503b4473310ced204d14a7650c5075734e: failed to begin transaction: context deadline exceeded"}
```