### PR TITLE
Fix BenchmarkMarkSectorsUnpinnable

### DIFF
--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -2312,6 +2312,23 @@ func BenchmarkMarkSectorsUnpinnable(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+		// recalculate sector stats
+		if _, err := store.pool.Exec(b.Context(), `
+		WITH counts AS (
+			SELECT
+				COUNT(*) FILTER (WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NOT NULL)::bigint AS pinned,
+				COUNT(*) FILTER (WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NULL)::bigint     AS unpinned,
+				COUNT(*) FILTER (WHERE host_id IS NULL     AND contract_sectors_map_id IS NULL)::bigint     AS unpinnable
+			FROM sectors
+		)
+		UPDATE stats s
+		SET
+			num_pinned_sectors     = counts.pinned,
+			num_unpinned_sectors   = counts.unpinned,
+			num_unpinnable_sectors = counts.unpinnable
+		FROM counts`); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	// 1/10 = 10%, 1/100 = 1%, 1/1000 = 0.1%


### PR DESCRIPTION
I noticed a failed run and figured we might as well fix it. I couldn't reproduce it locally but we have to reset sector stats in benchmarks that call store methods that manipulate the stats. This is due to the `CHECK`s we enforce on DB level.

https://github.com/SiaFoundation/indexd/actions/runs/19852643338/job/56882809653