### PR TITLE
Fix TestSharedObjects NDF

### DIFF
--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -689,7 +689,7 @@ func TestSharedObjects(t *testing.T) {
 	encryptionKey := frand.Bytes(32)
 
 	// create a shared URL for the object
-	shareURL, err := client1.CreateSharedObjectURL(ctx, obj.ID(), encryptionKey, time.Now().Add(time.Second))
+	shareURL, err := client1.CreateSharedObjectURL(ctx, obj.ID(), encryptionKey, time.Now().Add(2*time.Second))
 	if err != nil {
 		t.Fatal("failed to create shared object URL:", err)
 	}


### PR DESCRIPTION
Close #586

We sleep for 2 seconds in the test anyways so might as well set the link expiry to 2 seconds ahead.