### PR TITLE
Consider contracts in renew window not good for append or refresh

### DIFF
--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -164,8 +164,12 @@ func (c Contract) GoodForAccountFunding(target types.Currency) error {
 	}
 }
 
+func (c Contract) inRenewWindow(renewWindow, height uint64) bool {
+	return c.ProofHeight <= height+renewWindow
+}
+
 // GoodForAppend indicates whether a contract can be used to append sectors
-func (c Contract) GoodForAppend(prices proto.HostPrices, height uint64) error {
+func (c Contract) GoodForAppend(prices proto.HostPrices, renewWindow, height uint64) error {
 	switch {
 	case !c.Good:
 		return fmt.Errorf("contract is not good")
@@ -173,6 +177,8 @@ func (c Contract) GoodForAppend(prices proto.HostPrices, height uint64) error {
 		return fmt.Errorf("contract has reached maximum size")
 	case c.ProofHeight <= height:
 		return fmt.Errorf("contract is not revisable")
+	case c.inRenewWindow(renewWindow, height):
+		return fmt.Errorf("contract is in renew window")
 	case c.Size < c.Capacity:
 		return nil
 	}
@@ -189,7 +195,7 @@ func (c Contract) GoodForAppend(prices proto.HostPrices, height uint64) error {
 }
 
 // GoodForRefresh indicates whether a contract is likely to succeed refreshing.
-func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.Currency, period uint64) error {
+func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.Currency, renewWindow, height, period uint64) error {
 	_, collateral := contractFunding(settings, c.Size, fundTarget, period)
 	var totalCollateral types.Currency
 	if settings.ProtocolVersion.Cmp(rhp.ProtocolVersion502) >= 0 {
@@ -202,6 +208,10 @@ func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.C
 		return fmt.Errorf("contract is not good")
 	case c.Size >= maxContractSize:
 		return fmt.Errorf("contract has reached maximum size")
+	case c.ProofHeight <= height:
+		return fmt.Errorf("contract is not revisable")
+	case c.inRenewWindow(renewWindow, height):
+		return fmt.Errorf("contract is in renew window")
 	case totalCollateral.Cmp(settings.MaxCollateral) > 0:
 		return fmt.Errorf("host's max collateral %s is less than estimated collateral %s for refresh", settings.MaxCollateral, totalCollateral)
 	default:

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -261,9 +261,9 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, setting
 			candidate := candidateContract{
 				host:           host,
 				contract:       contract,
-				goodForRefresh: contract.GoodForRefresh(host.Settings, accountFundTarget, settings.Period),
+				goodForRefresh: contract.GoodForRefresh(host.Settings, accountFundTarget, settings.RenewWindow, height, settings.Period),
 				goodForFunding: contract.GoodForAccountFunding(accountFundTarget),
-				goodForAppend:  contract.GoodForAppend(host.Settings.Prices, height),
+				goodForAppend:  contract.GoodForAppend(host.Settings.Prices, settings.RenewWindow, height),
 			}
 
 			// determine which contract to use for maintenance with this host.

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -267,6 +267,7 @@ func TestPerformContractFormation(t *testing.T) {
 	maintenanceSettings := MaintenanceSettings{
 		Enabled:         true,
 		Period:          100,
+		RenewWindow:     10,
 		WantedContracts: 4,
 	}
 

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -414,6 +414,47 @@ func (cm *ContractManager) MaintenanceSettings(ctx context.Context) (Maintenance
 	return cm.store.MaintenanceSettings()
 }
 
+// ContractsForAppend returns all contracts that are good for appending data.
+// These contracts are revisable, not in their renew window, good and have not
+// reached their maximum size.
+func (cm *ContractManager) ContractsForAppend() (good []Contract, err error) {
+	settings, err := cm.store.MaintenanceSettings()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch maintenance settings: %w", err)
+	}
+
+	hostsMap := make(map[types.PublicKey]proto.HostPrices)
+
+	const batchSize = 50
+	for offset := 0; ; offset += batchSize {
+		batch, err := cm.store.Contracts(offset, batchSize, WithRevisable(true), WithGood(true))
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch contracts: %w", err)
+		} else if len(batch) == 0 {
+			break
+		}
+
+		height := cm.chain.TipState().Index.Height
+
+		for _, c := range batch {
+			hostPrices, ok := hostsMap[c.HostKey]
+			if !ok {
+				host, err := cm.hosts.Host(context.Background(), c.HostKey)
+				if err != nil {
+					return nil, fmt.Errorf("failed to fetch host %s: %w", c.HostKey.String(), err)
+				}
+				hostPrices = host.Settings.Prices
+				hostsMap[c.HostKey] = hostPrices
+			}
+
+			if c.GoodForAppend(hostPrices, settings.RenewWindow, height) == nil {
+				good = append(good, c)
+			}
+		}
+	}
+	return
+}
+
 // TriggerAccountRefill triggers a refill for the given account by marking it
 // for funding and then triggering the account funding process.
 func (cm *ContractManager) TriggerAccountRefill(ctx context.Context, hostKey types.PublicKey, account proto.Account) error {

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -106,7 +106,7 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 // provided. If the host refuses to pin a sector, it will be marked as lost.
 func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, hostKey types.PublicKey, hostPrices proto.HostPrices, contractIDs []types.FileContractID, sectors []types.Hash256, log *zap.Logger) error {
 	// NOTE: this is necessary to avoid looping forever
-	// if [AppendSectors] returns an error for all contracts.
+	// when [AppendSectors] returns an error for all contracts.
 	var success bool
 	for _, contractID := range contractIDs {
 		if len(sectors) == 0 {
@@ -119,9 +119,11 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 		if err != nil {
 			log.Debug("failed to pin sectors", zap.Error(err))
 			continue
-		} else if len(res.Sectors) > 0 {
-			success = true
 		}
+		// if the RPC returned, regardless of how many sectors were pinned,
+		// consider it a success as we made progress towards pinning unpinned
+		// sectors.
+		success = true
 
 		// Only the sectors that were attempted should be marked
 		// as missing. So sectors that were not part of the append

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -28,7 +28,9 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 		// perform integrity checks
 		results := make([]CheckSectorsResult, 0, len(toCheck))
 		for len(results) < len(toCheck) {
-			usable, err := m.hm.Usable(ctx, hostKey)
+			usableCtx, usableCancel := context.WithTimeout(ctx, time.Minute)
+			usable, err := m.hm.Usable(usableCtx, hostKey)
+			usableCancel()
 			if err != nil {
 				logger.Error("failed to check if host is usable", zap.Error(err))
 				return

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -70,6 +70,7 @@ type (
 	// manager.
 	ContractManager interface {
 		TriggerAccountRefill(ctx context.Context, hostKey types.PublicKey, account proto.Account) error
+		ContractsForAppend() ([]contracts.Contract, error)
 	}
 
 	// A HostClient defines the minimal interface for interacting with hosts that
@@ -92,7 +93,6 @@ type (
 	// in the database.
 	Store interface {
 		AddServiceAccount(ak types.PublicKey, meta accounts.AccountMeta, opts ...accounts.AddAccountOption) error
-		Contracts(offset, limit int, queryOpts ...contracts.ContractQueryOpt) ([]contracts.Contract, error)
 		Hosts(offset, limit int, queryOpts ...hosts.HostQueryOpt) ([]hosts.Host, error)
 		HostsForIntegrityChecks(maxLastCheck time.Time, limit int) ([]types.PublicKey, error)
 		HostsWithLostSectors() ([]types.PublicKey, error)

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -2,7 +2,6 @@ package slabs
 
 import (
 	"context"
-	"errors"
 	"io"
 	"math"
 	"slices"
@@ -216,17 +215,12 @@ func (s *mockStore) MigrateSector(root types.Hash256, hostKey types.PublicKey) (
 	}
 	s.migratedSectors[hostKey][root] = struct{}{}
 
-	contract, ok := s.contracts[hostKey]
-	if !ok {
-		return false, errors.New("host contract not found")
-	}
-
 	for acc := range s.accounts {
 		for slabID, slab := range s.pinnedSlabs[acc] {
 			for i, sector := range slab.Sectors {
 				if sector.Root == root {
 					s.pinnedSlabs[acc][slabID].Sectors[i].HostKey = &hostKey
-					s.pinnedSlabs[acc][slabID].Sectors[i].ContractID = &contract.ID
+					s.pinnedSlabs[acc][slabID].Sectors[i].ContractID = nil
 					return true, nil
 				}
 			}

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -446,6 +446,8 @@ func (m *mockAccountManager) DebitServiceAccount(ctx context.Context, hostKey ty
 }
 
 type mockContractManager struct {
+	mu               sync.Mutex
+	contracts        []contracts.Contract
 	triggeredRefills map[proto.Account]int
 }
 
@@ -456,8 +458,16 @@ func newMockContractManager() *mockContractManager {
 }
 
 func (m *mockContractManager) TriggerAccountRefill(ctx context.Context, hostKey types.PublicKey, account proto.Account) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.triggeredRefills[account]++
 	return nil
+}
+
+func (m *mockContractManager) ContractsForAppend() ([]contracts.Contract, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.contracts), nil
 }
 
 type mockhostManager struct {

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -339,17 +339,12 @@ func (s *mockStore) UnhealthySlabs(limit int) (result []SlabID, _ error) {
 					break
 				}
 
-				if sector.ContractID == nil || sector.HostKey == nil {
+				// a slab is unhealthy if any of its sectors are not pinned
+				// or are pinned to a bad contract
+				if sector.HostKey == nil {
 					result = append(result, slab.ID)
-					break
-				}
-				if sector.HostKey != nil {
-					hk := *sector.HostKey
-					contract, ok := s.contracts[hk]
-					if ok && !contract.Good {
-						result = append(result, slab.ID)
-						break
-					}
+				} else if contract, ok := s.contracts[*sector.HostKey]; ok && !contract.Good {
+					result = append(result, slab.ID)
 				}
 			}
 		}

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -21,20 +21,13 @@ func (m *SlabManager) migrateSlabs(ctx context.Context, slabIDs []SlabID, log *z
 	}
 
 	// fetch all available contracts
-	var goodContracts []contracts.Contract
-	const batchSize = 50
-	for offset := 0; ; offset += batchSize {
-		batch, err := m.store.Contracts(offset, batchSize, contracts.WithRevisable(true), contracts.WithGood(true))
-		if err != nil {
-			return fmt.Errorf("failed to fetch contracts: %w", err)
-		}
-		goodContracts = append(goodContracts, batch...)
-		if len(batch) < batchSize {
-			break
-		}
+	goodContracts, err := m.cm.ContractsForAppend()
+	if err != nil {
+		return fmt.Errorf("failed to fetch contracts: %w", err)
 	}
 
 	// fetch all available hosts with contracts
+	const batchSize = 500
 	var allHosts []hosts.Host
 	for offset := 0; ; offset += batchSize {
 		batch, err := m.store.Hosts(offset, batchSize, hosts.WithBlocked(false), hosts.WithActiveContracts(true))
@@ -63,7 +56,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 		log.Error("failed to fetch slab", zap.Error(err))
 		return
 	}
-	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, m.chain.Tip().Height, m.minHostDistanceKm)
+	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, m.minHostDistanceKm)
 	if len(indices) == 0 {
 		log.Debug("tried to migrate slab but no indices require migration")
 		return
@@ -156,7 +149,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 // sectors that require migration together with hosts that can be used to
 // migrate bad sectors to. These hosts are guaranteed to be at least
 // minHostDistance apart from each other and are returned in random order.
-func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, height uint64, minHostDistanceKm float64) ([]int, []types.PublicKey) {
+func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, minHostDistanceKm float64) ([]int, []types.PublicKey) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range allHosts {
@@ -168,8 +161,7 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 	// prepare a map of good contracts
 	goodContractMap := make(map[types.FileContractID]contracts.Contract)
 	for _, contract := range goodContracts {
-		host, ok := hostsMap[contract.HostKey]
-		if ok && contract.GoodForAppend(host.Settings.Prices, height) == nil {
+		if _, ok := hostsMap[contract.HostKey]; ok {
 			goodContractMap[contract.ID] = contract
 		}
 	}

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -21,6 +21,7 @@ func TestMigrateSlab(t *testing.T) {
 	log := zaptest.NewLogger(t)
 	// prepare dependencies
 	db := newMockStore()
+	contracts := newMockContractManager()
 	chain := newMockChainManager()
 	am := newMockAccountManager(db)
 	hm := newMockHostManager()
@@ -49,6 +50,8 @@ func TestMigrateSlab(t *testing.T) {
 		if i == 1 {
 			// bad contract
 			c.Good = false
+		} else {
+			contracts.contracts = append(contracts.contracts, c)
 		}
 		db.contracts[h.PublicKey] = c
 	}
@@ -84,7 +87,7 @@ func TestMigrateSlab(t *testing.T) {
 	msk := types.GeneratePrivateKey()
 	ssk := types.GeneratePrivateKey()
 	alerter := alerts.NewManager()
-	mgr, err := newSlabManager(chain, am, nil, hm, db, client, alerter, msk, ssk, WithLogger(log.Named("slabs")))
+	mgr, err := newSlabManager(chain, am, contracts, hm, db, client, alerter, msk, ssk, WithLogger(log.Named("slabs")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,6 +153,7 @@ func TestMigrateSlab(t *testing.T) {
 	client.hostSettings[h5.PublicKey] = h5.Settings
 	c := newTestContract(h5.PublicKey)
 	db.contracts[h5.PublicKey] = c
+	contracts.contracts = append(contracts.contracts, c)
 
 	// migrate the slab again
 	err = mgr.migrateSlabs(context.Background(), unhealthSlabIDs, log.Named("migrate"))
@@ -197,7 +201,7 @@ func TestSectorsToMigrate(t *testing.T) {
 			ProofHeight:      200,
 			ExpirationHeight: 300,
 		}
-		if err := c.GoodForAppend(goodSettings.Prices, 0); (err == nil) != goodForUpload {
+		if err := c.GoodForAppend(goodSettings.Prices, 0, 0); (err == nil) != goodForUpload {
 			// sanity check
 			t.Fatalf("contract %d: expected goodForUpload %v, got %v (%s)", contractIndex, goodForUpload, err == nil, err)
 		}
@@ -259,7 +263,7 @@ func TestSectorsToMigrate(t *testing.T) {
 	// helper to assert result of contractsForRepair
 	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots []int, expectedHosts []hosts.Host) {
 		t.Helper()
-		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 100, 10)
+		toRepair, toUse := sectorsToMigrate(slab, availableHosts, availableContracts, 10)
 		if len(toRepair) != len(expectedRoots) {
 			t.Fatalf("expected %d roots to repair, got %d: %v", len(expectedRoots), len(toRepair), toRepair)
 		} else if len(toUse) != len(expectedHosts) {

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -89,8 +89,8 @@ top:
 
 					if _, err := m.store.MigrateSector(shardRoot, hostKey); err != nil {
 						log.Error("failed to record migrated sector", zap.Error(err))
+						return
 					}
-
 					atomic.AddInt32(&migrated, 1)
 					return
 				}

--- a/slabs/uploads_test.go
+++ b/slabs/uploads_test.go
@@ -11,11 +11,12 @@ import (
 	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
 
 func TestUploadShards(t *testing.T) {
-	log := zap.NewNop()
+	log := zaptest.NewLogger(t)
 	// prepare dependencies
 	store := newMockStore()
 	chain := newMockChainManager()


### PR DESCRIPTION
Changes contracts in their renew window to not be good for appending or refreshing. This fixes an edge case where contracts would not be renewable, but continue to have sectors pinned to them. If renewal fails we can end up with an extra new contract, but that's acceptable.

Also fixes some busted logic in the mock store. We really should remove that ASAP since the logic differs significantly from the actual store. Another good reason to keep mocking to a minimum.

Depends on #703 

This is deployed on Zeus