### PR TITLE
Fix TestMigrations NDF

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -280,16 +280,32 @@ func (s *Store) BlockHosts(ctx context.Context, hks []types.PublicKey, reason st
 			if err != nil {
 				return fmt.Errorf("failed to add host %q to blocklist: %w", hk, err)
 			}
-			_, err = tx.Exec(ctx, `
-				UPDATE contracts
-				SET good = FALSE
-				FROM contracts c
-				INNER JOIN hosts h ON h.id = c.host_id
-				INNER JOIN hosts_blocklist hb ON hb.public_key = h.public_key
-				WHERE contracts.id = c.id AND h.public_key = $1
-				`, sqlPublicKey(hk))
+
+			var hostID int64
+			err = tx.QueryRow(ctx, "SELECT id FROM hosts WHERE public_key = $1", sqlPublicKey(hk)).Scan(&hostID)
+			if errors.Is(err, sql.ErrNoRows) {
+				continue // host does not exist in db, nothing to mark as bad
+			} else if err != nil {
+				return fmt.Errorf("failed to fetch host ID %q: %w", hk, err)
+			}
+
+			_, err = tx.Exec(ctx, `UPDATE contracts SET good = FALSE WHERE host_id = $1`, hostID)
 			if err != nil {
 				return fmt.Errorf("failed to update contracts: %w", err)
+			}
+
+			res, err := tx.Exec(ctx, `
+				UPDATE sectors
+				SET host_id = NULL
+				WHERE host_id = $1 AND contract_sectors_map_id IS NULL`, hostID)
+			if err != nil {
+				return fmt.Errorf("failed to update sectors: %w", err)
+			} else if unpinnable := res.RowsAffected(); unpinnable > 0 {
+				if err := incrementNumUnpinnableSectors(ctx, tx, unpinnable); err != nil {
+					return fmt.Errorf("failed to increment unpinnable sectors: %w", err)
+				} else if err := incrementNumUnpinnedSectors(ctx, tx, -unpinnable); err != nil {
+					return fmt.Errorf("failed to decrement unpinned sectors: %w", err)
+				}
 			}
 		}
 		return nil

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -138,14 +139,10 @@ func TestSectorStats(t *testing.T) {
 	assertStats(1, 0, 2, 0) // r0 still pinned, others unpinnable
 
 	// migrate sectors to h2
-	if migrated, err := store.MigrateSector(t.Context(), roots[1], hk4); err != nil {
+	_, err1 := store.MigrateSector(t.Context(), roots[1], hk4)
+	_, err2 := store.MigrateSector(t.Context(), roots[2], hk4)
+	if err := errors.Join(err1, err2); err != nil {
 		t.Fatal(err)
-	} else if !migrated {
-		t.Fatal("expected sector to be migrated")
-	} else if migrated, err := store.MigrateSector(t.Context(), roots[2], hk4); err != nil {
-		t.Fatal(err)
-	} else if !migrated {
-		t.Fatal("expected sector to be migrated")
 	}
 	assertStats(1, 2, 0, 2) // r0 still pinned, others unpinned and 2 migrated
 
@@ -173,14 +170,10 @@ func TestSectorStats(t *testing.T) {
 	}
 	assertStats(1, 0, 2, 2) // r0 and r1 are unpinnable
 
-	if migrated, err := store.MigrateSector(t.Context(), roots[0], hk4); err != nil {
+	_, err1 = store.MigrateSector(t.Context(), roots[0], hk4)
+	_, err2 = store.MigrateSector(t.Context(), roots[1], hk4)
+	if err := errors.Join(err1, err2); err != nil {
 		t.Fatal(err)
-	} else if !migrated {
-		t.Fatal("expected sector to be migrated")
-	} else if migrated, err := store.MigrateSector(t.Context(), roots[1], hk4); err != nil {
-		t.Fatal(err)
-	} else if !migrated {
-		t.Fatal("expected sector to be migrated")
 	}
 	assertStats(1, 2, 0, 4) // r2 is still pinned, r0 and r1 migrated and unpinned
 
@@ -190,7 +183,7 @@ func TestSectorStats(t *testing.T) {
 
 	assertStats(3, 0, 0, 4) // all sectors are pinned
 
-	// everything below this point verifies MarkSectorsLost properly tracks both
+	// the following section verifies MarkSectorsLost properly tracks both
 	// pinned and unpinned sectors, moving them to unpinnable but more
 	// importantly correctly decrementing from pinned/unpinned stats
 	if err := store.MarkSectorsLost(t.Context(), hk4, []types.Hash256{roots[0]}); err != nil {
@@ -198,10 +191,8 @@ func TestSectorStats(t *testing.T) {
 	}
 	assertStats(2, 0, 1, 4)
 
-	if migrated, err := store.MigrateSector(t.Context(), roots[0], hk4); err != nil {
+	if _, err := store.MigrateSector(t.Context(), roots[0], hk4); err != nil {
 		t.Fatal(err)
-	} else if !migrated {
-		t.Fatal("expected sector to be migrated")
 	}
 	assertStats(2, 1, 0, 5)
 
@@ -209,6 +200,25 @@ func TestSectorStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertStats(0, 0, 3, 5)
+
+	// the following section verifies BlockHosts properly unpins the sectors and
+	// updates the stats accordingly
+	if _, err := store.MigrateSector(t.Context(), roots[0], hk1); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(0, 1, 2, 6)
+
+	err := store.BlockHosts(t.Context(), []types.PublicKey{hk1}, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStats(0, 0, 3, 6)
+
+	if unpinned, err := store.UnpinnedSectors(t.Context(), hk1, 1); err != nil {
+		t.Fatal(err)
+	} else if len(unpinned) != 0 {
+		t.Fatalf("expected 0 unpinned sectors, got %d", len(unpinned))
+	}
 }
 
 func TestAccountStatsRegistered(t *testing.T) {

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -3,6 +3,7 @@ package slabs_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -66,32 +67,53 @@ func TestMigrations(t *testing.T) {
 	}
 	slabID := slabIDs[0]
 
-	// assert sectors were pinned
-	time.Sleep(time.Second)
-	pinned, err := app.Slab(context.Background(), slabID)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(pinned.Sectors) != 10 {
-		t.Fatalf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
-	} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[0].PublicKey {
-		t.Fatalf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[0].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
+	retry := func(tries int, durationBetweenAttempts time.Duration, fn func() error) error {
+		t.Helper()
+		var err error
+		for i := 0; i < tries; i++ {
+			err = fn()
+			if err == nil {
+				break
+			}
+			time.Sleep(durationBetweenAttempts)
+		}
+		return err
 	}
 
-	// add first host to blocklist
+	// assert sectors are pinned
+	if err := retry(100, 100*time.Millisecond, func() error {
+		slab, err := indexer.Store().Slab(t.Context(), slabID)
+		if err != nil {
+			return err
+		}
+		for _, sector := range slab.Sectors {
+			if sector.ContractID == nil || sector.HostKey == nil {
+				return fmt.Errorf("sector %s is not pinned yet", sector.Root)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// block the first host
 	err = indexer.Hosts().BlockHosts(context.Background(), []types.PublicKey{hosts[0].PublicKey}, "test blocklist reason")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// assert sectors are still pinned and the first shard was migrated to the free host
-	time.Sleep(3 * time.Second)
-	pinned, err = app.Slab(context.Background(), slabID)
-	if err != nil {
+	// assert sector was migrated
+	if err := retry(300, 100*time.Millisecond, func() error {
+		if pinned, err := app.Slab(context.Background(), slabID); err != nil {
+			t.Fatal(err)
+		} else if len(pinned.Sectors) != 10 {
+			return fmt.Errorf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
+		} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[10].PublicKey {
+			return fmt.Errorf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[10].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
+		}
+		return nil
+	}); err != nil {
 		t.Fatal(err)
-	} else if len(pinned.Sectors) != 10 {
-		t.Fatalf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
-	} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[10].PublicKey {
-		t.Fatalf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[10].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
 	}
 }
 

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -15,6 +15,11 @@ import (
 )
 
 func (m *SlabManager) migrateSlabs(ctx context.Context, slabIDs []SlabID, log *zap.Logger) error {
+	// return early if there are no slabs to migrate
+	if len(slabIDs) == 0 {
+		return nil
+	}
+
 	// fetch all available contracts
 	var goodContracts []contracts.Contract
 	const batchSize = 50


### PR DESCRIPTION
I found out that when we block a host that has unpinned sectors, those sectors end up in a somewhat awkward unpinnable state. They get out of this state though, but only after a certain period of time (the unpinnable sector threshold). For a slab to be unhealthy, its sectors have to be unpinnable, or linked to a contract that's inactive or bad.

I figured it's probably a good idea to mark the sectors as unpinnable in `BlockHosts`... I was on the fence about that one though, because it requires updating the sector stats. The alternative is to update the health query, or live with the fact that it takes some time to pick up on this issue.

Other findings:

We should open an issue to look into our hosts methods to see if we treat the blocklist correctly. For instance, I think `HostsWithUnpinnableSectors` should either not return blocked hosts, or we should update the call site. In the contract manager we don't use the `host.IsGood` but only check usability... decided to fix that separately though, we have to go through all of them anyway. 

Fixes https://github.com/SiaFoundation/indexd/issues/554 (passed 100 times on CI)
