### PR TITLE
Prevent the same host from storing more than one slab shard

### DIFF
--- a/client/v2/candidates.go
+++ b/client/v2/candidates.go
@@ -133,8 +133,16 @@ func (c *Candidates) Retry(host types.PublicKey) {
 
 // NewCandidates creates a new Candidates with the provided hosts.
 func NewCandidates(hosts []types.PublicKey) *Candidates {
+	seen := make(map[types.PublicKey]struct{})
+	uniqueHosts := make([]types.PublicKey, 0, len(hosts))
+	for _, host := range hosts {
+		if _, ok := seen[host]; !ok {
+			seen[host] = struct{}{}
+			uniqueHosts = append(uniqueHosts, host)
+		}
+	}
 	return &Candidates{
-		hosts: hosts,
+		hosts: uniqueHosts,
 	}
 }
 

--- a/client/v2/candidates_test.go
+++ b/client/v2/candidates_test.go
@@ -279,3 +279,24 @@ func TestProviderCandidates(t *testing.T) {
 		seen[pk] = true
 	}
 }
+
+func TestDuplicateCandidates(t *testing.T) {
+	hosts := []types.PublicKey{
+		types.GeneratePrivateKey().PublicKey(),
+		types.GeneratePrivateKey().PublicKey(),
+		types.GeneratePrivateKey().PublicKey(),
+	}
+	duplicates := append(slices.Clone(hosts), hosts[1], hosts[2], hosts[0], hosts[1])
+
+	candidates := NewCandidates(duplicates)
+	seen := make(map[types.PublicKey]struct{})
+	for pk := range candidates.Iter() {
+		if _, ok := seen[pk]; ok {
+			t.Fatalf("duplicate candidate host: %s", pk.String())
+		}
+		seen[pk] = struct{}{}
+	}
+	if len(seen) != len(hosts) {
+		t.Fatalf("expected %d unique candidates, got %d", len(hosts), len(seen))
+	}
+}

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -37,12 +37,15 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Lo
 	slabHosts := make(map[types.PublicKey]slabDownload)
 	candidates := make([]types.PublicKey, 0, len(slab.Sectors))
 	for i, sector := range slab.Sectors {
-		if sector.HostKey != nil {
-			candidates = append(candidates, *sector.HostKey)
-			slabHosts[*sector.HostKey] = slabDownload{
-				root:  sector.Root,
-				index: i,
-			}
+		if sector.HostKey == nil {
+			continue
+		} else if _, exists := slabHosts[*sector.HostKey]; exists {
+			continue // prevent duplicates
+		}
+		candidates = append(candidates, *sector.HostKey)
+		slabHosts[*sector.HostKey] = slabDownload{
+			root:  sector.Root,
+			index: i,
 		}
 	}
 	candidates = m.hosts.Prioritize(candidates)

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -160,8 +160,10 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 
 	// prepare a map of good contracts
 	goodContractMap := make(map[types.FileContractID]contracts.Contract)
+	hasGoodContract := make(map[types.PublicKey]struct{})
 	for _, contract := range goodContracts {
 		if _, ok := hostsMap[contract.HostKey]; ok {
+			hasGoodContract[contract.HostKey] = struct{}{}
 			goodContractMap[contract.ID] = contract
 		}
 	}
@@ -191,6 +193,8 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 			toMigrate = append(toMigrate, i)
 			continue
 		}
