### PR TITLE
Improve slab performance and add logging

### DIFF
--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -112,7 +112,7 @@ outer:
 				wg.Done()
 			}()
 
-			var start time.Time
+			start := time.Now()
 			var usage proto.Usage
 			usage, shards[sectorIdx], err = m.downloadShard(ctx, host, slab.Sectors[sectorIdx], pool)
 			if isErrLostSector(err) {

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -119,7 +119,10 @@ outer:
 				m.markSectorLost(ctx, host, slab.Sectors[sectorIdx].Root, logger)
 				return
 			} else if err != nil {
-				logger.Debug("failed to download shard", zap.Bool("timed out", time.Now().After(start.Add(m.shardTimeout))), zap.Error(err))
+				logger.Debug("failed to download shard",
+					zap.Bool("timeout", time.Now().After(start.Add(m.shardTimeout))),
+					zap.Error(err),
+				)
 				return
 			}
 

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
+	"lukechampine.com/frand"
 )
 
 var errNotEnoughShards = errors.New("not enough shards")
@@ -42,17 +43,15 @@ func newDownloadCandidates(allHosts []hosts.Host, slab Slab) downloadCandidates 
 		indices[hk] = i
 	}
 
-	// build sorted list of hosts, cheapest first
+	// build list of hosts, randomize order to avoid bias
 	hosts := make([]hosts.Host, 0, len(lookup))
 	for _, h := range allHosts {
 		if _, ok := indices[h.PublicKey]; ok {
 			hosts = append(hosts, h)
 		}
 	}
-	sort.Slice(hosts, func(i, j int) bool {
-		hiep := hosts[i].Settings.Prices.EgressPrice
-		hjep := hosts[j].Settings.Prices.EgressPrice
-		return hiep.Cmp(hjep) < 0
+	frand.Shuffle(len(hosts), func(i, j int) {
+		hosts[i], hosts[j] = hosts[j], hosts[i]
 	})
 
 	return downloadCandidates{hosts: hosts, indices: indices}
@@ -113,13 +112,14 @@ outer:
 				wg.Done()
 			}()
 
+			var start time.Time
 			var usage proto.Usage
 			usage, shards[sectorIdx], err = m.downloadShard(ctx, host, slab.Sectors[sectorIdx], pool)
 			if isErrLostSector(err) {
 				m.markSectorLost(ctx, host, slab.Sectors[sectorIdx].Root, logger)
 				return
 			} else if err != nil {
-				logger.Debug("failed to download shard", zap.Error(err))
+				logger.Debug("failed to download shard", zap.Bool("timed out", time.Now().After(start.Add(m.shardTimeout))), zap.Error(err))
 				return
 			}
 

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -120,7 +120,7 @@ outer:
 				return
 			} else if err != nil {
 				logger.Debug("failed to download shard",
-					zap.Bool("timeout", time.Now().After(start.Add(m.shardTimeout))),
+					zap.Bool("timeout", time.Since(start) > m.shardTimeout),
 					zap.Error(err),
 				)
 				return

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -82,7 +82,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		log.Warn("tried to migrate slab but no hosts are available for migration")
 		return
 	}
-	log = log.With(zap.Int("toMigrate", len(indices)), zap.Int("candidates", len(uploadCandidates)))
+	log = log.With(zap.Int("toMigrate", len(indices)), zap.Int("uploadCandidates", len(uploadCandidates)))
 
 	// download enough shards to reconstruct the slab's shards
 	// note: timeouts are set within downloadShards to avoid timing

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -61,7 +61,7 @@ func (m *SlabManager) uploadShards(ctx context.Context, slab Slab, shards [][]by
 		usage, root, err := m.uploadShard(ctx, host, bytes.NewReader(shard), pool)
 		if err != nil {
 			logger.Debug("failed to upload shard",
-				zap.Bool("timeout", time.Now().After(start.Add(m.shardTimeout))),
+				zap.Bool("timeout", time.Since(start) > m.shardTimeout),
 				zap.Stringer("hostKey", host.PublicKey),
 				zap.Error(err),
 			)

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -56,9 +57,14 @@ func (m *SlabManager) uploadShards(ctx context.Context, slab Slab, shards [][]by
 			break
 		}
 
+		start := time.Now()
 		usage, root, err := m.uploadShard(ctx, host, bytes.NewReader(shard), pool)
 		if err != nil {
-			logger.Debug("failed to upload shard", zap.Stringer("hostKey", host.PublicKey), zap.Error(err))
+			logger.Debug("failed to upload shard",
+				zap.Bool("timeout", time.Now().After(start.Add(m.shardTimeout))),
+				zap.Stringer("hostKey", host.PublicKey),
+				zap.Error(err),
+			)
 			goto nextCandidate
 		}
 


### PR DESCRIPTION
This PR randomizes download candidates and logs when a host times out on a shard download. I'll be following this up in light of https://github.com/SiaFoundation/indexd/issues/561