### PR TITLE
Fixed incorrect version number in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go.sia.tech/indexd
 
-go 1.25.0
+go 1.25
+
+toolchain go1.25.5
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.sia.tech/indexd
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438


### PR DESCRIPTION
Running `go build ./cmd/indexd` will produce:

```
go: download go1.25 for linux/amd64: toolchain not available
```

This is due to the incorrect version format in `go.mod`. The version number was `1.25` but should be `1.25.0`.

This PR corrects the mistake.