### PR TITLE
SDK: upload slab to hosts that aren't too close to each other

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -169,7 +169,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			// host should be good
 			log.Debug("host is not usable due to bad usability", zap.String("reasons", host.Usability.FailedChecks()))
 			return false
-		} else if spaced := set.CanAddHost(host); !spaced && !force {
+		} else if spaced := set.CanAddHost(host.Info()); !spaced && !force {
 			// host should be sufficiently spaced from other hosts
 			return false
 		} else if host.Settings.RemainingStorage < minRemainingStorage {
@@ -204,7 +204,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		}
 
 		// contract is good
-		set.Add(host)
+		set.Add(host.Info())
 		wanted--
 	}
 
@@ -267,7 +267,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 			}
 
 			// contract formed successfully
-			set.Add(host)
+			set.Add(host.Info())
 			wanted--
 
 			hostLog.Debug("formed contract", zap.Stringer("contractID", contract.ID))

--- a/hosts/distance.go
+++ b/hosts/distance.go
@@ -22,7 +22,7 @@ func NewSpacedSet(minDistanceKm float64) *SpacedSet {
 
 // Add adds the host to the set if it is sufficiently spaced apart from the
 // existing hosts. It returns true if the host was added, false otherwise.
-func (s *SpacedSet) Add(h Host) bool {
+func (s *SpacedSet) Add(h HostInfo) bool {
 	if s.CanAddHost(h) {
 		s.selected[h.PublicKey] = h.Location()
 		return true
@@ -31,19 +31,19 @@ func (s *SpacedSet) Add(h Host) bool {
 }
 
 // CanAddHost returns true if the host is sufficiently far removed from the
-// existing hosts in the set. If the minimum distance is zero, it only checks
-// for uniqueness.
-func (s *SpacedSet) CanAddHost(h Host) bool {
-	if s.minDistanceKm == 0 {
-		_, exists := s.selected[h.PublicKey]
-		return !exists
+// existing hosts in the set. Uniqueness is always enforced.
+func (s *SpacedSet) CanAddHost(h HostInfo) bool {
+	if _, exists := s.selected[h.PublicKey]; exists {
+		return false
 	}
 
-	location := h.Location()
-	for _, other := range s.selected {
-		distance := location.HaversineDistanceKm(other)
-		if distance < s.minDistanceKm {
-			return false
+	if s.minDistanceKm > 0 {
+		location := h.Location()
+		for _, other := range s.selected {
+			distance := location.HaversineDistanceKm(other)
+			if distance < s.minDistanceKm {
+				return false
+			}
 		}
 	}
 

--- a/hosts/distance_test.go
+++ b/hosts/distance_test.go
@@ -12,20 +12,20 @@ func TestSpacedSet(t *testing.T) {
 	// Brussels–Liège: ~90 km
 	// Ghent–Liège: ~125 km
 
-	brussels := Host{
+	brussels := HostInfo{
 		PublicKey:   types.PublicKey{1},
 		CountryCode: "BE",
 		Latitude:    50.8503,
 		Longitude:   4.3517,
 	} // Brussels
 
-	ghent := Host{
+	ghent := HostInfo{
 		PublicKey:   types.PublicKey{2},
 		CountryCode: "BE",
 		Latitude:    51.0543,
 		Longitude:   3.7174,
 	} // Ghent
-	liege := Host{
+	liege := HostInfo{
 		PublicKey:   types.PublicKey{3},
 		CountryCode: "BE",
 		Latitude:    50.6326,

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -104,12 +104,11 @@ type (
 	// key and addresses. It is used for listing usable hosts in the
 	// application API.
 	HostInfo struct {
-		PublicKey types.PublicKey    `json:"publicKey"`
-		Addresses []chain.NetAddress `json:"addresses"`
-
-		CountryCode string  `json:"countryCode"`
-		Latitude    float64 `json:"latitude"`
-		Longitude   float64 `json:"longitude"`
+		PublicKey   types.PublicKey    `json:"publicKey"`
+		Addresses   []chain.NetAddress `json:"addresses"`
+		CountryCode string             `json:"countryCode"`
+		Latitude    float64            `json:"latitude"`
+		Longitude   float64            `json:"longitude"`
 	}
 
 	// Usability represents a series of host checks that can be used to
@@ -160,17 +159,28 @@ type (
 	}
 )
 
+// Info returns the HostInfo of the host.
+func (h *Host) Info() HostInfo {
+	return HostInfo{
+		PublicKey:   h.PublicKey,
+		Addresses:   h.Addresses,
+		CountryCode: h.CountryCode,
+		Latitude:    h.Latitude,
+		Longitude:   h.Longitude,
+	}
+}
+
 // IsGood returns true if the host is considered good for storing data.
 func (h *Host) IsGood() bool {
 	return h.Usability.Usable() && !h.Blocked
 }
 
-// Location returns the geoip.Location of the host.
-func (h *Host) Location() geoip.Location {
+// Location returns the geoip location of the host.
+func (hi *HostInfo) Location() geoip.Location {
 	return geoip.Location{
-		CountryCode: h.CountryCode,
-		Latitude:    h.Latitude,
-		Longitude:   h.Longitude,
+		CountryCode: hi.CountryCode,
+		Latitude:    hi.Latitude,
+		Longitude:   hi.Longitude,
 	}
 }
 

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -636,9 +636,8 @@ WHERE
 
 		for _, h := range dbHosts {
 			usable = append(usable, hosts.HostInfo{
-				PublicKey: h.PublicKey,
-				Addresses: h.Addresses,
-
+				PublicKey:   h.PublicKey,
+				Addresses:   h.Addresses,
 				CountryCode: h.CountryCode,
 				Latitude:    h.Latitude,
 				Longitude:   h.Longitude,

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -667,12 +667,8 @@ func TestUsableHosts(t *testing.T) {
 		t.Fatal("unexpected", len(hosts))
 	} else if hosts[0].PublicKey != uh1 {
 		t.Fatal("unexpected host", hosts[0])
-	} else if hosts[0].CountryCode != locationUS.CountryCode {
-		t.Fatalf("expected country code %v, got %v", locationUS.CountryCode, hosts[0].CountryCode)
-	} else if hosts[0].Latitude != locationUS.Latitude {
-		t.Fatalf("expected latitude %v, got %v", locationUS.Latitude, hosts[0].Latitude)
-	} else if hosts[0].Longitude != locationUS.Longitude {
-		t.Fatalf("expected longitude %v, got %v", locationUS.Longitude, hosts[0].Longitude)
+	} else if hosts[0].Location() != locationUS {
+		t.Fatalf("expected location %v, got %v", locationUS, hosts[0].Location())
 	}
 
 	if hosts, err := db.UsableHosts(context.Background(), 0, 10, hosts.WithCountry(locationAU.CountryCode)); err != nil {
@@ -681,12 +677,8 @@ func TestUsableHosts(t *testing.T) {
 		t.Fatal("unexpected", len(hosts))
 	} else if hosts[0].PublicKey != uh2 {
 		t.Fatal("unexpected host", hosts[0])
-	} else if hosts[0].CountryCode != locationAU.CountryCode {
-		t.Fatalf("expected country code %v, got %v", locationAU.CountryCode, hosts[0].CountryCode)
-	} else if hosts[0].Latitude != locationAU.Latitude {
-		t.Fatalf("expected latitude %v, got %v", locationAU.Latitude, hosts[0].Latitude)
-	} else if hosts[0].Longitude != locationAU.Longitude {
-		t.Fatalf("expected longitude %v, got %v", locationAU.Longitude, hosts[0].Longitude)
+	} else if hosts[0].Location() != locationAU {
+		t.Fatalf("expected location %v, got %v", locationAU, hosts[0].Location())
 	}
 
 	// block usable hosts and add 3 new usable hosts in the EU

--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -13,12 +13,12 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4/quic"
 	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
 
@@ -76,13 +76,14 @@ type dialer struct {
 	log *zap.Logger
 	tg  *threadgroup.ThreadGroup
 
-	c      appClient
-	appKey types.PrivateKey
+	c                 appClient
+	appKey            types.PrivateKey
+	minHostDistanceKm float64
 
 	mu             sync.Mutex
-	addrs          map[types.PublicKey][]chain.NetAddress
 	conns          map[types.PublicKey]*connEntry
 	cachedSettings map[types.PublicKey]proto.HostSettings
+	hosts          map[types.PublicKey]hosts.HostInfo
 }
 
 // newDialer returns a new Dialer.
@@ -90,13 +91,14 @@ func newDialer(c appClient, appKey types.PrivateKey, log *zap.Logger) (*dialer, 
 	d := &dialer{
 		log: log.Named("dialer"),
 
-		c:      c,
-		appKey: appKey,
+		c:                 c,
+		appKey:            appKey,
+		minHostDistanceKm: 10,
 
 		tg:             threadgroup.New(),
-		addrs:          make(map[types.PublicKey][]chain.NetAddress),
 		conns:          make(map[types.PublicKey]*connEntry),
 		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
+		hosts:          make(map[types.PublicKey]hosts.HostInfo),
 	}
 	if err := d.initHosts(); err != nil {
 		return nil, err
@@ -163,25 +165,25 @@ func (d *dialer) updateHosts(ctx context.Context) error {
 	defer cancel()
 
 	offset, limit := 0, 100
-	addrs := make(map[types.PublicKey][]chain.NetAddress)
+	hosts := make(map[types.PublicKey]hosts.HostInfo)
 	for {
-		hosts, err := d.c.Hosts(ctx, api.WithOffset(offset), api.WithLimit(limit))
+		batch, err := d.c.Hosts(ctx, api.WithOffset(offset), api.WithLimit(limit))
 		if err != nil {
 			return fmt.Errorf("failed to get hosts: %w", err)
 		}
 
-		for _, host := range hosts {
-			addrs[host.PublicKey] = host.Addresses
+		for _, host := range batch {
+			hosts[host.PublicKey] = host
 		}
 
-		offset += len(hosts)
-		if len(hosts) < limit {
+		offset += len(batch)
+		if len(batch) < limit {
 			break
 		}
 	}
 
 	d.mu.Lock()
-	d.addrs = addrs
+	d.hosts = hosts
 	d.mu.Unlock()
 	return nil
 }
@@ -202,9 +204,15 @@ func (d *dialer) clearHostConnection(hostKey types.PublicKey) {
 func (d *dialer) Hosts() (hks []types.PublicKey) {
 	// grab current state
 	d.mu.Lock()
-	addrs := slices.Collect(maps.Keys(d.addrs))
+	infos := slices.Collect(maps.Values(d.hosts))
 	conns := slices.Collect(maps.Values(d.conns))
 	d.mu.Unlock()
+
+	// build lookup map
+	lookup := make(map[types.PublicKey]hosts.HostInfo)
+	for _, hi := range infos {
+		lookup[hi.PublicKey] = hi
+	}
 
 	// prioritize hosts we already have a connection with
 	seen := make(map[types.PublicKey]struct{})
@@ -216,18 +224,30 @@ func (d *dialer) Hosts() (hks []types.PublicKey) {
 	}
 
 	// add remaining hosts
-	for _, hk := range addrs {
+	for hk := range lookup {
 		if _, ok := seen[hk]; !ok {
 			hks = append(hks, hk)
 		}
 	}
 
-	return
+	// enforce minimum distance between hosts
+	set := hosts.NewSpacedSet(d.minHostDistanceKm)
+	spaced := make([]types.PublicKey, 0, len(hks))
+	others := make([]types.PublicKey, 0, len(hks))
+	for _, hk := range hks {
+		if hi, ok := lookup[hk]; ok && set.Add(hi) {
+			spaced = append(spaced, hk)
+		} else {
+			others = append(others, hk)
+		}
+	}
+
+	return append(spaced, others...)
 }
 
 func (d *dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.TransportClient, error) {
 	d.mu.Lock()
-	h, ok := d.addrs[hostKey]
+	h, ok := d.hosts[hostKey]
 	if !ok {
 		d.mu.Unlock()
 		return nil, fmt.Errorf("missing host with key: %v", hostKey)
@@ -275,7 +295,7 @@ func (d *dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 		entry.setTransport(tc, err == nil)
 	}()
 
-	for _, addr := range h {
+	for _, addr := range h.Addresses {
 		if addr.Protocol == siamux.Protocol {
 			tc, err = siamux.Dial(ctx, addr.Address, hostKey)
 			if err == nil {
@@ -285,7 +305,7 @@ func (d *dialer) dialHost(ctx context.Context, hostKey types.PublicKey) (rhp.Tra
 			}
 		}
 	}
-	for _, addr := range h {
+	for _, addr := range h.Addresses {
 		if addr.Protocol == quic.Protocol {
 			tc, err = quic.Dial(ctx, addr.Address, hostKey)
 			if err == nil {

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -199,7 +199,7 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 		// add the host to the spaced set to ensure we don't use hosts that are
 		// too close to existing hosts
 		if host, ok := hostsMap[*sector.HostKey]; ok {
-			set.Add(host)
+			set.Add(host.Info())
 		}
 	}
 
@@ -207,7 +207,7 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 	// are sufficiently far apart
 	var candidates []hosts.Host
 	for _, contract := range goodContractMap {
-		if host, ok := hostsMap[contract.HostKey]; ok && set.Add(host) {
+		if host, ok := hostsMap[contract.HostKey]; ok && set.Add(host.Info()) {
 			candidates = append(candidates, host)
 		}
 	}


### PR DESCRIPTION
This updates the dialer to return hosts that are at least 10km removed from one another first. Hosts that are in too close proximity of a selected host gets pushed to the end of the list. Couple of approaches here, in the future we probably want to be smarter about this. I kind of liked this minimum LoC approach that satisfies the issue imo, reusing the spaced set we also use in the contractor.

Fixes https://github.com/SiaFoundation/indexd/issues/474