### PR TITLE
Only fund active accounts

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -43,7 +43,7 @@ type (
 	// update them after funding.
 	Store interface {
 		Host(ctx context.Context, hostKey types.PublicKey) (hosts.Host, error)
-		HostAccountsForFunding(ctx context.Context, hk types.PublicKey, limit int) ([]HostAccount, error)
+		HostAccountsForFunding(ctx context.Context, hk types.PublicKey, threshold time.Time, limit int) ([]HostAccount, error)
 		ScheduleAccountsForFunding(ctx context.Context, hostKey types.PublicKey) error
 		UpdateHostAccounts(ctx context.Context, accounts []HostAccount) error
 
@@ -124,7 +124,7 @@ func (m *AccountManager) FundAccounts(ctx context.Context, host hosts.Host, cont
 
 	var exhausted bool
 	for !exhausted {
-		accounts, err := m.store.HostAccountsForFunding(ctx, host.PublicKey, AccountFundBatch)
+		accounts, err := m.store.HostAccountsForFunding(ctx, host.PublicKey, time.Now().Add(-accountActivityThreshold), AccountFundBatch)
 		if err != nil {
 			return fmt.Errorf("failed to fetch accounts for funding: %w", err)
 		} else if len(accounts) < AccountFundBatch {

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -141,8 +141,8 @@ func (s *Store) UpdateAccount(ctx context.Context, oldAK, newAK types.PublicKey)
 	})
 }
 
-// HostAccountsForFunding returns up to limit accounts for the given host key
-// that are due for funding.
+// HostAccountsForFunding returns up to `limit` active (after the `threshold`
+// time) accounts for the given host key that are due for funding.
 func (s *Store) HostAccountsForFunding(ctx context.Context, hk types.PublicKey, threshold time.Time, limit int) ([]accounts.HostAccount, error) {
 	if limit < 0 {
 		return nil, errors.New("limit can not be negative")

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -143,7 +143,7 @@ func (s *Store) UpdateAccount(ctx context.Context, oldAK, newAK types.PublicKey)
 
 // HostAccountsForFunding returns up to limit accounts for the given host key
 // that are due for funding.
-func (s *Store) HostAccountsForFunding(ctx context.Context, hk types.PublicKey, limit int) ([]accounts.HostAccount, error) {
+func (s *Store) HostAccountsForFunding(ctx context.Context, hk types.PublicKey, threshold time.Time, limit int) ([]accounts.HostAccount, error) {
 	if limit < 0 {
 		return nil, errors.New("limit can not be negative")
 	} else if limit == 0 {
@@ -160,7 +160,7 @@ func (s *Store) HostAccountsForFunding(ctx context.Context, hk types.PublicKey, 
 			return err
 		}
 
-		newAccs, err := newHostAccountsForFunding(ctx, tx, hk, hostID, limit)
+		newAccs, err := newHostAccountsForFunding(ctx, tx, hk, hostID, threshold, limit)
 		if err != nil {
 			return fmt.Errorf("failed to query new accounts for funding: %w", err)
 		} else if len(newAccs) >= limit {
@@ -169,7 +169,7 @@ func (s *Store) HostAccountsForFunding(ctx context.Context, hk types.PublicKey, 
 		}
 
 		limit -= len(newAccs)
-		existingAccs, err := existingHostAccountsForFunding(ctx, tx, hk, hostID, limit)
+		existingAccs, err := existingHostAccountsForFunding(ctx, tx, hk, hostID, threshold, limit)
 		if err != nil {
 			return fmt.Errorf("failed to query existing accounts for funding: %w", err)
 		}
@@ -325,15 +325,15 @@ func addAccount(ctx context.Context, tx *txn, account types.PublicKey, serviceAc
 	return nil
 }
 
-func newHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, limit int) ([]accounts.HostAccount, error) {
+func newHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, threshold time.Time, limit int) ([]accounts.HostAccount, error) {
 	accs := make([]accounts.HostAccount, 0, limit)
 
 	rows, err := tx.Query(ctx, `
 SELECT a.public_key
 FROM accounts a
 LEFT JOIN account_hosts ah ON a.id = ah.account_id AND ah.host_id = $1
-WHERE ah.account_id IS NULL
-LIMIT $2;`, hostID, limit)
+WHERE ah.account_id IS NULL AND a.last_used >= $2
+LIMIT $3;`, hostID, threshold, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -353,16 +353,16 @@ LIMIT $2;`, hostID, limit)
 	return accs, nil
 }
 
-func existingHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, limit int) ([]accounts.HostAccount, error) {
+func existingHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey, hostID int64, threshold time.Time, limit int) ([]accounts.HostAccount, error) {
 	accs := make([]accounts.HostAccount, 0, limit)
 
 	rows, err := tx.Query(ctx, `
 SELECT public_key, consecutive_failed_funds, next_fund
 FROM account_hosts ha
 INNER JOIN accounts a ON a.id = ha.account_id
-WHERE ha.host_id = $1 AND ha.next_fund <= NOW()
+WHERE ha.host_id = $1 AND ha.next_fund <= NOW() AND a.last_used >= $2
 ORDER BY next_fund ASC
-LIMIT $2`, hostID, limit)
+LIMIT $3`, hostID, threshold, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -350,7 +350,8 @@ func TestHostAccountsForFunding(t *testing.T) {
 	hk2 := store.addTestHost(t)
 
 	// assert there are no accounts to fund
-	accs, err := store.HostAccountsForFunding(context.Background(), hk1, 10)
+	activeThreshold := time.Now().Add(-time.Hour)
+	accs, err := store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 0 {
@@ -362,7 +363,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	store.addTestAccount(t, ak1)
 
 	// assert there's now one account to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -394,7 +395,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert there are no accounts to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 0 {
@@ -406,7 +407,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	store.addTestAccount(t, ak2)
 
 	// assert h1 has one account to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -418,7 +419,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert h2 has two accounts to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk2, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk2, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 2 {
@@ -428,7 +429,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert limit is applied
-	accs, err = store.HostAccountsForFunding(context.Background(), hk2, 1)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk2, activeThreshold, 1)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -447,7 +448,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert both accounts are returned
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 2 {
@@ -466,7 +467,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// only ak1 should be returned
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -485,7 +486,8 @@ func TestUpdateHostAccounts(t *testing.T) {
 	store.addTestAccount(t, ak)
 
 	// fetch accounts for funding
-	accounts, err := store.HostAccountsForFunding(context.Background(), hk, 10)
+	activeThreshold := time.Now().Add(-time.Hour)
+	accounts, err := store.HostAccountsForFunding(context.Background(), hk, activeThreshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accounts) != 1 {
@@ -559,6 +561,7 @@ func BenchmarkHostAccountsForFunding(b *testing.B) {
 	}
 
 	// run benchmark for different number of accounts
+	threshold := time.Now().Add(-time.Hour)
 	for _, numAccounts := range []int{10_000, 100_000, 1_000_000} {
 		// prepare accounts
 		prune("accounts")
@@ -578,7 +581,7 @@ func BenchmarkHostAccountsForFunding(b *testing.B) {
 		for _, hk := range hosts {
 			var accs []accounts.HostAccount
 			if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) (err error) {
-				accs, err = newHostAccountsForFunding(context.Background(), tx, hk, hostIDs[hk], batchSize)
+				accs, err = newHostAccountsForFunding(context.Background(), tx, hk, hostIDs[hk], threshold, batchSize)
 				return
 			}); err != nil {
 				b.Fatal(err)
@@ -599,14 +602,14 @@ func BenchmarkHostAccountsForFunding(b *testing.B) {
 
 				if err := store.transaction(context.Background(), func(ctx context.Context, tx *txn) error {
 					// fetch accounts without account_host entry
-					if accounts, err := newHostAccountsForFunding(context.Background(), tx, hk, hostID, batchSize); err != nil {
+					if accounts, err := newHostAccountsForFunding(context.Background(), tx, hk, hostID, threshold, batchSize); err != nil {
 						return err
 					} else if len(accounts) != batchSize {
 						return fmt.Errorf("expected %d new accounts, got %d", batchSize, len(accounts))
 					}
 
 					// fetch accounts with account_host entry
-					if accounts, err := existingHostAccountsForFunding(context.Background(), tx, hk, hostID, batchSize); err != nil {
+					if accounts, err := existingHostAccountsForFunding(context.Background(), tx, hk, hostID, threshold, batchSize); err != nil {
 						return err
 					} else if len(accounts) != batchSize {
 						return fmt.Errorf("expected %d new accounts, got %d", batchSize, len(accounts))
@@ -648,10 +651,11 @@ func BenchmarkUpdateHostAccounts(b *testing.B) {
 		}
 	}
 
+	threshold := time.Now().Add(-time.Hour)
 	b.ResetTimer()
 	for i := range b.N {
 		b.StopTimer()
-		accounts, err := store.HostAccountsForFunding(context.Background(), hosts[i%numHosts], batchSize)
+		accounts, err := store.HostAccountsForFunding(context.Background(), hosts[i%numHosts], threshold, batchSize)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -447,6 +447,14 @@ func TestHostAccountsForFunding(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// if we raise threshold neither account should be returned
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold.Add(2*time.Hour), 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(accs) != 0 {
+		t.Fatal("expected zero accounts")
+	}
+
 	// assert both accounts are returned
 	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
 	if err != nil {

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -350,8 +350,8 @@ func TestHostAccountsForFunding(t *testing.T) {
 	hk2 := store.addTestHost(t)
 
 	// assert there are no accounts to fund
-	activeThreshold := time.Now().Add(-time.Hour)
-	accs, err := store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
+	threshold := time.Now().Add(-time.Hour)
+	accs, err := store.HostAccountsForFunding(context.Background(), hk1, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 0 {
@@ -363,7 +363,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	store.addTestAccount(t, ak1)
 
 	// assert there's now one account to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -395,7 +395,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert there are no accounts to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 0 {
@@ -407,7 +407,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	store.addTestAccount(t, ak2)
 
 	// assert h1 has one account to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -419,7 +419,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert h2 has two accounts to fund
-	accs, err = store.HostAccountsForFunding(context.Background(), hk2, activeThreshold, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk2, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 2 {
@@ -429,7 +429,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert limit is applied
-	accs, err = store.HostAccountsForFunding(context.Background(), hk2, activeThreshold, 1)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk2, threshold, 1)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -448,7 +448,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// if we raise threshold neither account should be returned
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold.Add(2*time.Hour), 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, threshold.Add(2*time.Hour), 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 0 {
@@ -456,7 +456,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// assert both accounts are returned
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 2 {
@@ -475,7 +475,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 	}
 
 	// only ak1 should be returned
-	accs, err = store.HostAccountsForFunding(context.Background(), hk1, activeThreshold, 10)
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accs) != 1 {
@@ -494,8 +494,8 @@ func TestUpdateHostAccounts(t *testing.T) {
 	store.addTestAccount(t, ak)
 
 	// fetch accounts for funding
-	activeThreshold := time.Now().Add(-time.Hour)
-	accounts, err := store.HostAccountsForFunding(context.Background(), hk, activeThreshold, 10)
+	threshold := time.Now().Add(-time.Hour)
+	accounts, err := store.HostAccountsForFunding(context.Background(), hk, threshold, 10)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accounts) != 1 {


### PR DESCRIPTION
Close #601

With changes:
```
goos: linux
goarch: amd64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkHostAccountsForFunding/10000_accounts-4                  90      14735955 ns/op
BenchmarkHostAccountsForFunding/100000_accounts-4                 22      57609661 ns/op
BenchmarkHostAccountsForFunding/1000000_accounts-4               100      10689208 ns/op
PASS
ok      go.sia.tech/indexd/persist/postgres 430.014s
```

`master`:
```
goos: linux
goarch: amd64
pkg: go.sia.tech/indexd/persist/postgres
cpu: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
BenchmarkHostAccountsForFunding/10000_accounts-4                 147       8004118 ns/op
BenchmarkHostAccountsForFunding/100000_accounts-4                 25      44758543 ns/op
BenchmarkHostAccountsForFunding/1000000_accounts-4                46      25817512 ns/op
PASS
ok      go.sia.tech/indexd/persist/postgres 368.942s
```