### PR TITLE
Improve contract query performance

### DIFF
--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -38,8 +39,8 @@ func (s *Store) ContractsStats(ctx context.Context) (resp admin.ContractsStatsRe
 		var numContracts, numGood, totalCapacity, totalSize uint64
 		err := tx.QueryRow(ctx, `
 			WITH globals AS (
-    			SELECT scanned_height FROM global_settings
-       		)
+			SELECT scanned_height FROM global_settings
+			)
 			SELECT
 				COUNT(*),       				-- non-expired contracts
 				COALESCE(SUM(good::int), 0), 	-- good contracts
@@ -48,11 +49,10 @@ func (s *Store) ContractsStats(ctx context.Context) (resp admin.ContractsStatsRe
 			FROM contracts
 			CROSS JOIN globals
 			WHERE
-				proof_height > globals.scanned_height AND
+				state IN (0,1) AND
 				renewed_to IS NULL AND
-				(state = $1 OR state = $2)
-		`, contracts.ContractStatePending, contracts.ContractStateActive).
-			Scan(&numContracts, &numGood, &totalCapacity, &totalSize)
+				proof_height > globals.scanned_height
+		`).Scan(&numContracts, &numGood, &totalCapacity, &totalSize)
 		if err != nil {
 			return err
 		}
@@ -66,12 +66,11 @@ func (s *Store) ContractsStats(ctx context.Context) (resp admin.ContractsStatsRe
 			FROM contracts
 			CROSS JOIN globals
 			WHERE
-				proof_height > globals.scanned_height AND
+				state IN (0,1) AND
 				renewed_to IS NULL AND
-				(state = $1 OR state = $2) AND
+				proof_height > globals.scanned_height AND
 				globals.scanned_height + globals.contracts_renew_window >= proof_height
-		`, contracts.ContractStatePending, contracts.ContractStateActive).
-			Scan(&numRenewing)
+		`).Scan(&numRenewing)
 		if err != nil {
 			return err
 		}
@@ -216,6 +215,7 @@ func (s *Store) Contracts(ctx context.Context, offset, limit int, queryOpts ...c
 	var contracts []contracts.Contract
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		rows, err := tx.Query(ctx, `
+EXPLAIN (ANALYZE, BUFFERS, TIMING ON)
 SELECT c.contract_id, c.formation, h.public_key, c.proof_height, c.expiration_height, c.renewed_from, c.renewed_to, c.revision_number, c.state, c.capacity, c.size, c.contract_price, c.initial_allowance, c.remaining_allowance, c.miner_fee, c.used_collateral, c.total_collateral, c.good, c.append_sector_spending, c.free_sector_spending, c.fund_account_spending, c.sector_roots_spending, c.next_prune, c.last_broadcast_attempt
 FROM contracts c
 INNER JOIN hosts h ON c.host_id = h.id
@@ -225,8 +225,8 @@ WHERE
 	-- active filter
 	(
 		$2::boolean IS NULL OR
-		($2::boolean = TRUE AND c.state <= 1 AND c.renewed_to IS NULL) OR
-		($2::boolean = FALSE AND c.state > 1)
+		($2::boolean = TRUE AND c.state IN (0,1) AND c.renewed_to IS NULL) OR
+		($2::boolean = FALSE AND c.state IN (2,3,4))
 	)
 LIMIT $3 OFFSET $4`, opts.Good, opts.Revisable, limit, offset)
 		if err != nil {
@@ -234,13 +234,20 @@ LIMIT $3 OFFSET $4`, opts.Good, opts.Revisable, limit, offset)
 		}
 		defer rows.Close()
 
+		var sb strings.Builder
 		for rows.Next() {
+			var line string
+			rows.Scan(&line)
+			sb.WriteString(line + "\n")
+			continue
+
 			contract, err := scanContract(rows)
 			if err != nil {
 				return fmt.Errorf("failed to scan contract: %w", err)
 			}
 			contracts = append(contracts, contract)
 		}
