### PR TITLE
Improve unhealthy slabs

### DIFF
--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -679,48 +679,62 @@ func (s *Store) UnpinnedSectors(ctx context.Context, hostKey types.PublicKey, li
 //
 // NOTE: For the sake of scalability, we don't prioritize any slabs and instead
 // simply fetch the first batch we find.
-func (s *Store) UnhealthySlabs(ctx context.Context, maxRepairAttempt time.Time, limit int) ([]slabs.SlabID, error) {
+func (s *Store) UnhealthySlabs(ctx context.Context, maxRepairAttempt time.Time, limit int) (results []slabs.SlabID, err error) {
 	now := time.Now()
 	if maxRepairAttempt.After(now) {
 		return nil, fmt.Errorf("maxRepairAttempt (%v) must be in the past (current time: %v)", maxRepairAttempt, now) // developer error
 	}
 
-	var results []slabs.SlabID
-	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		for range limit {
-			var slabID slabs.SlabID
-			err := tx.QueryRow(ctx, `UPDATE slabs
-				SET last_repair_attempt = $1
-				WHERE id = (
-					SELECT slabs.id
-					FROM slabs
-					INNER JOIN slab_sectors ON slabs.id = slab_sectors.slab_id
-					INNER JOIN sectors ON slab_sectors.sector_id = sectors.id
-					LEFT JOIN contract_sectors_map csm ON sectors.contract_sectors_map_id = csm.id
-					LEFT JOIN contracts ON csm.contract_id = contracts.contract_id
-					WHERE
-						(
-							-- stored on bad contract
-							(sectors.contract_sectors_map_id IS NOT NULL AND contracts.good = FALSE) OR
-							contracts.state NOT IN ($2, $3) OR
-							-- not stored on any host
-							(sectors.host_id IS NULL)
-						)
-						AND (slabs.last_repair_attempt < $4)
-					LIMIT 1
-				)
-				RETURNING digest
-		`, now, sqlContractState(contracts.ContractStateActive), sqlContractState(contracts.ContractStatePending), maxRepairAttempt).Scan((*sqlHash256)(&slabID))
-			if errors.Is(err, sql.ErrNoRows) {
-				break
-			} else if err != nil {
-				return fmt.Errorf("failed to query unhealthy slabs: %w", err)
+	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		const query = `SELECT s.id, s.digest
+FROM slabs s
+WHERE s.last_repair_attempt < $1
+AND EXISTS (
+  SELECT 1
+  FROM slab_sectors ss
+  JOIN sectors sec ON sec.id = ss.sector_id
+  LEFT JOIN contract_sectors_map csm ON csm.id = sec.contract_sectors_map_id
+  LEFT JOIN contracts c ON c.contract_id = csm.contract_id
+  WHERE ss.slab_id = s.id
+    AND (
+      sec.host_id IS NULL
+      OR (sec.contract_sectors_map_id IS NOT NULL
+          AND (c.good = FALSE OR c.state NOT IN ($2, $3)))
+    )
+)
+ORDER BY s.last_repair_attempt ASC
+LIMIT $4;`
+		var selected []int64
+		rows, err := tx.Query(ctx, query, maxRepairAttempt, sqlContractState(contracts.ContractStateActive), sqlContractState(contracts.ContractStatePending), limit)
+		if err != nil {
+			return fmt.Errorf("failed to query unhealthy slabs: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var id int64
+			var digest slabs.SlabID
+			if err := rows.Scan(&id, (*sqlHash256)(&digest)); err != nil {
+				return fmt.Errorf("failed to scan unhealthy slab: %w", err)
 			}
-			results = append(results, slabID)
+			results = append(results, digest)
+			selected = append(selected, id)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to read unhealthy slabs: %w", err)
+		}
+		rows.Close()
+		if len(selected) == 0 {
+			return nil
+		}
+
+		// update last_repair_attempt for the selected slabs
+		if _, err := tx.Exec(ctx, `UPDATE slabs SET last_repair_attempt = $1 WHERE id = ANY($2)`, now, selected); err != nil {
+			return fmt.Errorf("failed to update last_repair_attempt: %w", err)
 		}
 		return nil
 	})
-	return results, err
+	return
 }
 
 // MigrateSector updates a sector that was just migrated in the database to be

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1824,7 +1824,7 @@ func BenchmarkUnhealthySlabs(b *testing.B) {
 
 	// 30 hosts to simulate default redundancy
 	var hks []types.PublicKey
-	for i := byte(0); i < 30; i++ {
+	for i := range byte(30) {
 		hks = append(hks, store.addTestHost(b, types.PublicKey{i}))
 	}
 


### PR DESCRIPTION
While the benchmark is quite a bit slower the query is significantly faster on Zeus. The new query plan gets through a lot of filtering early.

**Before (select 100 unhealthy slabs)**
```
 Limit  (cost=1.45..92.65 rows=100 width=8) (actual time=582.779..583.503 rows=100.00 loops=1)
   Buffers: shared hit=49771 read=62367 written=1680
   ->  Nested Loop  (cost=1.45..6841421.51 rows=7501518 width=8) (actual time=582.777..583.492 rows=100.00 loops=1)
         Buffers: shared hit=49771 read=62367 written=1680
         ->  Nested Loop  (cost=1.01..4420697.50 rows=7501518 width=8) (actual time=582.559..582.927 rows=100.00 loops=1)
               Buffers: shared hit=49396 read=62342 written=1680
               ->  Merge Right Join  (cost=0.58..821327.93 rows=7504601 width=8) (actual time=582.509..582.666 rows=100.00 loops=1)
                     Merge Cond: (csm.id = sectors.contract_sectors_map_id)
                     Filter: (((sectors.contract_sectors_map_id IS NOT NULL) AND (NOT contracts.good)) OR (contracts.state <> ALL ('{0,1}'::integer[])) OR (sectors.host_id IS NULL))
                     Rows Removed by Filter: 268204
                     Buffers: shared hit=49108 read=62329 written=1680
                     ->  Nested Loop Left Join  (cost=0.14..7407.60 rows=190 width=7) (actual time=3.390..5.004 rows=12.00 loops=1)
                           Join Filter: (csm.contract_id = contracts.contract_id)
                           Rows Removed by Join Filter: 15344
                           Buffers: shared hit=130 read=161
                           ->  Index Scan using contract_sectors_map_pkey on contract_sectors_map csm  (cost=0.14..18.73 rows=190 width=37) (actual time=0.009..0.028 rows=12.00 loops=1)
                                 Index Searches: 1
                                 Buffers: shared hit=3 read=1
                           ->  Materialize  (cost=0.00..324.22 rows=2481 width=36) (actual time=0.011..0.304 rows=1279.67 loops=12)
                                 Storage: Memory  Maximum Storage: 185kB
                                 Buffers: shared hit=127 read=160
                                 ->  Seq Scan on contracts  (cost=0.00..311.81 rows=2481 width=36) (actual time=0.120..2.221 rows=2434.00 loops=1)
                                       Buffers: shared hit=127 read=160
                     ->  Index Scan using sectors_contract_sectors_map_id_uploaded_at_idx on sectors  (cost=0.43..706018.73 rows=7877193 width=16) (actual time=0.016..532.788 rows=268304.00 loops=1)
                           Index Searches: 1
                           Buffers: shared hit=48978 read=62168 written=1680
               ->  Index Only Scan using slab_sectors_sector_id_slab_id_idx on slab_sectors  (cost=0.43..0.47 rows=1 width=16) (actual time=0.002..0.002 rows=1.00 loops=100)
                     Index Cond: (sector_id = sectors.id)
                     Heap Fetches: 0
                     Index Searches: 100
                     Buffers: shared hit=288 read=13
         ->  Memoize  (cost=0.43..0.46 rows=1 width=8) (actual time=0.005..0.005 rows=1.00 loops=100)
               Cache Key: slab_sectors.slab_id
               Cache Mode: logical
               Hits: 0  Misses: 100  Evictions: 0  Overflows: 0  Memory Usage: 11kB
               Buffers: shared hit=375 read=25
               ->  Index Scan using slabs_pkey on slabs  (cost=0.42..0.45 rows=1 width=8) (actual time=0.003..0.003 rows=1.00 loops=100)
                     Index Cond: (id = slab_sectors.slab_id)
                     Filter: (last_repair_attempt < now())
                     Index Searches: 100
                     Buffers: shared hit=375 read=25
 Planning:
   Buffers: shared hit=118 read=13
 Planning Time: 2.450 ms
 Execution Time: 583.590 ms
```

**After (select 100 unhealthy slabs)**
```
 Limit  (cost=1001.74..13735.57 rows=100 width=49) (actual time=28.141..31.410 rows=100.00 loops=1)
   Buffers: shared hit=11364 read=533 dirtied=15 written=2
   ->  Gather Merge  (cost=1001.74..27799327.91 rows=218303 width=49) (actual time=28.140..31.397 rows=100.00 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         Buffers: shared hit=11364 read=533 dirtied=15 written=2
         ->  Nested Loop Semi Join  (cost=1.72..27773130.31 rows=90960 width=49) (actual time=7.125..12.350 rows=100.00 loops=3)
               Buffers: shared hit=11364 read=533 dirtied=15 written=2
               ->  Parallel Index Scan using slabs_id_last_repair_attempt_idx on slabs s  (cost=0.43..44108.93 rows=245386 width=49) (actual time=3.121..3.628 rows=111.33 loops=3)
                     Index Cond: (last_repair_attempt < now())
                     Index Searches: 1
                     Buffers: shared hit=26 read=67 written=1
               ->  Nested Loop Left Join  (cost=1.29..172.23 rows=31 width=8) (actual time=0.078..0.078 rows=0.90 loops=334)
                     Filter: ((sec.host_id IS NULL) OR ((sec.contract_sectors_map_id IS NOT NULL) AND ((NOT c.good) OR (c.state <> ALL ('{0,1}'::integer[])))))
                     Rows Removed by Filter: 3
                     Buffers: shared hit=11338 read=466 dirtied=15 written=1
                     ->  Nested Loop  (cost=0.86..20.20 rows=36 width=16) (actual time=0.048..0.063 rows=3.52 loops=334)
                           Buffers: shared hit=5498 read=406 written=1
                           ->  Index Only Scan using slab_sectors_pkey on slab_sectors ss  (cost=0.43..1.32 rows=36 width=16) (actual time=0.034..0.035 rows=3.52 loops=334)
                                 Index Cond: (slab_id = s.id)
                                 Heap Fetches: 0
                                 Index Searches: 334
                                 Buffers: shared hit=931 read=78 written=1
                           ->  Index Scan using sectors_pkey on sectors sec  (cost=0.43..0.52 rows=1 width=16) (actual time=0.008..0.008 rows=1.00 loops=1176)
                                 Index Cond: (id = ss.sector_id)
                                 Index Searches: 1176
                                 Buffers: shared hit=4470 read=328
                     ->  Nested Loop Left Join  (cost=0.43..4.21 rows=1 width=7) (actual time=0.004..0.004 rows=1.00 loops=1176)
                           Buffers: shared hit=5840 read=60 dirtied=15
                           ->  Index Scan using contract_sectors_map_pkey on contract_sectors_map csm  (cost=0.14..0.16 rows=1 width=37) (actual time=0.001..0.001 rows=1.00 loops=1176)
                                 Index Cond: (id = sec.contract_sectors_map_id)
                                 Index Searches: 1176
                                 Buffers: shared hit=2353 read=1
                           ->  Index Scan using contracts_contract_id_key on contracts c  (cost=0.28..4.04 rows=1 width=36) (actual time=0.002..0.002 rows=1.00 loops=1176)
                                 Index Cond: (contract_id = csm.contract_id)
                                 Index Searches: 1176
                                 Buffers: shared hit=3471 read=59
 Planning:
   Buffers: shared hit=77
 Planning Time: 0.963 ms
 Execution Time: 31.460 ms
```