### PR TITLE
Return "unspecified" block reason for blocked hosts without reason

### DIFF
--- a/api/admin/prometheus.go
+++ b/api/admin/prometheus.go
@@ -131,6 +131,17 @@ func (h HostStats) PrometheusMetric() []prometheus.Metric {
 		})
 	}
 
+	if h.Blocked && len(h.BlockedReasons) == 0 {
+		metrics = append(metrics, prometheus.Metric{
+			Name: "indexd_host_blocked_reason",
+			Labels: map[string]any{
+				"public_key": h.PublicKey.String(),
+				"reason":     "Unknown",
+			},
+			Value: 1,
+		})
+	}
+
 	return metrics
 }
 


### PR DESCRIPTION
Our dashboard is currently missing hosts that were manually blocked because those hosts don't have an associated reason. This PR adds a default reason called `Unknown` to the response in case a host is blocked but doesn't have any other reasons for being blocked. 