+		fmt.Println(sb.String())
 		return rows.Err()
 	}); err != nil {
 		return nil, err
@@ -257,11 +264,11 @@ func (s *Store) ContractsForBroadcasting(ctx context.Context, minBroadcast time.
 	var fcids []types.FileContractID
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-SELECT c.contract_id
-FROM contracts c
-WHERE c.renewed_to IS NULL AND c.state <= $1 AND c.last_broadcast_attempt < $2
-ORDER BY c.last_broadcast_attempt ASC
-LIMIT $3`, sqlContractState(contracts.ContractStateActive), minBroadcast, limit)
+			SELECT c.contract_id
+			FROM contracts c
+			WHERE c.state IN (0, 1) AND c.renewed_to IS NULL AND c.last_broadcast_attempt < $1
+			ORDER BY c.last_broadcast_attempt ASC
+			LIMIT $2`, minBroadcast, limit)
 		if err != nil {
 			return fmt.Errorf("failed to fetch contracts for broadcasting: %w", err)
 		}
@@ -289,11 +296,15 @@ func (s *Store) ContractsForFunding(ctx context.Context, hk types.PublicKey, lim
 		rows, err := tx.Query(ctx, `
 SELECT c.contract_id
 FROM contracts c
-INNER JOIN hosts h ON c.host_id = h.id
-WHERE h.public_key = $1 AND c.good = TRUE AND c.state <= $2 AND c.remaining_allowance > 0
+WHERE
+	c.host_id = (SELECT id FROM hosts WHERE public_key = $1) AND
+	c.state IN (0, 1) AND
+	c.renewed_to IS NULL AND
+	c.good AND
+	c.remaining_allowance > 0
 ORDER BY c.remaining_allowance DESC
-LIMIT $3
-`, sqlPublicKey(hk), sqlContractState(contracts.ContractStateActive), limit)
+LIMIT $2
+`, sqlPublicKey(hk), limit)
 		if err != nil {
 			return fmt.Errorf("failed to fetch contracts for funding: %w", err)
 		}
@@ -321,9 +332,14 @@ func (s *Store) ContractsForPinning(ctx context.Context, hk types.PublicKey, max
 		rows, err := tx.Query(ctx, `
 SELECT c.contract_id
 FROM contracts c
-INNER JOIN hosts h ON c.host_id = h.id
-WHERE h.public_key = $1 AND c.good = TRUE AND c.state <= $2 AND c.remaining_allowance > 0 AND c.size < $3
-ORDER BY c.capacity DESC, c.size DESC`, sqlPublicKey(hk), sqlContractState(contracts.ContractStateActive), maxContractSize)
+WHERE
+	c.host_id = (SELECT id FROM hosts WHERE public_key = $1) AND
+	c.state IN (0, 1) AND
+	c.renewed_to IS NULL AND
+	c.good AND
+	c.remaining_allowance > 0 AND
+	c.size < $2
+ORDER BY c.capacity DESC, c.size DESC`, sqlPublicKey(hk), maxContractSize)
 		if err != nil {
 			return fmt.Errorf("failed to fetch contracts for pinning: %w", err)
 		}
@@ -350,9 +366,14 @@ func (s *Store) ContractsForPruning(ctx context.Context, hk types.PublicKey) ([]
 		rows, err := tx.Query(ctx, `
 SELECT c.contract_id
 FROM contracts c
-INNER JOIN hosts h ON c.host_id = h.id
-WHERE h.public_key = $1 AND c.good = TRUE AND c.state <= $2 AND c.remaining_allowance > 0 AND c.next_prune < NOW()
-ORDER BY c.size DESC`, sqlPublicKey(hk), sqlContractState(contracts.ContractStateActive))
+WHERE
+	c.host_id = (SELECT id FROM hosts WHERE public_key = $1) AND
+	c.state IN (0, 1) AND
+	c.renewed_to IS NULL AND
+	c.good AND
+	c.remaining_allowance > 0 AND
+	c.next_prune < NOW()
+ORDER BY c.size DESC`, sqlPublicKey(hk))
 		if err != nil {
 			return fmt.Errorf("failed to fetch contracts for pruning: %w", err)
 		}
@@ -402,8 +423,7 @@ SELECT
 FROM contract_elements fces
 INNER JOIN contracts c ON fces.contract_id = c.contract_id
 CROSS JOIN current_height
-WHERE current_height.scanned_height >= c.expiration_height + $1;
-`, maxBlocksSinceExpiry)
+WHERE current_height.scanned_height >= c.expiration_height + $1;`, maxBlocksSinceExpiry)
 		if err != nil {
 			return err
 		}
@@ -578,8 +598,7 @@ func (s *Store) MarkUnrenewableContractsBad(ctx context.Context, minProofHeight 
 // pending and have a formation height older than 'maxFormation'.
 func (s *Store) RejectPendingContracts(ctx context.Context, maxFormation time.Time) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, `UPDATE contracts SET state = $1 WHERE state = $2 AND formation < $3`,
-			sqlContractState(contracts.ContractStateRejected), sqlContractState(contracts.ContractStatePending), maxFormation)
+		_, err := tx.Exec(ctx, `UPDATE contracts SET state = 4 WHERE state = 0 AND formation < $1`, maxFormation)
 		return err
 	})
 }

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -38,7 +38,7 @@ func (s *Store) ContractsStats(ctx context.Context) (resp admin.ContractsStatsRe
 		var numContracts, numGood, totalCapacity, totalSize uint64
 		err := tx.QueryRow(ctx, `
 			WITH globals AS (
-			SELECT scanned_height FROM global_settings
+				SELECT scanned_height FROM global_settings
 			)
 			SELECT
 				COUNT(*),       				-- non-expired contracts

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -320,7 +320,7 @@ LIMIT $2
 func (s *Store) ContractsForPinning(ctx context.Context, hk types.PublicKey, maxContractSize uint64) ([]types.FileContractID, error) {
 	var fcids []types.FileContractID
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		// covered by index contracts_capacity_size_contract_id_idx
+		// covered by index contracts_host_id_active_good_idx
 		rows, err := tx.Query(ctx, `
 SELECT c.contract_id
 FROM contracts c

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -27,10 +27,6 @@ const (
 	maxLimit     = 500
 )
 
-var (
-	apiLimits = []int{defaultLimit, maxLimit, 2 * maxLimit}
-)
-
 func TestContracts(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
@@ -1482,6 +1478,10 @@ func BenchmarkContracts(b *testing.B) {
 		maxContractSize     = 10 * 1 << 40 // 10TB
 		numContractsPerHost = 100
 		numHosts            = 1000
+	)
+
+	var (
+		apiLimits = []int{defaultLimit, maxLimit, 2 * maxLimit}
 	)
 
 	randomTime := func() time.Time {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -22,6 +22,15 @@ import (
 	"lukechampine.com/frand"
 )
 
+const (
+	defaultLimit = 100
+	maxLimit     = 500
+)
+
+var (
+	apiLimits = []int{defaultLimit, maxLimit, 2 * maxLimit}
+)
+
 func TestContracts(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
@@ -1479,6 +1488,7 @@ func BenchmarkContracts(b *testing.B) {
 		maxOneHour := time.Duration(frand.Uint64n(60*60)) * time.Second
 		return time.Now().Add(-30 * time.Minute).Add(maxOneHour)
 	}
+	_ = randomTime
 
 	// prepare database
 	store := initPostgres(b, zap.NewNop())
@@ -1510,6 +1520,13 @@ func BenchmarkContracts(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	// analyze tables to ensure query planner has up-to-date statistics
+	_, vErr1 := store.pool.Exec(b.Context(), `VACUUM (ANALYZE) hosts;`)
+	_, vErr2 := store.pool.Exec(b.Context(), `VACUUM (ANALYZE) contracts;`)
+	if err := errors.Join(vErr1, vErr2); err != nil {
+		b.Fatal(err)
+	}
+
 	b.Run("contract", func(b *testing.B) {
 		if b.N > len(contractIDs) {
 			b.Fatalf("too many iterations, %d > %d", b.N, len(contractIDs))
@@ -1523,7 +1540,22 @@ func BenchmarkContracts(b *testing.B) {
 		}
 	})
 
-	for _, limit := range []int{100, 1000} {
+	b.Run("contracts_revisions", func(b *testing.B) {
+		for b.Loop() {
+			contractID := contractIDs[frand.Intn(len(contractIDs))]
+			contract, _, err := store.ContractRevision(context.Background(), contractID)
+			if err != nil {
+				b.Fatal(err)
+			}
+			contract.Revision.RevisionNumber++
+			if err := store.UpdateContractRevision(context.Background(), contract); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	// benchmark store.Contracts and all permutations of its parameters
+	for _, limit := range apiLimits {
 		b.Run(fmt.Sprintf("contracts_%d", limit), func(b *testing.B) {
 			for b.Loop() {
 				_, err := store.Contracts(context.Background(), 0, limit)
@@ -1532,15 +1564,7 @@ func BenchmarkContracts(b *testing.B) {
 				}
 			}
 		})
-		b.Run(fmt.Sprintf("contracts_revisable_%d", limit), func(b *testing.B) {
-			for b.Loop() {
-				_, err := store.Contracts(context.Background(), 0, limit, contracts.WithRevisable(true))
-				if err != nil {
-					b.Fatal(err)
-				}
-			}
-		})
-		b.Run(fmt.Sprintf("contracts_revisable+good_%d", limit), func(b *testing.B) {
+		b.Run(fmt.Sprintf("contracts_revisable_good_limit_%d", limit), func(b *testing.B) {
 			for b.Loop() {
 				_, err := store.Contracts(context.Background(), 0, limit, contracts.WithRevisable(true), contracts.WithGood(true))
 				if err != nil {
@@ -1548,7 +1572,33 @@ func BenchmarkContracts(b *testing.B) {
 				}
 			}
 		})
+		b.Run(fmt.Sprintf("contracts_revisable_bad_limit_%d", limit), func(b *testing.B) {
+			for b.Loop() {
+				_, err := store.Contracts(context.Background(), 0, limit, contracts.WithRevisable(true), contracts.WithGood(false))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("contracts_nonrevisable_good_limit_%d", limit), func(b *testing.B) {
+			for b.Loop() {
+				_, err := store.Contracts(context.Background(), 0, limit, contracts.WithRevisable(false), contracts.WithGood(true))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("contracts_nonrevisable_bad_limit_%d", limit), func(b *testing.B) {
+			for b.Loop() {
+				_, err := store.Contracts(context.Background(), 0, limit, contracts.WithRevisable(false), contracts.WithGood(false))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 
+	for _, limit := range apiLimits {
 		b.Run(fmt.Sprintf("contracts_for_broadcasting_%d", limit), func(b *testing.B) {
 			for b.Loop() {
 				_, err := store.ContractsForBroadcasting(context.Background(), randomTime(), limit)
@@ -1557,7 +1607,10 @@ func BenchmarkContracts(b *testing.B) {
 				}
 			}
 		})
-		b.Run(fmt.Sprintf("contracts_for_funding_%d", limit), func(b *testing.B) {
+	}
+
+	for _, limit := range apiLimits {
+		b.Run(fmt.Sprintf("contracts_for_funding_limit_%d", limit), func(b *testing.B) {
 			for b.Loop() {
 				_, err := store.ContractsForFunding(context.Background(), hosts[frand.Intn(len(hosts))], limit)
 				if err != nil {
@@ -1585,17 +1638,26 @@ func BenchmarkContracts(b *testing.B) {
 		}
 	})
 
-	b.Run("contracts_revisions", func(b *testing.B) {
+	b.Run("reject_expired_contracts", func(b *testing.B) {
+		now := time.Now()
+		start := now.Add(-30 * time.Minute)
+
 		for b.Loop() {
-			contractID := contractIDs[frand.Intn(len(contractIDs))]
-			contract, _, err := store.ContractRevision(context.Background(), contractID)
+			err := store.RejectPendingContracts(context.Background(), start)
 			if err != nil {
 				b.Fatal(err)
 			}
-			contract.Revision.RevisionNumber++
-			if err := store.UpdateContractRevision(context.Background(), contract); err != nil {
-				b.Fatal(err)
+
+			b.StopTimer()
+			start = start.Add(time.Minute)
+			if start.Equal(now.Add(30 * time.Minute)) {
+				start = now.Add(-30 * time.Minute)
+				_, err := store.pool.Exec(b.Context(), `UPDATE contracts SET state = 0, formation = $1::timestamptz + ((random() * 2 - 1) * (INTERVAL '30 minutes')) WHERE state = 4 AND id %2 = 0`, now)
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
+			b.StartTimer()
 		}
 	})
 }
@@ -1792,13 +1854,37 @@ func insertRandomContract(b *testing.B, tx *txn, hostID int64, hostKey types.Pub
 		return time.Now().Add(-30 * time.Minute).Add(maxOneHour)
 	}
 
+	// randomContractState returns a random contract state that somewhat resembles production
+	// distribution.
+	//
+	//   -  5%   Pending
+	//   - 10%   Active
+	//   - 75%   Resolved
+	//   -  5%   Expired
+	//   -  5%   Rejected
+	randomContractState := func() contracts.ContractState {
+		r := frand.Uint64n(100) // 0–99
+		switch {
+		case r < 5:
+			return contracts.ContractStatePending
+		case r < 15:
+			return contracts.ContractStateActive
+		case r < 90:
+			return contracts.ContractStateResolved
+		case r < 95:
+			return contracts.ContractStateExpired
+		default:
+			return contracts.ContractStateRejected
+		}
+	}
+
 	revision := newTestRevision(hostKey)
 	revision.Filesize = frand.Uint64n(1e9)                                                            // random size
 	revision.Capacity = revision.Filesize + frand.Uint64n(1e3)                                        // random capacity
 	revision.RenterOutput.Value = types.Siacoins(100).Add(types.Siacoins(uint32(frand.Uint64n(100)))) // random allowance
 
 	if _, err := tx.Exec(b.Context(), `
-		INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, next_prune) VALUES ($1, $2, $3, 1, 2, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14);`,
+		INSERT INTO contracts (host_id, contract_id, raw_revision, proof_height, expiration_height, contract_price, initial_allowance, miner_fee, total_collateral, remaining_allowance, state, good, size, capacity, last_broadcast_attempt, next_prune, formation) VALUES ($1, $2, $3, 1, 2, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15);`,
 		hostID,
 		sqlHash256(fcid),
 		sqlFileContract(revision),
@@ -1807,12 +1893,13 @@ func insertRandomContract(b *testing.B, tx *txn, hostID int64, hostKey types.Pub
 		sqlCurrency(types.ZeroCurrency),
 		sqlCurrency(revision.RemainingAllowance().Add(types.Siacoins(1))), // 1SC more than initial allowance
 		sqlCurrency(revision.RemainingAllowance()),
-		sqlContractState(uint8(frand.Uint64n(5))), // random contract state (40% active)
-		frand.Uint64n(2) == 0,                     // random good state (50% good)
+		sqlContractState(randomContractState()),
+		frand.Uint64n(10) < 7, // random good state (70% good - based on production data)
 		revision.Filesize,
 		revision.Capacity,
 		randomTime(), // random last_broadcast_attempt
 		randomTime(), // random next_prune
+		randomTime(), // random formation
 	); err != nil {
 		b.Fatal(err)
 	} else if _, err := tx.Exec(b.Context(), `INSERT INTO contract_sectors_map (contract_id) VALUES ($1)`, sqlHash256(fcid)); err != nil {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1488,7 +1488,6 @@ func BenchmarkContracts(b *testing.B) {
 		maxOneHour := time.Duration(frand.Uint64n(60*60)) * time.Second
 		return time.Now().Add(-30 * time.Minute).Add(maxOneHour)
 	}
-	_ = randomTime
 
 	// prepare database
 	store := initPostgres(b, zap.NewNop())

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -220,28 +220,39 @@ CREATE TABLE contracts (
   -- raw contract revision data
   raw_revision BYTEA NOT NULL
 );
-CREATE INDEX contracts_state_formation_idx ON contracts(state, formation); -- for rejecting expired contracts
-CREATE INDEX contracts_state_good_idx ON contracts(state) WHERE state <= 1 AND good; -- for filtering contracts
-CREATE INDEX contracts_last_broadcast_attempt_contract_id_idx ON contracts (last_broadcast_attempt ASC, contract_id) WHERE renewed_to IS NULL; -- for fetching contracts for broadcasting
-CREATE INDEX contracts_host_id_remaining_allowance_contract_id_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for funding
-CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (capacity DESC, size DESC, contract_id) WHERE good = true AND remaining_allowance > 0; -- for fetching contracts for pinning
-
--- stats indices
-CREATE INDEX contracts_proof_height_idx ON contracts (proof_height);
-CREATE INDEX contracts_state_active_idx ON contracts(state) WHERE (state = 0 OR state = 1) AND renewed_to IS NULL;
-CREATE INDEX contracts_active_host_size_idx ON contracts(proof_height, host_id) INCLUDE (size) WHERE (state = 0 OR state = 1) AND renewed_to IS NULL;
 
 -- foreign key constraint index
 CREATE INDEX contracts_host_id_idx ON contracts(host_id);
+
+-- fetching contracts statistics
+CREATE INDEX contracts_active_host_size_idx ON contracts(proof_height, host_id) INCLUDE (good, capacity, size) WHERE state IN (0,1) AND renewed_to IS NULL;
+
+ -- listing contracts
+CREATE INDEX contracts_host_id_active_good_idx ON contracts(host_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good;
+CREATE INDEX contracts_host_id_active_bad_idx ON contracts(host_id) WHERE state IN (0,1) AND renewed_to IS NULL AND NOT good;
+CREATE INDEX contracts_host_id_inactive_good_idx ON contracts (host_id) WHERE state IN (2,3,4) AND good;
+CREATE INDEX contracts_host_id_inactive_bad_idx ON contracts (host_id) WHERE state IN (2,3,4) AND NOT good;
+
+-- contracts for broadcasting
+CREATE INDEX contracts_last_broadcast_attempt_active_idx ON contracts (last_broadcast_attempt ASC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL;
+
+-- contracts for funding
+CREATE INDEX contracts_host_id_remaining_allowance_active_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
+
+-- contracts for pinning
+CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, capacity DESC, size DESC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
+
+-- contracts for pruning
+CREATE INDEX contracts_size_contract_id_idx ON contracts (host_id, size DESC, contract_id) INCLUDE(next_prune) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
+
+-- rejecting contracts
+CREATE INDEX contracts_formation_pending_idx ON contracts(formation) WHERE state = 0;
 
 CREATE TABLE contract_sectors_map (
     id SERIAL PRIMARY KEY,
     contract_id BYTEA UNIQUE REFERENCES contracts(contract_id) NOT NULL
 );
 CREATE INDEX contract_sectors_map_contract_id_idx ON contract_sectors_map(contract_id);
-
--- speeds up usable hosts lookup
-CREATE INDEX contracts_host_active_idx ON contracts (host_id) WHERE state <= 1;
 
 CREATE TABLE contract_elements (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -239,9 +239,6 @@ CREATE INDEX contracts_last_broadcast_attempt_active_idx ON contracts (last_broa
 -- contracts for funding
 CREATE INDEX contracts_host_id_remaining_allowance_active_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
 
--- contracts for pinning
-CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, (capacity - size) DESC, size, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
-
 -- contracts for pruning
 CREATE INDEX contracts_size_contract_id_idx ON contracts (host_id, size DESC, contract_id) INCLUDE(next_prune) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
 

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -301,4 +301,37 @@ ALTER TABLE objects ADD COLUMN signature BYTEA UNIQUE NOT NULL CHECK (LENGTH(sig
 		}
 		return nil
 	},
+	// recreate all contracts indices
+	func(ctx context.Context, tx *txn, l *zap.Logger) error {
+		if _, err := tx.Exec(ctx, `
+			DROP INDEX contracts_state_formation_idx;
+			DROP INDEX contracts_state_good_idx;
+			DROP INDEX contracts_last_broadcast_attempt_contract_id_idx;
+			DROP INDEX contracts_host_id_remaining_allowance_contract_id_idx;
+			DROP INDEX contracts_capacity_size_contract_id_idx;
+			DROP INDEX contracts_proof_height_idx;
+			DROP INDEX contracts_state_active_idx;
+			DROP INDEX contracts_active_host_size_idx;
+			DROP INDEX contracts_host_active_idx;
+		`); err != nil {
+			return fmt.Errorf("failed to drop contracts indices: %w", err)
+		}
+
+		if _, err := tx.Exec(ctx, `
+			CREATE INDEX contracts_active_host_size_idx ON contracts(proof_height, host_id) INCLUDE (good, capacity, size) WHERE state IN (0,1) AND renewed_to IS NULL;
+			CREATE INDEX contracts_host_id_active_good_idx ON contracts(host_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good;
+			CREATE INDEX contracts_host_id_active_bad_idx ON contracts(host_id) WHERE state IN (0,1) AND renewed_to IS NULL AND NOT good;
+			CREATE INDEX contracts_host_id_inactive_good_idx ON contracts (host_id) WHERE state IN (2,3,4) AND good;
+			CREATE INDEX contracts_host_id_inactive_bad_idx ON contracts (host_id) WHERE state IN (2,3,4) AND NOT good;
+			CREATE INDEX contracts_last_broadcast_attempt_active_idx ON contracts (last_broadcast_attempt ASC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL;
+			CREATE INDEX contracts_host_id_remaining_allowance_active_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
+			CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, capacity DESC, size DESC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
+			CREATE INDEX contracts_size_contract_id_idx ON contracts (host_id, size DESC, contract_id) INCLUDE(next_prune) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
+			CREATE INDEX contracts_formation_pending_idx ON contracts(formation) WHERE state = 0;
+		`); err != nil {
+			return fmt.Errorf("failed to create contracts indices: %w", err)
+		}
+
+		return nil
+	},
 }

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -334,7 +334,6 @@ CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, (cap
 			CREATE INDEX contracts_host_id_inactive_bad_idx ON contracts (host_id) WHERE state IN (2,3,4) AND NOT good;
 			CREATE INDEX contracts_last_broadcast_attempt_active_idx ON contracts (last_broadcast_attempt ASC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL;
 			CREATE INDEX contracts_host_id_remaining_allowance_active_idx ON contracts (host_id, remaining_allowance DESC, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
-			CREATE INDEX contracts_capacity_size_contract_id_idx ON contracts (host_id, (capacity - size) DESC, size, contract_id) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
 			CREATE INDEX contracts_size_contract_id_idx ON contracts (host_id, size DESC, contract_id) INCLUDE(next_prune) WHERE state IN (0,1) AND renewed_to IS NULL AND good AND remaining_allowance > 0;
 			CREATE INDEX contracts_formation_pending_idx ON contracts(formation) WHERE state = 0;
 		`); err != nil {


### PR DESCRIPTION
I went over every index on our contracts table and used our benchmarks to analyze every query plan individually. Our benchmarks don't always reflect improvements, but I did manage to get quite a lot of performance gains. 

I made tiny changes to our test setup:
- random contracts more accurately reflect production usage (used zeus)
- vacuum contracts and hosts table more accurately reflects a running instance

The obvious wins are:

| Benchmark | Before (plan) | After (plan) | Best time (before → after) | Change |
| -- | -- | -- | -- | --- |
| contracts_for_broadcasting | BitmapHeapScan + Top-N sort | Index-only scan on contracts_last_broadcast_attempt_active_idx (ORDER BY covered) | 7.02 ms → 0.86 ms | ~88% faster |
| contracts_for_funding (limit) | Nested loop + sort on remaining_allowance | Index-only scan on contracts_host_id_remaining_allowance_active_idx (ORDER BY covered) | 0.46 ms → 0.41 ms | ~11% faster |
| reject_expired_contracts | Heap scan of pending + time check | Partial index contracts_formation_pending_idx | 10.11 ms → 5.22 ms | ~48% faster |
| contracts_stats (active slice) | Broader scans | Index-only scan on contracts_active_host_size_idx (INCLUDEs) | 2.45 ms → 0.98 ms | ~60% faster |

The query plan definitely improved for the main `store.Contracts` query, but it's not clear in the benchmarks. I dumped all query plans pre and post change in Chat GPT though and this is the result:


Benchmark | Before (plan) | After (plan) | Change
-- | -- | -- | --- |
contracts_1000 | Merge Join on host_id; Index Scan contracts_host_id_idx + hosts_pkey | Merge Join on host_id; Index Scan contracts_host_id_idx + hosts_pkey (unchanged) | +2.3%
contracts_revisable_good_limit_1000 | Merge Join; Index Scan contracts_host_active_idx with Filter (good AND renewed_to IS NULL) | Merge Join; Index Scan contracts_host_id_active_good_idx (predicate-matching partial) | +16.0%
contracts_revisable_bad_limit_1000 | Merge Join; Index Scan contracts_host_active_idx with Filter (!good AND renewed_to IS NULL) | Merge Join; Index Scan contracts_host_id_active_bad_idx (predicate-matching partial) | +39.3%
contracts_nonrevisable_good_limit_1000 | Nested Loop; Seq Scan contracts (filter good AND state>1) + Memoize → hosts_pkey | Merge Join; Index Scan contracts_host_id_inactive_good_idx (partial) | +19.4%
contracts_nonrevisable_bad_limit_1000 | Nested Loop; Seq Scan contracts (filter !good AND state>1) + Memoize → hosts_pkey | Merge Join; Index Scan contracts_host_id_inactive_bad_idx (partial) | +45.0%


There is no regression, if the benchmark ended up being slightly slower (<5%) I went in and verified it manually. All query plans are either the same or have improved. Unfortunately that doesn't always show in the benchmarks at every possible limit.

I can pull these out into separate PRs if you want, I did not do so because it's 200 lines, because I want to avoid the endless migration conflicts, but most importantly because I wrote some custom code to easily compare my changes before and after making changes to the schema and print a query plan, it was just easier to do everything in one go.

This should resolve https://github.com/SiaFoundation/indexd/issues/478 - I also rewrote our queries to be more consistent over all, but kept it focused on contracts only.