### PR TITLE
Update `store.MarkSlabRepaired`

### DIFF
--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -19,7 +19,7 @@ import (
 func (s *Store) MarkSlabRepaired(ctx context.Context, slabID slabs.SlabID, success bool) error {
 	return s.transaction(ctx, func(ctx context.Context, tx *txn) error {
 		if success {
-			if res, err := tx.Exec(ctx, `UPDATE slabs SET consecutive_failed_repairs = 0 WHERE digest = $1`, sqlHash256(slabID)); err != nil {
+			if res, err := tx.Exec(ctx, `UPDATE slabs SET consecutive_failed_repairs = 0, next_repair_attempt = NOW() WHERE digest = $1`, sqlHash256(slabID)); err != nil {
 				return fmt.Errorf("failed to mark slab as repaired: %w", err)
 			} else if res.RowsAffected() == 0 {
 				return slabs.ErrSlabNotFound

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -188,7 +188,7 @@ func TestMarkSlabRepaired(t *testing.T) {
 		t.Fatal(err)
 	}
 	simulateSuccessfulRepair()
-	assertSlabState(0, oneHourAgo)
+	assertSlabState(0, time.Now())
 }
 
 func TestPinnedSlab(t *testing.T) {


### PR DESCRIPTION
I was looking at the repair code and I found out we don't set `next_repair_attempt` to the current timestamp when we've successfully repaired a slab. That's an oversight because it makes the slab jump the queue as soon as it becomes unhealthy. 

\- - 

Unrelated but I want to discuss it anyway: I think we should start prioritizing slabs based on their health. I ran some queries and, on average, the position in our queue is about 100k positions off of its true position in the queue if the unhealthy slabs were sorted on their health... with our worst slabs having 16 bad sectors, this is becoming an issue.