### PR TITLE
Smarter slab validation

### DIFF
--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -865,14 +865,9 @@ func TestHostsStatsAPI(t *testing.T) {
 func TestSectorStatsAPI(t *testing.T) {
 	// create cluster with three hosts
 	logger := newTestLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithHosts(3), testutils.WithLogger(logger))
+	cluster := testutils.NewCluster(t, testutils.WithHosts(10), testutils.WithLogger(logger))
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
-
-	// convenience variables
-	h1 := cluster.Hosts[0]
-	h2 := cluster.Hosts[1]
-	h3 := cluster.Hosts[2]
 
 	// assert 0 slabs
 	stats, err := adminClient.StatsSectors(context.Background())
@@ -888,11 +883,12 @@ func TestSectorStatsAPI(t *testing.T) {
 	slabIDs, err := indexer.App(account).PinSlabs(context.Background(), slabs.SlabPinParams{
 		EncryptionKey: [32]byte{1},
 		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{Root: frand.Entropy256(), HostKey: h1.PublicKey()},
-			{Root: frand.Entropy256(), HostKey: h2.PublicKey()},
-			{Root: frand.Entropy256(), HostKey: h3.PublicKey()},
-		},
+		Sectors: func() (s []slabs.PinnedSector) {
+			for _, h := range cluster.Hosts {
+				s = append(s, slabs.PinnedSector{Root: frand.Entropy256(), HostKey: h.PublicKey()})
+			}
+			return s
+		}(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -100,7 +100,7 @@ func TestApplicationAPI(t *testing.T) {
 	ctx := t.Context()
 	// create cluster with three hosts
 	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithHosts(3), testutils.WithLogger(logger))
+	cluster := testutils.NewCluster(t, testutils.WithHosts(10), testutils.WithLogger(logger))
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
 	time.Sleep(time.Second)
@@ -109,13 +109,9 @@ func TestApplicationAPI(t *testing.T) {
 	hosts, err := adminClient.Hosts(ctx)
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
-	} else if len(hosts) != 3 {
-		t.Fatal("expected 3 hosts, got", len(hosts))
+	} else if len(hosts) != 10 {
+		t.Fatal("expected 10 hosts, got", len(hosts))
 	}
-
-	h1 := hosts[0]
-	h2 := hosts[1]
-	h3 := hosts[2]
 
 	// prepare account
 	sk, key := newAccount(t, cluster)
@@ -143,20 +139,15 @@ func TestApplicationAPI(t *testing.T) {
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),
 			MinShards:     1,
-			Sectors: []slabs.PinnedSector{
-				{
-					Root:    frand.Entropy256(),
-					HostKey: h1.PublicKey,
-				},
-				{
-					Root:    frand.Entropy256(),
-					HostKey: h2.PublicKey,
-				},
-				{
-					Root:    frand.Entropy256(),
-					HostKey: h3.PublicKey,
-				},
-			},
+			Sectors: func() (s []slabs.PinnedSector) {
+				for _, host := range hosts {
+					s = append(s, slabs.PinnedSector{
+						Root:    frand.Entropy256(),
+						HostKey: host.PublicKey,
+					})
+				}
+				return s
+			}(),
 		}
 	}
 
@@ -176,8 +167,8 @@ func TestApplicationAPI(t *testing.T) {
 	p := params()
 	p.Sectors = p.Sectors[:2]
 	_, err = client.PinSlabs(context.Background(), p)
-	if err == nil || !strings.Contains(err.Error(), slabs.ErrInsufficientRedundancy.Error()) {
-		t.Fatal("expected [slabs.ErrInsufficientRedundancy], got:", err)
+	if err == nil || !strings.Contains(err.Error(), "not enough redundancy") {
+		t.Fatal("expected redundancy error, got:", err)
 	}
 
 	// assert hosts returns all usable hosts
@@ -185,17 +176,17 @@ func TestApplicationAPI(t *testing.T) {
 	usableHosts, err := client.Hosts(context.Background())
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
-	} else if len(usableHosts) != 3 {
-		t.Fatal("expected 3 usable hosts, got", len(usableHosts))
+	} else if len(usableHosts) != 10 {
+		t.Fatal("expected 10 usable hosts, got", len(usableHosts))
 	}
 
 	// add quic to h1
 	if err := indexer.Store().UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
-		h1.Addresses = append(h1.Addresses, chain.NetAddress{
+		hosts[0].Addresses = append(hosts[0].Addresses, chain.NetAddress{
 			Protocol: quic.Protocol,
 			Address:  "127.0.0.1:1234",
 		})
-		return tx.AddHostAnnouncement(h1.PublicKey, chain.V2HostAnnouncement(h1.Addresses), time.Now())
+		return tx.AddHostAnnouncement(hosts[0].PublicKey, chain.V2HostAnnouncement(hosts[0].Addresses), time.Now())
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -212,11 +203,11 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// set h1 to US
-	if err := indexer.Store().UpdateHost(context.Background(), h1.PublicKey, h1.Settings, locationUS, true, h1.LastSuccessfulScan); err != nil {
+	if err := indexer.Store().UpdateHost(context.Background(), hosts[0].PublicKey, hosts[0].Settings, locationUS, true, hosts[0].LastSuccessfulScan); err != nil {
 		t.Fatal(err)
 	}
 	// set h2 to AU
-	if err := indexer.Store().UpdateHost(context.Background(), h2.PublicKey, h2.Settings, locationAU, true, h2.LastSuccessfulScan); err != nil {
+	if err := indexer.Store().UpdateHost(context.Background(), hosts[1].PublicKey, hosts[1].Settings, locationAU, true, hosts[1].LastSuccessfulScan); err != nil {
 		t.Fatal(err)
 	}
 
@@ -226,7 +217,7 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("failed to get hosts:", err)
 	} else if len(usableHosts) != 1 {
 		t.Fatal("expected 1 host, got", len(usableHosts))
-	} else if usableHosts[0].PublicKey != h1.PublicKey {
+	} else if usableHosts[0].PublicKey != hosts[0].PublicKey {
 		t.Fatal("got wrong quic host")
 	}
 
@@ -236,7 +227,7 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("failed to get hosts:", err)
 	} else if len(usableHosts) != 1 {
 		t.Fatal("expected 1 host, got", len(usableHosts))
-	} else if usableHosts[0].PublicKey != h1.PublicKey {
+	} else if usableHosts[0].PublicKey != hosts[0].PublicKey {
 		t.Fatal("got wrong quic host")
 	} else if usableHosts[0].CountryCode != locationUS.CountryCode {
 		t.Fatalf("expected country code %v, got %v", locationUS.CountryCode, usableHosts[0].CountryCode)
@@ -252,7 +243,7 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("failed to get hosts:", err)
 	} else if len(usableHosts) != 1 {
 		t.Fatal("expected 1 host, got", len(usableHosts))
-	} else if usableHosts[0].PublicKey != h2.PublicKey {
+	} else if usableHosts[0].PublicKey != hosts[1].PublicKey {
 		t.Fatal("got wrong quic host")
 	} else if usableHosts[0].CountryCode != locationAU.CountryCode {
 		t.Fatalf("expected country code %v, got %v", locationAU.CountryCode, usableHosts[0].CountryCode)
@@ -263,7 +254,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// block h1
-	err = adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{h1.PublicKey}, "test blocklist reason")
+	err = adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{hosts[0].PublicKey}, "test blocklist reason")
 	if err != nil {
 		t.Fatal("failed to add host to blocklist:", err)
 	}
@@ -272,8 +263,8 @@ func TestApplicationAPI(t *testing.T) {
 	usableHosts, err = client.Hosts(context.Background())
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
-	} else if len(usableHosts) != 2 {
-		t.Fatal("expected 2 usable hosts, got", len(usableHosts))
+	} else if len(usableHosts) != 9 {
+		t.Fatal("expected 9 usable hosts, got", len(usableHosts))
 	}
 
 	// assert limit and offset are applied
@@ -281,7 +272,7 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("failed to get hosts with limit:", err)
 	} else if len(usableHosts) != 1 {
 		t.Fatal("expected 1 usable host, got", len(usableHosts))
-	} else if usableHosts, err := client.Hosts(context.Background(), api.WithOffset(2), api.WithLimit(1)); err != nil {
+	} else if usableHosts, err := client.Hosts(context.Background(), api.WithOffset(9), api.WithLimit(1)); err != nil {
 		t.Fatal("failed to get hosts with limit:", err)
 	} else if len(usableHosts) != 0 {
 		t.Fatal("expected 0 usable hosts, got", len(usableHosts))
@@ -550,7 +541,7 @@ func TestSharedObjects(t *testing.T) {
 
 	// create cluster with three hosts
 	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithHosts(3), testutils.WithLogger(logger))
+	cluster := testutils.NewCluster(t, testutils.WithHosts(12), testutils.WithLogger(logger))
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
 	time.Sleep(time.Second)
@@ -559,8 +550,8 @@ func TestSharedObjects(t *testing.T) {
 	hosts, err := adminClient.Hosts(ctx)
 	if err != nil {
 		t.Fatal("failed to get hosts:", err)
-	} else if len(hosts) != 3 {
-		t.Fatal("expected 3 hosts, got", len(hosts))
+	} else if len(hosts) != 12 {
+		t.Fatal("expected 12 hosts, got", len(hosts))
 	}
 
 	// prepare accounts
@@ -592,29 +583,20 @@ func TestSharedObjects(t *testing.T) {
 	client1, sk1 := prepareAcccount(t)
 	client2, _ := prepareAcccount(t)
 
-	h1 := hosts[0]
-	h2 := hosts[1]
-	h3 := hosts[2]
-
 	// helper to generate slab pin parameters
 	randomSlab := func() slabs.SlabPinParams {
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),
 			MinShards:     1,
-			Sectors: []slabs.PinnedSector{
-				{
-					Root:    frand.Entropy256(),
-					HostKey: h1.PublicKey,
-				},
-				{
-					Root:    frand.Entropy256(),
-					HostKey: h2.PublicKey,
-				},
-				{
-					Root:    frand.Entropy256(),
-					HostKey: h3.PublicKey,
-				},
-			},
+			Sectors: func() (s []slabs.PinnedSector) {
+				for _, h := range hosts {
+					s = append(s, slabs.PinnedSector{
+						Root:    frand.Entropy256(),
+						HostKey: h.PublicKey,
+					})
+				}
+				return s
+			}(),
 		}
 	}
 	// generate and pin a slab

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -18,7 +18,7 @@ import (
 func TestContractPruning(t *testing.T) {
 	// create cluster
 	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(3))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10))
 	indexer := cluster.Indexer
 	time.Sleep(time.Second)
 
@@ -26,13 +26,12 @@ func TestContractPruning(t *testing.T) {
 	a1 := types.GeneratePrivateKey()
 	indexer.AddAccount(t, a1.PublicKey())
 
-	// assert we have 3 usable hosts
 	time.Sleep(time.Second)
 	hosts, err := indexer.Hosts().Hosts(context.Background(), 0, 10, hosts.WithUsable(true), hosts.WithActiveContracts(true))
 	if err != nil {
 		t.Fatal(err)
-	} else if len(hosts) != 3 {
-		t.Fatalf("expected 3 usable hosts, got %d", len(hosts))
+	} else if len(hosts) != 10 {
+		t.Fatalf("expected 10 usable hosts, got %d", len(hosts))
 	}
 
 	// convenience variables
@@ -117,7 +116,7 @@ func TestContractPruning(t *testing.T) {
 func TestSectorPinning(t *testing.T) {
 	// create cluster
 	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(3))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10))
 	indexer := cluster.Indexer
 	store := indexer.Store()
 	time.Sleep(time.Second)
@@ -126,13 +125,12 @@ func TestSectorPinning(t *testing.T) {
 	a1 := types.GeneratePrivateKey()
 	indexer.AddAccount(t, a1.PublicKey())
 
-	// assert we have 3 usable hosts
 	time.Sleep(time.Second)
 	hosts, err := indexer.Hosts().Hosts(context.Background(), 0, 10, hosts.WithUsable(true), hosts.WithActiveContracts(true))
 	if err != nil {
 		t.Fatal(err)
-	} else if len(hosts) != 3 {
-		t.Fatalf("expected 3 usable hosts, got %d", len(hosts))
+	} else if len(hosts) != 10 {
+		t.Fatalf("expected 10 usable hosts, got %d", len(hosts))
 	}
 
 	// convenience variables

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -138,8 +138,9 @@ func (s *SDK) Upload(ctx context.Context, r io.Reader, opts ...UploadOption) (Ob
 		opt(&uo)
 	}
 
-	if (uo.parityShards+uo.dataShards)/uo.dataShards < 2 {
-		return Object{}, errors.New("redundancy must be at least 2x")
+	totalShards := int(uo.dataShards) + int(uo.parityShards)
+	if err := slabs.ValidateECParams(int(uo.dataShards), totalShards); err != nil {
+		return Object{}, err
 	}
 
 	obj := Object{masterKey: frand.Bytes(32)}

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -15,11 +15,11 @@ import (
 func TestMigrations(t *testing.T) {
 	// create cluster
 	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(7), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(500*time.Millisecond))))
 
 	// create some more utxos
 	indexer := cluster.Indexer
-	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 10)
+	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 11)
 
 	// add an account
 	a1 := types.GeneratePrivateKey()
@@ -29,10 +29,10 @@ func TestMigrations(t *testing.T) {
 	app := indexer.App(a1)
 
 	// fetch hosts
-	hosts := testutils.WaitForHosts(t, app, 7)
+	hosts := testutils.WaitForHosts(t, app, 11)
 
 	// upload sectors to hosts
-	encryptionKey, shards, roots := slabs.NewTestShards(t, 2, 4)
+	encryptionKey, shards, roots := slabs.NewTestShards(t, 1, 10)
 	for i := range shards {
 		client := indexer.HostClient(t, hosts[i].PublicKey)
 		hs, err := client.Settings(context.Background())
@@ -47,7 +47,7 @@ func TestMigrations(t *testing.T) {
 	// pin the slab
 	slabIDs, err := app.PinSlabs(context.Background(), slabs.SlabPinParams{
 		EncryptionKey: encryptionKey,
-		MinShards:     2,
+		MinShards:     1,
 		Sectors: []slabs.PinnedSector{
 			{Root: roots[0], HostKey: hosts[0].PublicKey},
 			{Root: roots[1], HostKey: hosts[1].PublicKey},
@@ -55,6 +55,10 @@ func TestMigrations(t *testing.T) {
 			{Root: roots[3], HostKey: hosts[3].PublicKey},
 			{Root: roots[4], HostKey: hosts[4].PublicKey},
 			{Root: roots[5], HostKey: hosts[5].PublicKey},
+			{Root: roots[6], HostKey: hosts[6].PublicKey},
+			{Root: roots[7], HostKey: hosts[7].PublicKey},
+			{Root: roots[8], HostKey: hosts[8].PublicKey},
+			{Root: roots[9], HostKey: hosts[9].PublicKey},
 		},
 	})
 	if err != nil {
@@ -67,13 +71,13 @@ func TestMigrations(t *testing.T) {
 	pinned, err := app.Slab(context.Background(), slabID)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(pinned.Sectors) != 6 {
-		t.Fatalf("expected 6 pinned sectors, got %d", len(pinned.Sectors))
+	} else if len(pinned.Sectors) != 10 {
+		t.Fatalf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
 	} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[0].PublicKey {
 		t.Fatalf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[0].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
 	}
 
-	// add h1 to blocklist
+	// add first host to blocklist
 	err = indexer.Hosts().BlockHosts(context.Background(), []types.PublicKey{hosts[0].PublicKey}, "test blocklist reason")
 	if err != nil {
 		t.Fatal(err)
@@ -84,17 +88,17 @@ func TestMigrations(t *testing.T) {
 	pinned, err = app.Slab(context.Background(), slabID)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(pinned.Sectors) != 6 {
-		t.Fatalf("expected 6 pinned sectors, got %d", len(pinned.Sectors))
-	} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[6].PublicKey {
-		t.Fatalf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[6].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
+	} else if len(pinned.Sectors) != 10 {
+		t.Fatalf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
+	} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[10].PublicKey {
+		t.Fatalf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[10].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
 	}
 }
 
 func TestUpdateLastUsed(t *testing.T) {
 	// create cluster
 	logger := testutils.NewLogger(false)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(3), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
 
 	// create some more utxos
 	indexer := cluster.Indexer
@@ -108,10 +112,10 @@ func TestUpdateLastUsed(t *testing.T) {
 	app := indexer.App(a1)
 
 	// fetch hosts
-	hosts := testutils.WaitForHosts(t, app, 3)
+	hosts := testutils.WaitForHosts(t, app, 10)
 
 	// upload sectors to hosts
-	encryptionKey, shards, roots := slabs.NewTestShards(t, 1, 2)
+	encryptionKey, shards, roots := slabs.NewTestShards(t, 1, 9)
 	for i := range shards {
 		client := indexer.HostClient(t, hosts[i].PublicKey)
 		hs, err := client.Settings(context.Background())
@@ -138,11 +142,12 @@ func TestUpdateLastUsed(t *testing.T) {
 	slabIDs, err := app.PinSlabs(context.Background(), slabs.SlabPinParams{
 		EncryptionKey: encryptionKey,
 		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{Root: roots[0], HostKey: hosts[0].PublicKey},
-			{Root: roots[1], HostKey: hosts[1].PublicKey},
-			{Root: roots[2], HostKey: hosts[2].PublicKey},
-		},
+		Sectors: func() (s []slabs.PinnedSector) {
+			for i, h := range hosts {
+				s = append(s, slabs.PinnedSector{Root: roots[i], HostKey: h.PublicKey})
+			}
+			return s
+		}(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -91,9 +91,6 @@ var (
 	// ErrObjectUnpinnedSlab is returned when an user attempts to save an
 	// object containing a slab that is not pinned to their account.
 	ErrObjectUnpinnedSlab = errors.New("object contains unpinned slab")
-
-	// ErrInvalidSlab is returned when an invalid slab is being pinned
-	ErrInvalidSlab = errors.New("slab is invalid")
 )
 
 // ID returns the object's ID, which is a hash of its slabs.

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -11,17 +12,16 @@ import (
 )
 
 const (
-	// DefaultRedundancy is the default minimum redundancy for slabs.
-	DefaultRedundancy = 3
+	// minRecoveryProbability is the minimum acceptable probability of being able to
+	// recover the original data. If the calculated probability is below this
+	// threshold, the slab will be rejected.
+	minRecoveryProbability = 99.99
 
-	// MaxTotalShards is the maximum number of total shards (data + parity) allowed in a slab.
-	MaxTotalShards = 256
+	// maxTotalShards is the maximum number of total shards (data + parity) allowed in a slab.
+	maxTotalShards = 256
 )
 
 var (
-	// ErrInsufficientRedundancy is returned when the minimum redundancy of slabs is not met.
-	ErrInsufficientRedundancy = errors.New("insufficient redundancy")
-
 	// ErrSlabNotFound is returned when a slab is not found in the database.
 	ErrSlabNotFound = errors.New("slab not found")
 
@@ -121,21 +121,19 @@ func (s SlabPinParams) Size() uint64 {
 // are no duplicate host keys or empty roots in the sectors.
 func (s SlabPinParams) Validate() error {
 	if s.EncryptionKey == ([32]byte{}) {
-		return fmt.Errorf("%w: encryption key is empty", ErrInvalidSlab)
-	} else if len(s.Sectors) < int(s.MinShards*DefaultRedundancy) {
-		return fmt.Errorf("%w: %w: minimum redundancy of %dx is not met", ErrInvalidSlab, ErrInsufficientRedundancy, DefaultRedundancy)
-	} else if len(s.Sectors) > MaxTotalShards {
-		return fmt.Errorf("%w: total number of shards %d exceeds maximum of %d", ErrInvalidSlab, len(s.Sectors), MaxTotalShards)
+		return errors.New("encryption key is empty")
+	} else if err := ValidateECParams(int(s.MinShards), len(s.Sectors)); err != nil {
+		return err
 	}
 
 	hks := make(map[types.PublicKey]struct{}, len(s.Sectors))
 	for i, sector := range s.Sectors {
 		if sector.Root == (types.Hash256{}) {
-			return fmt.Errorf("%w: sector root is empty", ErrInvalidSlab)
+			return fmt.Errorf("sector %d invalid: root is empty", i)
 		} else if sector.HostKey == (types.PublicKey{}) {
-			return fmt.Errorf("%w: sector %d host key is empty", ErrInvalidSlab, i)
+			return fmt.Errorf("sector %d invalid: host key is empty", i)
 		} else if _, exists := hks[sector.HostKey]; exists {
-			return fmt.Errorf("%w: duplicate host key %s in slab pin params", ErrInvalidSlab, sector.HostKey)
+			return fmt.Errorf("sector %d is invalid: duplicate host key %q", i, sector.HostKey)
 		}
 		hks[sector.HostKey] = struct{}{}
 	}
@@ -179,4 +177,45 @@ func (m *SlabManager) SlabIDs(ctx context.Context, account proto.Account, offset
 // object.
 func (m *SlabManager) PruneSlabs(ctx context.Context, account proto.Account) error {
 	return m.store.PruneSlabs(ctx, account)
+}
+
+// ValidateECParams checks the erasure coding parameters are
+// acceptable and ensure sufficient durability of the data. If they
+// are not, an error is returned.
+//
+// It does this by calculating the probability of being able to recover
+// the original data. The calculation assumes that each shard has a
+// fixed probability of being available, and uses the binomial
+// distribution to calculate the probability of having at least
+// `n` data shards available out of `m` total shards.
+func ValidateECParams(dataShards, totalShards int) error {
+	switch {
+	case totalShards > maxTotalShards:
+		return fmt.Errorf("total number of shards %d exceeds maximum of %d", totalShards, maxTotalShards)
+	case dataShards == 0:
+		return errors.New("data shards cannot be zero")
+	case totalShards == 0:
+		return errors.New("total shards cannot be zero")
+	case dataShards > totalShards:
+		return fmt.Errorf("data shards %d cannot be greater than total shards %d", dataShards, totalShards)
+	}
+
+	const recoveryProbability = 0.75 // probability of being able to recover a single shard.
+	q := 1 - recoveryProbability
+	term := math.Pow(q, float64(totalShards))
+	for i := range dataShards {
+		term *= float64(totalShards-i) / float64(i+1) * (recoveryProbability / q)
+	}
+	sum := term
+	for i := dataShards; i < totalShards; i++ {
+		term *= float64(totalShards-i) / float64(i+1) * (recoveryProbability / q)
+		sum += term
+	}
+	prob := sum * 100
+	if prob < minRecoveryProbability {
+		// the error message is rounded down to two decimal places since more precision
+		// is not useful and `%0.2f` can round up creating confusing error messages.
+		return fmt.Errorf("not enough redundancy %d-of-%d: recovery probability %0.2f%% is below minimum threshold of %0.2f%%", dataShards, totalShards, math.Floor(prob*100)/100, minRecoveryProbability)
+	}
+	return nil
 }

--- a/slabs/slabs_test.go
+++ b/slabs/slabs_test.go
@@ -1,6 +1,7 @@
 package slabs
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -12,20 +13,15 @@ func TestSlabPinParamsValidate(t *testing.T) {
 	params := SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     1,
-		Sectors: []PinnedSector{
-			{
-				Root:    frand.Entropy256(),
-				HostKey: frand.Entropy256(),
-			},
-			{
-				Root:    frand.Entropy256(),
-				HostKey: frand.Entropy256(),
-			},
-			{
-				Root:    frand.Entropy256(),
-				HostKey: frand.Entropy256(),
-			},
-		},
+		Sectors: func() (s []PinnedSector) {
+			for range 30 {
+				s = append(s, PinnedSector{
+					Root:    frand.Entropy256(),
+					HostKey: frand.Entropy256(),
+				})
+			}
+			return s
+		}(),
 	}
 	if err := params.Validate(); err != nil {
 		t.Fatal("unexpected", err)
@@ -46,12 +42,12 @@ func TestSlabPinParamsValidate(t *testing.T) {
 
 	// assert insufficient redundancy is illegal
 	params.Sectors = params.Sectors[:1]
-	if err := params.Validate(); err == nil || !strings.Contains(err.Error(), "minimum redundancy of 3x is not met") {
+	if err := params.Validate(); err == nil || !strings.Contains(err.Error(), "not enough redundancy") {
 		t.Fatal("unexpected", err)
 	}
 
 	// assert exceeding max total shards is illegal
-	params.Sectors = make([]PinnedSector, MaxTotalShards+1)
+	params.Sectors = make([]PinnedSector, maxTotalShards+1)
 	if err := params.Validate(); err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
 		t.Fatal("unexpected", err)
 	}
@@ -88,5 +84,67 @@ func TestSlabPinParamsDigest(t *testing.T) {
 		t.Fatal(err)
 	} else if slabID != expectedID {
 		t.Fatalf("expected %v, got %v", expectedID, slabID)
+	}
+}
+
+func TestValidateECParams(t *testing.T) {
+	tests := []struct {
+		minShards   int
+		totalShards int
+		ok          bool
+	}{
+		{
+			minShards:   0,
+			totalShards: 6,
+			ok:          false,
+		},
+		{
+			minShards:   6,
+			totalShards: 0,
+			ok:          false,
+		},
+		{
+			minShards:   4,
+			totalShards: 2,
+			ok:          false,
+		},
+		{
+			minShards:   1,
+			totalShards: 3,
+			ok:          false,
+		},
+		{
+			minShards:   2,
+			totalShards: 6,
+			ok:          false,
+		},
+		{
+			minShards:   4,
+			totalShards: 8,
+			ok:          false,
+		},
+		{
+			minShards:   1,
+			totalShards: 10,
+			ok:          true,
+		},
+		{
+			minShards:   10,
+			totalShards: 30,
+			ok:          true,
+		},
+		{
+			minShards:   30,
+			totalShards: 60,
+			ok:          true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%d-of-%d", test.minShards, test.totalShards), func(t *testing.T) {
+			err := ValidateECParams(test.minShards, test.totalShards)
+			if (err == nil) != test.ok {
+				t.Fatalf("expected %v, got %v", test.ok, err == nil)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Changes the hardcoded redundancy of 3× to a probability of recovery. This rejects slabs with parameters that are more likely to result in data loss, even if they meet the 3× requirement (e.g., 1/3 or 2/6), and enables more exotic combinations, such as 30/60 for 2×.