### PR TITLE
Fix verify sector cost computation

### DIFF
--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -8,6 +8,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/mux/v2"
 	"go.uber.org/zap"
 )
 
@@ -33,7 +34,7 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 				batch, err = m.verifier.VerifySectors(ctx, host, toCheck[len(results):])
 				return err
 			})
-			if errors.Is(err, context.Canceled) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, mux.ErrClosedStream) || errors.Is(err, errInsufficientServiceAccountBalance) || errors.Is(err, errHostUnreachable) {
 				logger.Debug("integrity checks got interrupted", zap.Error(err))
 				if errors.Is(err, errInsufficientServiceAccountBalance) {
 					if err := m.cm.TriggerAccountRefill(ctx, hostKey, m.verifier.account()); err != nil {

--- a/slabs/sectorverifier.go
+++ b/slabs/sectorverifier.go
@@ -11,6 +11,7 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/mux/v2"
 )
 
 const (
@@ -125,7 +126,7 @@ func (v *SectorVerifier) VerifySectors(ctx context.Context, host hosts.Host, roo
 
 		// verify the sector
 		res, err := hc.VerifySector(ctx, host.Settings.Prices, v.token(host.PublicKey), root)
-		if errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, mux.ErrClosedStream) {
 			return results, err // interrupted
 		}
 

--- a/slabs/sectorverifier.go
+++ b/slabs/sectorverifier.go
@@ -64,7 +64,7 @@ func (v *SectorVerifier) CheckBalance(ctx context.Context, host hosts.Host) (typ
 	balance, err := v.am.ServiceAccountBalance(ctx, host.PublicKey, v.account())
 	if err != nil {
 		return types.ZeroCurrency, fmt.Errorf("failed to get service account balance: %w", err)
-	} else if balance.Cmp(host.Settings.Prices.RPCVerifySectorCost().RenterCost()) < 0 {
+	} else if balance.Cmp(host.Settings.Prices.RPCReadSectorCost(proto.LeafSize).RenterCost()) < 0 {
 		return types.ZeroCurrency, errInsufficientServiceAccountBalance
 	}
 	return balance, nil
@@ -103,7 +103,7 @@ func (v *SectorVerifier) VerifySectors(ctx context.Context, host hosts.Host, roo
 		return nil, err
 	}
 
-	cost := host.Settings.Prices.RPCVerifySectorCost().RenterCost()
+	cost := host.Settings.Prices.RPCReadSectorCost(proto.LeafSize).RenterCost()
 	var results []CheckSectorsResult
 	var resetOnce sync.Once
 	for _, root := range roots {

--- a/slabs/sectorverifier_test.go
+++ b/slabs/sectorverifier_test.go
@@ -22,7 +22,7 @@ func (c *mockHostClient) VerifySector(ctx context.Context, hostPrices proto.Host
 	if !ok {
 		panic("unknown sector: " + root.String())
 	}
-	return rhp.RPCVerifySectorResult{Usage: hostPrices.RPCVerifySectorCost()}, err
+	return rhp.RPCVerifySectorResult{Usage: hostPrices.RPCReadSectorCost(proto.LeafSize)}, err
 }
 
 func TestSectorVerifier(t *testing.T) {

--- a/slabs/sectorverifier_test.go
+++ b/slabs/sectorverifier_test.go
@@ -11,6 +11,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/mux/v2"
 )
 
 func (c *mockHostClient) Close() error {
@@ -43,7 +44,7 @@ func TestSectorVerifier(t *testing.T) {
 		PublicKey: hk,
 		Settings: proto.HostSettings{
 			Prices: proto.HostPrices{
-				EgressPrice: oneSC.Div64(proto.SectorSize), // 1SC per sector
+				EgressPrice: oneSC.Div64(4096), // 1SC per checked sector
 				ValidUntil:  time.Now().Add(time.Hour),
 			},
 		},
@@ -129,7 +130,13 @@ func TestSectorVerifier(t *testing.T) {
 	dialer.clients[host.PublicKey].integrity[r2] = context.Canceled // verification interrupted
 	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{SectorSuccess}, context.Canceled)
 
-	// case 5: interruption via expired prices
+	// case 5: interruption via gracefully closed stream
+	updateBalance(types.Siacoins(10))
+	dialer.clients[host.PublicKey].integrity[r1] = nil                 // good sector
+	dialer.clients[host.PublicKey].integrity[r2] = mux.ErrClosedStream // verification interrupted
+	assertResults([]types.Hash256{r1, r2}, []CheckSectorsResult{SectorSuccess}, mux.ErrClosedStream)
+
+	// case 6: interruption via expired prices
 	updateBalance(types.Siacoins(10))
 	dialer.clients[host.PublicKey].integrity[r1] = nil // good sector
 	host.Settings.Prices.ValidUntil = time.Time{}


### PR DESCRIPTION
This potentially slows down our integrity checks. Since we end up subtracting 1000x the amount we actually pay from the service account.