### PR TITLE
Ignore full hosts during migration

### DIFF
--- a/slabs/dialer.go
+++ b/slabs/dialer.go
@@ -176,6 +176,9 @@ func (c *connPool) retry(ctx context.Context, hostKey types.PublicKey, addrs []c
 		// is similar, indicating that the stream hit a timeout which was set
 		// using SetDeadline. In both cases, the mux is still healthy.
 		return err
+	} else if errors.Is(err, errNotEnoughStorage) {
+		// No sense in retrying if the host does not have enough storage left
+		return err
 	}
 
 	// clear connection if we got transport error
@@ -219,6 +222,9 @@ func (c *connPool) uploadShard(ctx context.Context, h hosts.Host, migrationToken
 		settings, err := client.Settings(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch host settings: %w", err)
+		}
+		if settings.RemainingStorage < proto.SectorSize {
+			return errNotEnoughStorage
 		}
 
 		result, err = client.WriteSector(ctx, settings.Prices, migrationToken, shard, proto.SectorSize)

--- a/slabs/dialer.go
+++ b/slabs/dialer.go
@@ -223,7 +223,8 @@ func (c *connPool) uploadShard(ctx context.Context, h hosts.Host, migrationToken
 		if err != nil {
 			return fmt.Errorf("failed to fetch host settings: %w", err)
 		}
-		if settings.RemainingStorage < proto.SectorSize {
+		// not enough space left for 1 sector
+		if settings.RemainingStorage < 1 {
 			return proto.ErrNotEnoughStorage
 		}
 

--- a/slabs/dialer.go
+++ b/slabs/dialer.go
@@ -176,9 +176,9 @@ func (c *connPool) retry(ctx context.Context, hostKey types.PublicKey, addrs []c
 		// is similar, indicating that the stream hit a timeout which was set
 		// using SetDeadline. In both cases, the mux is still healthy.
 		return err
-	} else if errors.Is(err, errNotEnoughStorage) {
+	} else if errors.Is(err, proto.ErrNotEnoughStorage) {
 		// No sense in retrying if the host does not have enough storage left
-		return err
+		return fmt.Errorf("%w: remaining storage less than sector size", proto.ErrNotEnoughStorage)
 	}
 
 	// clear connection if we got transport error
@@ -224,7 +224,7 @@ func (c *connPool) uploadShard(ctx context.Context, h hosts.Host, migrationToken
 			return fmt.Errorf("failed to fetch host settings: %w", err)
 		}
 		if settings.RemainingStorage < proto.SectorSize {
-			return errNotEnoughStorage
+			return proto.ErrNotEnoughStorage
 		}
 
 		result, err = client.WriteSector(ctx, settings.Prices, migrationToken, shard, proto.SectorSize)

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	errNotEnoughHosts = errors.New("not enough hosts")
-	errRootMismatch   = errors.New("sector root of shard doesn't match expected root")
+	errNotEnoughHosts   = errors.New("not enough hosts")
+	errRootMismatch     = errors.New("sector root of shard doesn't match expected root")
+	errNotEnoughStorage = errors.New("host doesn't have enough storage remaining for a sector")
 )
 
 type (

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -15,9 +15,8 @@ import (
 )
 
 var (
-	errNotEnoughHosts   = errors.New("not enough hosts")
-	errRootMismatch     = errors.New("sector root of shard doesn't match expected root")
-	errNotEnoughStorage = errors.New("host doesn't have enough storage remaining for a sector")
+	errNotEnoughHosts = errors.New("not enough hosts")
+	errRootMismatch   = errors.New("sector root of shard doesn't match expected root")
 )
 
 type (


### PR DESCRIPTION
Fixes #642

Check that host has at least `MinRemainingStorage` bytes available to be an upload candidate for migrations. 