### PR TITLE
Fix index-out-of-range panic in `store.ListObjects`

### DIFF
--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -151,7 +151,7 @@ func (s *Store) ListObjects(ctx context.Context, account proto.Account, cursor s
 			return err
 		}
 
-		objectIDs := make(map[types.Hash256]int64, len(events))
+		objectIDs := make(map[types.Hash256]int64)
 		for i := range events {
 			if events[i].Deleted {
 				continue

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -151,7 +151,7 @@ func (s *Store) ListObjects(ctx context.Context, account proto.Account, cursor s
 			return err
 		}
 
-		var objectIDs []int64
+		objectIDs := make(map[types.Hash256]int64, len(events))
 		for i := range events {
 			if events[i].Deleted {
 				continue
@@ -169,7 +169,7 @@ func (s *Store) ListObjects(ctx context.Context, account proto.Account, cursor s
 				return fmt.Errorf("failed to query objects: %w", err)
 			}
 			events[i].Object = &obj
-			objectIDs = append(objectIDs, objID)
+			objectIDs[events[i].Key] = objID
 		}
 		if err := rows.Err(); err != nil {
 			return err
@@ -186,7 +186,7 @@ func (s *Store) ListObjects(ctx context.Context, account proto.Account, cursor s
 				FROM object_slabs
 				WHERE object_id = $1
 				ORDER BY slab_index ASC
-			`, objectIDs[i])
+			`, objectIDs[events[i].Key])
 			if err != nil {
 				return fmt.Errorf("failed to query slabs: %w", err)
 			}

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -224,6 +224,13 @@ func TestObjects(t *testing.T) {
 	if !errors.Is(err, slabs.ErrObjectNotFound) {
 		t.Fatalf("expected ErrObjectNotFound, got %v", err)
 	}
+
+	// assert listing objects for accounts that include a deleted object works
+	obj2Acc1 := randomObject(pinSlabs(acc1, randomSlabs(3)))
+	if err := store.SaveObject(context.Background(), acc1, obj2Acc1); err != nil {
+		t.Fatal(err)
+	}
+	assertObjects(acc1, 1, 1)
 }
 
 // TestListObjectsRegression is a small regression tests that asserts proper


### PR DESCRIPTION
ListObjects is not handling deleted events properly, resulting in a panic.

```
{"level":"info","ts":"2025-10-11T03:04:16Z","logger":"stdlib","caller":"http/server.go:3679","msg":"http: panic serving 172.18.0.3:56736: runtime error: index out of range [25] with length 25
```

