### PR TITLE
Fix sector stats

### DIFF
--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -512,7 +512,7 @@ func (s *Store) PruneContractSectorsMap(ctx context.Context, maxBlocksSinceExpir
 			return err
 		} else if err := incrementNumPinnedSectors(ctx, tx, -totalUnpinned); err != nil {
 			return fmt.Errorf("failed to update number of pinned sectors: %w", err)
-		} else if err := incrementUnpinnedSectors(ctx, tx, totalUnpinned); err != nil {
+		} else if err := incrementNumUnpinnedSectors(ctx, tx, totalUnpinned); err != nil {
 			return fmt.Errorf("failed to update number of unpinned sectors: %w", err)
 		}
 

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -387,4 +387,24 @@ FROM objects o;
 		}
 		return nil
 	},
+	// reset stats
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		if _, err := tx.Exec(ctx, `
+		WITH counts AS (
+			SELECT
+				COUNT(*) FILTER (WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NOT NULL)::bigint AS pinned,
+				COUNT(*) FILTER (WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NULL)::bigint     AS unpinned,
+				COUNT(*) FILTER (WHERE host_id IS NULL     AND contract_sectors_map_id IS NULL)::bigint     AS unpinnable
+			FROM sectors
+		)
+		UPDATE stats s
+		SET
+			num_pinned_sectors     = counts.pinned,
+			num_unpinned_sectors   = counts.unpinned,
+			num_unpinnable_sectors = counts.unpinnable
+		FROM counts`); err != nil {
+			return fmt.Errorf("failed to reset sector stats: %w", err)
+		}
+		return nil
+	},
 }

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -58,7 +58,7 @@ func (s *Store) MarkSectorsLost(ctx context.Context, hostKey types.PublicKey, ro
 			return fmt.Errorf("failed to increment host's lost sectors: %w", err)
 		} else if err := incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
 			return fmt.Errorf("failed to update pinned sectors: %w", err)
