### PR TITLE
Increase maintenance frequency

### DIFF
--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -13,7 +13,6 @@ import (
 
 func (cm *ContractManager) performAccountFunding(ctx context.Context, force bool, log *zap.Logger) error {
 	start := time.Now()
-	log = log.Named("accounts")
 
 	// fund accounts on usable hosts with active contracts
 	opts := []hosts.HostQueryOpt{
@@ -69,8 +68,6 @@ func (cm *ContractManager) performAccountFunding(ctx context.Context, force bool
 }
 
 func (cm *ContractManager) performContractMaintenance(ctx context.Context, log *zap.Logger) error {
-	log.Debug("performing contract maintenance")
-
 	// fetch settings and determine if maintenance is supposed to run
 	settings, err := cm.store.MaintenanceSettings(ctx)
 	if err != nil {
@@ -119,9 +116,8 @@ func (cm *ContractManager) performContractMaintenance(ctx context.Context, log *
 // to perform on contracts
 func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 	log := cm.log.Named("maintenance")
-
-	ticker := time.NewTicker(cm.maintenanceFrequency)
-	defer ticker.Stop()
+	t := time.NewTimer(cm.maintenanceFrequency)
+	defer t.Stop()
 
 	for {
 		if !cm.waitUntilSynced(ctx, log) {
@@ -142,54 +138,33 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 			if err := cm.performContractPruning(ctx, true, log); err != nil {
 				log.Error("contract pruning failed", zap.Error(err))
 			}
+			continue
 		case <-cm.triggerMaintenanceChan:
-			// reset ticker
-			ticker.Stop()
-			ticker = time.NewTicker(cm.maintenanceFrequency)
-
 			log.Debug("triggering maintenance")
-		case <-ticker.C:
+		case <-t.C:
+			log.Debug("starting scheduled maintenance")
 		}
 
-		if !performMaintenanceJob("contract maintenance", func() error {
-			return cm.performContractMaintenance(ctx, log)
-		}, log) {
-			return
-		}
+		contractMaintenanceLog := log.Named("contracts")
+		logError(cm.performContractMaintenance(ctx, contractMaintenanceLog), contractMaintenanceLog)
+		fundingLog := log.Named("accounts")
+		logError(cm.performAccountFunding(ctx, false, fundingLog), fundingLog)
+		pruningLog := log.Named("pruning")
+		logError(cm.performContractPruning(ctx, false, pruningLog), pruningLog)
+		pinningLog := log.Named("pinning")
+		logError(cm.performSectorPinning(ctx, pinningLog), pinningLog)
 
-		if !performMaintenanceJob("account funding", func() error {
-			return cm.performAccountFunding(ctx, false, log)
-		}, log) {
-			return
-		}
-
-		if !performMaintenanceJob("contract pruning", func() error {
-			return cm.performContractPruning(ctx, false, log)
-		}, log) {
-			return
-		}
-
-		if !performMaintenanceJob("sector pinning", func() error {
-			return cm.performSectorPinning(ctx, log)
-		}, log) {
-			return
-		}
-
+		unpinnableLog := log.Named("unpinnable")
 		threshold := time.Now().Add(-pruneUnpinnableThreshold)
-		if !performMaintenanceJob("pruning unpinnable sectors", func() error {
-			return cm.store.PruneUnpinnableSectors(ctx, threshold)
-		}, log) {
-			return
-		}
+		logError(cm.store.PruneUnpinnableSectors(ctx, threshold), unpinnableLog)
+		t.Reset(cm.maintenanceFrequency)
+		log.Debug("maintenance complete")
 	}
 }
 
-func performMaintenanceJob(descr string, fn func() error, log *zap.Logger) bool {
-	if err := fn(); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return false
-		}
-		log.Error(descr+" failed", zap.Error(err))
+func logError(err error, log *zap.Logger) {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
 	}
-	return true
+	log.Error("maintenance failed", zap.Error(err))
 }

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -428,7 +428,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, chai
 		expiredContractBroadcastBuffer:    144,           // 144 block after expiration
 		expiredContractPruneBuffer:        144,           // 144 blocks after broadcast
 		expiredContractSectorsPruneBuffer: 36,            // 36 blocks (~6 hours) after expiration
-		maintenanceFrequency:              10 * time.Minute,
+		maintenanceFrequency:              time.Minute,
 		minHostDistanceKm:                 10,                 // 10km
 		pruneIntervalSuccess:              24 * time.Hour,     // 1 day
 		pruneIntervalFailure:              3 * time.Hour,      // 3 hours

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -15,7 +15,6 @@ import (
 
 func (cm *ContractManager) performSectorPinning(ctx context.Context, log *zap.Logger) error {
 	start := time.Now()
-	log = log.Named("sectorpinning")
 
 	// fetch hosts for pinning, a host is eligble for pinning if it is not
 	// blocked, has unpinned sectors and has an active contract

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -20,7 +20,6 @@ const (
 
 func (cm *ContractManager) performContractPruning(ctx context.Context, force bool, log *zap.Logger) error {
 	start := time.Now()
-	log = log.Named("contractpruning")
 
 	// if force is true, schedule all (active and good) contracts for pruning
 	if force {


### PR DESCRIPTION
Decreases the maintenance frequency from 10 minutes to one to hopefully reduce out of funds errors on the service accounts. Also switches the ticker for a timer. The ticker can fire immediately if maintenance takes longer than the frequency. This change means there is always the same amount of time between maintenances regardless of how long they run for. Also refactors the maintenance loop to run each task regardless of the success of the previous task.