### PR TITLE
Add contract public key filtering

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -601,6 +601,7 @@ func (a *admin) handleGETContracts(jc jape.Context) {
 		opts = append(opts, contracts.WithGood(good))
 	}
 
+	// filter by ID
 	if strs := jc.Request.Form["id"]; len(strs) > 0 {
 		ids := make([]types.FileContractID, len(strs))
 		for i := range strs {
@@ -612,6 +613,20 @@ func (a *admin) handleGETContracts(jc jape.Context) {
 			ids[i] = id
 		}
 		opts = append(opts, contracts.WithIDs(ids))
+	}
+
+	// filter by host public key
+	if strs := jc.Request.Form["hostkey"]; len(strs) > 0 {
+		hks := make([]types.PublicKey, len(strs))
+		for i := range strs {
+			var hk types.PublicKey
+			if err := hk.UnmarshalText([]byte(strs[i])); err != nil {
+				jc.Error(fmt.Errorf("failed to parse public key %s: %w", strs[i], err), http.StatusBadRequest)
+				return
+			}
+			hks[i] = hk
+		}
+		opts = append(opts, contracts.WithHostKeys(hks))
 	}
 
 	contracts, err := a.contracts.Contracts(jc.Request.Context(), offset, limit, opts...)

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -367,6 +367,13 @@ func TestContractsAPI(t *testing.T) {
 		t.Fatal("expected 1 contract", len(contracts))
 	}
 
+	// assert public key filtering works
+	if contracts, err := adminClient.Contracts(context.Background(), admin.WithHostKeys([]types.PublicKey{h.PublicKey()})); err != nil {
+		t.Fatal(err)
+	} else if len(contracts) != 1 {
+		t.Fatal("expected 1 contract", len(contracts))
+	}
+
 	// assert WithRevisable filters out non-revisable contracts
 	if contracts, err := adminClient.Contracts(context.Background(), admin.WithRevisable(true)); err != nil {
 		t.Fatal(err)

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -63,7 +63,7 @@ func WithIDs(ids []types.FileContractID) ContractQueryParameterOption {
 
 // WithHostKeys sets the 'hostkey' parameter (multiple times if there is more
 // than one host key provided).
-func WithHostKeys(ids []types.FileContractID) ContractQueryParameterOption {
+func WithHostKeys(ids []types.PublicKey) ContractQueryParameterOption {
 	return func(q url.Values) {
 		strs := make([]string, len(ids))
 		for i := range ids {

--- a/api/admin/options.go
+++ b/api/admin/options.go
@@ -61,6 +61,18 @@ func WithIDs(ids []types.FileContractID) ContractQueryParameterOption {
 	}
 }
 
+// WithHostKeys sets the 'hostkey' parameter (multiple times if there is more
+// than one host key provided).
+func WithHostKeys(ids []types.FileContractID) ContractQueryParameterOption {
+	return func(q url.Values) {
+		strs := make([]string, len(ids))
+		for i := range ids {
+			strs[i] = ids[i].String()
+		}
+		q["hostkey"] = strs
+	}
+}
+
 // WithGood sets the 'good' parameter. When good is set to 'true', all contracts
 // that are considered bad will be filtered out. Examples of such contracts are
 // contracts with blocked hosts or those that failed to renew when nearing their

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -60,7 +60,7 @@ func WithIDs(ids []types.FileContractID) ContractQueryOpt {
 }
 
 // WithHostKeys limits the set of returned contracts to those on a host with a
-// a public key in the provided slice
+// public key in the provided slice
 func WithHostKeys(hks []types.PublicKey) ContractQueryOpt {
 	return func(opts *ContractQueryOpts) {
 		opts.HostKeys = hks

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -30,6 +30,7 @@ type (
 		Revisable *bool
 		Good      *bool
 		IDs       []types.FileContractID
+		HostKeys  []types.PublicKey
 	}
 
 	// ContractQueryOpt is a functional option for querying contracts.
@@ -55,6 +56,14 @@ func WithRevisable(revisable bool) ContractQueryOpt {
 func WithIDs(ids []types.FileContractID) ContractQueryOpt {
 	return func(opts *ContractQueryOpts) {
 		opts.IDs = ids
+	}
+}
+
+// WithHostKeys limits the set of returned contracts to those assigned to a
+// host with a public key in the provided slice
+func WithHostKeys(hks []types.PublicKey) ContractQueryOpt {
+	return func(opts *ContractQueryOpts) {
+		opts.HostKeys = hks
 	}
 }
 

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -59,8 +59,8 @@ func WithIDs(ids []types.FileContractID) ContractQueryOpt {
 	}
 }
 
-// WithHostKeys limits the set of returned contracts to those assigned to a
-// host with a public key in the provided slice
+// WithHostKeys limits the set of returned contracts to those on a host with a
+// a public key in the provided slice
 func WithHostKeys(hks []types.PublicKey) ContractQueryOpt {
 	return func(opts *ContractQueryOpts) {
 		opts.HostKeys = hks

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -505,6 +505,15 @@ paths:
               $ref: "#/components/schemas/FileContractID"
           style: form
           explode: true
+        - name: hostkey
+          in: query
+          description: If provided, only include contracts assigned to this set of hosts.
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/PublicKey"
+          style: form
+          explode: true
       responses:
         "200":
           description: A list of contracts

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -507,7 +507,7 @@ paths:
           explode: true
         - name: hostkey
           in: query
-          description: If provided, only include contracts assigned to this set of hosts.
+          description: If provided, only include contracts on this set of hosts.
           schema:
             type: array
             items:

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -227,7 +227,7 @@ WHERE
 	-- ID filter
 	AND ((CARDINALITY($5::bytea[]) = 0) OR (contract_id = ANY($5)))
 	-- public key filter
-	AND ((CARDINALITY($6::bytea[]) = 0) OR (contract_id = ANY($6)))
+	AND ((CARDINALITY($6::bytea[]) = 0) OR (h.public_key = ANY($6)))
 LIMIT $3 OFFSET $4`, opts.Good, opts.Revisable, limit, offset, ids, hks)
 		if err != nil {
 			return fmt.Errorf("failed to query contracts: %w", err)

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -204,6 +204,11 @@ func (s *Store) Contracts(ctx context.Context, offset, limit int, queryOpts ...c
 		ids[i] = sqlHash256(opts.IDs[i])
 	}
 
+	hks := make([]sqlPublicKey, len(opts.HostKeys))
+	for i := range hks {
+		hks[i] = sqlPublicKey(opts.HostKeys[i])
+	}
+
 	var contracts []contracts.Contract
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		rows, err := tx.Query(ctx, `
@@ -221,7 +226,9 @@ WHERE
 	)
 	-- ID filter
 	AND ((CARDINALITY($5::bytea[]) = 0) OR (contract_id = ANY($5)))
-LIMIT $3 OFFSET $4`, opts.Good, opts.Revisable, limit, offset, ids)
+	-- public key filter
+	AND ((CARDINALITY($6::bytea[]) = 0) OR (contract_id = ANY($6)))
+LIMIT $3 OFFSET $4`, opts.Good, opts.Revisable, limit, offset, ids, hks)
 		if err != nil {
 			return fmt.Errorf("failed to query contracts: %w", err)
 		}

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -33,9 +33,8 @@ func TestContracts(t *testing.T) {
 	// add a host with three contracts
 	hk1 := store.addTestHost(t)
 	hk2 := store.addTestHost(t)
-	fcid1 := types.FileContractID{1}
-	fcid2 := types.FileContractID{2}
-	store.addTestContracts(t, hk1, fcid1, fcid2)
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID{1})
+	fcid2 := store.addTestContract(t, hk1, types.FileContractID{2})
 	fcid3 := store.addTestContract(t, hk2, types.FileContractID{3})
 
 	// mark the second one resolved so it's considered inactive
@@ -157,7 +156,7 @@ func TestContractElement(t *testing.T) {
 	}
 
 	// add a contract and an element
-	fcid := store.addTestContract(t, hk)
+	fcid := store.addTestContract(t, hk, types.FileContractID(hk))
 	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
 		return tx.UpdateContractElements(types.V2FileContractElement{
 			ID: fcid,
@@ -1215,7 +1214,7 @@ func TestUpdateNextPruned(t *testing.T) {
 
 	// add a host with one contract
 	hk := store.addTestHost(t)
-	fcid := store.addTestContract(t, hk)
+	fcid := store.addTestContract(t, hk, types.FileContractID(hk))
 
 	// assert contract is marked to be pruned within 24h
 	tomorrow := time.Now().Add(24 * time.Hour)
@@ -1307,7 +1306,7 @@ func TestUpdateContractRevision(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	hk := store.addTestHost(t)
-	contractID := store.addTestContract(t, hk)
+	contractID := store.addTestContract(t, hk, types.FileContractID(hk))
 
 	contract, renewed, err := store.ContractRevision(context.Background(), contractID)
 	if err != nil {
@@ -1369,9 +1368,9 @@ func TestUpdateContractRenewedTo(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	hk1 := store.addTestHost(t)
-	contractID := store.addTestContract(t, hk1)
+	contractID := store.addTestContract(t, hk1, types.FileContractID(hk1))
 	hk2 := store.addTestHost(t)
-	renewedToID := store.addTestContract(t, hk2)
+	renewedToID := store.addTestContract(t, hk2, types.FileContractID(hk2))
 
 	if contract, err := store.Contract(context.Background(), contractID); err != nil {
 		t.Fatal(err)
@@ -1419,7 +1418,7 @@ func TestMarkBroadcastAttempt(t *testing.T) {
 	hk := store.addTestHost(t)
 
 	// assert broadcast attempt is defaulted
-	fcid := store.addTestContract(t, hk)
+	fcid := store.addTestContract(t, hk, types.FileContractID(hk))
 	contract, err := store.Contract(context.Background(), fcid)
 	if err != nil {
 		t.Fatal(err)
@@ -1820,7 +1819,7 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	var hks []types.PublicKey
 	for range nHosts {
 		hk := store.addTestHost(b)
-		store.addTestContract(b, hk)
+		store.addTestContract(b, hk, types.FileContractID(hk))
 		hks = append(hks, hk)
 	}
 
@@ -1888,35 +1887,14 @@ func BenchmarkPrunableContractRoots(b *testing.B) {
 	}
 }
 
-func (s *Store) addTestContract(t testing.TB, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
+func (s *Store) addTestContract(t testing.TB, hk types.PublicKey, fcid types.FileContractID) types.FileContractID {
 	t.Helper()
-
-	var fcid types.FileContractID
-	switch len(fcids) {
-	case 0:
-		fcid = types.FileContractID(hk)
-	case 1:
-		fcid = fcids[0]
-	default:
-		panic("developer error")
-	}
 
 	err := s.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, proto.Usage{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	return fcid
-}
-
-func (s *Store) addTestContracts(t testing.TB, hk types.PublicKey, fcids ...types.FileContractID) {
-	t.Helper()
-
-	for _, fcid := range fcids {
-		err := s.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, proto.Usage{})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
 }
 
 func newTestRevision(hk types.PublicKey) types.V2FileContract {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -33,8 +33,9 @@ func TestContracts(t *testing.T) {
 	// add a host with three contracts
 	hk1 := store.addTestHost(t)
 	hk2 := store.addTestHost(t)
-	fcid1 := store.addTestContract(t, hk1, types.FileContractID{1})
-	fcid2 := store.addTestContract(t, hk1, types.FileContractID{2})
+	fcid1 := types.FileContractID{1}
+	fcid2 := types.FileContractID{2}
+	store.addTestContracts(t, hk1, fcid1, fcid2)
 	fcid3 := store.addTestContract(t, hk2, types.FileContractID{3})
 
 	// mark the second one resolved so it's considered inactive
@@ -1896,6 +1897,18 @@ func (s *Store) addTestContract(t testing.TB, hk types.PublicKey, fcids ...types
 		t.Fatal(err)
 	}
 	return fcid
+}
+
+func (s *Store) addTestContracts(t testing.TB, hk types.PublicKey, fcids ...types.FileContractID) {
+	t.Helper()
+
+	for _, fcid := range fcids {
+		err := s.AddFormedContract(context.Background(), hk, fcid, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, proto.Usage{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return
 }
 
 func newTestRevision(hk types.PublicKey) types.V2FileContract {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1662,6 +1662,15 @@ func BenchmarkContracts(b *testing.B) {
 				}
 			}
 		})
+
+		b.Run(fmt.Sprintf("contracts_hosts_%d", limit), func(b *testing.B) {
+			for b.Loop() {
+				_, err := store.Contracts(context.Background(), 0, limit, contracts.WithHostKeys(hosts))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 
 	for _, limit := range apiLimits {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -31,10 +31,11 @@ func TestContracts(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// add a host with three contracts
-	hk := store.addTestHost(t)
-	fcid1 := store.addTestContract(t, hk, types.FileContractID{1})
-	fcid2 := store.addTestContract(t, hk, types.FileContractID{2})
-	fcid3 := store.addTestContract(t, hk, types.FileContractID{3})
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID{1})
+	fcid2 := store.addTestContract(t, hk1, types.FileContractID{2})
+	fcid3 := store.addTestContract(t, hk2, types.FileContractID{3})
 
 	// mark the second one resolved so it's considered inactive
 	if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
@@ -82,6 +83,19 @@ func TestContracts(t *testing.T) {
 		t.Fatalf("expected contract %v, got %v", fcid3, css[0].ID)
 	}
 
+	// assert public key filtering works
+	if css, err := store.Contracts(context.Background(), 0, 10, contracts.WithHostKeys([]types.PublicKey{hk1})); err != nil {
+		t.Fatal(err)
+	} else if len(css) != 2 {
+		t.Fatal("expected 2 contracts, got", len(css))
+	} else if css, err := store.Contracts(context.Background(), 0, 10, contracts.WithHostKeys([]types.PublicKey{hk2})); err != nil {
+		t.Fatal(err)
+	} else if len(css) != 1 {
+		t.Fatal("expected 1 contract, got", len(css))
+	} else if css[0].ID != fcid3 {
+		t.Fatalf("expected contract %v, got %v", fcid3, css[0].ID)
+	}
+
 	// assert WithRevisable(true)
 	if css, err := store.Contracts(context.Background(), 0, 10, contracts.WithRevisable(true)); err != nil {
 		t.Fatal(err)
@@ -118,7 +132,7 @@ func TestContracts(t *testing.T) {
 
 	// assert WithRevisable(true) takes into account renewed_to
 	fcid4 := types.FileContractID{4}
-	if err := store.AddRenewedContract(context.Background(), fcid1, fcid4, newTestRevision(hk), types.ZeroCurrency, types.ZeroCurrency, proto.Usage{}); err != nil {
+	if err := store.AddRenewedContract(context.Background(), fcid1, fcid4, newTestRevision(hk1), types.ZeroCurrency, types.ZeroCurrency, proto.Usage{}); err != nil {
 		t.Fatal(err)
 	} else if css, err := store.Contracts(context.Background(), 0, 10, contracts.WithRevisable(true), contracts.WithGood(true)); err != nil {
 		t.Fatal(err)

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1917,7 +1917,6 @@ func (s *Store) addTestContracts(t testing.TB, hk types.PublicKey, fcids ...type
 			t.Fatal(err)
 		}
 	}
-	return
 }
 
 func newTestRevision(hk types.PublicKey) types.V2FileContract {

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -417,7 +417,7 @@ func TestHosts(t *testing.T) {
 
 		// form contract
 		if contract {
-			db.addTestContract(t, hk)
+			db.addTestContract(t, hk, types.FileContractID(hk))
 		}
 		return hk
 	}
@@ -587,7 +587,7 @@ func TestUsableHosts(t *testing.T) {
 
 		// handle contract
 		if contract {
-			db.addTestContract(t, hk)
+			db.addTestContract(t, hk, types.FileContractID(hk))
 		}
 		return hk
 	}
@@ -802,8 +802,8 @@ func TestHostsWithLostSectors(t *testing.T) {
 	hk2 := db.addTestHost(t)
 
 	// add a contract for each host
-	db.addTestContract(t, hk1)
-	db.addTestContract(t, hk2)
+	db.addTestContract(t, hk1, types.FileContractID(hk1))
+	db.addTestContract(t, hk2, types.FileContractID(hk2))
 
 	// pin a slab that adds 2 sectors to each host
 	root1 := frand.Entropy256()
@@ -893,14 +893,14 @@ func TestHostsWithUnpinnableSectors(t *testing.T) {
 
 	// host2 has a contract but no sectors -> not returned
 	hk2 := db.addTestHost(t)
-	db.addTestContract(t, hk2)
+	db.addTestContract(t, hk2, types.FileContractID(hk2))
 
 	// host3 has no contracts but a sector -> returned
 	hk3 := db.addTestHost(t)
 
 	// host4 has a contract and a pinned sector -> not returned
 	hk4 := db.addTestHost(t)
-	db.addTestContract(t, hk4)
+	db.addTestContract(t, hk4, types.FileContractID(hk4))
 
 	_, err := db.PinSlabs(context.Background(), account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
@@ -1118,7 +1118,7 @@ func TestPruneHosts(t *testing.T) {
 	}
 
 	// add contract to h2
-	db.addTestContract(t, h2)
+	db.addTestContract(t, h2, types.FileContractID(h2))
 
 	// assert only h1 got pruned if we set the cutoff in the future
 	n, err = db.PruneHosts(context.Background(), time.Now().Add(time.Second), 1)
@@ -1641,8 +1641,8 @@ func TestHostsForPinning(t *testing.T) {
 	}
 
 	// add contract for both hosts
-	fcid1 := db.addTestContract(t, hk1)
-	_ = db.addTestContract(t, hk2)
+	fcid1 := db.addTestContract(t, hk1, types.FileContractID(hk1))
+	_ = db.addTestContract(t, hk2, types.FileContractID(hk2))
 
 	// assert both hosts are returned now
 	hks, err = db.HostsForPinning(context.Background())
@@ -1695,8 +1695,8 @@ func TestHostsForPruning(t *testing.T) {
 	db.addTestAccount(t, types.PublicKey(acc))
 
 	// add contract for both hosts
-	fcid1 := db.addTestContract(t, hk1)
-	fcid2 := db.addTestContract(t, hk2)
+	fcid1 := db.addTestContract(t, hk1, types.FileContractID(hk1))
+	fcid2 := db.addTestContract(t, hk2, types.FileContractID(hk2))
 
 	// assert there's no hosts for pruning yet
 	if hks, err := db.HostsForPruning(context.Background()); err != nil {
@@ -2145,7 +2145,7 @@ func BenchmarkHostsWithUnpinnableSectors(b *testing.B) {
 
 		// 10% of hosts have unpinned sectors which results in 100 out of 1000.
 		if i%10 != 0 {
-			store.addTestContract(b, hk)
+			store.addTestContract(b, hk, types.FileContractID(hk))
 		}
 	}
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -32,7 +32,7 @@ func TestMigrateSector(t *testing.T) {
 	hk2 := store.addTestHost(t)
 
 	// add contract for first host
-	fcid1 := store.addTestContract(t, hk1)
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID(hk1))
 
 	// pin a slab to add 2 sectors which are both stored on the first host
 	pinTime := time.Now().Round(time.Microsecond)
@@ -1072,7 +1072,7 @@ func TestUnhealthySlabs(t *testing.T) {
 
 	// add a host and a contract
 	hk := store.addTestHost(t)
-	contractID := store.addTestContract(t, hk)
+	contractID := store.addTestContract(t, hk, types.FileContractID(hk))
 
 	// add two slabs & immediately reset the LRA-time
 	slabID1 := store.pinTestSlab(t, account, 1, []types.PublicKey{hk, hk})
@@ -1234,7 +1234,7 @@ func TestPruneUnpinnableSectors(t *testing.T) {
 
 	// add host with a contract
 	hk := store.addTestHost(t)
-	store.addTestContract(t, hk)
+	store.addTestContract(t, hk, types.FileContractID(hk))
 
 	// pin a slab to add a few sectors to the database
 	root1 := frand.Entropy256()
@@ -1319,7 +1319,7 @@ func TestUnpinnedSectors(t *testing.T) {
 	account := proto.Account{1}
 	store.addTestAccount(t, types.PublicKey(account))
 	hk := store.addTestHost(t)
-	store.addTestContract(t, hk)
+	store.addTestContract(t, hk, types.FileContractID(hk))
 
 	// create 4 sectors
 	_, err := store.PinSlabs(context.Background(), account, time.Time{}, slabs.SlabPinParams{
@@ -1433,7 +1433,7 @@ func TestPinnedSectorsStatistics(t *testing.T) {
 	assertStats(0, 4)
 
 	// add contract and pin all sectors
-	fcid := store.addTestContract(t, hk)
+	fcid := store.addTestContract(t, hk, types.FileContractID(hk))
 	if err := store.PinSectors(t.Context(), fcid, []types.Hash256{r1, r2, r3, r4}); err != nil {
 		t.Fatal(err)
 	}
@@ -1641,7 +1641,7 @@ func BenchmarkUnpinnedSectors(b *testing.B) {
 	account := proto.Account{1}
 	store.addTestAccount(b, types.PublicKey(account))
 	hk := store.addTestHost(b)
-	store.addTestContract(b, hk)
+	store.addTestContract(b, hk, types.FileContractID(hk))
 
 	// prepare base db
 	const (
@@ -1797,7 +1797,7 @@ func BenchmarkPinSectors(b *testing.B) {
 	account := proto.Account{1}
 	store.addTestAccount(b, types.PublicKey(account))
 	hk := store.addTestHost(b)
-	store.addTestContract(b, hk)
+	store.addTestContract(b, hk, types.FileContractID(hk))
 
 	// prepare base db
 	const (
@@ -1891,8 +1891,8 @@ func BenchmarkUnhealthySlabs(b *testing.B) {
 	}
 
 	// add 2 contracts
-	store.addTestContract(b, hks[0])
-	store.addTestContract(b, hks[1])
+	store.addTestContract(b, hks[0], types.FileContractID(hks[0]))
+	store.addTestContract(b, hks[1], types.FileContractID(hks[1]))
 
 	// mark the second contract as bad
 	res, err := store.pool.Exec(context.Background(), "UPDATE contracts SET good = FALSE WHERE id = 2") // id 2 is bad
@@ -2000,7 +2000,7 @@ func BenchmarkUnpinSlab(b *testing.B) {
 
 	// add host with one contract
 	hk := store.addTestHost(b)
-	store.addTestContract(b, hk)
+	store.addTestContract(b, hk, types.FileContractID(hk))
 
 	// prepare base db
 	const (
@@ -2255,8 +2255,8 @@ func TestMarkSectorsLost(t *testing.T) {
 	hk2 := store.addTestHost(t)
 
 	// add a contract for each host
-	store.addTestContract(t, hk1)
-	store.addTestContract(t, hk2)
+	store.addTestContract(t, hk1, types.FileContractID(hk1))
+	store.addTestContract(t, hk2, types.FileContractID(hk2))
 
 	// pin a slab that adds 2 sectors to each host
 	root1 := frand.Entropy256()
@@ -2356,7 +2356,7 @@ func BenchmarkMarkSectorsLost(b *testing.B) {
 	account := proto.Account{1}
 	store.addTestAccount(b, types.PublicKey(account))
 	hk := store.addTestHost(b)
-	store.addTestContract(b, hk)
+	store.addTestContract(b, hk, types.FileContractID(hk))
 
 	// prepare base db
 	const (
@@ -2484,7 +2484,7 @@ func BenchmarkMigrateSector(b *testing.B) {
 	var hks []types.PublicKey
 	for range 100 {
 		hk := store.addTestHost(b)
-		store.addTestContract(b, hk)
+		store.addTestContract(b, hk, types.FileContractID(hk))
 		hks = append(hks, hk)
 	}
 

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -85,7 +85,7 @@ func TestSectorStats(t *testing.T) {
 
 	hk1 := store.addTestHost(t)
 	hk2 := store.addTestHost(t)
-	fcid := store.addTestContract(t, hk1)
+	fcid := store.addTestContract(t, hk1, types.FileContractID(hk1))
 
 	root := types.Hash256(frand.Entropy256())
 	slab := slabs.SlabPinParams{


### PR DESCRIPTION
#522

```
goos: linux
goarch: amd64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkContracts/contract-4         	    5374	    490908 ns/op
BenchmarkContracts/contracts_revisions-4         	     259	   4920985 ns/op
BenchmarkContracts/contracts_100-4               	     188	   6106600 ns/op
BenchmarkContracts/contracts_revisable_good_limit_100-4         	     226	   6010090 ns/op
BenchmarkContracts/contracts_revisable_bad_limit_100-4          	     224	   5996961 ns/op
BenchmarkContracts/contracts_nonrevisable_good_limit_100-4      	     272	   4042951 ns/op
BenchmarkContracts/contracts_nonrevisable_bad_limit_100-4       	     204	   5592475 ns/op
BenchmarkContracts/contracts_ids_100-4                          	     189	   7432187 ns/op
BenchmarkContracts/contracts_hosts_100-4                        	     261	   4540227 ns/op
BenchmarkContracts/contracts_500-4                              	     100	  12596781 ns/op
BenchmarkContracts/contracts_revisable_good_limit_500-4         	      94	  13299831 ns/op
BenchmarkContracts/contracts_revisable_bad_limit_500-4          	      58	  17404876 ns/op
BenchmarkContracts/contracts_nonrevisable_good_limit_500-4      	      94	  14565901 ns/op
BenchmarkContracts/contracts_nonrevisable_bad_limit_500-4       	      70	  17216938 ns/op
BenchmarkContracts/contracts_ids_500-4                          	      76	  20095927 ns/op
BenchmarkContracts/contracts_hosts_500-4                        	      87	  20185904 ns/op
BenchmarkContracts/contracts_1000-4                             	      27	  39376046 ns/op
BenchmarkContracts/contracts_revisable_good_limit_1000-4        	      49	  38541111 ns/op
BenchmarkContracts/contracts_revisable_bad_limit_1000-4         	      56	  32985936 ns/op
BenchmarkContracts/contracts_nonrevisable_good_limit_1000-4     	      44	  30156836 ns/op
BenchmarkContracts/contracts_nonrevisable_bad_limit_1000-4      	      34	  37178106 ns/op
BenchmarkContracts/contracts_ids_1000-4                         	      38	  41198805 ns/op
BenchmarkContracts/contracts_hosts_1000-4                       	      70	  32263264 ns/op
...
PASS
ok  	go.sia.tech/indexd/persist/postgres	266.123s
```