### PR TITLE
Remove extra app key wrapper

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -154,6 +154,15 @@ top:
 	return sectors, nil
 }
 
+// AppKey returns the app key used by the SDK.
+//
+// It should be kept secret. Applications
+// should store it securely to authenticate with
+// the indexer.
+func (s *SDK) AppKey() types.PrivateKey {
+	return s.appKey
+}
+
 // Upload uploads the data to hosts and pins it to the indexer.
 //
 // Returns the metadata of the slabs that were pinned

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -211,7 +211,7 @@ func TestE2E(t *testing.T) {
 	cluster.WaitForContracts(t)
 
 	b := NewBuilder(cluster.Indexer.AppAPIAddr(), AppMetadata{})
-	client, err := b.SDK(&AppKey{privateKey}, WithLogger(log.Named("sdk")))
+	client, err := b.SDK(privateKey, WithLogger(log.Named("sdk")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -2,8 +2,6 @@ package sdk
 
 import (
 	"context"
-	"crypto/ed25519"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"time"
@@ -37,40 +35,7 @@ type (
 		ServiceURL  string
 		CallbackURL string
 	}
-
-	// An AppKey represents a key used to authenticate an application.
-	// It is derived from a BIP-39 seed phrase and a shared secret
-	// provided by the indexer during app connection.
-	//
-	// This key should be stored securely by the application and never
-	// shared with anyone else. It can be regenerated using the same app
-	// ID, user account, and seed phrase.
-	AppKey struct {
-		key types.PrivateKey
-	}
 )
-
-// String returns the base64-encoded representation of the app key.
-func (ak *AppKey) String() string {
-	return base64.RawURLEncoding.EncodeToString(ak.key[:32])
-}
-
-// MarshalText encodes the app key as a base64-encoded string.
-func (ak *AppKey) MarshalText() ([]byte, error) {
-	return []byte(ak.String()), nil
-}
-
-// UnmarshalText decodes a base64-encoded app key.
-func (ak *AppKey) UnmarshalText(text []byte) error {
-	buf, err := base64.RawURLEncoding.DecodeString(string(text))
-	if err != nil {
-		return fmt.Errorf("failed to decode app key: %w", err)
-	} else if len(buf) != ed25519.SeedSize {
-		return fmt.Errorf("invalid app key size: expected %d, got %d", ed25519.SeedSize, len(buf))
-	}
-	ak.key = types.NewPrivateKeyFromSeed(buf)
-	return nil
-}
 
 // A Builder helps connect an application to an indexer
 // and initialize an SDK instance.
@@ -112,14 +77,13 @@ func (b *Builder) WaitForApproval(ctx context.Context) (bool, error) {
 	}
 }
 
-// GenerateAppKey derives an application key from a BIP-39 seed phrase that
-// can be used to upload and download data from the indexer and
+// Register derives an application key from a BIP-39 seed phrase and
 // registers it with the indexer.
 //
 // This key should be stored securely by the application and never
 // shared with anyone else. It can be regenerated using the same app
 // ID, user account, and seed phrase.
-func (b *Builder) GenerateAppKey(ctx context.Context, mnemonic string) (*AppKey, error) {
+func (b *Builder) Register(ctx context.Context, mnemonic string) (*SDK, error) {
 	if b.sharedSecret == (types.Hash256{}) {
 		return nil, fmt.Errorf("app not connected")
 	}
@@ -127,14 +91,14 @@ func (b *Builder) GenerateAppKey(ctx context.Context, mnemonic string) (*AppKey,
 	appKey, err := deriveAppKey(mnemonic, b.request.AppID, b.sharedSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive app key: %w", err)
-	} else if err := b.client.RegisterApp(ctx, b.registerResp.RegisterURL, appKey.key); err != nil {
+	} else if err := b.client.RegisterApp(ctx, b.registerResp.RegisterURL, appKey); err != nil {
 		return nil, fmt.Errorf("failed to register app key: %w", err)
 	}
 
 	// prevent attempted re-use
 	b.registerResp = nil
 	clear(b.sharedSecret[:])
-	return appKey, nil
+	return b.SDK(appKey)
 }
 
 // RequestConnection sends a request to connect an application to the indexer.
@@ -150,26 +114,22 @@ func (b *Builder) RequestConnection(ctx context.Context) (string, error) {
 	return resp.ResponseURL, nil
 }
 
-// Connected checks if the application is connected to the indexer.
-func (b *Builder) Connected(ctx context.Context, appKey *AppKey) (bool, error) {
-	return b.client.CheckAppAuth(ctx, appKey.key)
-}
-
-// SDK creates a new SDK instance using the given application key.
-func (b *Builder) SDK(appKey *AppKey, opts ...Option) (*SDK, error) {
-	if ok, err := b.client.CheckAppAuth(context.Background(), appKey.key); err != nil {
+// SDK creates a new SDK instance using the given application key. If the
+// key is not authorized, an error is returned.
+func (b *Builder) SDK(appKey types.PrivateKey, opts ...Option) (*SDK, error) {
+	if ok, err := b.client.CheckAppAuth(context.Background(), appKey); err != nil {
 		return nil, fmt.Errorf("failed to check app auth: %w", err)
 	} else if !ok {
 		return nil, fmt.Errorf("app key is not authorized")
 	}
-	hostStore, err := newCachedHostStore(b.client, appKey.key)
+	hostStore, err := newCachedHostStore(b.client, appKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create host store: %w", err)
 	}
-	return initSDK(appKey.key, b.client, client.New(client.NewProvider(hostStore)), opts...), nil
+	return initSDK(appKey, b.client, client.New(client.NewProvider(hostStore)), opts...), nil
 }
 
-func deriveAppKey(mnemonic string, appID types.Hash256, sharedSecret types.Hash256) (*AppKey, error) {
+func deriveAppKey(mnemonic string, appID types.Hash256, sharedSecret types.Hash256) (types.PrivateKey, error) {
 	var seed [32]byte
 	if err := wallet.SeedFromPhrase(&seed, mnemonic); err != nil {
 		return nil, fmt.Errorf("failed to derive seed from phrase: %w", err)
@@ -178,7 +138,7 @@ func deriveAppKey(mnemonic string, appID types.Hash256, sharedSecret types.Hash2
 	buf := keys.Derive(append(seed[:], sharedSecret[:]...), appID[:], []byte("indexd app key derivation"), 32)
 	defer clear(buf)
 
-	return &AppKey{types.NewPrivateKeyFromSeed(buf)}, nil
+	return types.NewPrivateKeyFromSeed(buf), nil
 }
 
 // NewBuilder creates a new Builder for connecting applications to the indexer.

--- a/sdk/connect_test.go
+++ b/sdk/connect_test.go
@@ -64,12 +64,6 @@ func TestConnect(t *testing.T) {
 		ServiceURL:  "https://example.com",
 	})
 
-	mnemonic := sdk.NewSeedPhrase()
-
-	if _, err := builder.GenerateAppKey(t.Context(), mnemonic); err == nil {
-		t.Fatal("expected error when generating app key before connection")
-	}
-
 	responseURL, err := builder.RequestConnection(t.Context())
 	if err != nil {
 		t.Fatal("failed to request connection:", err)
@@ -101,30 +95,14 @@ func TestConnect(t *testing.T) {
 		t.Fatal("expected connection to be approved")
 	}
 
-	appKey, err := builder.GenerateAppKey(t.Context(), mnemonic)
+	mnemonic := sdk.NewSeedPhrase()
+	client, err := builder.Register(t.Context(), mnemonic)
 	if err != nil {
 		t.Fatal("failed to generate app key after approval:", err)
 	}
-
-	connected, err := builder.Connected(t.Context(), appKey)
-	if err != nil {
-		t.Fatal("failed to check connection status:", err)
-	} else if !connected {
-		t.Fatal("expected app to be connected")
-	}
-
-	// expect generating the app key again to fail since it has already
-	// been generated
-	if _, err := builder.GenerateAppKey(t.Context(), mnemonic); err == nil {
-		t.Fatal("expected error when generating app key second time")
-	}
-
-	// create SDK instance
-	client, err := builder.SDK(appKey)
-	if err != nil {
-		t.Fatal("failed to create SDK instance:", err)
-	}
 	defer client.Close()
+
+	appKey1 := client.AppKey()
 
 	// verify the key can be used to access resources owned by the app
 	if _, err := client.ListObjects(t.Context(), slabs.Cursor{}, 10); err != nil {
@@ -135,7 +113,6 @@ func TestConnect(t *testing.T) {
 
 	// go through the connection flow again to verify multiple connections generate
 	// the same app key
-
 	builder = sdk.NewBuilder(cluster.Indexer.AppAPIAddr(), sdk.AppMetadata{
 		ID:          appID,
 		Name:        "Test App",
@@ -160,17 +137,14 @@ func TestConnect(t *testing.T) {
 		t.Fatal("expected connection to be approved")
 	}
 
-	appKey2, err := builder.GenerateAppKey(t.Context(), mnemonic)
+	client2, err := builder.Register(t.Context(), mnemonic)
 	if err != nil {
 		t.Fatal("failed to generate app key after approval:", err)
-	} else if appKey.String() != appKey2.String() {
-		t.Fatal("expected regenerated app key to match original")
 	}
+	defer client2.Close()
 
-	connected, err = builder.Connected(t.Context(), appKey2)
-	if err != nil {
-		t.Fatal("failed to check connection status:", err)
-	} else if !connected {
-		t.Fatal("expected app to be connected")
+	appKey2 := client2.AppKey()
+	if !bytes.Equal(appKey1, appKey2) {
+		t.Fatal("expected regenerated app key to match original")
 	}
 }

--- a/sdk/encrypt_test.go
+++ b/sdk/encrypt_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"testing"
@@ -16,11 +17,17 @@ import (
 // with other implementations.
 func TestDeriveAppKeyGolden(t *testing.T) {
 	const (
-		mnemonic        = "glare own entire dish exact open theme family harsh room scrap rose"
-		appIDStr        = "0e90d697f5045a6593f1c43ebf79a369e2bc72cc5c7b6282f3b5aeb0de6e4005"
-		sharedSecretStr = "cf02d945fe4bfe614d823dc13c19aa8501699e656d0f7915490c3056d5c97dc6"
-		expectedAppKey  = "t1Bh80uzrqsjKwZx2i0DR8VHNDoAJrtVNcKR2WT9CaE"
+		mnemonic          = "glare own entire dish exact open theme family harsh room scrap rose"
+		appIDStr          = "0e90d697f5045a6593f1c43ebf79a369e2bc72cc5c7b6282f3b5aeb0de6e4005"
+		sharedSecretStr   = "cf02d945fe4bfe614d823dc13c19aa8501699e656d0f7915490c3056d5c97dc6"
+		expectedAppKeyStr = "b75061f34bb3aeab232b0671da2d0347c547343a0026bb5535c291d964fd09a1"
 	)
+
+	seed, err := hex.DecodeString(expectedAppKeyStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedAppKey := types.NewPrivateKeyFromSeed(seed)
 
 	var appID, sharedSecret types.Hash256
 	if err := appID.UnmarshalText([]byte(appIDStr)); err != nil {
@@ -32,9 +39,8 @@ func TestDeriveAppKeyGolden(t *testing.T) {
 	appKey, err := deriveAppKey(mnemonic, appID, sharedSecret)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if appKey.String() != expectedAppKey {
-		t.Fatalf("derived app key mismatch: expected %q, got %q", expectedAppKey, appKey)
+	} else if !bytes.Equal(appKey, expectedAppKey) {
+		t.Fatal("derived app key does not match expected")
 	}
 }
 

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -127,14 +127,12 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 	// note: timeouts are set within uploadShards to avoid timing out the database
 	uploadStart := time.Now()
 	migrated, err := m.uploadShards(ctx, slab, shards, uploadCandidates, log.Named("migrate"))
-	log = log.With(zap.Duration("uploadElapsed", time.Since(uploadStart)), zap.Int("toMigrate", len(indices)), zap.Int("migrated", migrated))
+	log = log.With(zap.Duration("uploadElapsed", time.Since(uploadStart)), zap.Int("migrated", migrated))
 	if err != nil {
 		log.Warn("failed to upload migrated shards", zap.Error(err))
 	}
 
-	repaired := migrated == len(indices)
-	log = log.With(zap.Bool("repaired", repaired), zap.Int("migrated", migrated), zap.Int("toMigrate", len(indices)))
-	if err := m.store.MarkSlabRepaired(slabID, repaired); err != nil {
+	if err := m.store.MarkSlabRepaired(slabID, migrated == len(indices)); err != nil {
 		log.Error("failed to mark slab repaired", zap.Error(err))
 	}
 


### PR DESCRIPTION
Removes the unnecessary AppKey wrapper in favor of using PrivateKey directly. The integrator can store it however they want. Removes the ability to pass an arbitrary app key into the final register call and forces the developer to derive it from a seed.