### PR TITLE
Remove pagination from `/stats/hosts` 

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -73,7 +73,7 @@ type (
 		UsabilitySettings(ctx context.Context) (hosts.UsabilitySettings, error)
 		UpdateUsabilitySettings(ctx context.Context, us hosts.UsabilitySettings) error
 
-		Stats(ctx context.Context, offset, limit int) ([]hosts.HostStats, error)
+		Stats(ctx context.Context) ([]hosts.HostStats, error)
 	}
 
 	// PinManager defines an interface for managing pinned settings.
@@ -105,7 +105,7 @@ type (
 	Store interface {
 		AccountStats(ctx context.Context) (AccountStatsResponse, error)
 		ContractsStats(ctx context.Context) (ContractsStatsResponse, error)
-		HostStats(ctx context.Context, offset, limit int) ([]hosts.HostStats, error)
+		HostStats(ctx context.Context) ([]hosts.HostStats, error)
 		SectorStats(ctx context.Context) (SectorsStatsResponse, error)
 
 		LastScannedIndex(context.Context) (types.ChainIndex, error)
@@ -934,12 +934,7 @@ func (a *admin) handleGETStatsContracts(jc jape.Context) {
 }
 
 func (a *admin) handleGETStatsHosts(jc jape.Context) {
-	offset, limit, ok := api.ParseOffsetLimit(jc)
-	if !ok {
-		return
-	}
-
-	stats, err := a.hosts.Stats(jc.Request.Context(), offset, limit)
+	stats, err := a.hosts.Stats(jc.Request.Context())
 	if jc.Check("failed to retrieve host stats", err) != nil {
 		return
 	}

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -907,28 +907,13 @@ func TestHostsStatsAPI(t *testing.T) {
 	admin := cluster.Indexer.Admin
 	time.Sleep(time.Second)
 
-	res, err := admin.StatsHosts(t.Context(), 0, 10)
+	res, err := admin.StatsHosts(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(res.Hosts) != 2 {
 		t.Fatal("expected 2 hosts", len(res.Hosts))
 	} else if res.Hosts[0].PublicKey == res.Hosts[1].PublicKey {
 		t.Fatal("expected hosts to have different public keys")
-	}
-
-	// assert offset and limit are being applied
-	res, err = admin.StatsHosts(t.Context(), 1, 1)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(res.Hosts) != 1 {
-		t.Fatal("expected 1 host", len(res.Hosts))
-	}
-
-	res, err = admin.StatsHosts(t.Context(), 2, 1)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(res.Hosts) != 0 {
-		t.Fatal("expected 0 hosts", len(res.Hosts))
 	}
 }
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -294,11 +294,8 @@ func (c *Client) StatsContracts(ctx context.Context) (resp ContractsStatsRespons
 }
 
 // StatsHosts returns statistics about the hosts managed by the indexer.
-func (c *Client) StatsHosts(ctx context.Context, offset, limit int) (resp HostStatsResponse, err error) {
-	values := url.Values{}
-	values.Set("offset", fmt.Sprintf("%d", offset))
-	values.Set("limit", fmt.Sprintf("%d", limit))
-	err = c.c.GET(ctx, "/stats/hosts?"+values.Encode(), &resp)
+func (c *Client) StatsHosts(ctx context.Context) (resp HostStatsResponse, err error) {
+	err = c.c.GET(ctx, "/stats/hosts", &resp)
 	return
 }
 

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -96,7 +96,7 @@ type (
 	Store interface {
 		Host(ctx context.Context, hk types.PublicKey) (Host, error)
 		Hosts(ctx context.Context, offset, limit int, queryOpts ...HostQueryOpt) ([]Host, error)
-		HostStats(ctx context.Context, offset, limit int) ([]HostStats, error)
+		HostStats(ctx context.Context) ([]HostStats, error)
 
 		HostsForScanning(ctx context.Context) ([]types.PublicKey, error)
 		HostsForPruning(ctx context.Context) ([]types.PublicKey, error)
@@ -391,8 +391,8 @@ func (m *HostManager) UpdateChainState(tx UpdateTx, applied []chain.ApplyUpdate)
 }
 
 // Stats returns statistics about the hosts in the database.
-func (m *HostManager) Stats(ctx context.Context, offset, limit int) ([]HostStats, error) {
-	return m.store.HostStats(ctx, offset, limit)
+func (m *HostManager) Stats(ctx context.Context) ([]HostStats, error) {
+	return m.store.HostStats(ctx)
 }
 
 // hostsForScanning returns the public keys of the hosts that need to be

--- a/hosts/manager_test.go
+++ b/hosts/manager_test.go
@@ -48,7 +48,7 @@ func (s *mockStore) Hosts(ctx context.Context, offset, limit int, opts ...HostQu
 
 func (s *mockStore) HostsForScanning(ctx context.Context) ([]types.PublicKey, error) { return nil, nil }
 
-func (s *mockStore) HostStats(ctx context.Context, offset, limit int) ([]HostStats, error) {
+func (s *mockStore) HostStats(ctx context.Context) ([]HostStats, error) {
 	return nil, nil
 }
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1453,20 +1453,6 @@ func BenchmarkHosts(b *testing.B) {
 		})
 	}
 
-	for _, limit := range []int{100, 500} {
-		b.Run(fmt.Sprintf("HostStats_%d", limit), func(b *testing.B) {
-			for b.Loop() {
-				offset := frand.Intn(numHosts - limit)
-				stats, err := store.HostStats(context.Background(), offset, limit)
-				if err != nil {
-					b.Fatal(err)
-				} else if len(stats) != limit {
-					b.Fatalf("expected %d host stats, got %d", limit, len(stats)) // sanity check
-				}
-			}
-		})
-	}
-
 	b.Run("UpdateHost", func(b *testing.B) {
 		ts := time.Now()
 		hs := proto4.HostSettings{
@@ -2333,12 +2319,11 @@ func BenchmarkHostStats(b *testing.B) {
 	}
 
 	for b.Loop() {
-		offset := frand.Intn(numHosts - limit)
-		stats, err := store.HostStats(b.Context(), offset, limit)
+		stats, err := store.HostStats(b.Context())
 		if err != nil {
 			b.Fatal(err)
-		} else if len(stats) != limit {
-			b.Fatalf("expected %d host stats, got %d", limit, len(stats))
+		} else if len(stats) == 0 {
+			b.Fatalf("expected host stats, got none")
 		}
 	}
 }

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -76,7 +76,7 @@ func (s *Store) AccountStats(ctx context.Context) (admin.AccountStatsResponse, e
 
 // HostStats reports statistics about used hosts. We consider a host to be used
 // as soon as we spent any funds on it.
-func (s *Store) HostStats(ctx context.Context, offset, limit int) ([]hosts.HostStats, error) {
+func (s *Store) HostStats(ctx context.Context) ([]hosts.HostStats, error) {
 	var stats []hosts.HostStats
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
@@ -96,8 +96,6 @@ func (s *Store) HostStats(ctx context.Context, offset, limit int) ([]hosts.HostS
 				LEFT JOIN hosts_blocklist hb ON hb.public_key = h.public_key
 				WHERE h.usage_total_spent > 0
 				ORDER BY h.usage_total_spent DESC
-				OFFSET $1
-				LIMIT $2
 			)
 			SELECT
 				h.public_key,
@@ -116,8 +114,7 @@ func (s *Store) HostStats(ctx context.Context, offset, limit int) ([]hosts.HostS
 				AND renewed_to IS NULL
 				AND proof_height > (SELECT scanned_height FROM globals)
 			) cs ON TRUE
-			ORDER BY h.usage_total_spent DESC;
-		`, offset, limit)
+			ORDER BY h.usage_total_spent DESC;`)
 		if err != nil {
 			return err
 		}

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -269,7 +269,7 @@ func TestHostStats(t *testing.T) {
 	hk3 := store.addTestHost(t)
 
 	// assert empty stats
-	stats, err := store.HostStats(t.Context(), 0, 10)
+	stats, err := store.HostStats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(stats) != 0 {
@@ -282,7 +282,7 @@ func TestHostStats(t *testing.T) {
 	store.addTestContract(t, hk3, types.FileContractID(hk3))
 
 	// assert empty stats - no usage
-	stats, err = store.HostStats(t.Context(), 0, 10)
+	stats, err = store.HostStats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(stats) != 0 {
@@ -297,8 +297,7 @@ func TestHostStats(t *testing.T) {
 	testRevision := newTestRevision(types.PublicKey{})
 
 	// assert updated stats
-
-	stats, err = store.HostStats(t.Context(), 0, 10)
+	stats, err = store.HostStats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(stats) != 2 {
@@ -321,7 +320,7 @@ func TestHostStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stats, err = store.HostStats(t.Context(), 0, 10)
+	stats, err = store.HostStats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(stats) != 2 {
@@ -341,7 +340,7 @@ func TestHostStats(t *testing.T) {
 	}
 
 	// assert updated stats
-	stats, err = store.HostStats(t.Context(), 0, 10)
+	stats, err = store.HostStats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(stats) != 2 {
@@ -365,7 +364,7 @@ func TestHostStats(t *testing.T) {
 	}
 
 	// assert updated stats
-	stats, err = store.HostStats(t.Context(), 0, 10)
+	stats, err = store.HostStats(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	} else if len(stats) != 2 {
@@ -374,18 +373,5 @@ func TestHostStats(t *testing.T) {
 		t.Fatalf("expected first host to have 0 active contract size, got %d", stats[0].ActiveContractsSize)
 	} else if stats[1].ActiveContractsSize != 0 {
 		t.Fatalf("expected second host to have 0 active contract size, got %d", stats[1].ActiveContractsSize)
-	}
-
-	// assert limit and offset are applied
-	if stats, err := store.HostStats(t.Context(), 1, 1); err != nil {
-		t.Fatal(err)
-	} else if len(stats) != 1 {
-		t.Fatalf("expected 1 host, got %d", len(stats))
-	} else if stats[0].PublicKey != hk1 {
-		t.Fatalf("expected host to be hk1, got %s", stats[0].PublicKey.String())
-	} else if stats, err := store.HostStats(t.Context(), 2, 1); err != nil {
-		t.Fatal(err)
-	} else if len(stats) != 0 {
-		t.Fatalf("expected 0 hosts, got %d", len(stats))
 	}
 }


### PR DESCRIPTION
Stats endpoints should return all values at all times. This is consistent with our other stats endpoints. 
The benchmark is not great but it's not slow either, this is 10k hosts and an M1 so should be good enough.

```
cpu: Apple M1 Max
BenchmarkHostStats-10                 15          70805567 ns/op        13205928 B/op     383090 allocs/op
PASS
```

