### PR TITLE
Filter hosts by pubkeys

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -666,7 +666,7 @@ func (a *admin) handleGETHosts(jc jape.Context) {
 		}
 		opts = append(opts, hosts.WithActiveContracts(activeContracts))
 	}
-	if strs := jc.Request.Form["pk"]; len(strs) > 0 {
+	if strs := jc.Request.Form["hostkey"]; len(strs) > 0 {
 		hks := make([]types.PublicKey, len(strs))
 		for i := range strs {
 			var hk types.PublicKey

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"net/http"
+	"strings"
 
 	"errors"
 	"fmt"
@@ -667,9 +668,20 @@ func (a *admin) handleGETHosts(jc jape.Context) {
 		opts = append(opts, hosts.WithActiveContracts(activeContracts))
 	}
 	if jc.Request.FormValue("publickeys") != "" {
-		var hks []types.PublicKey
-		if jc.DecodeForm("publickeys", &hks) != nil {
+		var s string
+		if jc.DecodeForm("publickeys", &s) != nil {
 			return
+		}
+		split := strings.Split(s, ",")
+
+		hks := make([]types.PublicKey, len(split))
+		for i := range split {
+			var hk types.PublicKey
+			if err := hk.UnmarshalText([]byte(split[i])); err != nil {
+				jc.Error(fmt.Errorf("failed to parse host key %s: %w", split[i], err), http.StatusBadRequest)
+				return
+			}
+			hks[i] = hk
 		}
 		opts = append(opts, hosts.WithPublicKeys(hks))
 	}

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -666,6 +666,13 @@ func (a *admin) handleGETHosts(jc jape.Context) {
 		}
 		opts = append(opts, hosts.WithActiveContracts(activeContracts))
 	}
+	if jc.Request.FormValue("publickeys") != "" {
+		var hks []types.PublicKey
+		if jc.DecodeForm("publickeys", &hks) != nil {
+			return
+		}
+		opts = append(opts, hosts.WithPublicKeys(hks))
+	}
 
 	hosts, err := a.hosts.Hosts(jc.Request.Context(), offset, limit, opts...)
 	if jc.Check("failed to get hosts", err) != nil {

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"net/http"
-	"strings"
 
 	"errors"
 	"fmt"
@@ -667,18 +666,12 @@ func (a *admin) handleGETHosts(jc jape.Context) {
 		}
 		opts = append(opts, hosts.WithActiveContracts(activeContracts))
 	}
-	if jc.Request.FormValue("publickeys") != "" {
-		var s string
-		if jc.DecodeForm("publickeys", &s) != nil {
-			return
-		}
-		split := strings.Split(s, ",")
-
-		hks := make([]types.PublicKey, len(split))
-		for i := range split {
+	if strs := jc.Request.Form["pk"]; len(strs) > 0 {
+		hks := make([]types.PublicKey, len(strs))
+		for i := range strs {
 			var hk types.PublicKey
-			if err := hk.UnmarshalText([]byte(split[i])); err != nil {
-				jc.Error(fmt.Errorf("failed to parse host key %s: %w", split[i], err), http.StatusBadRequest)
+			if err := hk.UnmarshalText([]byte(strs[i])); err != nil {
+				jc.Error(fmt.Errorf("failed to parse host key %s: %w", strs[i], err), http.StatusBadRequest)
 				return
 			}
 			hks[i] = hk

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -595,6 +595,20 @@ func TestHostsAPI(t *testing.T) {
 		t.Fatalf("invalid number of hosts: %d", len(notContracted))
 	}
 
+	// test filtering by public key
+	hosts, err := adminClient.Hosts(context.Background(), admin.WithPublicKeys([]types.PublicKey{h1.PublicKey()}))
+	if err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	} else if hosts[0].PublicKey != h1.PublicKey() {
+		t.Fatal("expected public key for host 1")
+	} else if hosts, err := adminClient.Hosts(context.Background(), admin.WithPublicKeys([]types.PublicKey{h1.PublicKey(), h2.PublicKey()})); err != nil {
+		t.Fatal(err)
+	} else if len(hosts) != 2 {
+		t.Fatalf("expected 2 host, got %d", len(hosts))
+	}
+
 	// manually scan host
 	host1, err := adminClient.Host(context.Background(), h1.PublicKey())
 	if err != nil {

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -1,9 +1,9 @@
 package admin
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/alerts"
@@ -88,8 +88,11 @@ func WithActiveContracts(activeContracts bool) HostQueryParameterOption {
 // WithPublicKeys sets the 'publickeys' parameter.
 func WithPublicKeys(hks []types.PublicKey) HostQueryParameterOption {
 	return func(q url.Values) {
-		data, _ := json.Marshal(hks)
-		q.Set("publickeys", string(data))
+		strs := make([]string, len(hks))
+		for i := range hks {
+			strs[i] = hks[i].String()
+		}
+		q.Set("publickeys", strings.Join(strs, ","))
 	}
 }
 

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -84,14 +84,15 @@ func WithActiveContracts(activeContracts bool) HostQueryParameterOption {
 	}
 }
 
-// WithPublicKeys sets the 'publickeys' parameter.
+// WithPublicKeys sets the 'hostkey' parameter (multiple times if there is more
+// than one host key provided).
 func WithPublicKeys(hks []types.PublicKey) HostQueryParameterOption {
 	return func(q url.Values) {
 		strs := make([]string, len(hks))
 		for i := range hks {
 			strs[i] = hks[i].String()
 		}
-		q["pk"] = strs
+		q["hostkey"] = strs
 	}
 }
 

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -1,9 +1,11 @@
 package admin
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 
+	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/api"
 	"go.uber.org/zap"
@@ -80,6 +82,14 @@ func WithUsable(usable bool) HostQueryParameterOption {
 func WithActiveContracts(activeContracts bool) HostQueryParameterOption {
 	return func(q url.Values) {
 		q.Set("activecontracts", fmt.Sprint(activeContracts))
+	}
+}
+
+// WithPublicKeys sets the 'publickeys' parameter.
+func WithPublicKeys(hks []types.PublicKey) HostQueryParameterOption {
+	return func(q url.Values) {
+		data, _ := json.Marshal(hks)
+		q.Set("publickeys", string(data))
 	}
 }
 

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/alerts"
@@ -92,7 +91,7 @@ func WithPublicKeys(hks []types.PublicKey) HostQueryParameterOption {
 		for i := range hks {
 			strs[i] = hks[i].String()
 		}
-		q.Set("publickeys", strings.Join(strs, ","))
+		q["pk"] = strs
 	}
 }
 

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -47,9 +47,10 @@ type (
 	HostQueryOpt func(*hostsQueryOpts)
 
 	hostsQueryOpts struct {
-		ActiveContracts *bool // return hosts that have active contracts or not
-		Blocked         *bool // return (un)blocked hosts
-		Good            *bool // return good/bad hosts
+		ActiveContracts *bool             // return hosts that have active contracts or not
+		Blocked         *bool             // return (un)blocked hosts
+		Good            *bool             // return good/bad hosts
+		PublicKeys      []types.PublicKey // do not return hosts with public keys outside of this list
 	}
 )
 
@@ -74,6 +75,14 @@ func WithBlocked(blocked bool) HostQueryOpt {
 func WithActiveContracts(activeContracts bool) HostQueryOpt {
 	return func(opts *hostsQueryOpts) {
 		opts.ActiveContracts = &activeContracts
+	}
+}
+
+// WithPublicKeys limits the set of returned to hosts to those with a public
+// key in the provided slice.
+func WithPublicKeys(hks []types.PublicKey) HostQueryOpt {
+	return func(opts *hostsQueryOpts) {
+		opts.PublicKeys = hks
 	}
 }
 

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -737,6 +737,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: publickeys
+          in: query
+          description: Only include hosts that have public keys within this comma separated set of public keys
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: A list of hosts

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -737,12 +737,15 @@ paths:
           required: false
           schema:
             type: boolean
-        - name: publickeys
+        - name: hostkey
           in: query
-          description: Only include hosts that have public keys within this comma separated set of public keys
-          required: false
+          description: If provided, only include hosts from this set of public keys.
           schema:
-            type: string
+            type: array
+            items:
+              $ref: "#/components/schemas/PublicKey"
+          style: form
+          explode: true
       responses:
         "200":
           description: A list of hosts

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -129,6 +129,11 @@ func (s *Store) Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts
 		opt(&opts)
 	}
 
+	hks := make([]sqlPublicKey, len(opts.PublicKeys))
+	for i := range hks {
+		hks[i] = sqlPublicKey(opts.PublicKeys[i])
+	}
+
 	var hosts []hosts.Host
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		rows, err := tx.Query(ctx, `
@@ -196,8 +201,10 @@ WHERE
 	AND (($4::boolean IS NULL) OR ($4::boolean = hosts.blocked))
 	-- active contracts filter
 	AND (($5::boolean IS NULL) OR ($5::boolean = EXISTS (SELECT 1 FROM contracts WHERE host_id = hosts.id AND state >= $6 AND state <= $7)))
+	-- public key filter
+	AND ((CARDINALITY($8::bytea[]) = 0) OR (public_key = ANY($8)))
 	LIMIT $1 OFFSET $2
-;`, limit, offset, opts.Good, opts.Blocked, opts.ActiveContracts, contracts.ContractStatePending, contracts.ContractStateActive)
+;`, limit, offset, opts.Good, opts.Blocked, opts.ActiveContracts, contracts.ContractStatePending, contracts.ContractStateActive, hks)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts: %w", err)
 		}

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -506,9 +506,14 @@ func TestHosts(t *testing.T) {
 	assertHosts([]types.PublicKey{hk1, hk2}, 0, 4, hosts.WithActiveContracts(true))
 	assertHosts([]types.PublicKey{hk3, hk4}, 0, 4, hosts.WithActiveContracts(false))
 
+	// public keys
+	assertHosts([]types.PublicKey{hk1, hk2}, 0, 4, hosts.WithPublicKeys([]types.PublicKey{hk1, hk2}))
+	assertHosts([]types.PublicKey{hk1, hk2, hk3, hk4}, 0, 4, hosts.WithPublicKeys([]types.PublicKey{hk1, hk2, hk3, hk4}))
+
 	// mix filters
 	assertHosts([]types.PublicKey{hk3}, 0, 4, hosts.WithUsable(true), hosts.WithBlocked(true))
 	assertHosts([]types.PublicKey{hk2}, 0, 4, hosts.WithUsable(false), hosts.WithBlocked(false), hosts.WithActiveContracts(true))
+	assertHosts([]types.PublicKey{hk2}, 0, 4, hosts.WithUsable(false), hosts.WithPublicKeys([]types.PublicKey{hk1, hk2}))
 
 	// mix filters and offset/limit
 	assertHosts([]types.PublicKey{hk1}, 0, 1, hosts.WithUsable(true))
@@ -520,6 +525,7 @@ func TestHosts(t *testing.T) {
 	assertHosts([]types.PublicKey{hk1}, 0, 1, hosts.WithBlocked(false))
 	assertHosts([]types.PublicKey{hk2}, 1, 1, hosts.WithBlocked(false))
 	assertHosts([]types.PublicKey{hk2}, 1, 1, hosts.WithActiveContracts(true))
+	assertHosts([]types.PublicKey{hk3}, 1, 1, hosts.WithPublicKeys([]types.PublicKey{hk2, hk3, hk4}))
 }
 
 func TestUsableHosts(t *testing.T) {


### PR DESCRIPTION
Re: #522

Add options to filter hosts by host public keys to the store and the admin API.  We add a "pk" query parameter containing a string encoded public key which can be repeated multiple times if there are multiple pubkeys.