### PR TITLE
Update `store.SaveObject`

### DIFF
--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -287,12 +287,22 @@ func (s *Store) SaveObject(account proto.Account, obj slabs.SealedObject) error 
 			return accounts.ErrNotFound
 		}
 
+		// ensure empty slices are passed as nil
+		var encryptedMetaKey []byte
+		if len(obj.EncryptedMetadataKey) > 0 {
+			encryptedMetaKey = obj.EncryptedMetadataKey
+		}
+		var encryptedMeta []byte
+		if len(obj.EncryptedMetadata) > 0 {
+			encryptedMeta = obj.EncryptedMetadata
+		}
+
 		var objectID int64
 		err = tx.QueryRow(ctx, `
 			INSERT INTO objects (object_key, account_id, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature) VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (account_id, object_key) DO UPDATE SET (encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, updated_at) = (EXCLUDED.encrypted_data_key, EXCLUDED.encrypted_meta_key, EXCLUDED.encrypted_metadata, EXCLUDED.data_signature, EXCLUDED.meta_signature, NOW())
 			RETURNING id`,
-			sqlHash256(obj.ID()), accountID, obj.EncryptedDataKey, obj.EncryptedMetadataKey, obj.EncryptedMetadata, sqlSignature(obj.DataSignature), sqlSignature(obj.MetadataSignature)).Scan(&objectID)
+			sqlHash256(obj.ID()), accountID, obj.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(obj.DataSignature), sqlSignature(obj.MetadataSignature)).Scan(&objectID)
 		if err != nil {
 			return fmt.Errorf("failed to insert object: %w", err)
 		}

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -390,6 +390,103 @@ func TestListObjectsRegression(t *testing.T) {
 	}
 }
 
+func TestSaveObject(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	// create account
+	acc := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(acc))
+
+	// add host and contract
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// pin a slab
+	slab := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    frand.Entropy256(),
+			HostKey: hk,
+		}},
+	}
+	if _, err := store.PinSlabs(acc, time.Time{}, slab); err != nil {
+		t.Fatal(err)
+	}
+
+	// assert saving an object with metadata
+	objWithMeta := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: frand.Bytes(72),
+		EncryptedMetadata:    frand.Bytes(100),
+		Slabs:                []slabs.SlabSlice{slab.Slice(0, 100)},
+		DataSignature:        types.Signature(frand.Bytes(64)),
+		MetadataSignature:    types.Signature(frand.Bytes(64)),
+	}
+
+	if err := store.SaveObject(acc, objWithMeta); err != nil {
+		t.Fatalf("failed to save object with metadata: %v", err)
+	}
+
+	// assert we can retrieve it correctly
+	got, err := store.Object(acc, objWithMeta.ID())
+	if err != nil {
+		t.Fatalf("failed to get object: %v", err)
+	} else if len(got.EncryptedMetadataKey) != 72 {
+		t.Fatalf("unexpected key length, got %d bytes", len(got.EncryptedMetadataKey))
+	} else if !bytes.Equal(got.EncryptedMetadataKey, objWithMeta.EncryptedMetadataKey) {
+		t.Fatal("unexpected key")
+	} else if !bytes.Equal(got.EncryptedMetadata, objWithMeta.EncryptedMetadata) {
+		t.Fatal("unexpected metadata")
+	}
+
+	// assert saving an object without metadata
+	objNoMeta := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: nil,
+		EncryptedMetadata:    nil,
+		Slabs:                []slabs.SlabSlice{slab.Slice(100, 100)},
+		DataSignature:        types.Signature(frand.Bytes(64)),
+		MetadataSignature:    types.Signature(frand.Bytes(64)),
+	}
+
+	if err := store.SaveObject(acc, objNoMeta); err != nil {
+		t.Fatalf("failed to save object without metadata: %v", err)
+	}
+
+	got, err = store.Object(acc, objNoMeta.ID())
+	if err != nil {
+		t.Fatalf("failed to get object: %v", err)
+	} else if len(got.EncryptedMetadataKey) != 0 {
+		t.Fatalf("unexpected key length, got %d bytes", len(got.EncryptedMetadataKey))
+	} else if len(got.EncryptedMetadata) != 0 {
+		t.Fatalf("unexpected metadata length, got %d bytes", len(got.EncryptedMetadata))
+	}
+
+	// assert saving an object with empty metadata slice
+	objEmptyMeta := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: []byte{},
+		EncryptedMetadata:    []byte{},
+		Slabs:                []slabs.SlabSlice{slab.Slice(200, 100)},
+		DataSignature:        types.Signature(frand.Bytes(64)),
+		MetadataSignature:    types.Signature(frand.Bytes(64)),
+	}
+
+	if err := store.SaveObject(acc, objEmptyMeta); err != nil {
+		t.Fatalf("failed to save object with empty metadata slice: %v", err)
+	}
+
+	got, err = store.Object(acc, objEmptyMeta.ID())
+	if err != nil {
+		t.Fatalf("failed to get object: %v", err)
+	} else if len(got.EncryptedMetadataKey) != 0 {
+		t.Fatalf("unexpected key length, got %d bytes", len(got.EncryptedMetadataKey))
+	} else if len(got.EncryptedMetadata) != 0 {
+		t.Fatalf("unexpected metadata length, got %d bytes", len(got.EncryptedMetadata))
+	}
+}
+
 func TestSharedObjects(t *testing.T) {
 	store := initPostgres(t, zap.NewNop())
 


### PR DESCRIPTION
This PR fixes the following SQL violation that occurs when saving an object without metadata.

```
Error: "Upload command failed: Failed to upload file: upload error: api error: indexd responded with an error: failed to insert object: ERROR: new row for relation \"objects\" violates check constraint \"objects_encrypted_meta_key_check\" (SQLSTATE 23514)\n"
```