### PR TITLE
Account for remaining funds in contract when pinning

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -130,11 +130,17 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 		maxRemainingSectors := (maxContractSize - contract.Revision.Filesize) / proto.SectorSize
 		maxAppendSectors := (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
 		duration := contract.Revision.ExpirationHeight - hostPrices.TipHeight
-		sectorCollateralCost := hostPrices.RPCAppendSectorsCost(1, duration).RiskedCollateral
+		appendSectorCost := hostPrices.RPCAppendSectorsCost(1, duration)
+
+		sectorCollateralCost := appendSectorCost.RiskedCollateral
 		if sectorCollateralCost.IsZero() {
 			sectorCollateralCost = types.NewCurrency64(1) // avoid division by zero
 		}
-		maxAppendSectors += contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
+
+		maxSectorsByCollateral := contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
+		maxSectorsByAllowance := contract.Revision.RemainingAllowance().Div(appendSectorCost.RenterCost()).Big().Uint64()
+		maxAppendSectors += min(maxSectorsByAllowance, maxSectorsByCollateral)
+
 		// ensure the maximum contract size is not exceeded
 		maxAppendSectors = min(maxAppendSectors, maxRemainingSectors)
 		if maxAppendSectors == 0 {

--- a/client/client.go
+++ b/client/client.go
@@ -136,9 +136,13 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 		if sectorCollateralCost.IsZero() {
 			sectorCollateralCost = types.NewCurrency64(1) // avoid division by zero
 		}
+		sectorRenterCost := appendSectorCost.RenterCost()
+		if sectorRenterCost.IsZero() {
+			sectorRenterCost = types.NewCurrency64(1) // avoid division by zero
+		}
 
 		maxSectorsByCollateral := contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
-		maxSectorsByAllowance := contract.Revision.RemainingAllowance().Div(appendSectorCost.RenterCost()).Big().Uint64()
+		maxSectorsByAllowance := contract.Revision.RemainingAllowance().Div(sectorRenterCost).Big().Uint64()
 		maxAppendSectors += min(maxSectorsByAllowance, maxSectorsByCollateral)
 
 		// ensure the maximum contract size is not exceeded


### PR DESCRIPTION
I saw a few of the following in the logs when investigating pinning:

```
indexd-1  | 2025-11-05T13:35:05Z	DEBUG	contracts.maintenance.pinning	failed to pin sectors	{"hostKey": "ed25519:d5bfc8fcf4976b1b17f8ddcd843afc50ce52f144a2dbcff75bd75b0fdbe41249", "contractID": "19d4d9eec1d4308475a1b037e3e7b76ecf84d8b78c091f9ae9f15f4b99b9a544", "error": "failed to append sectors: failed to revise contract: insufficient renter funds: 510.829573520488398848 uS < 3.682831928865318764544 mS (5)"}
```

which seemed weird since it should be `contract is out of funds` which is our custom error

This PR fixes this by taking into accounts the remaining allowance of a contract. After deploying this,  the errors became fewer and the ones that remained turned into 

```
indexd-1  | 2025-11-05T14:44:39Z	DEBUG	contracts.maintenance.pinning	failed to pin sectors to contract	{"hostKey": "ed25519:163d53521afb9c7aea38fc598786438c6cf6ce856bd347c627e961923d8ebb8c", "contractID": "4bbe5464abf89c4e22c7d64df143d37d745eee387ac9eebc66f815cadf105cbe", "error": "contract is out of funds"}
```

as expected