### PR TITLE
Ignore `bad` contracts when forming contracts

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -96,7 +96,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, period 
 	var activeContracts []Contract
 	const batchSize = 50
 	for offset := 0; ; offset += batchSize {
-		batch, err := cm.store.Contracts(ctx, offset, batchSize, WithRevisable(true))
+		batch, err := cm.store.Contracts(ctx, offset, batchSize, WithGood(true), WithRevisable(true))
 		if err != nil {
 			return fmt.Errorf("failed to fetch active contracts: %w", err)
 		}


### PR DESCRIPTION
🧪  is very tricky since it's an option we forgot to pass, the host does get properly ignored the only side-effect here is that it messes up the logging, giving the impression we're re-evaluating blocked hosts to form contracts with. 

https://github.com/SiaFoundation/indexd/issues/598 

PS I already opened [an issue](https://github.com/SiaFoundation/indexd/issues/612) to discuss the matter, but this ties in with `HostsWithUnpinnableSectors`, which could potentially return a blocked host and cause us to forcefully form a contract with it. We should prioritise fixing that asap.