+		// prevent duplicate hosts
+		delete(hostsMap, *sector.HostKey)
 
 		if sector.ContractID != nil {
 			if _, ok := goodContractMap[*sector.ContractID]; !ok {
@@ -203,18 +207,14 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 
 		// sector will not be migrated. Remove it from the hosts map
 		// and add it to the spaced set.
-		delete(hostsMap, *sector.HostKey)
 		set.Add(host.Info())
 	}
-
-	// return all hosts with contracts that are good, currently not in use and
-	// are sufficiently far apart
 	var candidates []types.PublicKey
-	for _, contract := range goodContractMap {
-		if host, ok := hostsMap[contract.HostKey]; ok && set.Add(host.Info()) {
+	for _, host := range hostsMap {
+		// must have a good contract and be sufficiently far apart
+		if _, ok := hasGoodContract[host.PublicKey]; ok && set.Add(host.Info()) {
 			candidates = append(candidates, host.PublicKey)
 		}
 	}
-
 	return toMigrate, candidates
 }

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -30,6 +30,15 @@ func (m *SlabManager) uploadShards(ctx context.Context, slab Slab, shards [][]by
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// defensive programming to ensure shards are
+	// never uploaded to the same host twice.
+	var used sync.Map
+	for _, sector := range slab.Sectors {
+		if sector.HostKey != nil {
+			used.Store(*sector.HostKey, struct{}{})
+		}
+	}
+
 	// prioritize available candidates based on latest reliability and performance
 	candidates := client.NewCandidates(m.hosts.Prioritize(available))
 
@@ -79,6 +88,8 @@ top:
 						cancel()
 						log.Error("shard root mismatch after upload, user data corrupt", zap.Stringer("expected", shardRoot), zap.Stringer("actual", result.Root))
 						return
+					} else if _, existed := used.Swap(hostKey, struct{}{}); existed {
+						log.Panic("host already used for another shard", zap.Stringer("hostKey", hostKey)) // developer error
 					}
 
 					// debit service account


### PR DESCRIPTION
Currently causing panics on Zeus

```
indexd=# SELECT host_id, COUNT(*) FROM sectors s INNER JOIN slab_sectors ss ON (ss.sector_id=s.id) WHERE ss.slab_id=2116678 GROUP BY host_id;
 host_id | count 
---------+-------
     625 |     1
         |     2
    1630 |     1
     162 |     1
      22 |     1
     197 |     1
     932 |     1
     577 |     1
     189 |     1
      82 |     1
     257 |     1
    1682 |     1
     610 |     1
      95 |     1
     198 |     1
    1143 |     1
     179 |     **2**
    1885 |     1
    1134 |     1
     360 |     1
     374 |     1
     222 |     1
     183 |     1
    1099 |     1
     935 |     1
    1074 |     1
      18 |     1
      27 |     1
```
```
2025-12-03T21:27:44Z	PANIC	slabs.migrations	failed to reconstruct shards	{"slab": "85009ffe61c5bdf33d4423f8ccdb9d225bc4398127d27520df4a0b0866c435ca", "toMigrate": 11, "uploadCandidates": 110, "downloadElapsed": "10.865670204s", "error": "too few shards given"}

goroutine 96561968 [running]:
go.uber.org/zap/zapcore.CheckWriteAction.OnWrite(0x1?, 0x1?, {0x0?, 0x0?, 0xc06f6906c0?})
	go.uber.org/zap@v1.27.1/zapcore/entry.go:196 +0x54
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc003102340, {0xc03b885e40, 0x1, 0x1})
	go.uber.org/zap@v1.27.1/zapcore/entry.go:272 +0x22a
go.uber.org/zap.(*Logger).Panic(0xa?, {0x114c2dd?, 0x0?}, {0xc03b885e40, 0x1, 0x1})
	go.uber.org/zap@v1.27.1/logger.go:285 +0x4b
go.sia.tech/indexd/slabs.(*SlabManager).migrateSlab(0xc00031a100, {0x1b13b70, 0xc0002a86e0}, {0x85, 0x0, 0x9f, 0xfe, 0x61, 0xc5, 0xbd, ...}, ...)
	go.sia.tech/indexd/slabs/migrations.go:111 +0xcf5
go.sia.tech/indexd/slabs.(*SlabManager).migrateSlabs.func1()
	go.sia.tech/indexd/slabs/migrations.go:46 +0x1d4
sync.(*WaitGroup).Go.func1()
	sync/waitgroup.go:239 +0x4a
created by sync.(*WaitGroup).Go in goroutine 232
	sync/waitgroup.go:237 +0x73
```