### PR TITLE
Add `cluster.WaitForContracts` and `cluster.App`

### DIFF
--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -20,9 +20,14 @@ func TestAccountFunding(t *testing.T) {
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(1))
 	indexer := cluster.Indexer
 
-	// add an account
-	a1 := types.GeneratePrivateKey()
-	indexer.Store().AddTestAccount(t, a1.PublicKey())
+	// create an app
+	app := cluster.App(t)
+
+	// fetch account
+	acc, err := app.Account(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// assert we have one usable host
 	time.Sleep(time.Second)
@@ -34,11 +39,9 @@ func TestAccountFunding(t *testing.T) {
 	}
 
 	// convenience variables
-	acc := proto.Account(a1.PublicKey())
 	hk := hosts[0].PublicKey
 	hp := hosts[0].Settings.Prices
 	hc := indexer.HostClient(t, hk)
-	token := proto.NewAccountToken(a1, hk)
 	target := types.Siacoins(2)
 
 	// assert we have one active contract
@@ -51,7 +54,7 @@ func TestAccountFunding(t *testing.T) {
 	}
 
 	// assert the account is funded
-	balance, err := hc.AccountBalance(context.Background(), acc)
+	balance, err := hc.AccountBalance(context.Background(), acc.AccountKey)
 	if err != nil {
 		t.Fatal(err)
 	} else if !balance.Equals(target) {
@@ -61,13 +64,13 @@ func TestAccountFunding(t *testing.T) {
 	// spend some money
 	var sector [proto.SectorSize]byte
 	frand.Read(sector[:])
-	_, err = hc.WriteSector(context.Background(), hp, token, bytes.NewReader(sector[:]), proto.SectorSize)
+	_, err = hc.WriteSector(context.Background(), hp, app.AccountToken(hk), bytes.NewReader(sector[:]), proto.SectorSize)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// assert it was spent
-	balance, err = hc.AccountBalance(context.Background(), acc)
+	balance, err = hc.AccountBalance(context.Background(), acc.AccountKey)
 	if err != nil {
 		t.Fatal(err)
 	} else if !balance.Add(hp.RPCWriteSectorCost(proto.SectorSize).RenterCost()).Equals(target) {
@@ -82,7 +85,7 @@ func TestAccountFunding(t *testing.T) {
 
 	// assert it was refilled
 	time.Sleep(time.Second)
-	balance, err = hc.AccountBalance(context.Background(), acc)
+	balance, err = hc.AccountBalance(context.Background(), acc.AccountKey)
 	if err != nil {
 		t.Fatal(err)
 	} else if !balance.Equals(target) {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -939,7 +939,8 @@ func TestSectorStatsAPI(t *testing.T) {
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
 
-	testutils.WaitForContracts(t, adminClient, len(cluster.Hosts))
+	// wait for contracts to be formed
+	cluster.WaitForContracts(t)
 
 	// assert 0 slabs
 	stats, err := adminClient.StatsSectors(context.Background())

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -545,7 +545,8 @@ func TestSharedObjects(t *testing.T) {
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
 
-	testutils.WaitForContracts(t, adminClient, len(cluster.Hosts))
+	// wait for contracts to be formed
+	cluster.WaitForContracts(t)
 
 	// assert hosts are registered
 	hosts, err := adminClient.Hosts(ctx)

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
@@ -138,6 +139,11 @@ func (c *Client) signedRequestBinary(ctx context.Context, method, route string, 
 	d := types.NewDecoder(io.LimitedReader{R: body, N: math.MaxInt64})
 	resp.DecodeFrom(d)
 	return d.Err()
+}
+
+// AccountToken generates an account token for the given host.
+func (c *Client) AccountToken(host types.PublicKey) proto.AccountToken {
+	return proto.NewAccountToken(c.appkey, host)
 }
 
 // Hosts returns all usable hosts.

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -20,24 +20,26 @@ func TestContractPruning(t *testing.T) {
 	logger := testutils.NewLogger(false)
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10))
 	indexer := cluster.Indexer
-	time.Sleep(time.Second)
 
-	// add an account
-	a1 := types.GeneratePrivateKey()
-	indexer.Store().AddTestAccount(t, a1.PublicKey())
+	// create an app
+	app := cluster.App(t)
 
-	time.Sleep(time.Second)
+	// fetch account
+	acc, err := app.Account(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// wait for contracts to be formed
+	cluster.WaitForContracts(t)
+
+	// assert we have 10 usable hosts
 	hosts, err := indexer.Hosts().Hosts(context.Background(), 0, 10, hosts.WithUsable(true), hosts.WithActiveContracts(true))
 	if err != nil {
 		t.Fatal(err)
 	} else if len(hosts) != 10 {
 		t.Fatalf("expected 10 usable hosts, got %d", len(hosts))
 	}
-
-	// convenience variables
-	acc := proto.Account(a1.PublicKey())
-	client := indexer.App(a1)
-	store := indexer.Store()
 
 	// prepare pin params
 	params := slabs.SlabPinParams{
@@ -49,7 +51,7 @@ func TestContractPruning(t *testing.T) {
 	for _, host := range hosts {
 		var sector [proto.SectorSize]byte
 		frand.Read(sector[:])
-		_, err = indexer.HostClient(t, host.PublicKey).WriteSector(context.Background(), host.Settings.Prices, proto.NewAccountToken(a1, host.PublicKey), bytes.NewReader(sector[:]), proto.SectorSize)
+		_, err = indexer.HostClient(t, host.PublicKey).WriteSector(context.Background(), host.Settings.Prices, app.AccountToken(host.PublicKey), bytes.NewReader(sector[:]), proto.SectorSize)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -57,14 +59,14 @@ func TestContractPruning(t *testing.T) {
 	}
 
 	// pin the slab
-	slabIDs, err := client.PinSlabs(context.Background(), params)
+	slabIDs, err := app.PinSlabs(context.Background(), params)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// assert the slab is pinned
 	time.Sleep(time.Second)
-	res, err := store.Slabs(context.Background(), acc, slabIDs)
+	res, err := indexer.Store().Slabs(context.Background(), acc.AccountKey, slabIDs)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(res) != 1 {
@@ -90,7 +92,7 @@ func TestContractPruning(t *testing.T) {
 	}
 
 	// unpin the slab
-	if err := client.UnpinSlab(context.Background(), slabIDs[0]); err != nil {
+	if err := app.UnpinSlab(context.Background(), slabIDs[0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +104,7 @@ func TestContractPruning(t *testing.T) {
 	// assert the contracts are pruned
 	time.Sleep(time.Second)
 	for _, host := range hosts {
-		contract, _, err := store.ContractRevision(context.Background(), contracts[host.PublicKey])
+		contract, _, err := indexer.Store().ContractRevision(context.Background(), contracts[host.PublicKey])
 		if err != nil {
 			t.Fatal(err)
 		} else if contract.Revision.Filesize != 0 {
@@ -118,12 +120,15 @@ func TestSectorPinning(t *testing.T) {
 	logger := testutils.NewLogger(false)
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10))
 	indexer := cluster.Indexer
-	store := indexer.Store()
-	time.Sleep(time.Second)
 
-	// add an account
-	a1 := types.GeneratePrivateKey()
-	indexer.Store().AddTestAccount(t, a1.PublicKey())
+	// create an app
+	app := cluster.App(t)
+
+	// fetch account
+	acc, err := app.Account(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	time.Sleep(time.Second)
 	hosts, err := indexer.Hosts().Hosts(context.Background(), 0, 10, hosts.WithUsable(true), hosts.WithActiveContracts(true))
@@ -132,10 +137,6 @@ func TestSectorPinning(t *testing.T) {
 	} else if len(hosts) != 10 {
 		t.Fatalf("expected 10 usable hosts, got %d", len(hosts))
 	}
-
-	// convenience variables
-	acc := proto.Account(a1.PublicKey())
-	client := indexer.App(a1)
 
 	// prepare pin params
 	params := slabs.SlabPinParams{
@@ -147,7 +148,7 @@ func TestSectorPinning(t *testing.T) {
 	for _, host := range hosts {
 		var sector [proto.SectorSize]byte
 		frand.Read(sector[:])
-		_, err = indexer.HostClient(t, host.PublicKey).WriteSector(context.Background(), host.Settings.Prices, proto.NewAccountToken(a1, host.PublicKey), bytes.NewReader(sector[:]), proto.SectorSize)
+		_, err = indexer.HostClient(t, host.PublicKey).WriteSector(context.Background(), host.Settings.Prices, app.AccountToken(host.PublicKey), bytes.NewReader(sector[:]), proto.SectorSize)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -155,7 +156,7 @@ func TestSectorPinning(t *testing.T) {
 	}
 
 	// pin the slab
-	slabIDs, err := client.PinSlabs(context.Background(), params)
+	slabIDs, err := app.PinSlabs(context.Background(), params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +164,7 @@ func TestSectorPinning(t *testing.T) {
 
 	// assert the slab is pinned
 	time.Sleep(time.Second)
-	res, err := store.Slabs(context.Background(), acc, slabIDs)
+	res, err := indexer.Store().Slabs(context.Background(), acc.AccountKey, slabIDs)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(res) != 1 {
@@ -178,12 +179,12 @@ func TestSectorPinning(t *testing.T) {
 	}
 
 	// unpin the slab
-	if err := client.UnpinSlab(context.Background(), slabID); err != nil {
+	if err := app.UnpinSlab(context.Background(), slabID); err != nil {
 		t.Fatal(err)
 	}
 
 	// assert the slab is unpinned
-	_, err = store.Slabs(context.Background(), acc, slabIDs)
+	_, err = indexer.Store().Slabs(context.Background(), acc.AccountKey, slabIDs)
 	if !errors.Is(err, slabs.ErrSlabNotFound) {
 		t.Fatal("unexpected error", err)
 	}

--- a/internal/testutils/cluster.go
+++ b/internal/testutils/cluster.go
@@ -9,6 +9,8 @@ import (
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/testutil"
+	"go.sia.tech/indexd/api/app"
+	"go.sia.tech/indexd/contracts"
 	"go.uber.org/zap"
 )
 
@@ -107,6 +109,14 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	return cluster
 }
 
+// App adds a new test account and returns an app client for it.
+func (c *Cluster) App(t testing.TB) *app.Client {
+	t.Helper()
+	sk := types.GeneratePrivateKey()
+	c.Indexer.Store().AddTestAccount(t, sk.PublicKey())
+	return c.Indexer.App(sk)
+}
+
 // AddHosts adds the given hosts to the cluster.
 func (c *Cluster) AddHosts(ctx context.Context, t testing.TB, hosts ...*Host) {
 	t.Helper()
@@ -179,4 +189,36 @@ func (c *Cluster) NewHosts(t testing.TB, n int) []*Host {
 		hosts = append(hosts, cn.NewHost(t, pk, c.log.Named("host-"+pk.PublicKey().String())))
 	}
 	return hosts
+}
+
+// WaitForContracts waits until a contract is formed with every host in the cluster
+func (c *Cluster) WaitForContracts(t *testing.T) {
+	t.Helper()
+	cm := c.Indexer.Contracts()
+
+	required := make(map[types.PublicKey]struct{})
+	for _, h := range c.Hosts {
+		required[h.PublicKey()] = struct{}{}
+	}
+
+	for range 100 {
+		contracts, err := cm.Contracts(t.Context(), 0, math.MaxInt, contracts.WithGood(true), contracts.WithRevisable(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		seen := make(map[types.PublicKey]struct{})
+		for _, c := range contracts {
+			if _, ok := required[c.HostKey]; ok {
+				seen[c.HostKey] = struct{}{}
+			}
+		}
+
+		if len(seen) == len(required) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("not all contracts formed after timeout")
 }

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -341,39 +341,3 @@ func shutdownWithTimeout(shutdownFn func(context.Context) error) error {
 		return shutdownFn(context.Background())
 	})
 }
-
-// WaitForHosts waits for the given number of hosts and returns them.
-func WaitForHosts(t *testing.T, app *app.Client, n int) []hosts.HostInfo {
-	t.Helper()
-	start := time.Now()
-	limit := 10 * time.Second
-	for {
-		hosts, err := app.Hosts(t.Context())
-		if err != nil {
-			t.Fatal(err)
-		} else if len(hosts) == n {
-			return hosts
-		} else if time.Since(start) > limit {
-			t.Fatalf("timed out waiting for %d hosts, got %d", n, len(hosts))
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
-// WaitForContracts waits for the given number of contracts to be formed.
-func WaitForContracts(t *testing.T, admin *admin.Client, n int) {
-	t.Helper()
-	start := time.Now()
-	limit := 10 * time.Second
-	for {
-		contracts, err := admin.Contracts(t.Context())
-		if err != nil {
-			t.Fatal(err)
-		} else if len(contracts) == n {
-			return
-		} else if time.Since(start) > limit {
-			t.Fatalf("timed out waiting for %d hosts, got %d", n, len(contracts))
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -17,30 +17,26 @@ func TestMigrations(t *testing.T) {
 	// create cluster
 	logger := testutils.NewLogger(false)
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(500*time.Millisecond))))
+	indexer := cluster.Indexer
+
+	// create an app
+	app := cluster.App(t)
 
 	// create some more utxos
-	indexer := cluster.Indexer
 	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 11)
 
-	// add an account
-	a1 := types.GeneratePrivateKey()
-	indexer.Store().AddTestAccount(t, a1.PublicKey())
-
-	// convenience variables
-	app := indexer.App(a1)
-
-	// fetch hosts
-	hosts := testutils.WaitForHosts(t, app, 11)
+	// wait for contracts to be formed
+	cluster.WaitForContracts(t)
 
 	// upload sectors to hosts
 	encryptionKey, shards, roots := slabs.NewTestShards(t, 1, 10)
 	for i := range shards {
-		client := indexer.HostClient(t, hosts[i].PublicKey)
+		client := indexer.HostClient(t, cluster.Hosts[i].PublicKey())
 		hs, err := client.Settings(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := client.WriteSector(context.Background(), hs.Prices, proto.NewAccountToken(a1, hosts[i].PublicKey), bytes.NewReader(shards[i]), proto.SectorSize); err != nil {
+		if _, err := client.WriteSector(context.Background(), hs.Prices, app.AccountToken(cluster.Hosts[i].PublicKey()), bytes.NewReader(shards[i]), proto.SectorSize); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -50,16 +46,16 @@ func TestMigrations(t *testing.T) {
 		EncryptionKey: encryptionKey,
 		MinShards:     1,
 		Sectors: []slabs.PinnedSector{
-			{Root: roots[0], HostKey: hosts[0].PublicKey},
-			{Root: roots[1], HostKey: hosts[1].PublicKey},
-			{Root: roots[2], HostKey: hosts[2].PublicKey},
-			{Root: roots[3], HostKey: hosts[3].PublicKey},
-			{Root: roots[4], HostKey: hosts[4].PublicKey},
-			{Root: roots[5], HostKey: hosts[5].PublicKey},
-			{Root: roots[6], HostKey: hosts[6].PublicKey},
-			{Root: roots[7], HostKey: hosts[7].PublicKey},
-			{Root: roots[8], HostKey: hosts[8].PublicKey},
-			{Root: roots[9], HostKey: hosts[9].PublicKey},
+			{Root: roots[0], HostKey: cluster.Hosts[0].PublicKey()},
+			{Root: roots[1], HostKey: cluster.Hosts[1].PublicKey()},
+			{Root: roots[2], HostKey: cluster.Hosts[2].PublicKey()},
+			{Root: roots[3], HostKey: cluster.Hosts[3].PublicKey()},
+			{Root: roots[4], HostKey: cluster.Hosts[4].PublicKey()},
+			{Root: roots[5], HostKey: cluster.Hosts[5].PublicKey()},
+			{Root: roots[6], HostKey: cluster.Hosts[6].PublicKey()},
+			{Root: roots[7], HostKey: cluster.Hosts[7].PublicKey()},
+			{Root: roots[8], HostKey: cluster.Hosts[8].PublicKey()},
+			{Root: roots[9], HostKey: cluster.Hosts[9].PublicKey()},
 		},
 	})
 	if err != nil {
@@ -97,7 +93,7 @@ func TestMigrations(t *testing.T) {
 	}
 
 	// block the first host
-	err = indexer.Hosts().BlockHosts(context.Background(), []types.PublicKey{hosts[0].PublicKey}, []string{t.Name()})
+	err = indexer.Hosts().BlockHosts(context.Background(), []types.PublicKey{cluster.Hosts[0].PublicKey()}, []string{t.Name()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,8 +104,8 @@ func TestMigrations(t *testing.T) {
 			t.Fatal(err)
 		} else if len(pinned.Sectors) != 10 {
 			return fmt.Errorf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
-		} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != hosts[10].PublicKey {
-			return fmt.Errorf("expected sector %s on host %s, got %s on host %s", roots[0], hosts[10].PublicKey, pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
+		} else if pinned.Sectors[0].Root != roots[0] || pinned.Sectors[0].HostKey != cluster.Hosts[10].PublicKey() {
+			return fmt.Errorf("expected sector %s on host %s, got %s on host %s", roots[0], cluster.Hosts[10].PublicKey(), pinned.Sectors[0].Root, pinned.Sectors[0].HostKey)
 		}
 		return nil
 	}); err != nil {
@@ -122,29 +118,25 @@ func TestUpdateLastUsed(t *testing.T) {
 	logger := testutils.NewLogger(false)
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
 
+	// create an app
+	app := cluster.App(t)
+
 	// create some more utxos
 	indexer := cluster.Indexer
 	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 10)
 
-	// add an account
-	a1 := types.GeneratePrivateKey()
-	indexer.Store().AddTestAccount(t, a1.PublicKey())
-
-	// convenience variables
-	app := indexer.App(a1)
-
-	// fetch hosts
-	hosts := testutils.WaitForHosts(t, app, 10)
+	// wait for contracts to be formed
+	cluster.WaitForContracts(t)
 
 	// upload sectors to hosts
 	encryptionKey, shards, roots := slabs.NewTestShards(t, 1, 9)
 	for i := range shards {
-		client := indexer.HostClient(t, hosts[i].PublicKey)
+		client := indexer.HostClient(t, cluster.Hosts[i].PublicKey())
 		hs, err := client.Settings(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := client.WriteSector(context.Background(), hs.Prices, proto.NewAccountToken(a1, hosts[i].PublicKey), bytes.NewReader(shards[i]), proto.SectorSize); err != nil {
+		if _, err := client.WriteSector(context.Background(), hs.Prices, app.AccountToken(cluster.Hosts[i].PublicKey()), bytes.NewReader(shards[i]), proto.SectorSize); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -165,8 +157,8 @@ func TestUpdateLastUsed(t *testing.T) {
 		EncryptionKey: encryptionKey,
 		MinShards:     1,
 		Sectors: func() (s []slabs.PinnedSector) {
-			for i, h := range hosts {
-				s = append(s, slabs.PinnedSector{Root: roots[i], HostKey: h.PublicKey})
+			for i, h := range cluster.Hosts {
+				s = append(s, slabs.PinnedSector{Root: roots[i], HostKey: h.PublicKey()})
 			}
 			return s
 		}(),


### PR DESCRIPTION
This PR does two things:

1. gets rid of our two `WaitForX` helpers and moves it into a single method on the cluster itself that checks whether all hosts have an active contract. This is effectively a combination of the two but I think it's better located on the cluster and it's redundant to have two helpers. Waiting for active contracts instead of just the hosts will avoid races and NDFs.

2. It adds a helper called `App` that adds a test account and returns an app client for that account.

I'm pushing it separately because it's unrelated to account funding.
