### PR TITLE
Add slow host logging

### DIFF
--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -67,7 +67,7 @@ func (dc *downloadCandidates) next() (hosts.Host, bool) {
 // downloadShards downloads at least the minimum number of shards required to
 // recover the slab.
 func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []hosts.Host, pool *connPool, log *zap.Logger) ([][]byte, error) {
-	start := time.Now()
+	dlStart := time.Now()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -82,12 +82,10 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []
 	var wg sync.WaitGroup
 	sema := make(chan struct{}, slab.MinShards)
 
-	var stalledCnt uint8
-	var stalledDur time.Duration
-	const stallThreshold = 15 * time.Second
-
+	var waitDur time.Duration
+	const slowHostsThreshold = 10 * time.Second
 	var slowMu sync.Mutex
-	var slowHosts []types.PublicKey
+	slowHosts := make(map[types.PublicKey]time.Duration)
 
 outer:
 	for {
@@ -96,12 +94,10 @@ outer:
 		case <-ctx.Done():
 		case sema <- struct{}{}:
 		}
+		waitDur += time.Since(waiting)
 
-		if time.Since(waiting) > stallThreshold {
-			stalledCnt++
-			stalledDur += time.Since(waiting)
-		}
 		if ctx.Err() != nil {
+			// context cancelled, either due to timeout or enough shards downloaded
 			break outer
 		}
 
@@ -127,17 +123,16 @@ outer:
 			log := log.With(zap.Stringer("hostKey", host.PublicKey), zap.Stringer("sectorRoot", sector.Root))
 			start := time.Now()
 			usage, data, err := m.downloadShard(ctx, host, sector, pool)
+			elapsed := time.Since(start)
+			if elapsed >= slowHostsThreshold {
+				slowMu.Lock()
+				slowHosts[host.PublicKey] = elapsed
+				slowMu.Unlock()
+			}
 			if err != nil {
-				elapsed := time.Since(start)
-				if elapsed >= m.shardTimeout {
-					slowMu.Lock()
-					slowHosts = append(slowHosts, host.PublicKey)
-					slowMu.Unlock()
-				}
-
 				lost := isErrLostSector(err)
 				log.Debug("failed to download shard",
-					zap.Duration("elapsed", elapsed),
+					zap.Bool("timeout", time.Since(start) > m.shardTimeout),
 					zap.Bool("lost", lost),
 					zap.Error(err),
 				)
@@ -164,11 +159,15 @@ outer:
 	wg.Wait()
 
 	if len(slowHosts) > 0 {
+		var slowHostStrs []string
+		for hk := range slowHosts {
+			slowHostStrs = append(slowHostStrs, fmt.Sprintf("%v|%v", hk, slowHosts[hk]))
+		}
 		m.log.Warn("slow download",
-			zap.Uint8("stallCount", stalledCnt),
-			zap.Duration("stallDuration", stalledDur),
-			zap.Duration("totalDuration", time.Since(start)),
-			zap.Stringers("slowestHosts", slowHosts),
+			zap.Duration("waitDuration", waitDur),
+			zap.Duration("totalDuration", time.Since(dlStart)),
+			zap.Strings("slowHosts", slowHostStrs),
+			zap.Duration("slowHostsThreshold", slowHostsThreshold),
 		)
 	}
 
@@ -181,6 +180,7 @@ outer:
 func (m *SlabManager) downloadShard(ctx context.Context, h hosts.Host, sector Sector, pool *connPool) (proto.Usage, []byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, m.shardTimeout)
 	defer cancel()
+
 	return pool.downloadShard(ctx, h, m.migrationToken(h), sector)
 }
 

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -70,6 +70,7 @@ func (dc *downloadCandidates) next() (hosts.Host, bool) {
 // downloadShards downloads at least the minimum number of shards required to
 // recover the slab.
 func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []hosts.Host, pool *connPool, logger *zap.Logger) ([][]byte, error) {
+	start := time.Now()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -85,15 +86,30 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []
 	sema := make(chan struct{}, slab.MinShards)
 	var downloadErr error
 
+	var stalledCnt uint8
+	var stalledDur time.Duration
+	const stallThreshold = 15 * time.Second
+
+	var slowMu sync.Mutex
+	var slowHosts []types.PublicKey
+
 outer:
 	for {
+		waiting := time.Now()
 		select {
 		case <-ctx.Done():
+		case sema <- struct{}{}:
+		}
+
+		if time.Since(waiting) > stallThreshold {
+			stalledCnt++
+			stalledDur += time.Since(waiting)
+		}
+		if ctx.Err() != nil {
 			if n := downloaded.Load(); uint(n) < slab.MinShards {
 				downloadErr = fmt.Errorf("downloaded %d out of %d shards: %w", downloaded.Load(), slab.MinShards, ctx.Err())
 			}
 			break outer
-		case sema <- struct{}{}:
 		}
 
 		host, ok := candidates.next()
@@ -119,8 +135,15 @@ outer:
 				m.markSectorLost(ctx, host, slab.Sectors[sectorIdx].Root, logger)
 				return
 			} else if err != nil {
+				elapsed := time.Since(start)
+				if elapsed >= m.shardTimeout {
+					slowMu.Lock()
+					slowHosts = append(slowHosts, host.PublicKey)
+					slowMu.Unlock()
+				}
+
 				logger.Debug("failed to download shard",
-					zap.Bool("timeout", time.Since(start) > m.shardTimeout),
+					zap.Duration("elapsed", elapsed),
 					zap.Error(err),
 				)
 				return
@@ -138,6 +161,17 @@ outer:
 	}
 
 	wg.Wait()
+
+	if len(slowHosts) > 0 {
+		m.log.Warn("slow download",
+			zap.Uint8("stallCount", stalledCnt),
+			zap.Duration("stallDuration", stalledDur),
+			zap.Duration("totalDuration", time.Since(start)),
+			zap.Stringers("slowestHosts", slowHosts),
+			zap.Error(downloadErr),
+		)
+	}
+
 	if downloadErr != nil {
 		return nil, downloadErr
 	}
@@ -147,7 +181,6 @@ outer:
 func (m *SlabManager) downloadShard(ctx context.Context, h hosts.Host, sector Sector, pool *connPool) (proto.Usage, []byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, m.shardTimeout)
 	defer cancel()
-
 	return pool.downloadShard(ctx, h, m.migrationToken(h), sector)
 }
 


### PR DESCRIPTION
Our migrations are slow and it looks like it's mainly due to slow downloads. We don't have any exact numbers but it looks like it takes us more than 2 mins on average to download a single slab, so it's actually _very_ slow and it's likely just stalling on a couple of slow hosts. 

We do have some logs and it appears it's the same handful of hosts that are slow each and every time and are clogging up the works. This PR is meant to give us insights into how many times we're "stalled" in a slab download, what portion of the download time we're sitting idle and doing nothing, whether or not it's the same slow hosts that ruin the fun for everybody. Which is kind of interesting because we removed sorting and now randomize download candidates. Also I think data distribution is not even but also not the worst. 

Our download code doesn't have overdrive, if the shard was downloaded successfully we don't release the semaphore. 
```go
defer func() {
    if err != nil {
        <-sema // only release next candidate on failure
    }
    wg.Done()
}()
```