### PR TITLE
Always consider service accounts for funding even when "inactive"

### DIFF
--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -332,7 +332,7 @@ func newHostAccountsForFunding(ctx context.Context, tx *txn, hk types.PublicKey,
 SELECT a.public_key
 FROM accounts a
 LEFT JOIN account_hosts ah ON a.id = ah.account_id AND ah.host_id = $1
-WHERE ah.account_id IS NULL AND a.last_used >= $2
+WHERE ah.account_id IS NULL AND (a.last_used >= $2 OR a.service_account = TRUE)
 LIMIT $3;`, hostID, threshold, limit)
 	if err != nil {
 		return nil, err
@@ -360,7 +360,7 @@ func existingHostAccountsForFunding(ctx context.Context, tx *txn, hk types.Publi
 SELECT public_key, consecutive_failed_funds, next_fund
 FROM account_hosts ha
 INNER JOIN accounts a ON a.id = ha.account_id
-WHERE ha.host_id = $1 AND ha.next_fund <= NOW() AND a.last_used >= $2
+WHERE ha.host_id = $1 AND ha.next_fund <= NOW() AND (a.last_used >= $2 OR a.service_account = TRUE)
 ORDER BY next_fund ASC
 LIMIT $3`, hostID, threshold, limit)
 	if err != nil {

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -499,7 +499,7 @@ func TestHostAccountsForFunding(t *testing.T) {
 		t.Fatal(err)
 	} else if len(accs) != 2 {
 		t.Fatalf("expected two accounts, got %d", len(accs))
-	} else if accs[0].AccountKey != proto.Account(sa1) && accs[1].AccountKey != proto.Account(sa2) {
+	} else if accs[0].AccountKey != proto.Account(sa1) || accs[1].AccountKey != proto.Account(sa2) {
 		t.Fatal("unexpected accounts")
 	}
 }

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -483,6 +483,25 @@ func TestHostAccountsForFunding(t *testing.T) {
 	} else if accs[0].AccountKey != proto.Account(ak1) {
 		t.Fatal("unexpected account")
 	}
+
+	// add 2 service accounts
+	sa1 := types.GeneratePrivateKey().PublicKey()
+	sa2 := types.GeneratePrivateKey().PublicKey()
+	for _, sa := range []types.PublicKey{sa1, sa2} {
+		if err := store.AddServiceAccount(t.Context(), sa, accounts.AccountMeta{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// both service accounts should be returned for hk1
+	accs, err = store.HostAccountsForFunding(context.Background(), hk1, time.Now().Add(time.Hour), 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(accs) != 2 {
+		t.Fatalf("expected two accounts, got %d", len(accs))
+	} else if accs[0].AccountKey != proto.Account(sa1) && accs[1].AccountKey != proto.Account(sa2) {
+		t.Fatal("unexpected accounts")
+	}
 }
 
 func TestUpdateHostAccounts(t *testing.T) {


### PR DESCRIPTION
This serves as a hot fix for the issue we have been seeing on Zeus. Long term we probably want to consider moving service accounts into memory and on their own schedule since we only got 3 in total.