-		} else if err := incrementUnpinnedSectors(ctx, tx, pinned); err != nil {
+		} else if err := incrementNumUnpinnedSectors(ctx, tx, pinned); err != nil {
 			return fmt.Errorf("failed to update unpinned sectors: %w", err)
 		} else {
 			return nil
@@ -180,7 +180,7 @@ func (s *Store) markFailingSectorsLostBatch(ctx context.Context, hostKey types.P
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
 		} else if err := incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
 			return fmt.Errorf("failed to update pinned sectors: %w", err)
-		} else if err := incrementUnpinnedSectors(ctx, tx, pinned); err != nil {
+		} else if err := incrementNumUnpinnedSectors(ctx, tx, pinned); err != nil {
 			return fmt.Errorf("failed to update unpinned sectors: %w", err)
 		} else {
 			return nil
@@ -295,7 +295,7 @@ func (s *Store) PinSlabs(ctx context.Context, account proto.Account, nextIntegri
 
 			// update number of unpinned sectors
 			if unpinned > 0 {
-				if err := incrementUnpinnedSectors(ctx, tx, unpinned); err != nil {
+				if err := incrementNumUnpinnedSectors(ctx, tx, unpinned); err != nil {
 					return fmt.Errorf("failed to increment number of unpinned sectors: %w", err)
 				}
 
@@ -606,7 +606,7 @@ func (s *Store) PinSectors(ctx context.Context, contractID types.FileContractID,
 		} else if unpinned > 0 {
 			if err := incrementNumPinnedSectors(ctx, tx, unpinned); err != nil {
 				return fmt.Errorf("failed to update number of pinned sectors: %w", err)
-			} else if err := incrementUnpinnedSectors(ctx, tx, -unpinned); err != nil {
+			} else if err := incrementNumUnpinnedSectors(ctx, tx, -unpinned); err != nil {
 				return fmt.Errorf("failed to update number of unpinned sectors: %w", err)
 			}
 		}
@@ -627,9 +627,11 @@ func (s *Store) PruneUnpinnableSectors(ctx context.Context, threshold time.Time)
 	            AND uploaded_at <= $1`, threshold)
 		if err != nil {
 			return fmt.Errorf("failed to prune unpinnable sectors: %w", err)
-		} else if res.RowsAffected() > 0 {
-			if err := incrementNumUnpinnableSlabs(ctx, tx, uint64(res.RowsAffected())); err != nil {
+		} else if unpinnable := res.RowsAffected(); unpinnable > 0 {
+			if err := incrementNumUnpinnableSectors(ctx, tx, unpinnable); err != nil {
 				return fmt.Errorf("failed to increment unpinnable sectors: %w", err)
+			} else if err := incrementNumUnpinnedSectors(ctx, tx, -unpinnable); err != nil {
+				return fmt.Errorf("failed to decrement unpinned sectors: %w", err)
 			}
 		}
 		return nil
@@ -745,11 +747,12 @@ LIMIT $4;`
 // the meantime, this operation is a no-op.
 func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey types.PublicKey) (migrated bool, err error) {
 	err = s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		var hostID sql.NullInt64
 		var contractMapID sql.NullInt64
 		err := tx.QueryRow(ctx, `
-			SELECT contract_sectors_map_id
+			SELECT host_id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = $1`, sqlHash256(root)).Scan(&contractMapID)
+			WHERE sector_root = $1`, sqlHash256(root)).Scan(&hostID, &contractMapID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // not migrated
 		}
@@ -773,7 +776,14 @@ func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey t
 			// sector was pinned before, update stats
 			if err := incrementNumPinnedSectors(ctx, tx, -1); err != nil {
 				return fmt.Errorf("failed to decrement pinned sectors: %w", err)
-			} else if err := incrementUnpinnedSectors(ctx, tx, 1); err != nil {
+			} else if err := incrementNumUnpinnedSectors(ctx, tx, 1); err != nil {
+				return fmt.Errorf("failed to increment unpinned sectors: %w", err)
+			}
+		} else if !hostID.Valid {
+			// sector was unpinnable before, update stats
+			if err := incrementNumUnpinnableSectors(ctx, tx, -1); err != nil {
+				return fmt.Errorf("failed to decrement unpinnable sectors: %w", err)
+			} else if err := incrementNumUnpinnedSectors(ctx, tx, 1); err != nil {
 				return fmt.Errorf("failed to increment unpinned sectors: %w", err)
 			}
 		}

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -29,12 +29,12 @@ func incrementNumPinnedSectors(ctx context.Context, tx *txn, delta int64) error 
 	return err
 }
 
-func incrementNumUnpinnableSlabs(ctx context.Context, tx *txn, incr uint64) error {
-	_, err := tx.Exec(ctx, "UPDATE stats SET num_unpinnable_sectors = num_unpinnable_sectors + $1", incr)
+func incrementNumUnpinnableSectors(ctx context.Context, tx *txn, delta int64) error {
+	_, err := tx.Exec(ctx, "UPDATE stats SET num_unpinnable_sectors = num_unpinnable_sectors + $1", delta)
 	return err
 }
 
-func incrementUnpinnedSectors(ctx context.Context, tx *txn, delta int64) error {
+func incrementNumUnpinnedSectors(ctx context.Context, tx *txn, delta int64) error {
 	_, err := tx.Exec(ctx, "UPDATE stats SET num_unpinned_sectors = num_unpinned_sectors + $1", delta)
 	return err
 }

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -75,6 +75,82 @@ func TestSectorStatsNumSlabs(t *testing.T) {
 	}
 }
 
+// TestSectorStats is a regression test that verifies that the sector stats are
+// updated correctly when sectors are pinned, unpinned, migrated and pruned.
+func TestSectorStats(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	fcid := store.addTestContract(t, hk1)
+
+	root := types.Hash256(frand.Entropy256())
+	slab := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    root,
+			HostKey: hk1,
+		}},
+	}
+	if _, err := store.PinSlabs(t.Context(), account, time.Time{}, slab); err != nil {
+		t.Fatal(err)
+	}
+
+	assertStats := func(pinned, unpinned, unpinnable, migrated int64) {
+		t.Helper()
+		stats, err := store.SectorStats(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stats.Pinned != pinned || stats.Unpinned != unpinned || stats.Unpinnable != unpinnable || stats.Migrated != migrated {
+			t.Fatalf("unexpected sector stats: pinned=%d unpinned=%d unpinnable=%d migrated=%d", stats.Pinned, stats.Unpinned, stats.Unpinnable, stats.Migrated)
+		}
+	}
+
+	assertStats(0, 1, 0, 0)
+
+	if err := store.PinSectors(t.Context(), fcid, []types.Hash256{root}); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(1, 0, 0, 0)
+
+	if migrated, err := store.MigrateSector(t.Context(), root, hk2); err != nil {
+		t.Fatal(err)
+	} else if !migrated {
+		t.Fatal("expected sector to be migrated")
+	}
+	assertStats(0, 1, 0, 1)
+
+	var uploadedAt time.Time
+	if err := store.pool.QueryRow(t.Context(), `
+		SELECT uploaded_at
+		FROM sectors
+		WHERE sector_root = $1
+	`, sqlHash256(root)).Scan(&uploadedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PruneUnpinnableSectors(t.Context(), uploadedAt.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(0, 0, 1, 1)
+
+	if migrated, err := store.MigrateSector(t.Context(), root, hk1); err != nil {
+		t.Fatal(err)
+	} else if !migrated {
+		t.Fatal("expected sector to be migrated")
+	}
+	assertStats(0, 1, 0, 2)
+
+	if err := store.PinSectors(t.Context(), fcid, []types.Hash256{root}); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(1, 0, 0, 2)
+}
+
 func TestAccountStatsRegistered(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 


### PR DESCRIPTION
When we prune unpinnable sectors, we should increment the corresponding statistic, but decrement the unpinned sectors count. When we then migrate the sectors we should mark them as unpinned to fix the counts. I dropped a query in the issue linked below that clearly shows what's going on. The discrepancy between the amount of unpinned sectors in the database and the stats is exactly the number of unpinnable sectors.

Note: after merging we should keep an eye out on `num_unpinnable_sectors`, there's a `44334` delta there that I can't quite explain. Recalculating the stats will help us track that down if it proves to be an issue still. The pinned and unpinned sector counts should match the stats perfectly, so I'm guessing `num_unpinnable` will sort itself out.

Fixes #524 

