### PR TITLE
Fix collateral cap for renewals

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -259,7 +259,7 @@ func (c *HostClient) RenewContract(ctx context.Context, settings proto.HostSetti
 	if err := c.withRevision(ctx, params.ContractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
 		estimatedRenewal, _ := proto.RenewContract(contract.Revision, settings.Prices, params)
 		if estimatedRenewal.NewContract.TotalCollateral.Cmp(settings.MaxCollateral) > 0 {
-			capped, underflow := settings.MaxCollateral.SubWithUnderflow(contract.Revision.RiskedCollateral()) // cap to remaining collateral
+			capped, underflow := settings.MaxCollateral.SubWithUnderflow(estimatedRenewal.NewContract.RiskedCollateral()) // cap to remaining collateral
 			if underflow {
 				capped = types.ZeroCurrency
 			}


### PR DESCRIPTION
While I was investigating the last 8 failing renewals I saw the following error:

```
indexd-1  | 2025-11-07T10:22:34Z	ERROR	contracts.maintenance.contracts.renew	failed to renew contract	{"contractID": "25340075382cc87217ea64020716d73d914d129c00b6afa8ea6b97d0797da4f8", "error": "failed to renew contract: failed to renew contract: failed to read host inputs response: required collateral 9.82837337030324966872055808 KS exceeds max collateral 7 KS (3) (3)"}
```

which should have been fixed recently. Turns out the cap was slightly off since the previous contract's risked collateral doesn't necessarily match the risked collateral we use when validating the request.

After deploying this PR this error turned into
```
indexd-1    | 2025-11-07T11:04:27Z	ERROR	contracts.maintenance.contracts.renew	failed to renew contract	{"contractID": "25340075382cc87217ea64020716d73d914d129c00b6afa8ea6b97d0797da4f8", "error": "failed to renew contract: failed to renew contract: failed to read final response: internal error (2)"}

```
and then on the next try
```
indexd-1    | 2025-11-07T11:09:45Z	ERROR	contracts.maintenance.contracts.renew	failed to renew contract	{"contractID": "25340075382cc87217ea64020716d73d914d129c00b6afa8ea6b97d0797da4f8", "error": "failed to renew contract: failed to renew contract: failed to read final response: failed to broadcast renewal set: transaction fa269d67ec407c8a1062087da48f7964ec882183a22830de4827d437fb4cf7cb conflicts with pool: file contract renewal 0 parent (25340075382cc87217ea64020716d73d914d129c00b6afa8ea6b97d0797da4f8) has already been resolved in transaction ef42b32d395c639b714c8a475285663de10e35406314829114023cb37ad58e0a (3)"}
```

Which is unfortunately not a successful renewal but it should mean we got past the request validation.

EDIT: Good news is that the `internal error` led me to https://github.com/SiaFoundation/hostd/pull/861