### PR TITLE
Don't redial mux when stream times out

### DIFF
--- a/sdk/dialer.go
+++ b/sdk/dialer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"go.sia.tech/coreutils/threadgroup"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/mux/v2"
 	"go.uber.org/zap"
 )
 
@@ -328,7 +330,16 @@ func (d *dialer) retry(ctx context.Context, hostKey types.PublicKey, fn func(rhp
 	}
 	if err := fn(tc); err == nil {
 		return nil
+	} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
 	} else if proto.ErrorCode(err) != proto.ErrorCodeTransport {
+		return err
+	} else if errors.Is(err, mux.ErrClosedStream) || errors.Is(err, os.ErrDeadlineExceeded) {
+		// ErrClosedStream indicates that we closed the stream gracefully, so
+		// the transport is still intact. This usually happens because we close
+		// streams by cancelling or timing out contexts. os.ErrDeadlineExceeded
+		// is similar, indicating that the stream hit a timeout which was set
+		// using SetDeadline. In both cases, the mux is still healthy.
 		return err
 	}
 

--- a/slabs/dialer.go
+++ b/slabs/dialer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"slices"
 	"sync"
 
@@ -15,6 +16,7 @@ import (
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/mux/v2"
 	"go.uber.org/zap"
 )
 
@@ -166,6 +168,13 @@ func (c *connPool) retry(ctx context.Context, hostKey types.PublicKey, addrs []c
 	} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return err
 	} else if proto.ErrorCode(err) != proto.ErrorCodeTransport {
+		return err
+	} else if errors.Is(err, mux.ErrClosedStream) || errors.Is(err, os.ErrDeadlineExceeded) {
+		// ErrClosedStream indicates that we closed the stream gracefully, so
+		// the transport is still intact. This usually happens because we close
+		// streams by cancelling or timing out contexts. os.ErrDeadlineExceeded
+		// is similar, indicating that the stream hit a timeout which was set
+		// using SetDeadline. In both cases, the mux is still healthy.
 		return err
 	}
 

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -12,6 +12,7 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/mux/v2"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
@@ -114,11 +115,15 @@ outer:
 			usage, data, err := m.downloadShard(ctx, host, sector, pool)
 			if err != nil {
 				lost := isErrLostSector(err)
-				log.Debug("failed to download shard",
-					zap.Bool("timeout", time.Since(start) > m.shardTimeout),
-					zap.Bool("lost", lost),
-					zap.Error(err),
-				)
+				interrupted := ctx.Err() != nil && (errors.Is(err, mux.ErrClosedStream) || errors.Is(err, ctx.Err()))
+				if !interrupted {
+					log.Debug("failed to download shard",
+						zap.Bool("timeout", time.Since(start) > m.shardTimeout),
+						zap.Duration("elapsed", time.Since(start)),
+						zap.Bool("lost", lost),
+						zap.Error(err),
+					)
+				}
 				if lost {
 					if err := m.store.MarkSectorsLost(ctx, host.PublicKey, []types.Hash256{sector.Root}); err != nil {
 						log.Error("failed to mark sector as lost", zap.Error(err))


### PR DESCRIPTION
Fixes https://github.com/SiaFoundation/indexd/issues/626

Turns out that every time a stream was closed due to being interrupted by a closed context, we went ahead and closed the underlying mux. Leading to every other stream from the same mux across slabs failing as well.

Fixing this turns all the `underlying connection was closed` errors into `stream was gracefully closed` errors which we now don't log if the context was cancelled since those shards are expected to fail.