### PR TITLE
Add `HostsForFunding`

### DIFF
--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -159,16 +159,20 @@ func (s *hostManagerMock) WithScannedHost(ctx context.Context, hk types.PublicKe
 	return fn(h)
 }
 
-func (s *hostManagerMock) HostsForPruning(ctx context.Context) ([]types.PublicKey, error) {
-	return s.store.HostsForPruning(ctx)
-}
-
 func (s *hostManagerMock) Host(ctx context.Context, hk types.PublicKey) (hosts.Host, error) {
 	return s.store.Host(ctx, hk)
 }
 
+func (s *hostManagerMock) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) {
+	return s.store.HostsForFunding(ctx)
+}
+
 func (s *hostManagerMock) HostsForPinning(ctx context.Context) ([]types.PublicKey, error) {
 	return s.store.HostsForPinning(ctx)
+}
+
+func (s *hostManagerMock) HostsForPruning(ctx context.Context) ([]types.PublicKey, error) {
+	return s.store.HostsForPruning(ctx)
 }
 
 func (s *hostManagerMock) HostsWithUnpinnableSectors(ctx context.Context) ([]types.PublicKey, error) {

--- a/contracts/fund_test.go
+++ b/contracts/fund_test.go
@@ -87,13 +87,21 @@ func (s *storeMock) ContractsForFunding(_ context.Context, hk types.PublicKey, l
 	return out, nil
 }
 
-func (s *storeMock) HostsForFunding(_ context.Context) ([]types.PublicKey, error) {
+func (s *storeMock) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) {
+	hasContract := make(map[types.PublicKey]struct{})
+	for _, c := range s.contracts {
+		hasContract[c.HostKey] = struct{}{}
+	}
+
 	var hks []types.PublicKey
 	for hk, host := range s.hosts {
 		if host.Usability == hosts.GoodUsability && !host.Blocked {
-			hks = append(hks, hk)
+			if _, ok := hasContract[hk]; ok {
+				hks = append(hks, hk)
+			}
 		}
 	}
+
 	return hks, nil
 }
 

--- a/contracts/fund_test.go
+++ b/contracts/fund_test.go
@@ -87,6 +87,16 @@ func (s *storeMock) ContractsForFunding(_ context.Context, hk types.PublicKey, l
 	return out, nil
 }
 
+func (s *storeMock) HostsForFunding(_ context.Context) ([]types.PublicKey, error) {
+	var hks []types.PublicKey
+	for hk, host := range s.hosts {
+		if host.Usability == hosts.GoodUsability && !host.Blocked {
+			hks = append(hks, hk)
+		}
+	}
+	return hks, nil
+}
+
 func TestPerformAccountFunding(t *testing.T) {
 	amMock := &accountsManagerMock{}
 	store := newStoreMock()

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -7,61 +7,53 @@ import (
 	"sync"
 	"time"
 
-	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/core/types"
 	"go.uber.org/zap"
 )
 
 func (cm *ContractManager) performAccountFunding(ctx context.Context, force bool, log *zap.Logger) error {
 	start := time.Now()
 
-	// fund accounts on usable hosts with active contracts
-	opts := []hosts.HostQueryOpt{
-		hosts.WithUsable(true),
-		hosts.WithBlocked(false),
-		hosts.WithActiveContracts(true),
+	// fetch hosts
+	hostsToFund, err := cm.hosts.HostsForFunding(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch hosts for account funding: %w", err)
 	}
 
-	const batchSize = 50
-	for offset := 0; ; offset += batchSize {
-		// fetch hosts
-		hostsToFund, err := cm.hosts.Hosts(ctx, offset, batchSize, opts...)
-		if err != nil {
-			return fmt.Errorf("failed to fetch hosts for account funding: %w", err)
-		}
+	// fund accounts on all hosts
+	var wg sync.WaitGroup
+	for _, hk := range hostsToFund {
+		wg.Add(1)
+		go func(ctx context.Context, hostKey types.PublicKey, log *zap.Logger) {
+			ctx, cancel := context.WithTimeout(ctx, fundTimeout)
+			defer func() {
+				wg.Done()
+				cancel()
+			}()
 
-		// fund accounts on all hosts
-		var wg sync.WaitGroup
-		for _, host := range hostsToFund {
-			wg.Add(1)
-			go func(ctx context.Context, host hosts.Host, log *zap.Logger) {
-				ctx, cancel := context.WithTimeout(ctx, fundTimeout)
-				defer func() {
-					wg.Done()
-					cancel()
-				}()
+			host, err := cm.hosts.Host(ctx, hostKey)
+			if err != nil {
+				log.Error("failed to fetch host for funding", zap.Error(err))
+				return
+			}
 
-				contractIDs, err := cm.store.ContractsForFunding(ctx, host.PublicKey, 10)
-				if err != nil {
-					log.Error("failed to fetch contracts for funding", zap.Error(err))
-					return
-				} else if len(contractIDs) == 0 {
-					log.Debug("no contracts for funding")
-					return
-				}
+			contractIDs, err := cm.store.ContractsForFunding(ctx, host.PublicKey, 10)
+			if err != nil {
+				log.Error("failed to fetch contracts for funding", zap.Error(err))
+				return
+			} else if len(contractIDs) == 0 {
+				log.Debug("no contracts for funding")
+				return
+			}
 
-				err = cm.accounts.FundAccounts(ctx, host, contractIDs, force, log)
-				if err != nil {
-					log.Debug("failed to fund accounts", zap.Error(err))
-					return
-				}
-			}(ctx, host, log.With(zap.Stringer("hostKey", host.PublicKey)))
-		}
-		wg.Wait()
-
-		if len(hostsToFund) < batchSize {
-			break
-		}
+			err = cm.accounts.FundAccounts(ctx, host, contractIDs, force, log)
+			if err != nil {
+				log.Debug("failed to fund accounts", zap.Error(err))
+				return
+			}
+		}(ctx, hk, log.With(zap.Stringer("hostKey", hk)))
 	}
+	wg.Wait()
 
 	log.Debug("funding finished", zap.Duration("duration", time.Since(start)))
 	return ctx.Err()

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -86,6 +86,7 @@ type (
 	HostManager interface {
 		Host(ctx context.Context, hostKey types.PublicKey) (hosts.Host, error)
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
+		HostsForFunding(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPruning(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPinning(ctx context.Context) ([]types.PublicKey, error)
 		BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -96,9 +96,10 @@ type (
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...HostQueryOpt) ([]Host, error)
 		HostStats(ctx context.Context, offset, limit int) ([]HostStats, error)
 
-		HostsForScanning(ctx context.Context) ([]types.PublicKey, error)
+		HostsForFunding(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPruning(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPinning(ctx context.Context) ([]types.PublicKey, error)
+		HostsForScanning(ctx context.Context) ([]types.PublicKey, error)
 		HostsWithUnpinnableSectors(ctx context.Context) ([]types.PublicKey, error)
 
 		BlockHosts(ctx context.Context, hostKeys []types.PublicKey, reasons []string) error
@@ -143,6 +144,11 @@ func (hm *HostManager) Host(ctx context.Context, hostKey types.PublicKey) (Host,
 // Hosts returns a list of hosts filtered by the given query options.
 func (hm *HostManager) Hosts(ctx context.Context, offset, limit int, queryOpts ...HostQueryOpt) ([]Host, error) {
 	return hm.store.Hosts(ctx, offset, limit, queryOpts...)
+}
+
+// HostsForFunding returns a list of hosts that need account funding.
+func (hm *HostManager) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) {
+	return hm.store.HostsForFunding(ctx)
 }
 
 // HostsForPruning returns a list of hosts with sectors that need pruning

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -90,6 +90,10 @@ func (s *mockStore) UpdateUsabilitySettings(_ context.Context, us UsabilitySetti
 	return nil
 }
 
+func (s *mockStore) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) {
+	return nil, nil
+}
+
 func (s *mockStore) HostsForPruning(ctx context.Context) ([]types.PublicKey, error) {
 	return nil, nil
 }

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -843,8 +843,6 @@ func (s *Store) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) 
 				SELECT 1
 				FROM contracts c
 				WHERE c.host_id = h.id AND c.state IN (0, 1) AND c.good AND c.renewed_to IS NULL
-			)  AND NOT EXISTS (
-				SELECT 1 FROM hosts_blocklist hb WHERE hb.public_key = h.public_key
 			)`)
 		if err != nil {
 			return fmt.Errorf("failed to query hosts for funding: %w", err)

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -866,7 +866,7 @@ func (s *Store) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) 
 }
 
 // HostsForPinning returns a list of host keys that can be used for sector
-// pinning. A host is eligble for pinning if it is not blocked, has unpinned
+// pinning. A host is eligible for pinning if it is not blocked, has unpinned
 // sectors and has an active contract.
 func (s *Store) HostsForPinning(ctx context.Context) ([]types.PublicKey, error) {
 	var hosts []types.PublicKey

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -830,6 +830,41 @@ func (s *Store) HostsForIntegrityChecks(ctx context.Context, maxLastCheck time.T
 	return hosts, nil
 }
 
+// HostsForFunding returns a list of host keys that need accounts funded on
+// them. A host is eligible for funding if it is not blocked and has an active
+// contract.
+func (s *Store) HostsForFunding(ctx context.Context) ([]types.PublicKey, error) {
+	var hosts []types.PublicKey
+	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT h.public_key
+			FROM hosts h
+			WHERE EXISTS (
+				SELECT 1
+				FROM contracts c
+				WHERE c.host_id = h.id AND c.state IN (0, 1) AND c.good AND c.renewed_to IS NULL
+			)  AND NOT EXISTS (
+				SELECT 1 FROM hosts_blocklist hb WHERE hb.public_key = h.public_key
+			)`)
+		if err != nil {
+			return fmt.Errorf("failed to query hosts for funding: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var hk sqlPublicKey
+			if err := rows.Scan(&hk); err != nil {
+				return err
+			}
+			hosts = append(hosts, types.PublicKey(hk))
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	return hosts, nil
+}
+
 // HostsForPinning returns a list of host keys that can be used for sector
 // pinning. A host is eligble for pinning if it is not blocked, has unpinned
 // sectors and has an active contract.

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1734,6 +1734,14 @@ func TestHostsForFunding(t *testing.T) {
 		return hks
 	}
 
+	// updateContractGood updates the 'good' field of the given contract.
+	updateContractGood := func(fcid types.FileContractID, good bool) {
+		t.Helper()
+		if _, err := store.pool.Exec(context.Background(), `UPDATE contracts SET good = $1 WHERE contract_id = $2`, good, sqlHash256(fcid)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// updateContractState updates the state of the given contract.
 	updateContractState := func(fcid types.FileContractID, state contracts.ContractState) {
 		t.Helper()
@@ -1778,9 +1786,17 @@ func TestHostsForFunding(t *testing.T) {
 	assertNumHostsForFunding(1)
 
 	// assert good is taken into account
-	if _, err := store.pool.Exec(context.Background(), `UPDATE contracts SET good = FALSE WHERE contract_id = $1`, sqlHash256(fcid1)); err != nil {
+	updateContractGood(fcid1, false)
+	assertNumHostsForFunding(0)
+	updateContractGood(fcid1, true)
+	assertNumHostsForFunding(1)
+
+	// assert renewed_to is taken into account
+	fcid3 := types.FileContractID{3}
+	if err := store.AddRenewedContract(t.Context(), fcid1, fcid3, newTestRevision(hk1), types.ZeroCurrency, types.ZeroCurrency, proto4.Usage{}); err != nil {
 		t.Fatal(err)
 	}
+	updateContractGood(fcid3, false)
 	assertNumHostsForFunding(0)
 }
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1716,6 +1716,74 @@ func newTestHostSettings(pk types.PublicKey) proto4.HostSettings {
 	}
 }
 
+func TestHostsForFunding(t *testing.T) {
+	// create database
+	log := zaptest.NewLogger(t)
+	store := initPostgres(t, log.Named("postgres"))
+
+	// assertNumHostsForFunding asserts that the number of hosts returned by
+	// HostsForFunding matches the expected number, and returns the host keys.
+	assertNumHostsForFunding := func(expected int) []types.PublicKey {
+		t.Helper()
+		hks, err := store.HostsForFunding(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		} else if len(hks) != expected {
+			t.Fatalf("expected %d hosts, got %d", expected, len(hks))
+		}
+		return hks
+	}
+
+	// updateContractState updates the state of the given contract.
+	updateContractState := func(fcid types.FileContractID, state contracts.ContractState) {
+		t.Helper()
+		if err := store.UpdateChainState(context.Background(), func(tx subscriber.UpdateTx) error {
+			return tx.UpdateContractState(fcid, state)
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// add two hosts
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+
+	// assert no hosts are returned, they don't have active contracts
+	assertNumHostsForFunding(0)
+
+	// add contract for both hosts
+	fcid1 := store.addTestContract(t, hk1, types.FileContractID(hk1))
+	store.addTestContract(t, hk2, types.FileContractID(hk2))
+
+	// assert both hosts are returned now
+	assertNumHostsForFunding(2)
+
+	// block h2
+	if err := store.BlockHosts(context.Background(), []types.PublicKey{hk2}, []string{t.Name()}); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert only h1 is returned
+	hks := assertNumHostsForFunding(1)
+	if hks[0] != hk1 {
+		t.Fatalf("expected host %v, got %v", hk1, hks[0])
+	}
+
+	// assert state is taken into account
+	updateContractState(fcid1, contracts.ContractStateResolved)
+	assertNumHostsForFunding(0)
+
+	// reset
+	updateContractState(fcid1, contracts.ContractStateActive)
+	assertNumHostsForFunding(1)
+
+	// assert good is taken into account
+	if _, err := store.pool.Exec(context.Background(), `UPDATE contracts SET good = FALSE WHERE contract_id = $1`, sqlHash256(fcid1)); err != nil {
+		t.Fatal(err)
+	}
+	assertNumHostsForFunding(0)
+}
+
 func TestHostsForPinning(t *testing.T) {
 	// create database
 	log := zaptest.NewLogger(t)
@@ -2010,6 +2078,66 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatal(err)
 	} else if len(hosts) != 0 {
 		t.Fatalf("expected 0 hosts, got %d", len(hosts))
+	}
+}
+
+// BenchmarkHostsForFunding benchmarks HostsForFunding.
+func BenchmarkHostsForFunding(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	const (
+		nHosts          = 1000
+		nBlocklistHosts = 1000
+	)
+
+	// prepare database
+	if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
+		for range nHosts {
+			hk := types.GeneratePrivateKey().PublicKey()
+
+			// add host
+			var hostID int64
+			if err := tx.QueryRow(ctx, `
+				INSERT INTO hosts (public_key, last_announcement) 
+				VALUES ($1, NOW()) 
+				RETURNING id;`, sqlPublicKey(hk)).Scan(&hostID); err != nil {
+				return err
+			}
+
+			// add contract
+			if frand.Intn(10) < 8 {
+				fcid := insertRandomContract(b, tx, hostID, hk)
+
+				// make some contracts not good
+				if frand.Intn(10) < 2 {
+					_, err := tx.Exec(ctx, `UPDATE contracts SET good = FALSE WHERE contract_id = $1`, sqlHash256(fcid))
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+
+		// populate blocklist since we LEFT JOIN it in HostsForFunding
+		for range nBlocklistHosts {
+			_, err := tx.Exec(ctx, "INSERT INTO hosts_blocklist (public_key) VALUES ($1)", sqlPublicKey(types.GeneratePrivateKey().PublicKey()))
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	for b.Loop() {
+		hosts, err := store.HostsForFunding(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		} else if len(hosts) == 0 {
+			b.Fatal("expected some hosts, got none")
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds `HostsForFunding` - making it more consistent but also avoids fetching full hosts since we'll need to scan the host anyway to get updated prices to calculate the fund target (see [this PR](https://github.com/SiaFoundation/indexd/pull/584/files#r2468791820) for context)

```
BenchmarkHostsForFunding         1660            771416 ns/op  
```