### PR TITLE
Detect changing seed 

### DIFF
--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -103,6 +103,13 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	go s.Run()
 	defer s.Close()
 
+	walletHash := types.HashBytes(walletKey[:])
+	if err := store.VerifyWalletKey(walletHash); errors.Is(err, wallet.ErrDifferentSeed) {
+		return errors.New("wallet seed change detected, cannot proceed")
+	} else if err != nil {
+		return fmt.Errorf("failed to verify wallet key: %w", err)
+	}
+
 	wm, err := wallet.NewSingleAddressWallet(walletKey, cm, store, s, wallet.WithLogger(log.Named("wallet")), wallet.WithReservationDuration(3*time.Hour))
 	if err != nil {
 		return fmt.Errorf("failed to create wallet: %w", err)

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -155,6 +155,9 @@ CREATE TABLE global_settings (
     scanned_height BIGINT NOT NULL DEFAULT 0 CHECK(scanned_height >= 0),
     scanned_block_id BYTEA NOT NULL DEFAULT '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea CHECK (LENGTH(scanned_block_id) = 32),
 
+    -- wallet info
+    wallet_hash BYTEA CHECK(wallet_hash IS NULL OR LENGTH(wallet_hash) = 32), -- used to prevent wallet seed changes
+
     -- contract manager settings
     contracts_maintenance_enabled BOOLEAN NOT NULL DEFAULT FALSE,
     contracts_wanted INTEGER NOT NULL DEFAULT 50 CHECK(contracts_wanted > 0), -- number of contracts to maintain

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -446,4 +446,9 @@ FROM objects o;
 		_, err := tx.Exec(ctx, `CREATE INDEX contracts_expiration_height_contract_id_idx ON contracts (expiration_height, contract_id) WHERE state = 1 AND renewed_to IS NULL;`)
 		return err
 	},
+	// add wallet_hash to global_settings to detect seed changes
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `ALTER TABLE global_settings ADD COLUMN wallet_hash BYTEA CHECK(wallet_hash IS NULL OR LENGTH(wallet_hash) = 32);`)
+		return err
+	},
 }

--- a/persist/postgres/wallet.go
+++ b/persist/postgres/wallet.go
@@ -23,6 +23,25 @@ var (
 
 var _ wallet.SingleAddressStore = (*Store)(nil)
 
+// VerifyWalletKey checks that the wallet seed matches the seed hash.
+// This detects if the user's recovery phrase has changed and the wallet needs
+// to rescan.
+func (s *Store) VerifyWalletKey(seedHash types.Hash256) error {
+	var hash []byte
+	return s.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
+		err := tx.QueryRow(ctx, `SELECT wallet_hash FROM global_settings`).Scan(&hash)
+		if err != nil {
+			return fmt.Errorf("failed to query wallet seed hash: %w", err)
+		} else if hash == nil {
+			_, err := tx.Exec(ctx, `UPDATE global_settings SET wallet_hash = $1`, sqlHash256(seedHash)) // wallet not initialized, set seed hash
+			return err
+		} else if seedHash != [32]byte(hash) {
+			return wallet.ErrDifferentSeed
+		}
+		return nil
+	})
+}
+
 // AddBroadcastedSet adds a set of broadcasted transactions. The wallet will
 // periodically rebroadcast the transactions in this set until all transactions
 // are gone from the transaction pool or one week has passed.

--- a/persist/postgres/wallet.go
+++ b/persist/postgres/wallet.go
@@ -24,8 +24,7 @@ var (
 var _ wallet.SingleAddressStore = (*Store)(nil)
 
 // VerifyWalletKey checks that the wallet seed matches the seed hash.
-// This detects if the user's recovery phrase has changed and the wallet needs
-// to rescan.
+// This detects if the user's recovery phrase has changed.
 func (s *Store) VerifyWalletKey(seedHash types.Hash256) error {
 	var hash []byte
 	return s.transaction(context.Background(), func(ctx context.Context, tx *txn) error {

--- a/persist/postgres/wallet_test.go
+++ b/persist/postgres/wallet_test.go
@@ -15,6 +15,33 @@ import (
 	"lukechampine.com/frand"
 )
 
+func TestVerifyWalletKey(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	hash1 := types.Hash256(frand.Entropy256())
+	// set initial seed hash
+	if err := store.VerifyWalletKey(hash1); err != nil {
+		t.Fatal(err)
+	}
+
+	// try to verify with same hash - should succeed
+	if err := store.VerifyWalletKey(hash1); err != nil {
+		t.Fatal(err)
+	}
+
+	// try to verify with another hash - should fail
+	hash2 := types.Hash256(frand.Entropy256())
+
+	if err := store.VerifyWalletKey(hash2); err == nil || !errors.Is(err, wallet.ErrDifferentSeed) {
+		t.Fatal(err)
+	}
+
+	// initial hash should still succeed
+	if err := store.VerifyWalletKey(hash1); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestSingleAddressWalletStoreTip(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 

--- a/persist/postgres/wallet_test.go
+++ b/persist/postgres/wallet_test.go
@@ -33,7 +33,7 @@ func TestVerifyWalletKey(t *testing.T) {
 	hash2 := types.Hash256(frand.Entropy256())
 
 	if err := store.VerifyWalletKey(hash2); err == nil || !errors.Is(err, wallet.ErrDifferentSeed) {
-		t.Fatal(err)
+		t.Fatalf("expected error %v, got %v", wallet.ErrDifferentSeed, err)
 	}
 
 	// initial hash should still succeed


### PR DESCRIPTION
Close #583

Logic mostly copied code from hostd.

There is a test for the DB method but I also tested the command.  As expected, after reconfiguring indexd and getting a new seed:

```
$ ./indexd 
2025-10-27T00:05:24-04:00       INFO    postgres        connected       {"database": "indexd", "host": "127.0.0.1", "port": 5432}
daemon startup failed: wallet seed change detected, cannot proceed
```
