### PR TITLE
Fix TestMigrations

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Test
         uses: n8maninger/action-golang-test@v2
         with:
-          args: -race;-failfast
+          args: -race;-failfast;-timeout=1h;-count=25;-run=^TestMigrations$

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Test
         uses: n8maninger/action-golang-test@v2
         with:
-          args: -race;-failfast;-timeout=1h;-count=100;-run=^TestMigrations$
+          args: -race;-failfast

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Test
         uses: n8maninger/action-golang-test@v2
         with:
-          args: -race;-failfast;-timeout=1h;-count=25;-run=^TestMigrations$
+          args: -race;-failfast;-timeout=1h;-count=100;-run=^TestMigrations$

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -88,7 +88,7 @@ func defaultIndexerCfg(log *zap.Logger) *indexerCfg {
 		slabOpts: []slabs.Option{
 			slabs.WithLogger(log.Named("slabs")),
 			slabs.WithHealthCheckInterval(500 * time.Millisecond),
-			slabs.WithMinHostDistance(0), // disable distance checks in tests
+			slabs.WithMinHostDistance(0), // disable location checks in tests
 		},
 	}
 }

--- a/internal/testutils/indexer.go
+++ b/internal/testutils/indexer.go
@@ -75,10 +75,21 @@ type (
 	}
 )
 
-func defaultIndexerCfg() *indexerCfg {
+func defaultIndexerCfg(log *zap.Logger) *indexerCfg {
 	return &indexerCfg{
 		maintenanceSettings: MaintenanceSettings,
-		slabOpts:            []slabs.Option{slabs.WithMinHostDistance(0)}, // disable distance checks in tests
+		contractOpts: []contracts.ContractManagerOpt{
+			contracts.WithLogger(log.Named("contracts")),
+			contracts.WithMaintenanceFrequency(500 * time.Millisecond),
+			contracts.WithMinHostDistance(0), // disable location checks in tests
+			contracts.WithSyncPollInterval(500 * time.Millisecond),
+			contracts.WithSectorRootsBatchSize(5), // small batch size for testing
+		},
+		slabOpts: []slabs.Option{
+			slabs.WithLogger(log.Named("slabs")),
+			slabs.WithHealthCheckInterval(500 * time.Millisecond),
+			slabs.WithMinHostDistance(0), // disable distance checks in tests
+		},
 	}
 }
 
@@ -121,7 +132,7 @@ func (i *Indexer) Hosts() *hosts.HostManager {
 // NewIndexer creates a new indexer for testing that is automatically closed up
 // after the test is finished.
 func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...IndexerOpt) *Indexer {
-	cfg := defaultIndexerCfg()
+	cfg := defaultIndexerCfg(log)
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -149,15 +160,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	dialer := client.NewDialer(c.cm, signer, store, log, client.WithRevisionSubmissionBuffer(1))
 	am := accounts.NewManager(store, accounts.NewFunder(dialer), accounts.WithLogger(log.Named("accounts")))
 
-	contractOpts := []contracts.ContractManagerOpt{
-		contracts.WithMinHostDistance(0), // disable location checks in tests
-		contracts.WithLogger(log.Named("contracts")),
-		contracts.WithMaintenanceFrequency(200 * time.Millisecond),
-		contracts.WithSyncPollInterval(100 * time.Millisecond),
-		contracts.WithSectorRootsBatchSize(5), // small batch size for testing
-	}
-	contractOpts = append(contractOpts, cfg.contractOpts...)
-	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, hm, s, wm, contractOpts...)
+	contracts, err := contracts.NewManager(walletKey, am, c.cm, store, dialer, hm, s, wm, cfg.contractOpts...)
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -12,11 +12,12 @@ import (
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestMigrations(t *testing.T) {
 	// create cluster
-	logger := zap.NewNop()
+	logger := zaptest.NewLogger(t)
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(500*time.Millisecond))))
 	indexer := cluster.Indexer
 

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -9,7 +9,6 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"go.uber.org/zap"
@@ -18,7 +17,7 @@ import (
 func TestMigrations(t *testing.T) {
 	// create cluster
 	logger := zap.NewNop()
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11), testutils.WithIndexer(testutils.WithContractOptions(contracts.WithMaintenanceFrequency(500*time.Millisecond)), testutils.WithSlabOptions(slabs.WithHealthCheckInterval(500*time.Millisecond))))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11))
 	indexer := cluster.Indexer
 
 	// create an app
@@ -118,7 +117,7 @@ func TestMigrations(t *testing.T) {
 func TestUpdateLastUsed(t *testing.T) {
 	// create cluster
 	logger := zap.NewNop()
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(time.Second))))
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10), testutils.WithIndexer())
 
 	// create an app
 	app := cluster.App(t)

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -9,16 +9,16 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/internal/testutils"
 	"go.sia.tech/indexd/slabs"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 )
 
 func TestMigrations(t *testing.T) {
 	// create cluster
-	logger := zaptest.NewLogger(t)
-	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11), testutils.WithIndexer(testutils.WithSlabOptions(slabs.WithHealthCheckInterval(500*time.Millisecond))))
+	logger := zap.NewNop()
+	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11), testutils.WithIndexer(testutils.WithContractOptions(contracts.WithMaintenanceFrequency(500*time.Millisecond)), testutils.WithSlabOptions(slabs.WithHealthCheckInterval(500*time.Millisecond))))
 	indexer := cluster.Indexer
 
 	// create an app


### PR DESCRIPTION
This PR tweaks the configuration of our test cluster to avoid NDFs, in particular `TestMigrations`. 

To fix `TestMigrations`, all that is necessary is to increase the maintenance frequency to a higher, more reasonable interval. The reason it fails is because there's a race between fetching a `Slab` and fetching good hosts and contracts. A hydrated slab goes through the contract sectors map, by the time the slab is being repaired, that contract might no longer be revisable, because it was renewed for instance -> causing it to be selected for migration.

I decided to move some of our configuration into the default cluster config because they are sane values.
I ran `TestMigrations` 100 times successfully both on changing only the maintenance freq _and_ all other config options.

Closes https://github.com/SiaFoundation/indexd/issues/651
