### PR TITLE
Close transport if another transport was faster when dialing

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -119,11 +119,18 @@ top:
 			}
 			if err != nil || dialCtx.Err() != nil {
 				// failed to connect or already connected elsewhere
+				if err == nil {
+					_ = transport.Close()
+				}
 				return
 			}
 			dialCancel()
 			t.mu.Lock()
-			t.tc = transport
+			if t.tc == nil {
+				t.tc = transport
+			} else {
+				_ = transport.Close()
+			}
 			t.mu.Unlock()
 		}(addr)
 	}


### PR DESCRIPTION
Small change to fix a race when dialing hosts on multiple interfaces in parallel. 