### PR TITLE
hotfix: don't override prices with prices that have a lower validity in the store

### DIFF
--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -438,7 +438,7 @@ settings_free_sector_price = $6,
 settings_tip_height = $7,
 settings_valid_until = $8,
 settings_signature = $9
-WHERE public_key = $10`
+WHERE public_key = $10 AND settings_valid_until < $8`
 	return s.transaction(func(ctx context.Context, tx *txn) error {
 		_, err := tx.Exec(ctx, query,
 			sqlCurrency(prices.ContractPrice),

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1469,7 +1469,19 @@ func TestUpdateHostPrices(t *testing.T) {
 		t.Fatal("expected host to be good")
 	}
 
+	// try to update the prices to a lower valid until time which should fail
+	// and the host should continue to be good
+	settings.Prices.ValidUntil = time.Now().Add(30 * time.Second)
+	if err := db.UpdateHostPrices(hostKey, settings.Prices); err != nil {
+		t.Fatal(err)
+	} else if host, err := db.Host(hostKey); err != nil {
+		t.Fatal(err)
+	} else if !host.IsGood() {
+		t.Fatal("expected host to be good")
+	}
+
 	// update host settings with gouging prices
+	settings.Prices.ValidUntil = time.Now().Add(24 * time.Hour)
 	settings.Prices.EgressPrice = types.Siacoins(15)
 	if err := db.UpdateHostPrices(hostKey, settings.Prices); err != nil {
 		t.Fatal(err)
@@ -1692,7 +1704,7 @@ func BenchmarkUsableHosts(b *testing.B) {
 			var hostID int64
 			err := tx.QueryRow(b.Context(), `
 				INSERT INTO hosts (
-					public_key, 
+					public_key,
 					last_announcement,
 					last_successful_scan,
 					settings_protocol_version,
@@ -1742,7 +1754,7 @@ func BenchmarkUsableHosts(b *testing.B) {
 
 			// add host addresses (50% QUIC)
 			if _, err := tx.Exec(ctx, `
-				INSERT INTO host_addresses (host_id, net_address, protocol) 
+				INSERT INTO host_addresses (host_id, net_address, protocol)
 				VALUES ($1, $2, $3)`, hostID, "foo.com", sqlNetworkProtocol(randomProtocol())); err != nil {
 				return fmt.Errorf("failed to insert host address: %w", err)
 			}
@@ -2241,8 +2253,8 @@ func BenchmarkHostsForFunding(b *testing.B) {
 			// add host
 			var hostID int64
 			if err := tx.QueryRow(ctx, `
-				INSERT INTO hosts (public_key, last_announcement) 
-				VALUES ($1, NOW()) 
+				INSERT INTO hosts (public_key, last_announcement)
+				VALUES ($1, NOW())
 				RETURNING id;`, sqlPublicKey(hk)).Scan(&hostID); err != nil {
 				return err
 			}


### PR DESCRIPTION
Otherwise, the host checks might think that the total validity of the prices is below the minimum and will consider hosts bad.