### PR TITLE
Update block reasons

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -66,7 +66,7 @@ type (
 		Host(ctx context.Context, hk types.PublicKey) (hosts.Host, error)
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
 
-		BlockHosts(ctx context.Context, hks []types.PublicKey, reason string) error
+		BlockHosts(ctx context.Context, hks []types.PublicKey, reasons []string) error
 		BlockedHosts(ctx context.Context, offset, limit int) ([]types.PublicKey, error)
 		UnblockHost(ctx context.Context, hk types.PublicKey) error
 
@@ -731,7 +731,7 @@ func (a *admin) handlePUTHostsBlocklist(jc jape.Context) {
 	if jc.Decode(&hosts) != nil {
 		return
 	}
-	jc.Check("failed to add host keys to blocklist", a.hosts.BlockHosts(jc.Request.Context(), hosts.HostKeys, hosts.Reason))
+	jc.Check("failed to add host keys to blocklist", a.hosts.BlockHosts(jc.Request.Context(), hosts.HostKeys, hosts.Reasons))
 	jc.Encode(nil)
 }
 

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -386,7 +386,7 @@ func TestContractsAPI(t *testing.T) {
 	}
 
 	// block host and assert it's not returned
-	if err := adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{h.PublicKey()}, t.Name()); err != nil {
+	if err := adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{h.PublicKey()}, []string{t.Name()}); err != nil {
 		t.Fatal(err)
 	} else if contracts, err := adminClient.Contracts(context.Background(), admin.WithGood(true)); err != nil {
 		t.Fatal(err)
@@ -538,7 +538,7 @@ func TestHostsAPI(t *testing.T) {
 	}
 
 	// block both hosts
-	if err := adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{h1.PublicKey(), h2.PublicKey()}, t.Name()); err != nil {
+	if err := adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{h1.PublicKey(), h2.PublicKey()}, []string{t.Name()}); err != nil {
 		t.Fatal(err)
 	} else if blocklist, err := adminClient.HostsBlocklist(context.Background()); err != nil {
 		t.Fatal(err)
@@ -548,14 +548,14 @@ func TestHostsAPI(t *testing.T) {
 		t.Fatal(err)
 	} else if !h1.Blocked {
 		t.Fatal("expected host to be blocked", h1.Blocked)
-	} else if h1.BlockedReason != t.Name() {
-		t.Fatalf("expected host to be blocked with reason %s, got %s", t.Name(), h1.BlockedReason)
+	} else if !reflect.DeepEqual(h1.BlockedReasons, []string{t.Name()}) {
+		t.Fatalf("expected host to be blocked with reasons %s, got %s", t.Name(), h1.BlockedReasons)
 	} else if h2, err := adminClient.Host(context.Background(), h2.PublicKey()); err != nil {
 		t.Fatal(err)
 	} else if !h2.Blocked {
 		t.Fatal("expected host to be blocked", h2.Blocked)
-	} else if h2.BlockedReason != t.Name() {
-		t.Fatalf("expected host to be blocked with reason %s, got %s", t.Name(), h2.BlockedReason)
+	} else if !reflect.DeepEqual(h2.BlockedReasons, []string{t.Name()}) {
+		t.Fatalf("expected host to be blocked with reasons %s, got %s", t.Name(), h2.BlockedReasons)
 	}
 
 	// unblock h1

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -182,10 +182,10 @@ func (c *Client) HostsBlocklist(ctx context.Context, opts ...api.URLQueryParamet
 }
 
 // HostsBlocklistAdd adds the given host keys to the blocklist.
-func (c *Client) HostsBlocklistAdd(ctx context.Context, hostKeys []types.PublicKey, reason string) (err error) {
+func (c *Client) HostsBlocklistAdd(ctx context.Context, hostKeys []types.PublicKey, reasons []string) (err error) {
 	err = c.c.PUT(ctx, "/hosts/blocklist", HostsBlocklistRequest{
 		HostKeys: hostKeys,
-		Reason:   reason,
+		Reasons:  reasons,
 	})
 	return
 }

--- a/api/admin/types.go
+++ b/api/admin/types.go
@@ -36,7 +36,7 @@ type (
 	// HostsBlocklistRequest is the request body for the [POST] /hosts/blocklist.
 	HostsBlocklistRequest struct {
 		HostKeys []types.PublicKey `json:"hostKeys"`
-		Reason   string            `json:"reason"`
+		Reasons  []string          `json:"reasons"`
 	}
 
 	// SectorsStatsResponse is the response body for the [GET] /stats/sectors

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -254,7 +254,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// block h1
-	err = adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{hosts[0].PublicKey}, "test blocklist reason")
+	err = adminClient.HostsBlocklistAdd(context.Background(), []types.PublicKey{hosts[0].PublicKey}, []string{t.Name()})
 	if err != nil {
 		t.Fatal("failed to add host to blocklist:", err)
 	}

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -121,7 +121,7 @@ func (s *storeMock) AddRenewedContract(ctx context.Context, renewedFrom, renewed
 	return nil
 }
 
-func (s *storeMock) BlockHosts(_ context.Context, hostKeys []types.PublicKey, reason string) error {
+func (s *storeMock) BlockHosts(_ context.Context, hostKeys []types.PublicKey, reasons []string) error {
 	for _, hostKey := range hostKeys {
 		host, ok := s.hosts[hostKey]
 		if !ok {
@@ -129,7 +129,7 @@ func (s *storeMock) BlockHosts(_ context.Context, hostKeys []types.PublicKey, re
 		}
 		if !host.Blocked {
 			host.Blocked = true
-			host.BlockedReason = reason
+			host.BlockedReasons = reasons
 			s.hosts[hostKey] = host
 		}
 

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -166,7 +166,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 		force := forceFormation[host.PublicKey]
 		if good := host.Usability.Usable(); !good {
 			// host should be good
-			log.Debug("host is not usable due to bad usability", zap.String("reasons", host.Usability.FailedChecks()))
+			log.Debug("host is not usable due to bad usability", zap.Strings("reasons", host.Usability.FailedChecks()))
 			return false
 		} else if spaced := set.CanAddHost(host.Info()); !spaced && !force {
 			// host should be sufficiently spaced from other hosts

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -179,8 +179,8 @@ func (s *hostManagerMock) Hosts(ctx context.Context, offset int, limit int, quer
 	return s.store.Hosts(ctx, offset, limit, queryOpts...)
 }
 
-func (s *hostManagerMock) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reason string) error {
-	return s.store.BlockHosts(ctx, hostKeys, reason)
+func (s *hostManagerMock) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error {
+	return s.store.BlockHosts(ctx, hostKeys, reasons)
 }
 
 // TestPerformContractFormationWithoutContracts tests the

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -20,10 +20,6 @@ import (
 )
 
 const (
-	blockingReasonUsability = "usability"
-
-	hostsFetchLimit = 100
-
 	minRemainingStorage = (10 * 1 << 30) / uint64(proto.SectorSize) // 10GB
 	maxContractSize     = 10 * 1 << 40                              // 10TB
 
@@ -92,7 +88,7 @@ type (
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
 		HostsForPruning(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPinning(ctx context.Context) ([]types.PublicKey, error)
-		BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reason string) error
+		BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error
 		HostsWithUnpinnableSectors(ctx context.Context) ([]types.PublicKey, error)
 
 		WithScannedHost(ctx context.Context, hk types.PublicKey, fn func(h hosts.Host) error) error
@@ -305,26 +301,31 @@ func (cm *ContractManager) blockBadHosts(ctx context.Context) error {
 	defer cancel()
 	log := cm.log.Named("blockhosts")
 
-	var hostsToBlock []hosts.Host
-	for offset := 0; ; offset += hostsFetchLimit {
-		hosts, err := cm.hosts.Hosts(ctx, offset, hostsFetchLimit,
-			hosts.WithUsable(false), hosts.WithBlocked(false), hosts.WithActiveContracts(true))
+	const batchSize = 100
+	toBlock := make(map[types.PublicKey][]string)
+	for offset := 0; ; offset += batchSize {
+		hosts, err := cm.hosts.Hosts(ctx, offset, batchSize,
+			hosts.WithUsable(false),
+			hosts.WithBlocked(false),
+			hosts.WithActiveContracts(true))
 		if err != nil {
 			return fmt.Errorf("failed to fetch hosts to block: %w", err)
 		}
-		hostsToBlock = append(hostsToBlock, hosts...)
-		if len(hosts) < hostsFetchLimit {
+		for _, host := range hosts {
+			toBlock[host.PublicKey] = host.Usability.FailedChecks()
+		}
+		if len(hosts) < batchSize {
 			break
 		}
 	}
 
-	for _, host := range hostsToBlock {
-		hostLog := log.With(zap.Stringer("hostKey", host.PublicKey))
-		if err := cm.hosts.BlockHosts(ctx, []types.PublicKey{host.PublicKey}, blockingReasonUsability); err != nil {
+	for hk, reasons := range toBlock {
+		hostLog := log.With(zap.Stringer("hostKey", hk))
+		if err := cm.hosts.BlockHosts(ctx, []types.PublicKey{hk}, reasons); err != nil {
 			hostLog.Error("failed to block host", zap.Error(err))
 			continue
 		}
-		log.Warn("blocking unusable host", zap.Any("usability", host.Usability))
+		log.Warn("blocking unusable host", zap.Any("usability", reasons))
 	}
 	return nil
 }

--- a/contracts/manager_test.go
+++ b/contracts/manager_test.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"go.sia.tech/core/rhp/v4"
@@ -36,7 +37,7 @@ func TestBlockBadHosts(t *testing.T) {
 	}
 
 	// helper to assert a blocked host has a blocked contract and vice versa
-	assertHostAndContract := func(hk types.PublicKey, blocked bool, reason string) {
+	assertHostAndContract := func(hk types.PublicKey, blocked bool, reasons []string) {
 		t.Helper()
 
 		host, err := store.Host(context.Background(), hk)
@@ -44,8 +45,8 @@ func TestBlockBadHosts(t *testing.T) {
 			t.Fatal(err)
 		} else if host.Blocked != blocked {
 			t.Fatalf("expected host %v to be blocked=%v, got blocked=%v", hk, blocked, host.Blocked)
-		} else if host.Blocked && host.BlockedReason != reason {
-			t.Fatalf("expected host %v to be blocked due to %s, got blocked due to %v", hk, reason, host.BlockedReason)
+		} else if host.Blocked && !reflect.DeepEqual(host.BlockedReasons, reasons) {
+			t.Fatalf("expected host %v to be blocked due to %v, got blocked due to %v", hk, reasons, host.BlockedReasons)
 		}
 		contract, err := store.Contract(context.Background(), types.FileContractID(hk))
 		if errors.Is(err, ErrNotFound) && hk == unusedBadHost.PublicKey {
@@ -58,11 +59,11 @@ func TestBlockBadHosts(t *testing.T) {
 	}
 
 	// a good host shouldn't be blocked
-	assertHostAndContract(goodHost.PublicKey, false, "")
+	assertHostAndContract(goodHost.PublicKey, false, nil)
 
 	// a bad host and its contract should be blocked
-	assertHostAndContract(badHost.PublicKey, true, blockingReasonUsability)
+	assertHostAndContract(badHost.PublicKey, true, badHost.Usability.FailedChecks())
 
 	// an unused host shouldn't be blocked
-	assertHostAndContract(unusedBadHost.PublicKey, false, "")
+	assertHostAndContract(unusedBadHost.PublicKey, false, nil)
 }

--- a/hosts/host.go
+++ b/hosts/host.go
@@ -2,7 +2,6 @@ package hosts
 
 import (
 	"errors"
-	"strings"
 	"time"
 
 	proto4 "go.sia.tech/core/rhp/v4"
@@ -103,7 +102,7 @@ type (
 		Settings               proto4.HostSettings `json:"settings"`
 		Usability              Usability           `json:"usability"`
 		Blocked                bool                `json:"blocked"`
-		BlockedReason          string              `json:"blockedReason"`
+		BlockedReasons         []string            `json:"blockedReasons"`
 		LostSectors            uint64              `json:"lostSectors"`
 		AccountFunding         types.Currency      `json:"accountFunding"`
 		TotalSpent             types.Currency      `json:"totalSpent"`
@@ -216,7 +215,7 @@ func (u Usability) Usable() bool {
 }
 
 // FailedChecks returns a string representing all failed Usability checks.
-func (u Usability) FailedChecks() string {
+func (u Usability) FailedChecks() []string {
 	var reasons []string
 	if !u.Uptime {
 		reasons = append(reasons, "Uptime")
@@ -254,5 +253,5 @@ func (u Usability) FailedChecks() string {
 	if !u.FreeSectorPrice {
 		reasons = append(reasons, "FreeSectorPrice")
 	}
-	return strings.Join(reasons, ",")
+	return reasons
 }

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -101,7 +101,7 @@ type (
 		HostsForPinning(ctx context.Context) ([]types.PublicKey, error)
 		HostsWithUnpinnableSectors(ctx context.Context) ([]types.PublicKey, error)
 
-		BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reason string) error
+		BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error
 		BlockedHosts(ctx context.Context, offset, limit int) ([]types.PublicKey, error)
 		UnblockHost(ctx context.Context, hk types.PublicKey) error
 
@@ -155,9 +155,9 @@ func (hm *HostManager) HostsForPinning(ctx context.Context) ([]types.PublicKey, 
 	return hm.store.HostsForPinning(ctx)
 }
 
-// BlockHosts blocks the given hosts for the given reason
-func (hm *HostManager) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reason string) error {
-	return hm.store.BlockHosts(ctx, hostKeys, reason)
+// BlockHosts blocks the given hosts for the given list of reasons
+func (hm *HostManager) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error {
+	return hm.store.BlockHosts(ctx, hostKeys, reasons)
 }
 
 // HostsWithUnpinnableSectors returns any hosts that have sectors that could not be pinned

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -52,7 +52,7 @@ func (s *mockStore) HostStats(ctx context.Context, offset, limit int) ([]HostSta
 	return nil, nil
 }
 
-func (s *mockStore) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reason string) error {
+func (s *mockStore) BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error {
 	return nil
 }
 

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -872,9 +872,11 @@ paths:
                   type: array
                   items:
                     $ref: "#/components/schemas/PublicKey"
-                reason:
-                  type: string
-                  description: Reason for blocking the hosts
+                reasons:
+                  type: array
+                  items:
+                    type: string
+                  description: Reasons for blocking the hosts
       responses:
         "200":
           description: Blocklist updated successfully
@@ -907,7 +909,7 @@ paths:
             })
             await admin.hostsBlocklistUpdate({
               hostkeys: ["ed25519:host-key-a", "ed25519:host-key-b"],
-              reason: "maintenance"
+              reasons: ["maintenance"]
             })
   /hosts/blocklist/{hostkey}:
     delete:

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -599,10 +599,12 @@ components:
         blocked:
           type: boolean
           description: Whether the host is blocked
-        blockedReason:
-          type: string
-          description: The reason why the host is blocked
-          example: "Host has been offline for too long"
+        blockedReasons:
+          type: array
+          items:
+            type: string
+          description: The reasons why the host is blocked
+          example: ["Uptime"]
         lostSectors:
           type: integer
           format: uint64

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -73,7 +74,7 @@ WITH globals AS (
 	FROM global_settings
 ), hosts AS (
 	SELECT
-		id, hosts.public_key, last_announcement, hb.public_key IS NOT NULL AS blocked, COALESCE(hb.reason, ''), lost_sectors,
+		id, hosts.public_key, last_announcement, hb.public_key IS NOT NULL AS blocked, hb.reasons, lost_sectors,
 		last_failed_scan, last_successful_scan, next_scan, consecutive_failed_scans, recent_uptime, usage_account_funding, usage_total_spent,
 		country_code, location,
 		settings_protocol_version, settings_release, settings_wallet_address,
@@ -151,7 +152,7 @@ WITH globals AS (
     FROM global_settings
 ), hosts AS (
 	SELECT
-		id, hosts.public_key, last_announcement, hb.public_key IS NOT NULL AS blocked, COALESCE(hb.reason, ''), lost_sectors,
+		id, hosts.public_key, last_announcement, hb.public_key IS NOT NULL AS blocked, hb.reasons, lost_sectors,
 		last_failed_scan, last_successful_scan, next_scan, consecutive_failed_scans, recent_uptime, usage_account_funding, usage_total_spent,
 		country_code, location,
 		settings_protocol_version, settings_release, settings_wallet_address,
@@ -270,23 +271,29 @@ func (s *Store) BlockedHosts(ctx context.Context, offset, limit int) ([]types.Pu
 }
 
 // BlockHosts adds the given host keys to the blocklist and marks all of its
-// contracts as bad.
-// If a host is already on the blocklist, the reason remains unchanged to
-// preserve the original reason for blocking.
-func (s *Store) BlockHosts(ctx context.Context, hks []types.PublicKey, reason string) error {
+// contracts as bad. If a host is already on the blocklist, the reasons are
+// updated to include any new reasons for blocking.
+func (s *Store) BlockHosts(ctx context.Context, hks []types.PublicKey, reasons []string) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		for _, hk := range hks {
-			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key, reason) VALUES ($1, $2) ON CONFLICT (public_key) DO NOTHING", sqlPublicKey(hk), reason)
-			if err != nil {
-				return fmt.Errorf("failed to add host %q to blocklist: %w", hk, err)
+			var hostID int64
+			var updated []string
+			err := tx.QueryRow(ctx, `SELECT h.id, COALESCE(hb.reasons, '{}') FROM hosts h LEFT JOIN hosts_blocklist hb ON hb.public_key = h.public_key WHERE h.public_key = $1`, sqlPublicKey(hk)).Scan(&hostID, &updated)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("failed to check existing blocklist entry for host %q: %w", hk, err)
 			}
 
-			var hostID int64
-			err = tx.QueryRow(ctx, "SELECT id FROM hosts WHERE public_key = $1", sqlPublicKey(hk)).Scan(&hostID)
-			if errors.Is(err, sql.ErrNoRows) {
-				continue // host does not exist in db, nothing to mark as bad
-			} else if err != nil {
-				return fmt.Errorf("failed to fetch host ID %q: %w", hk, err)
+			// deduplicate reasons
+			updated = append(updated, reasons...)
+			slices.Sort(updated)
+			updated = slices.Compact(updated)
+
+			// update blocklist
+			_, err = tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key, reasons) VALUES ($1, $2) ON CONFLICT (public_key) DO UPDATE SET reasons = $2", sqlPublicKey(hk), updated)
+			if err != nil {
+				return fmt.Errorf("failed to add host %q to blocklist: %w", hk, err)
+			} else if hostID == 0 {
+				continue // nothing to update
 			}
 
 			_, err = tx.Exec(ctx, `UPDATE contracts SET good = FALSE WHERE host_id = $1`, hostID)
@@ -710,7 +717,7 @@ func scanHost(s scanner) (dbHost, error) {
 		(*sqlPublicKey)(&host.PublicKey),
 		&host.LastAnnouncement,
 		&host.Blocked,
-		&host.BlockedReason,
+		&host.BlockedReasons,
 		&host.LostSectors,
 		&lastFailedScan,
 		&lastSuccessfulScan,

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -84,6 +84,54 @@ func TestAddHostAnnouncement(t *testing.T) {
 	}
 }
 
+func TestBlockHosts(t *testing.T) {
+	// create database
+	log := zaptest.NewLogger(t)
+	store := initPostgres(t, log.Named("postgres"))
+
+	hk1 := store.addTestHost(t, types.PublicKey{1})
+	hk2 := store.addTestHost(t, types.PublicKey{2})
+	hk3 := types.PublicKey{3} // not in DB
+
+	// assert block reasons
+	reasons := []string{"a", "b"}
+	if err := store.BlockHosts(t.Context(), []types.PublicKey{hk1, hk2}, reasons); err != nil {
+		t.Fatal(err)
+	}
+	for _, hk := range []types.PublicKey{hk1, hk2} {
+		host, err := store.Host(t.Context(), hk)
+		if err != nil {
+			t.Fatal(err)
+		} else if !host.Blocked {
+			t.Fatal("expected host to be blocked")
+		} else if !reflect.DeepEqual(host.BlockedReasons, reasons) {
+			t.Fatal("expected host to have correct blocked reasons", host.BlockedReasons)
+		}
+	}
+
+	// assert blocking unknown host works and doesn't error
+	if err := store.BlockHosts(t.Context(), []types.PublicKey{hk3}, reasons); err != nil {
+		t.Fatal(err)
+	}
+	if hks, err := store.BlockedHosts(t.Context(), 0, 10); err != nil {
+		t.Fatal(err)
+	} else if len(hks) != 3 {
+		t.Fatal("expected 3 blocked hosts, got", len(hks))
+	}
+
+	// assert reasons are deduplicated when blocking the same host
+	reasons = []string{"b", "c"}
+	if err := store.BlockHosts(t.Context(), []types.PublicKey{hk1}, reasons); err != nil {
+		t.Fatal(err)
+	}
+	host, err := store.Host(t.Context(), hk1)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(host.BlockedReasons, []string{"a", "b", "c"}) {
+		t.Fatal("expected host to have correct blocked reasons", host.BlockedReasons)
+	}
+}
+
 func TestHost(t *testing.T) {
 	// create database
 	log := zaptest.NewLogger(t)
@@ -409,7 +457,7 @@ func TestHosts(t *testing.T) {
 
 		// block host
 		if blocked {
-			err := db.BlockHosts(context.Background(), []types.PublicKey{hk}, "test")
+			err := db.BlockHosts(context.Background(), []types.PublicKey{hk}, []string{t.Name()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -477,8 +525,8 @@ func TestHosts(t *testing.T) {
 				t.Fatal("invalid settings")
 			} else if host.Blocked != blocked {
 				t.Fatalf("expected blocked %v, got %v", blocked, host.Blocked)
-			} else if host.Blocked && host.BlockedReason != "test" {
-				t.Fatalf("expected blocked reason 'test', got %v", host.BlockedReason)
+			} else if host.Blocked && !reflect.DeepEqual(host.BlockedReasons, []string{t.Name()}) {
+				t.Fatalf("expected blocked reasons 'test', got %v", host.BlockedReasons)
 			} else if host.Usability != usability {
 				t.Fatalf("expected usability %+v, got %+v", usability, host.Usability)
 			}
@@ -579,7 +627,7 @@ func TestUsableHosts(t *testing.T) {
 
 		// handle blocked
 		if blocked {
-			err := db.BlockHosts(context.Background(), []types.PublicKey{hk}, "test")
+			err := db.BlockHosts(context.Background(), []types.PublicKey{hk}, []string{t.Name()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -688,7 +736,7 @@ func TestUsableHosts(t *testing.T) {
 	}
 
 	// block usable hosts and add 3 new usable hosts in the EU
-	db.BlockHosts(context.Background(), []types.PublicKey{uh1, uh2}, t.Name())
+	db.BlockHosts(context.Background(), []types.PublicKey{uh1, uh2}, []string{t.Name()})
 	uh1 = addHost(10, geoip.Location{
 		CountryCode: "ES",    // Spain
 		Latitude:    41.3851, // Barcelona
@@ -1294,7 +1342,7 @@ func BenchmarkHosts(b *testing.B) {
 
 		// we LEFT JOIN the blocklist so we populate it with random entries
 		for range numBlocklist {
-			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key, reason) VALUES ($1, 'none') ON CONFLICT (public_key) DO NOTHING", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key) VALUES ($1)", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
 			if err != nil {
 				return err
 			}
@@ -1440,9 +1488,8 @@ func BenchmarkUsableHosts(b *testing.B) {
 	// prepare random blocklist (we LEFT JOIN the blocklist in UsableHosts)
 	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 		for range numBlocklist {
-			if _, err := tx.Exec(ctx, `
-				INSERT INTO hosts_blocklist (public_key, reason) 
-				VALUES ($1, 'none')`, sqlPublicKey(types.GeneratePrivateKey().PublicKey())); err != nil {
+			_, err := tx.Exec(ctx, `INSERT INTO hosts_blocklist (public_key) VALUES ($1)`, sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+			if err != nil {
 				return err
 			}
 		}
@@ -1668,7 +1715,7 @@ func TestHostsForPinning(t *testing.T) {
 	}
 
 	// block host 2
-	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk2}, "test"); err != nil {
+	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk2}, []string{t.Name()}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1715,7 +1762,7 @@ func TestHostsForPruning(t *testing.T) {
 	}
 
 	// block host 2 and assert it is not returned anymore
-	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk2}, "test"); err != nil {
+	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk2}, []string{t.Name()}); err != nil {
 		t.Fatal(err)
 	} else if hks, err := db.HostsForPruning(context.Background()); err != nil {
 		t.Fatal(err)
@@ -1760,7 +1807,7 @@ func BenchmarkHostsForPruning(b *testing.B) {
 	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 		for range nHosts {
 			// add host
-			hk := types.PublicKey(frand.Entropy256())
+			hk := types.GeneratePrivateKey().PublicKey()
 			var hostID int64
 			err := tx.QueryRow(ctx, `INSERT INTO hosts (public_key, last_announcement) VALUES ($1, NOW()) RETURNING id;`, sqlPublicKey(hk)).Scan(&hostID)
 			if err != nil {
@@ -1775,7 +1822,7 @@ func BenchmarkHostsForPruning(b *testing.B) {
 
 		// we LEFT JOIN the blocklist so we populate it with random entries
 		for range nBlocklistHosts {
-			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key, reason) VALUES ($1, 'none') ON CONFLICT (public_key) DO NOTHING", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key) VALUES ($1)", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
 			if err != nil {
 				return err
 			}
@@ -1886,7 +1933,7 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 	}
 
 	// block host 1 so that it's also not returned anymore
-	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk1}, ""); err != nil {
+	if err := db.BlockHosts(context.Background(), []types.PublicKey{hk1}, []string{t.Name()}); err != nil {
 		t.Fatal(err)
 	}
 	hosts, err = db.HostsForIntegrityChecks(context.Background(), oneHFromNow, 10)
@@ -1918,8 +1965,9 @@ func BenchmarkHostsForPinning(b *testing.B) {
 	hostToContractIDs := make(map[types.PublicKey][]types.FileContractID, nHosts)
 	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 		for range nHosts {
+			hk := types.GeneratePrivateKey().PublicKey()
+
 			// add host
-			hk := types.PublicKey(frand.Entropy256())
 			var hostID int64
 			err := tx.QueryRow(ctx, `INSERT INTO hosts (public_key, last_announcement) VALUES ($1, NOW()) RETURNING id;`, sqlPublicKey(hk)).Scan(&hostID)
 			if err != nil {
@@ -1934,7 +1982,7 @@ func BenchmarkHostsForPinning(b *testing.B) {
 
 		// we LEFT JOIN the blocklist so we populate it with random entries
 		for range nBlocklistHosts {
-			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key, reason) VALUES ($1, 'none') ON CONFLICT (public_key) DO NOTHING", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key) VALUES ($1)", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
 			if err != nil {
 				return err
 			}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -88,9 +88,9 @@ CREATE TABLE service_accounts (
 CREATE TABLE hosts_blocklist (
     public_key BYTEA PRIMARY KEY CHECK (LENGTH(public_key) = 32),
     added TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    reason TEXT NOT NULL
+    reasons TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]
 );
-CREATE INDEX hosts_blocklist_reason_idx ON hosts_blocklist (reason);
+CREATE INDEX hosts_blocklist_reasons_gin_idx ON hosts_blocklist USING GIN(reasons);
 
 CREATE TABLE host_addresses (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -427,4 +427,18 @@ FROM objects o;
 		}
 		return nil
 	},
+	// migrate hosts_blocklist reason column to TEXT[] array and add GIN index
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `
+			-- add reasons column and migrate data
+			ALTER TABLE hosts_blocklist ADD COLUMN reasons TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];
+			UPDATE hosts_blocklist SET reasons = ARRAY[reason];
+			
+			-- drop old column and create index
+			DROP INDEX hosts_blocklist_reason_idx;
+			ALTER TABLE hosts_blocklist DROP COLUMN reason;
+			CREATE INDEX hosts_blocklist_reasons_gin_idx ON hosts_blocklist USING GIN(reasons);
+		`)
+		return err
+	},
 }

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -208,7 +208,7 @@ func TestSectorStats(t *testing.T) {
 	}
 	assertStats(0, 1, 2, 6)
 
-	err := store.BlockHosts(t.Context(), []types.PublicKey{hk1}, t.Name())
+	err := store.BlockHosts(t.Context(), []types.PublicKey{hk1}, []string{t.Name()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -97,7 +97,7 @@ func TestMigrations(t *testing.T) {
 	}
 
 	// block the first host
-	err = indexer.Hosts().BlockHosts(context.Background(), []types.PublicKey{hosts[0].PublicKey}, "test blocklist reason")
+	err = indexer.Hosts().BlockHosts(context.Background(), []types.PublicKey{hosts[0].PublicKey}, []string{t.Name()})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently our blocked hosts have as reason in the database "usability". That's not very helpful, the UI helps but it would be great if we could create more complex queries to see why hosts are blocked and thus also cause slabs to become unhealthy. 

Related to https://github.com/SiaFoundation/indexd/issues/537