### PR TITLE
Fix missing pruning offset

### DIFF
--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -161,7 +161,7 @@ func (cm *ContractManager) pruneContract(ctx context.Context, client HostClient,
 		var indices []uint64
 		for i, root := range res.Roots {
 			if _, found := prunable[root]; found {
-				indices = append(indices, uint64(i))
+				indices = append(indices, offset+uint64(i))
 			}
 		}
 		if len(indices) == 0 {


### PR DESCRIPTION
Pruning currently deletes arbitrary sectors from the start of the contract since it does not account for the current offset when calling `FreeSectors` with a batch.

Fixes #627 