### PR TITLE
Fix shard recovery panic

### DIFF
--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -25,31 +25,28 @@ type downloadCandidates struct {
 
 func newDownloadCandidates(allHosts []hosts.Host, slab Slab) downloadCandidates {
 	// build host lookup
-	lookup := make(map[types.PublicKey]struct{}, len(allHosts))
+	lookup := make(map[types.PublicKey]hosts.Host, len(allHosts))
 	for _, h := range allHosts {
-		lookup[h.PublicKey] = struct{}{}
+		lookup[h.PublicKey] = h
 	}
 
-	// build indices lookup
+	hosts := make([]hosts.Host, 0, len(slab.Sectors))
 	indices := make(map[types.PublicKey]int, len(slab.Sectors))
 	for i, sector := range slab.Sectors {
 		if sector.HostKey == nil {
 			continue
 		}
 		hk := *sector.HostKey
-		if _, ok := lookup[hk]; !ok {
+		h, ok := lookup[hk]
+		if !ok {
 			continue
 		}
 		indices[hk] = i
+		hosts = append(hosts, h)
+		delete(lookup, hk) // avoid duplicate candidates
 	}
 
-	// build list of hosts, randomize order to avoid bias
-	hosts := make([]hosts.Host, 0, len(lookup))
-	for _, h := range allHosts {
-		if _, ok := indices[h.PublicKey]; ok {
-			hosts = append(hosts, h)
-		}
-	}
+	// shuffle hosts to avoid always downloading from the same host first
 	frand.Shuffle(len(hosts), func(i, j int) {
 		hosts[i], hosts[j] = hosts[j], hosts[i]
 	})
@@ -83,40 +80,38 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, allHosts []
 
 	var wg sync.WaitGroup
 	sema := make(chan struct{}, slab.MinShards)
-	var downloadErr error
 
 outer:
 	for {
 		select {
 		case <-ctx.Done():
-			if n := downloaded.Load(); uint(n) < slab.MinShards {
-				downloadErr = fmt.Errorf("downloaded %d out of %d shards: %w", downloaded.Load(), slab.MinShards, ctx.Err())
-			}
+			// context cancelled, either due to timeout or enough shards downloaded
 			break outer
 		case sema <- struct{}{}:
 		}
 
 		host, ok := candidates.next()
 		if !ok {
-			downloadErr = fmt.Errorf("downloaded %d out of %d shards: %w", downloaded.Load(), slab.MinShards, errNotEnoughHosts)
+			// no more candidates, but there may be in-flight downloads
 			break outer
 		}
 
 		wg.Add(1)
 		go func(host hosts.Host, sectorIdx int) {
-			sector := slab.Sectors[sectorIdx]
-			log := log.With(zap.Stringer("hostKey", host.PublicKey), zap.Stringer("sectorRoot", sector.Root))
-			var err error
 			defer func() {
-				if err != nil {
-					<-sema // only release next candidate on failure
-				}
+				<-sema
 				wg.Done()
 			}()
 
+			if ctx.Err() != nil {
+				// context already cancelled
+				return
+			}
+
+			sector := slab.Sectors[sectorIdx]
+			log := log.With(zap.Stringer("hostKey", host.PublicKey), zap.Stringer("sectorRoot", sector.Root))
 			start := time.Now()
-			var usage proto.Usage
-			usage, shards[sectorIdx], err = m.downloadShard(ctx, host, slab.Sectors[sectorIdx], pool)
+			usage, data, err := m.downloadShard(ctx, host, sector, pool)
 			if err != nil {
 				lost := isErrLostSector(err)
 				log.Debug("failed to download shard",
@@ -131,6 +126,7 @@ outer:
 				}
 				return
 			}
+			shards[sectorIdx] = data
 
 			err = m.am.DebitServiceAccount(ctx, host.PublicKey, m.migrationAccount, usage.RenterCost())
 			if err != nil {
@@ -144,8 +140,9 @@ outer:
 	}
 
 	wg.Wait()
-	if downloadErr != nil {
-		return nil, downloadErr
+
+	if downloaded.Load() < uint32(slab.MinShards) {
+		return nil, fmt.Errorf("downloaded %d sectors, minimum required: %d: %w", downloaded.Load(), slab.MinShards, errNotEnoughShards)
 	}
 	return shards, nil
 }

--- a/slabs/downloads_test.go
+++ b/slabs/downloads_test.go
@@ -40,8 +40,14 @@ func TestDownloadCandidates(t *testing.T) {
 		},
 	}
 
+	// try to add duplicate hosts
+	candidates := newDownloadCandidates([]hosts.Host{h1, h1, h1, h1, h2, h3, h4}, slab)
+	if len(candidates.hosts) != 3 {
+		t.Fatalf("expected 3 unique candidates, got %d", len(candidates.hosts))
+	}
+
 	// prepare candidates
-	candidates := newDownloadCandidates([]hosts.Host{h1, h2, h3, h4}, slab)
+	candidates = newDownloadCandidates([]hosts.Host{h1, h2, h3, h4}, slab)
 
 	// test next() method
 	selected := make(map[types.PublicKey]struct{})

--- a/slabs/downloads_test.go
+++ b/slabs/downloads_test.go
@@ -224,7 +224,7 @@ func TestDownloadShards(t *testing.T) {
 	t.Run("mark sector lost", func(t *testing.T) {
 		dialer.clients[hk1].sectors = make(map[types.Hash256][proto.SectorSize]byte)
 		_, err := sm.downloadShards(context.Background(), slab, []hosts.Host{host1, host2}, pool, zap.NewNop())
-		if !errors.Is(err, errNotEnoughHosts) {
+		if !errors.Is(err, errNotEnoughShards) {
 			t.Fatal("expected not enough hosts error due to lost sector")
 		} else if sectors, ok := store.lostSectors[hk1]; !ok {
 			t.Fatalf("expected lost sector for host %v, got none", hk1)

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -95,17 +95,20 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		return err
 	}
 	log = log.With(zap.Duration("downloadElapsed", time.Since(downloadStart)))
-	log.Debug("recovered shards")
 
 	// decrypt the shards
 	nonce := make([]byte, 24)
+	var recovered int
 	for i := range shards {
-		if len(shards[i]) > 0 {
-			nonce[0] = byte(i)
-			c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
-			c.XORKeyStream(shards[i], shards[i])
+		if len(shards[i]) == 0 {
+			continue
 		}
+		nonce[0] = byte(i)
+		c, _ := chacha20.NewUnauthenticatedCipher(slab.EncryptionKey[:], nonce)
+		c.XORKeyStream(shards[i], shards[i])
+		recovered++
 	}
+	log.Debug("recovered shards", zap.Int("recovered", recovered))
 
 	// indicate what shards are required
 	required := make([]bool, len(slab.Sectors))


### PR DESCRIPTION
Seems like we had a regression in our shard downloader. I've verified that none of these slabs have sectors stored on a duplicate host. This changes how the candidates list is built to ensure that candidates are distinct even if `allHosts` is not. Also removes `downloadErr` in favor of checking the number of shards recovered after all goroutines have returned because it was potentially being set before all inflight downloads actually complete.

```
{"level":"panic","ts":"2025-10-31T05:31:32Z","logger":"slabs.migrations","caller":"slabs/migrations.go:126","msg":"failed to reconstruct shards","slab":"a810d059bb87c92a5bde71d32c03f1d9bd0d865b9a20e830c67f936ccfbe240e","toMigrate":14,"uploadCandidates":57,"downloadElapsed":108.491030111,"error":"too few shards given"}
{"level":"panic","ts":"2025-10-31T06:21:45Z","logger":"slabs.migrations","caller":"slabs/migrations.go:126","msg":"failed to reconstruct shards","slab":"a9bd5aecae1e4a700e6d6e91baa9138b25028fd02589fe404b7ece0b1fb4dee3","toMigrate":8,"uploadCandidates":57,"downloadElapsed":88.078886062,"error":"too few shards given"}
{"level":"panic","ts":"2025-10-31T10:29:28Z","logger":"slabs.migrations","caller":"slabs/migrations.go:126","msg":"failed to reconstruct shards","slab":"86ad4aa471cc68e29c55c46321528ab1bf9527fbefe91eafb1ce6ad540d4d6cd","toMigrate":11,"uploadCandidates":54,"downloadElapsed":46.172501261,"error":"too few shards given"}
{"level":"panic","ts":"2025-10-31T13:23:24Z","logger":"slabs.migrations","caller":"slabs/migrations.go:126","msg":"failed to reconstruct shards","slab":"3ca75cf42f04bd7cf3b90f6a7252fe4cffb82af6b09e822aa5d9d3be2ed217e8","toMigrate":8,"uploadCandidates":49,"downloadElapsed":45.25965047,"error":"too few shards given"}
{"level":"panic","ts":"2025-10-31T14:29:57Z","logger":"slabs.migrations","caller":"slabs/migrations.go:126","msg":"failed to reconstruct shards","slab":"24b10521b84f144b6aa590a08b3f6144b48db76acf1b52e4b6948d33d366ef01","toMigrate":8,"uploadCandidates":58,"downloadElapsed":48.497010726,"error":"too few shards given"}
{"level":"panic","ts":"2025-10-31T17:25:37Z","logger":"slabs.migrations","caller":"slabs/migrations.go:126","msg":"failed to reconstruct shards","slab":"1c2e26a24f4b039eef439a04dc42e38cba4ccb597b6d44d9fb88f50998e721a3","toMigrate":10,"uploadCandidates":61,"downloadElapsed":48.769598796,"error":"too few shards given"}
```