### PR TITLE
Make migration count configurable

### DIFF
--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -764,7 +764,7 @@ func (s *Store) MigrateSector(ctx context.Context, root types.Hash256, hostKey t
 			WHERE sector_root = $1 AND hosts.public_key = $2
 		`, sqlHash256(root), sqlPublicKey(hostKey))
 		if err != nil {
-			return fmt.Errorf("failed to migrate sector: %w", err)
+			return err
 		} else if resp.RowsAffected() == 0 {
 			return nil
 		}

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -72,7 +72,7 @@ func (dc *downloadCandidates) next() (hosts.Host, bool) {
 // downloadShards downloads at least the minimum number of shards required to
 // recover the slab.
 func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []hosts.Host, logger *zap.Logger) ([][]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, m.slabTimeout)
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	shards := make([][]byte, len(slab.Sectors))

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"sync"
 	"time"
 
@@ -36,8 +37,8 @@ type (
 		migrationAccount    proto.Account
 		migrationAccountKey types.PrivateKey
 
-		shardTimeout time.Duration
-		slabTimeout  time.Duration
+		migrationBatchSize int
+		shardTimeout       time.Duration
 
 		alerter AlertsManager
 		am      AccountManager
@@ -141,6 +142,21 @@ func WithIntegrityCheckIntervals(success, failure time.Duration) Option {
 	}
 }
 
+// WithMigrationBatchSize sets the number of slabs to migrate in a single batch.
+// This directly impacts the number of concurrent downloads/uploads the contract
+// manager will perform when repairing slabs and the number of slabs held in
+// memory during repairs.
+//
+// The default is runtime.NumCPU().
+func WithMigrationBatchSize(size int) Option {
+	return func(m *SlabManager) {
+		if size <= 0 {
+			panic("migration batch size must be positive") // developer error
+		}
+		m.migrationBatchSize = size
+	}
+}
+
 // WithMinHostDistance sets the minimum distance between hosts used for storing
 // sectors of the same slab. The default is 10km, if set to 0, the distance
 // check is disabled.
@@ -192,7 +208,7 @@ func NewManager(am AccountManager, hm HostManager, store Store, dialer *client.D
 
 func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Dialer, alerter AlertsManager, migrationAccount, integrityAccount types.PrivateKey, opts ...Option) (*SlabManager, error) {
 	m := &SlabManager{
-		healthCheckInterval: 30 * time.Minute,
+		healthCheckInterval: 10 * time.Minute,
 
 		integrityCheckInterval:       7 * 24 * time.Hour,
 		failedIntegrityCheckInterval: 6 * time.Hour,
@@ -202,8 +218,8 @@ func newSlabManager(am AccountManager, hm HostManager, store Store, dialer Diale
 		migrationAccount:    proto.Account(migrationAccount.PublicKey()),
 		migrationAccountKey: migrationAccount,
 
-		shardTimeout: 30 * time.Second,
-		slabTimeout:  time.Minute,
+		shardTimeout:       2 * time.Minute,
+		migrationBatchSize: runtime.NumCPU(),
 
 		am:       am,
 		dialer:   dialer,
@@ -277,7 +293,7 @@ func (m *SlabManager) maintenanceLoop(ctx context.Context) {
 					return
 				}
 				if err := task(ctx); err != nil && !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-					m.log.Error("failed to perform "+descr, zap.Error(err))
+					m.log.Error("maintenance failed", zap.String("task", descr), zap.Error(err))
 				}
 			}
 		}()
@@ -354,10 +370,10 @@ func (m *SlabManager) performIntegrityChecks(ctx context.Context) error {
 
 func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 	start := time.Now()
-	logger := m.log.Named("migrations")
-	logger.Debug("starting slab migrations", zap.Time("start", start))
+	log := m.log.Named("migrations")
+	log.Debug("starting slab migrations", zap.Time("start", start))
 
-	const slabsPerBatch = 10
+	slabsPerBatch := m.migrationBatchSize
 	var exhausted bool
 	for !exhausted {
 		batch, err := m.store.UnhealthySlabs(ctx, start, slabsPerBatch)
@@ -367,7 +383,7 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 			exhausted = true
 		}
 
-		err = m.migrateSlabs(ctx, batch, logger)
+		err = m.migrateSlabs(ctx, batch, log)
 		if errors.Is(err, context.Canceled) {
 			break
 		} else if err != nil {
@@ -375,6 +391,6 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 		}
 	}
 
-	logger.Debug("finished slab migrations", zap.Duration("elapsed", time.Since(start)))
+	log.Debug("finished slab migrations", zap.Duration("elapsed", time.Since(start)))
 	return nil
 }

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -2,9 +2,9 @@ package slabs
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/klauspost/reedsolomon"
 	"go.sia.tech/core/types"
@@ -12,12 +12,9 @@ import (
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/chacha20"
-	"lukechampine.com/frand"
 )
 
-func (m *SlabManager) migrateSlabs(ctx context.Context, slabIDs []SlabID, l *zap.Logger) error {
-	logger := l.Named(hex.EncodeToString(frand.Bytes(16))) // unique id per batch
-
+func (m *SlabManager) migrateSlabs(ctx context.Context, slabIDs []SlabID, log *zap.Logger) error {
 	// fetch all available contracts
 	var goodContracts []contracts.Contract
 	const batchSize = 50
@@ -53,43 +50,45 @@ func (m *SlabManager) migrateSlabs(ctx context.Context, slabIDs []SlabID, l *zap
 
 	var wg sync.WaitGroup
 	for _, slabID := range slabIDs {
+		log := log.With(zap.String("slab", slabID.String()))
 		wg.Add(1)
-		go func() {
+		go func(slabID SlabID) {
 			defer wg.Done()
-			if err := m.migrateSlab(ctx, slabID, allHosts, goodContracts, ms.Period, logger); err != nil {
-				logger.Error("failed to migrate slab", zap.Error(err))
-				return
-			}
-		}()
+			m.migrateSlab(ctx, slabID, allHosts, goodContracts, ms.Period, log)
+		}(slabID)
 	}
 	wg.Wait()
 	return nil
 }
 
-func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts []hosts.Host, goodContracts []contracts.Contract, period uint64, l *zap.Logger) error {
-	logger := l.Named(slabID.String())
-
+func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts []hosts.Host, goodContracts []contracts.Contract, period uint64, log *zap.Logger) {
+	start := time.Now()
 	slab, err := m.store.Slab(ctx, slabID)
 	if err != nil {
-		return fmt.Errorf("failed to fetch slab %s: %w", slabID, err)
+		log.Error("failed to fetch slab", zap.Error(err))
+		return
 	}
 
 	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, period, m.minHostDistanceKm)
 	if len(indices) == 0 {
-		logger.Debug("tried to migrate slab but no indices require migration")
-		return nil
+		log.Debug("tried to migrate slab but no indices require migration")
+		return
 	} else if len(uploadCandidates) == 0 {
-		logger.Warn("tried to migrate slab but no hosts are available for migration")
-		return nil
+		log.Warn("tried to migrate slab but no hosts are available for migration")
+		return
 	}
+	log = log.With(zap.Int("toMigrate", len(indices)), zap.Int("candidates", len(uploadCandidates)))
 
 	// download enough shards to reconstruct the slab's shards
 	// note: timeouts are set within downloadShards to avoid timing
 	// out the database
-	shards, err := m.downloadShards(ctx, slab, allHosts, logger)
+	shards, err := m.downloadShards(ctx, slab, allHosts, log.Named("recover"))
 	if err != nil {
-		return fmt.Errorf("failed to download slab %s: %w", slab.ID, err)
+		log.Error("failed to download slab", zap.Error(err))
+		return
 	}
+	log = log.With(zap.Duration("downloadElapsed", time.Since(start)))
+	log.Debug("recovered shards")
 
 	// decrypt the shards
 	nonce := make([]byte, 24)
@@ -110,9 +109,15 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 	// reconstruct the missing shards
 	rs, err := reedsolomon.New(int(slab.MinShards), len(slab.Sectors)-int(slab.MinShards))
 	if err != nil {
-		return fmt.Errorf("failed to create reedsolomon encoder: %w", err)
+		// both of these are developer errors. New will only return an error
+		// if the parameters are invalid, which they shouldn't be since they
+		// originate from the database.
+		log.Panic("failed to create reedsolomon encoder", zap.Error(err))
 	} else if err := rs.ReconstructSome(shards, required); err != nil {
-		return fmt.Errorf("failed to reconstruct shards for slab %s: %w", slab.ID, err)
+		// reconstructing should only fail if there are not enough shards
+		// available, which should not happen since the download should have
+		// errored if not enough shards could be retrieved.
+		log.Panic("failed to reconstruct shards", zap.Error(err))
 	}
 
 	// re-encrypt the shards that are required
@@ -129,27 +134,26 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 
 	// migrate the shards
 	// note: timeouts are set within uploadShards to avoid timing out the database
-	migratedShards, err := m.uploadShards(ctx, slab, shards, uploadCandidates, logger)
-
+	uploadStart := time.Now()
+	migrated, err := m.uploadShards(ctx, slab, shards, uploadCandidates, log.Named("migrate"))
+	log = log.With(zap.Duration("uploadElapsed", time.Since(uploadStart)))
 	// update the database with the new locations for the migrated shards
-	for _, shard := range migratedShards {
-		if migrated, err := m.store.MigrateSector(ctx, shard.Root, shard.HostKey); err != nil {
-			return fmt.Errorf("failed to migrate sector %s: %w", shard.Root, err)
-		} else if !migrated {
-			logger.Warn("sector was not migrated", zap.String("root", shard.Root.String()), zap.String("host", shard.HostKey.String()))
+	for _, shard := range migrated {
+		if ok, err := m.store.MigrateSector(ctx, shard.Root, shard.HostKey); err != nil {
+			log.Error("failed to migrate sector", zap.Error(err))
+		} else if !ok {
+			log.Warn("sector was not migrated", zap.String("root", shard.Root.String()), zap.String("host", shard.HostKey.String()))
 		}
 	}
-
-	// return an error if the slab wasn't fully repaired
-	if err != nil {
-		return fmt.Errorf("failed to upload migrated shards for slab %s: %w", slab.ID, err)
-	} else if len(migratedShards) == 0 {
-		logger.Debug("no shards were migrated")
-		return nil
+	log = log.With(zap.Int("migrated", len(migrated)), zap.Duration("totalElapsed", time.Since(start)))
+	switch {
+	case err != nil:
+		log.Debug("failed to migrate all sectors", zap.Error(err)) // debug since this is not user actionable and will be retried
+	case len(migrated) == 0:
+		log.Error("did not migrate any sectors") // error since this is unexpected
+	default:
+		log.Debug("successfully migrated slab")
 	}
-
-	logger.Debug("successfully migrated slab", zap.Int("toMigrate", len(indices)), zap.Int("migrated", len(migratedShards)))
-	return nil
 }
 
 // sectorsToMigrate filters the sectors of a slab and returns the indices of the

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -31,9 +31,6 @@ type (
 // and should be tracked in the database. The given shards must not be nil and
 // the given hosts must all be good and be sufficiently spaced apart.
 func (m *SlabManager) uploadShards(ctx context.Context, slab Slab, shards [][]byte, uploadCandidates []hosts.Host, logger *zap.Logger) ([]Shard, error) {
-	ctx, cancel := context.WithTimeout(ctx, m.slabTimeout)
-	defer cancel()
-
 	uploaded := make([]Shard, 0, len(shards))
 
 	if len(slab.Sectors) != len(shards) {


### PR DESCRIPTION
- Removes the competing `shard`/`slab` timeouts in favor of a single timeout.
- Increases migration parallelism
- Increases frequency of health checks