### PR TITLE
Add a reference to the accounts table linking them to the `app_connect_keys` and return the key as part of the account API response

### DIFF
--- a/accounts/account.go
+++ b/accounts/account.go
@@ -66,7 +66,7 @@ type (
 	// Account represents an account in the indexer.
 	Account struct {
 		AccountKey     proto.Account `json:"accountKey"`
-		ConnectKey     *string       `json:"connectKey"`
+		ConnectKey     *string       `json:"connectKey,omitempty"`
 		ServiceAccount bool          `json:"serviceAccount"`
 		MaxPinnedData  uint64        `json:"maxPinnedData"`
 		PinnedData     uint64        `json:"pinnedData"`

--- a/accounts/account.go
+++ b/accounts/account.go
@@ -66,6 +66,7 @@ type (
 	// Account represents an account in the indexer.
 	Account struct {
 		AccountKey     proto.Account `json:"accountKey"`
+		ConnectKey     *string       `json:"connectKey"`
 		ServiceAccount bool          `json:"serviceAccount"`
 		MaxPinnedData  uint64        `json:"maxPinnedData"`
 		PinnedData     uint64        `json:"pinnedData"`

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -15,6 +15,9 @@ var (
 	ErrKeyExhausted = errors.New("key has no remaining uses")
 	// ErrKeyNotFound is returned when an app connect key is not found.
 	ErrKeyNotFound = errors.New("key not found")
+	// ErrKeyInUse is returned when deleting an app connect key with accounts
+	// associated to it.
+	ErrKeyInUse = errors.New("key in use")
 )
 
 type (

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -418,6 +418,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/PublicKey"
             - description: Public key of the account
+        connectKey:
+          type: string
+          description: The connect key associated with the account. Omitted for service accounts.
         serviceAccount:
           type: boolean
           description: Whether it is a service account or not.

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -34,8 +34,10 @@ func (s *Store) Accounts(ctx context.Context, offset, limit int, opts ...account
 
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		rows, err := tx.Query(ctx, `
-			SELECT public_key, connect_key, service_account, max_pinned_data, pinned_data, description, logo_url, service_url, last_used
-			FROM accounts
+			SELECT a.public_key, ak.app_key, a.service_account, a.max_pinned_data, a.pinned_data, a.description, a.logo_url, a.service_url, a.last_used
+			FROM accounts a
+			LEFT JOIN app_connect_keys ak
+			ON ak.id = a.connect_key_id
 			WHERE ($1::boolean IS NULL OR service_account = $1::boolean)
 			LIMIT $2 OFFSET $3
 		`, queryOpts.ServiceAccount, limit, offset)
@@ -64,7 +66,11 @@ func (s *Store) Account(ctx context.Context, ak types.PublicKey) (accounts.Accou
 	var account accounts.Account
 	account.AccountKey = proto.Account(ak) // no need to fetch key
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
-		account, err = scanAccount(tx.QueryRow(ctx, `SELECT public_key, connect_key, service_account, max_pinned_data, pinned_data, description, logo_url, service_url, last_used FROM accounts WHERE public_key = $1`, sqlPublicKey(ak)))
+		account, err = scanAccount(tx.QueryRow(ctx, `SELECT a.public_key, ak.app_key, a.service_account, a.max_pinned_data, a.pinned_data, a.description, a.logo_url, a.service_url, a.last_used
+FROM accounts a
+LEFT JOIN app_connect_keys ak
+ON ak.id = a.connect_key_id
+WHERE public_key = $1`, sqlPublicKey(ak)))
 		return err
 	})
 	return account, err
@@ -313,7 +319,15 @@ func addAccount(ctx context.Context, tx *txn, connectKey *string, account types.
 	for _, opt := range opts {
 		opt(&aao)
 	}
-	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key, connect_key, service_account, max_pinned_data, description, logo_url, service_url) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT DO NOTHING`, sqlPublicKey(account), connectKey, serviceAccount, aao.MaxPinnedData, meta.Description, meta.LogoURL, meta.ServiceURL)
+
+	var connectKeyID sql.NullInt64
+	if connectKey != nil {
+		if err := tx.QueryRow(ctx, `SELECT id FROM app_connect_keys WHERE app_key = $1`, connectKey).Scan(&connectKeyID); err != nil {
+			return fmt.Errorf("failed to get app connect key ID: %w", err)
+		}
+	}
+
+	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key, connect_key_id, service_account, max_pinned_data, description, logo_url, service_url) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT DO NOTHING`, sqlPublicKey(account), connectKeyID, serviceAccount, aao.MaxPinnedData, meta.Description, meta.LogoURL, meta.ServiceURL)
 	if err != nil {
 		return fmt.Errorf("failed to add account: %w", err)
 	} else if res.RowsAffected() == 0 {

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -397,6 +397,10 @@ LIMIT $2`, hostID, limit)
 }
 
 func scanAccount(s scanner) (account accounts.Account, err error) {
-	err = s.Scan((*sqlPublicKey)(&account.AccountKey), &account.ConnectKey, &account.ServiceAccount, &account.MaxPinnedData, &account.PinnedData, &account.Description, &account.LogoURL, &account.ServiceURL, &account.LastUsed)
+	var connectKey sql.NullString
+	err = s.Scan((*sqlPublicKey)(&account.AccountKey), &connectKey, &account.ServiceAccount, &account.MaxPinnedData, &account.PinnedData, &account.Description, &account.LogoURL, &account.ServiceURL, &account.LastUsed)
+	if connectKey.Valid {
+		account.ConnectKey = &connectKey.String
+	}
 	return
 }

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -34,7 +34,7 @@ func (s *Store) Accounts(ctx context.Context, offset, limit int, opts ...account
 
 	if err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		rows, err := tx.Query(ctx, `
-			SELECT public_key, service_account, max_pinned_data, pinned_data, description, logo_url, service_url, last_used
+			SELECT public_key, connect_key, service_account, max_pinned_data, pinned_data, description, logo_url, service_url, last_used
 			FROM accounts
 			WHERE ($1::boolean IS NULL OR service_account = $1::boolean)
 			LIMIT $2 OFFSET $3
@@ -64,7 +64,7 @@ func (s *Store) Account(ctx context.Context, ak types.PublicKey) (accounts.Accou
 	var account accounts.Account
 	account.AccountKey = proto.Account(ak) // no need to fetch key
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
-		account, err = scanAccount(tx.QueryRow(ctx, `SELECT public_key, service_account, max_pinned_data, pinned_data, description, logo_url, service_url, last_used FROM accounts WHERE public_key = $1`, sqlPublicKey(ak)))
+		account, err = scanAccount(tx.QueryRow(ctx, `SELECT public_key, connect_key, service_account, max_pinned_data, pinned_data, description, logo_url, service_url, last_used FROM accounts WHERE public_key = $1`, sqlPublicKey(ak)))
 		return err
 	})
 	return account, err
@@ -74,7 +74,7 @@ func (s *Store) Account(ctx context.Context, ak types.PublicKey) (accounts.Accou
 // account key.
 func (s *Store) AddServiceAccount(ctx context.Context, ak types.PublicKey, meta accounts.AccountMeta, opts ...accounts.AddAccountOption) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
-		return addAccount(ctx, tx, ak, true, meta, opts...)
+		return addAccount(ctx, tx, nil, ak, true, meta, opts...)
 	})
 }
 
@@ -306,14 +306,14 @@ func (s *Store) ServiceAccountBalance(ctx context.Context, hostKey types.PublicK
 	return balance, err
 }
 
-func addAccount(ctx context.Context, tx *txn, account types.PublicKey, serviceAccount bool, meta accounts.AccountMeta, opts ...accounts.AddAccountOption) error {
+func addAccount(ctx context.Context, tx *txn, connectKey *string, account types.PublicKey, serviceAccount bool, meta accounts.AccountMeta, opts ...accounts.AddAccountOption) error {
 	aao := accounts.AddAccountOptions{
 		MaxPinnedData: math.MaxInt64, // no limit by default
 	}
 	for _, opt := range opts {
 		opt(&aao)
 	}
-	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key, service_account, max_pinned_data, description, logo_url, service_url) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING`, sqlPublicKey(account), serviceAccount, aao.MaxPinnedData, meta.Description, meta.LogoURL, meta.ServiceURL)
+	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key, connect_key, service_account, max_pinned_data, description, logo_url, service_url) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT DO NOTHING`, sqlPublicKey(account), connectKey, serviceAccount, aao.MaxPinnedData, meta.Description, meta.LogoURL, meta.ServiceURL)
 	if err != nil {
 		return fmt.Errorf("failed to add account: %w", err)
 	} else if res.RowsAffected() == 0 {
@@ -383,6 +383,6 @@ LIMIT $2`, hostID, limit)
 }
 
 func scanAccount(s scanner) (account accounts.Account, err error) {
-	err = s.Scan((*sqlPublicKey)(&account.AccountKey), &account.ServiceAccount, &account.MaxPinnedData, &account.PinnedData, &account.Description, &account.LogoURL, &account.ServiceURL, &account.LastUsed)
+	err = s.Scan((*sqlPublicKey)(&account.AccountKey), &account.ConnectKey, &account.ServiceAccount, &account.MaxPinnedData, &account.PinnedData, &account.Description, &account.LogoURL, &account.ServiceURL, &account.LastUsed)
 	return
 }

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -36,8 +36,7 @@ func (s *Store) Accounts(ctx context.Context, offset, limit int, opts ...account
 		rows, err := tx.Query(ctx, `
 			SELECT a.public_key, ak.app_key, a.service_account, a.max_pinned_data, a.pinned_data, a.description, a.logo_url, a.service_url, a.last_used
 			FROM accounts a
-			LEFT JOIN app_connect_keys ak
-			ON ak.id = a.connect_key_id
+			LEFT JOIN app_connect_keys ak ON ak.id = a.connect_key_id
 			WHERE ($1::boolean IS NULL OR service_account = $1::boolean)
 			LIMIT $2 OFFSET $3
 		`, queryOpts.ServiceAccount, limit, offset)
@@ -68,8 +67,7 @@ func (s *Store) Account(ctx context.Context, ak types.PublicKey) (accounts.Accou
 	err := s.transaction(ctx, func(ctx context.Context, tx *txn) (err error) {
 		account, err = scanAccount(tx.QueryRow(ctx, `SELECT a.public_key, ak.app_key, a.service_account, a.max_pinned_data, a.pinned_data, a.description, a.logo_url, a.service_url, a.last_used
 FROM accounts a
-LEFT JOIN app_connect_keys ak
-ON ak.id = a.connect_key_id
+LEFT JOIN app_connect_keys ak ON ak.id = a.connect_key_id
 WHERE public_key = $1`, sqlPublicKey(ak)))
 		return err
 	})
@@ -322,7 +320,9 @@ func addAccount(ctx context.Context, tx *txn, connectKey *string, account types.
 
 	var connectKeyID sql.NullInt64
 	if connectKey != nil {
-		if err := tx.QueryRow(ctx, `SELECT id FROM app_connect_keys WHERE app_key = $1`, connectKey).Scan(&connectKeyID); err != nil {
+		if err := tx.QueryRow(ctx, `SELECT id FROM app_connect_keys WHERE app_key = $1`, connectKey).Scan(&connectKeyID); errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyNotFound
+		} else if err != nil {
 			return fmt.Errorf("failed to get app connect key ID: %w", err)
 		}
 	}

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -22,7 +22,7 @@ import (
 
 func (s *Store) addTestAccount(t testing.TB, ak types.PublicKey, opts ...accounts.AddAccountOption) {
 	err := s.transaction(t.Context(), func(ctx context.Context, tx *txn) error {
-		if err := addAccount(ctx, tx, ak, false, accounts.AccountMeta{}, opts...); err != nil {
+		if err := addAccount(ctx, tx, nil, ak, false, accounts.AccountMeta{}, opts...); err != nil {
 			return fmt.Errorf("failed to add account: %w", err)
 		}
 		return nil
@@ -162,7 +162,7 @@ func TestAddAccount(t *testing.T) {
 	t.Run("user account", func(t *testing.T) {
 		test(t, func(pk types.PublicKey, meta accounts.AccountMeta, opts ...accounts.AddAccountOption) (bool, error) {
 			err := store.transaction(t.Context(), func(ctx context.Context, tx *txn) error {
-				if err := addAccount(ctx, tx, pk, false, meta, opts...); err != nil {
+				if err := addAccount(ctx, tx, nil, pk, false, meta, opts...); err != nil {
 					return fmt.Errorf("failed to add account: %w", err)
 				}
 				return nil

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -124,7 +124,9 @@ func (s *Store) AppConnectKeys(ctx context.Context, offset, limit int) (keys []a
 func (s *Store) DeleteAppConnectKey(ctx context.Context, connectKey string) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		var count int64
-		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE connect_key = $1`, connectKey).Scan(&count); err != nil {
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE connect_key_id = (SELECT id FROM app_connect_keys WHERE app_key = $1)`, connectKey).Scan(&count); errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyNotFound
+		} else if err != nil {
 			return fmt.Errorf("failed to check if connect key in use: %w", err)
 		} else if count != 0 {
 			return accounts.ErrKeyInUse

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -123,6 +123,13 @@ func (s *Store) AppConnectKeys(ctx context.Context, offset, limit int) (keys []a
 // DeleteAppConnectKey deletes an application connection key from the database.
 func (s *Store) DeleteAppConnectKey(ctx context.Context, connectKey string) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
+		var count int64
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE connect_key = $1`, connectKey).Scan(&count); err != nil {
+			return fmt.Errorf("failed to check if connect key in use: %w", err)
+		} else if count != 0 {
+			return accounts.ErrKeyInUse
+		}
+
 		_, err := tx.Exec(ctx, `
 			DELETE FROM app_connect_keys WHERE app_key = $1
 		`, connectKey)
@@ -149,7 +156,7 @@ func (s *Store) UseAppConnectKey(ctx context.Context, connectKey string, appKey 
 			return accounts.ErrKeyExhausted
 		}
 
-		if err := addAccount(ctx, tx, appKey, false, accounts.AccountMeta{
+		if err := addAccount(ctx, tx, &connectKey, appKey, false, accounts.AccountMeta{
 			Description: meta.Description,
 			LogoURL:     meta.LogoURL,
 			ServiceURL:  meta.ServiceURL,

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -124,9 +124,7 @@ func (s *Store) AppConnectKeys(ctx context.Context, offset, limit int) (keys []a
 func (s *Store) DeleteAppConnectKey(ctx context.Context, connectKey string) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		var count int64
-		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE connect_key_id = (SELECT id FROM app_connect_keys WHERE app_key = $1)`, connectKey).Scan(&count); errors.Is(err, sql.ErrNoRows) {
-			return accounts.ErrKeyNotFound
-		} else if err != nil {
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM accounts WHERE connect_key_id = (SELECT id FROM app_connect_keys WHERE app_key = $1)`, connectKey).Scan(&count); err != nil {
 			return fmt.Errorf("failed to check if connect key in use: %w", err)
 		} else if count != 0 {
 			return accounts.ErrKeyInUse

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -19,18 +19,19 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
 
+	const connectKey = "foobar"
 	if key, err := store.AddAppConnectKey(ctx, accounts.UpdateAppConnectKey{
-		Key:           "foobar",
+		Key:           connectKey,
 		Description:   "test key",
 		MaxPinnedData: 10,
 		RemainingUses: 1,
 	}); err != nil {
 		t.Fatal("failed to add app connect key:", err)
-	} else if key.Key != "foobar" || key.Description != "test key" || key.RemainingUses != 1 {
+	} else if key.Key != connectKey || key.Description != "test key" || key.RemainingUses != 1 {
 		t.Fatalf("unexpected app connect key: %+v", key)
 	}
 
-	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+	if ok, err := store.ValidAppConnectKey(ctx, connectKey); err != nil {
 		t.Fatal("failed to validate app connect key:", err)
 	} else if !ok {
 		t.Fatal("expected app connect key to be valid")
@@ -51,6 +52,8 @@ func TestAppConnectKeys(t *testing.T) {
 			t.Fatalf("expected logo to be %q, got %q", logo, account.LogoURL)
 		} else if account.ServiceURL != service {
 			t.Fatalf("expected service url to be %q, got %q", service, account.ServiceURL)
+		} else if *account.ConnectKey != connectKey {
+			t.Fatalf("expected connect key to be %q, got %q", connectKey, *account.ConnectKey)
 		}
 	}
 
@@ -60,7 +63,7 @@ func TestAppConnectKeys(t *testing.T) {
 		LogoURL:     "logo",
 		ServiceURL:  "service",
 	}
-	if err := store.UseAppConnectKey(ctx, "foobar", acc, meta); err != nil {
+	if err := store.UseAppConnectKey(ctx, connectKey, acc, meta); err != nil {
 		t.Fatal("failed to use app connect key:", err)
 	}
 	assertAccount(acc, 0, 10, "desc", "logo", "service")
@@ -78,41 +81,33 @@ func TestAppConnectKeys(t *testing.T) {
 	}
 
 	// try again on an exhausted key
-	if err := store.UseAppConnectKey(ctx, "foobar", types.GeneratePrivateKey().PublicKey(), meta); !errors.Is(err, accounts.ErrKeyExhausted) {
+	if err := store.UseAppConnectKey(ctx, connectKey, types.GeneratePrivateKey().PublicKey(), meta); !errors.Is(err, accounts.ErrKeyExhausted) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyExhausted, err)
 	}
 
-	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+	if ok, err := store.ValidAppConnectKey(ctx, connectKey); err != nil {
 		t.Fatal("failed to validate app connect key:", err)
 	} else if ok {
 		t.Fatal("expected app connect key to be invalid")
 	}
 
 	if updated, err := store.UpdateAppConnectKey(ctx, accounts.UpdateAppConnectKey{
-		Key:           "foobar",
+		Key:           connectKey,
 		Description:   "updated key",
 		MaxPinnedData: 20,
 		RemainingUses: 1,
 	}); err != nil {
 		t.Fatal("failed to add app connect key:", err)
-	} else if updated.Key != "foobar" || updated.Description != "updated key" || updated.RemainingUses != 1 {
+	} else if updated.Key != connectKey || updated.Description != "updated key" || updated.RemainingUses != 1 {
 		t.Fatalf("unexpected updated app connect key: %+v", updated)
 	} else if updated.MaxPinnedData != 20 {
 		t.Fatalf("expected updated app connect key's max pinned data to be 20, got %d", updated.MaxPinnedData)
 	}
 
-	if ok, err := store.ValidAppConnectKey(ctx, "foobar"); err != nil {
+	if ok, err := store.ValidAppConnectKey(ctx, connectKey); err != nil {
 		t.Fatal("failed to validate app connect key:", err)
 	} else if !ok {
 		t.Fatal("expected app connect key to be valid")
-	}
-
-	if err := store.DeleteAppConnectKey(ctx, "foobar"); err != nil {
-		t.Fatal("failed to delete app connect key:", err)
-	}
-
-	if _, err := store.ValidAppConnectKey(ctx, "foobar"); !errors.Is(err, accounts.ErrKeyNotFound) {
-		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
 
 	stats, err := store.AccountStats(ctx)
@@ -123,6 +118,25 @@ func TestAppConnectKeys(t *testing.T) {
 	} else if stats.Registered != 1 {
 		t.Fatal("expected 1 registered account, got", stats.Registered)
 	}
+
+	if err := store.DeleteAppConnectKey(ctx, connectKey); !errors.Is(err, accounts.ErrKeyInUse) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrKeyInUse, err)
+	}
+
+	// delete account
+	if err := store.DeleteAccount(ctx, acc); err != nil {
+		t.Fatal(err)
+	}
+
+	// try deleting key again now that it's not in use
+	if err := store.DeleteAppConnectKey(ctx, connectKey); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.ValidAppConnectKey(ctx, connectKey); !errors.Is(err, accounts.ErrKeyNotFound) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
+	}
+
 }
 
 func TestAppConnectKey(t *testing.T) {

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -136,7 +136,6 @@ func TestAppConnectKeys(t *testing.T) {
 	if _, err := store.ValidAppConnectKey(ctx, connectKey); !errors.Is(err, accounts.ErrKeyNotFound) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
-
 }
 
 func TestAppConnectKey(t *testing.T) {

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -141,7 +141,6 @@ func TestAppConnectKeys(t *testing.T) {
 	if err := store.DeleteAppConnectKey(ctx, connectKey); !errors.Is(err, accounts.ErrKeyNotFound) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
-
 }
 
 func TestAppConnectKey(t *testing.T) {

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -1,5 +1,6 @@
 CREATE TABLE app_connect_keys (
-    app_key TEXT PRIMARY KEY,
+    id SERIAL PRIMARY KEY,
+    app_key TEXT UNIQUE NOT NULL,
     use_description TEXT NOT NULL,
     remaining_uses INTEGER NOT NULL,
     total_uses INTEGER NOT NULL DEFAULT 0,
@@ -12,7 +13,7 @@ CREATE TABLE app_connect_keys (
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
-    connect_key TEXT REFERENCES app_connect_keys(app_key),
+    connect_key_id INTEGER REFERENCES app_connect_keys(id),
 
     pinned_data BIGINT NOT NULL DEFAULT 0 CHECK (pinned_data >= 0), -- total pinned data in bytes
     max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0), -- max pinned data in bytes
@@ -23,7 +24,7 @@ CREATE TABLE accounts (
     last_used TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
 CREATE INDEX accounts_last_used_idx ON accounts(last_used);
-CREATE INDEX accounts_connect_key_idx ON accounts(connect_key);
+CREATE INDEX accounts_connect_key_id_idx ON accounts(connect_key_id);
 
 CREATE TABLE hosts (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -1,16 +1,3 @@
-CREATE TABLE accounts (
-    id SERIAL PRIMARY KEY,
-    public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
-    pinned_data BIGINT NOT NULL DEFAULT 0 CHECK (pinned_data >= 0), -- total pinned data in bytes
-    max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0), -- max pinned data in bytes
-    service_account BOOLEAN NOT NULL DEFAULT FALSE, -- true if this is a service account
-    description TEXT NOT NULL DEFAULT '',
-    logo_url TEXT NOT NULL DEFAULT '',
-    service_url TEXT NOT NULL DEFAULT '',
-    last_used TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
-);
-CREATE INDEX accounts_last_used_idx ON accounts(last_used);
-
 CREATE TABLE app_connect_keys (
     app_key TEXT PRIMARY KEY,
     use_description TEXT NOT NULL,
@@ -21,6 +8,22 @@ CREATE TABLE app_connect_keys (
     last_used TIMESTAMP WITH TIME ZONE,
     max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0)
 );
+
+CREATE TABLE accounts (
+    id SERIAL PRIMARY KEY,
+    public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),
+    connect_key TEXT REFERENCES app_connect_keys(app_key),
+
+    pinned_data BIGINT NOT NULL DEFAULT 0 CHECK (pinned_data >= 0), -- total pinned data in bytes
+    max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0), -- max pinned data in bytes
+    service_account BOOLEAN NOT NULL DEFAULT FALSE, -- true if this is a service account
+    description TEXT NOT NULL DEFAULT '',
+    logo_url TEXT NOT NULL DEFAULT '',
+    service_url TEXT NOT NULL DEFAULT '',
+    last_used TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+CREATE INDEX accounts_last_used_idx ON accounts(last_used);
+CREATE INDEX accounts_connect_key_idx ON accounts(connect_key);
 
 CREATE TABLE hosts (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -454,9 +454,26 @@ FROM objects o;
 	// add connect_key to accounts
 	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
 		_, err := tx.Exec(ctx, `
+ALTER TABLE app_connect_keys RENAME TO app_connect_keys_tmp;
+ALTER TABLE app_connect_keys_tmp DROP CONSTRAINT app_connect_keys_pkey;
+
+CREATE TABLE app_connect_keys (
+    id SERIAL PRIMARY KEY,
+    app_key TEXT UNIQUE NOT NULL,
+    use_description TEXT NOT NULL,
+    remaining_uses INTEGER NOT NULL,
+    total_uses INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used TIMESTAMP WITH TIME ZONE,
+    max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0)
+);
+INSERT INTO app_connect_keys (app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used, max_pinned_data) SELECT app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used, max_pinned_data FROM app_connect_keys_tmp;
+DROP TABLE app_connect_keys_tmp;
+
 -- add connect key column and create index
-ALTER TABLE accounts ADD COLUMN connect_key TEXT REFERENCES app_connect_keys(app_key);
-CREATE INDEX accounts_connect_key_idx ON accounts(connect_key);
+ALTER TABLE accounts ADD COLUMN connect_key_id INTEGER REFERENCES app_connect_keys(id);
+CREATE INDEX accounts_connect_key_id_idx ON accounts(connect_key_id);
 `)
 		return err
 	},

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -451,4 +451,13 @@ FROM objects o;
 		_, err := tx.Exec(ctx, `ALTER TABLE global_settings ADD COLUMN wallet_hash BYTEA CHECK(wallet_hash IS NULL OR LENGTH(wallet_hash) = 32);`)
 		return err
 	},
+	// add connect_key to accounts
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `
+-- add connect key column and create index
+ALTER TABLE accounts ADD COLUMN connect_key TEXT REFERENCES app_connect_keys(app_key);
+CREATE INDEX accounts_connect_key_idx ON accounts(connect_key);
+`)
+		return err
+	},
 }


### PR DESCRIPTION
Close #605

Sadly we haven't been collecting this information so we cannot really do a proper migration here.