### PR TITLE
Fix migration logic

### DIFF
--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -197,17 +197,15 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 	// - the sector is stored on a bad contract
 	var toMigrate []int
 	for i, sector := range slab.Sectors {
-		if sector.HostKey != nil {
-			host, ok := hostsMap[*sector.HostKey]
-			if !ok {
-				// sector is on a bad host
-				toMigrate = append(toMigrate, i)
-				continue
-			}
-
-			set.Add(host.Info())
-		} else {
+		if sector.HostKey == nil {
 			// sector is lost
+			toMigrate = append(toMigrate, i)
+			continue
+		}
+
+		host, ok := hostsMap[*sector.HostKey]
+		if !ok {
+			// sector is on a bad host
 			toMigrate = append(toMigrate, i)
 			continue
 		}
@@ -220,6 +218,11 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 			}
 			delete(goodContractMap, *sector.ContractID)
 		}
+
+		// sector will not be migrated. Remove it from the hosts map
+		// and add it to the spaced set.
+		delete(hostsMap, *sector.HostKey)
+		set.Add(host.Info())
 	}
 
 	// return all hosts with contracts that are good, currently not in use and

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -192,24 +192,33 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 
 	// determine whether the sector needs to be migrated. That's the case if
 	// one of the following is true:
-	// - the sector was marked lost (contract ID and host key are nil)
+	// - the sector is stored on a bad host
+	// - the sector is lost (host key is nil)
 	// - the sector is stored on a bad contract
 	var toMigrate []int
 	for i, sector := range slab.Sectors {
-		isLost := sector.ContractID == nil && sector.HostKey == nil
-		goodContract := sector.ContractID != nil && goodContractMap[*sector.ContractID] != contracts.Contract{}
-		if isLost || !goodContract {
+		if sector.HostKey != nil {
+			host, ok := hostsMap[*sector.HostKey]
+			if !ok {
+				// sector is on a bad host
+				toMigrate = append(toMigrate, i)
+				continue
+			}
+
+			set.Add(host.Info())
+		} else {
+			// sector is lost
 			toMigrate = append(toMigrate, i)
 			continue
 		}
 
-		// remove contract from the map since we don't want to use it again
-		delete(goodContractMap, *sector.ContractID)
-
-		// add the host to the spaced set to ensure we don't use hosts that are
-		// too close to existing hosts
-		if host, ok := hostsMap[*sector.HostKey]; ok {
-			set.Add(host.Info())
+		if sector.ContractID != nil {
+			if _, ok := goodContractMap[*sector.ContractID]; !ok {
+				// sector is on a bad contract
+				toMigrate = append(toMigrate, i)
+				continue
+			}
+			delete(goodContractMap, *sector.ContractID)
 		}
 	}
 

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -185,10 +185,12 @@ func TestMigrateSlab(t *testing.T) {
 }
 
 func TestSectorsToMigrate(t *testing.T) {
-	newHost := func(i byte, usable, blocked bool) hosts.Host {
+	hostIndex := byte(0)
+	newHost := func(usable, blocked bool) hosts.Host {
+		hostIndex++
 		h := hosts.Host{
 			Blocked:   blocked,
-			PublicKey: types.PublicKey{i},
+			PublicKey: types.PublicKey{hostIndex},
 			Settings:  goodSettings,
 			Latitude:  frand.Float64()*180 - 90,
 			Longitude: frand.Float64()*360 - 180,
@@ -199,9 +201,11 @@ func TestSectorsToMigrate(t *testing.T) {
 		return h
 	}
 
-	newContract := func(i byte, hk types.PublicKey, goodForUpload bool) contracts.Contract {
+	contractIndex := byte(0)
+	newContract := func(hk types.PublicKey, goodForUpload bool) contracts.Contract {
+		contractIndex++
 		c := contracts.Contract{
-			ID:                 types.FileContractID{i},
+			ID:                 types.FileContractID{contractIndex},
 			HostKey:            hk,
 			Good:               goodForUpload,
 			RemainingAllowance: types.MaxCurrency,
@@ -209,23 +213,26 @@ func TestSectorsToMigrate(t *testing.T) {
 		}
 		if isGood := c.GoodForUpload(goodSettings.Prices, goodSettings.MaxCollateral, 100); isGood != goodForUpload {
 			// sanity check
-			t.Fatalf("contract %d: expected goodForUpload %v, got %v", i, goodForUpload, isGood)
+			t.Fatalf("contract %d: expected goodForUpload %v, got %v", contractIndex, goodForUpload, isGood)
 		}
 		return c
 	}
 
 	// good host with good contract
-	goodHost := newHost(1, true, false)
-	goodContract := newContract(1, goodHost.PublicKey, true)
+	goodHost := newHost(true, false)
+	goodContract := newContract(goodHost.PublicKey, true)
+
+	// good host with no contract
+	goodHostNoContract := newHost(true, false)
 
 	// good host with bad contract
-	badContract := newContract(2, goodHost.PublicKey, false)
+	badContract := newContract(goodHost.PublicKey, false)
 
 	// good host with identical location as the good host
-	sameLocationHost := newHost(2, true, false)
+	sameLocationHost := newHost(true, false)
 	sameLocationHost.Latitude = goodHost.Latitude
 	sameLocationHost.Longitude = goodHost.Longitude
-	sameLocationContract := newContract(3, sameLocationHost.PublicKey, true)
+	sameLocationContract := newContract(sameLocationHost.PublicKey, true)
 
 	// prepare a slab that has one good sector and multiple bad sectors for
 	// various reasons
@@ -258,13 +265,13 @@ func TestSectorsToMigrate(t *testing.T) {
 			// unpinned sector -> don't migrate (pinning loop will take care of it)
 			{
 				Root:    types.Hash256{5},
-				HostKey: &goodContract.HostKey,
+				HostKey: &goodHostNoContract.PublicKey,
 			},
 		},
 	}
 
 	// helper to assert result of contractsForRepair
-	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots, expectedHosts []int) {
+	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots []int, expectedHosts []hosts.Host) {
 		t.Helper()
 		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 100, 10)
 		if len(toRepair) != len(expectedRoots) {
@@ -279,7 +286,7 @@ func TestSectorsToMigrate(t *testing.T) {
 		}
 		expectedHostsMap := make(map[types.PublicKey]struct{})
 		for i := range expectedHosts {
-			expectedHostsMap[types.PublicKey{byte(expectedHosts[i])}] = struct{}{}
+			expectedHostsMap[expectedHosts[i].PublicKey] = struct{}{}
 		}
 		for i := range toUse {
 			if _, ok := expectedHostsMap[toUse[i].PublicKey]; !ok {
@@ -290,42 +297,42 @@ func TestSectorsToMigrate(t *testing.T) {
 
 	// with no contracts or hosts, all sectors require migration but no
 	// contracts are available
-	assertResult(nil, nil, []int{0, 1, 2, 3, 4}, []int{})
+	assertResult(nil, nil, []int{0, 1, 2, 3, 4}, nil)
 
 	// calling contractsForRepair with just the hosts and contracts the slab is stored on should
 	// return the missing sectors and no contracts
-	allHosts := []hosts.Host{goodHost, sameLocationHost}
+	allHosts := []hosts.Host{goodHost, goodHostNoContract, sameLocationHost}
 	allContracts := []contracts.Contract{goodContract, badContract, sameLocationContract}
-	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
+	assertResult(allHosts, allContracts, []int{1, 2}, nil)
 
 	// prepare a bunch of hosts and contracts which can't be used for repairs
-	badHost2 := newHost(3, false, false)
-	cBadHost2 := newContract(4, badHost2.PublicKey, true)
+	badHost2 := newHost(false, false)
+	cBadHost2 := newContract(badHost2.PublicKey, true)
 
-	blockedHost := newHost(4, true, true)
-	cBlockedHost := newContract(5, blockedHost.PublicKey, true)
+	blockedHost := newHost(true, true)
+	cBlockedHost := newContract(blockedHost.PublicKey, true)
 
-	sameLocationHost2 := newHost(5, true, false)
+	sameLocationHost2 := newHost(true, false)
 	sameLocationHost2.Latitude = goodHost.Latitude
 	sameLocationHost2.Longitude = goodHost.Longitude
-	cSameLocationHost2 := newContract(6, sameLocationHost2.PublicKey, true)
+	cSameLocationHost2 := newContract(sameLocationHost2.PublicKey, true)
 
 	// add the bad hosts+contracts and try again - expect same result
 	allHosts = append(allHosts, badHost2, blockedHost, sameLocationHost2)
 	allContracts = append(allContracts, cBadHost2, cBlockedHost, cSameLocationHost2)
-	assertResult(allHosts, allContracts, []int{1, 2}, []int{})
+	assertResult(allHosts, allContracts, []int{1, 2}, nil)
 
 	// prepare 2 good hosts
-	goodHost2 := newHost(6, true, false)
-	cGoodHost2 := newContract(7, goodHost2.PublicKey, true)
+	goodHost2 := newHost(true, false)
+	cGoodHost2 := newContract(goodHost2.PublicKey, true)
 
-	goodHost3 := newHost(7, true, false)
-	cGoodHost3 := newContract(8, goodHost3.PublicKey, true)
+	goodHost3 := newHost(true, false)
+	cGoodHost3 := newContract(goodHost3.PublicKey, true)
 
 	// should use them
 	allHosts = append(allHosts, goodHost2, goodHost3)
 	allContracts = append(allContracts, cGoodHost2, cGoodHost3)
-	assertResult(allHosts, allContracts, []int{1, 2}, []int{6, 7})
+	assertResult(allHosts, allContracts, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
 }
 
 func newTestContract(hk types.PublicKey) contracts.Contract {

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -255,6 +255,11 @@ func TestSectorsToMigrate(t *testing.T) {
 				ContractID: &sameLocationContract.ID,
 				HostKey:    &sameLocationContract.HostKey,
 			},
+			// unpinned sector -> don't migrate (pinning loop will take care of it)
+			{
+				Root:    types.Hash256{5},
+				HostKey: &goodContract.HostKey,
+			},
 		},
 	}
 
@@ -285,7 +290,7 @@ func TestSectorsToMigrate(t *testing.T) {
 
 	// with no contracts or hosts, all sectors require migration but no
 	// contracts are available
-	assertResult(nil, nil, []int{0, 1, 2, 3}, []int{})
+	assertResult(nil, nil, []int{0, 1, 2, 3, 4}, []int{})
 
 	// calling contractsForRepair with just the hosts and contracts the slab is stored on should
 	// return the missing sectors and no contracts


### PR DESCRIPTION
The current `toMigrate` logic will cause migration on sectors that are unpinned, but otherwise healthy. `goodContract = false` whenever contract id is unset. This doesn't necessarily mean the sector needs migrated, it might just need pinned.