### PR TITLE
fix contract revert logic

### DIFF
--- a/contracts/chain.go
+++ b/contracts/chain.go
@@ -19,6 +19,7 @@ type (
 	UpdateTx interface {
 		ContractElements() ([]types.V2FileContractElement, error)
 		IsKnownContract(contractID types.FileContractID) (bool, error)
+		DeleteContractElements(contractIDs ...types.FileContractID) error
 		UpdateContractElements(fces ...types.V2FileContractElement) error
 		UpdateContractState(contractID types.FileContractID, state ContractState) error
 		UpdateContractRenewedTo(contractID types.FileContractID, renewedTo *types.FileContractID) error
@@ -100,104 +101,123 @@ func (m *ContractManager) UpdateChainState(tx UpdateTx, reverted []chain.RevertU
 	return nil
 }
 
-func (m *ContractManager) applyChainUpdate(tx *updateTx, cau chain.ApplyUpdate) error {
-	for _, diff := range cau.V2FileContractElementDiffs() {
+func (m *ContractManager) applyV2ContractDiffs(tx *updateTx, diffs []consensus.V2FileContractElementDiff) error {
+	var updated []types.V2FileContractElement
+	var resolved []types.FileContractID
+	for _, diff := range diffs {
 		if known, err := tx.IsKnownContract(diff.V2FileContractElement.ID); err != nil {
 			return fmt.Errorf("failed to determine whether contract is known: %w", err)
 		} else if !known {
 			continue // ignore unknown contracts
 		}
-		if err := m.applyContractDiff(tx, diff); err != nil {
-			return fmt.Errorf("failed to apply contract diff: %w", err)
+
+		switch {
+		case diff.Created:
+			if err := tx.UpdateContractState(diff.V2FileContractElement.ID, ContractStateActive); err != nil {
+				return fmt.Errorf("failed to update contract state for %v: %w", diff.V2FileContractElement.ID, err)
+			}
+			updated = append(updated, diff.V2FileContractElement)
+		case diff.Resolution != nil:
+			if err := tx.UpdateContractState(diff.V2FileContractElement.ID, ContractStateResolved); err != nil {
+				return fmt.Errorf("failed to update contract state for %v: %w", diff.V2FileContractElement.ID, err)
+			} else if _, ok := diff.Resolution.(*types.V2FileContractRenewal); ok {
+				// update renewed to for renewals
+				renewedTo := diff.V2FileContractElement.ID.V2RenewalID()
+				if err := tx.UpdateContractRenewedTo(diff.V2FileContractElement.ID, &renewedTo); err != nil {
+					return fmt.Errorf("failed to update renewed to for %v: %w", diff.V2FileContractElement.ID, err)
+				}
+			}
+			// contract was resolved, this element is no longer needed
+			resolved = append(resolved, diff.V2FileContractElement.ID)
+		default:
+			fce := diff.V2FileContractElement
+			if rev, ok := diff.V2RevisionElement(); ok {
+				fce = rev
+			}
+			updated = append(updated, fce)
 		}
+	}
+
+	if len(updated) > 0 {
+		// update created and revised contract elements
+		if err := tx.UpdateContractElements(updated...); err != nil {
+			return fmt.Errorf("failed to update modified contract elements: %w", err)
+		}
+	}
+
+	if len(resolved) > 0 {
+		// delete resolved contract elements
+		if err := tx.DeleteContractElements(resolved...); err != nil {
+			return fmt.Errorf("failed to delete resolved contract elements: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *ContractManager) applyChainUpdate(tx *updateTx, cau chain.ApplyUpdate) error {
+	if err := m.applyV2ContractDiffs(tx, cau.V2FileContractElementDiffs()); err != nil {
+		return fmt.Errorf("failed to apply contract diffs: %w", err)
 	}
 
 	// update state element proofs
 	return updateContractElementProofs(tx, cau)
 }
 
-func (m *ContractManager) applyContractDiff(tx *updateTx, diff consensus.V2FileContractElementDiff) error {
-	// update contract state
-	if diff.Resolution != nil || diff.Created {
-		var state ContractState
-		switch {
-		case diff.Resolution != nil:
-			state = ContractStateResolved
-			if _, ok := diff.Resolution.(*types.V2FileContractRenewal); ok {
-				renewedTo := diff.V2FileContractElement.ID.V2RenewalID()
-				if err := tx.UpdateContractRenewedTo(diff.V2FileContractElement.ID, &renewedTo); err != nil {
-					return fmt.Errorf("failed to update renewed to for %v: %w", diff.V2FileContractElement.ID, err)
-				}
-			}
-		case diff.Created:
-			state = ContractStateActive
-		default:
-			panic("unknown state") // unreachable
-		}
-		if err := tx.UpdateContractState(diff.V2FileContractElement.ID, state); err != nil {
-			return fmt.Errorf("failed to update contract state for %v: %w", diff.V2FileContractElement.ID, err)
-		}
-		m.log.Info("contract state changed", zap.Stringer("contractID", diff.V2FileContractElement.ID),
-			zap.Stringer("state", state))
-	}
-
-	// update contract elements
-	fce := diff.V2FileContractElement
-	if rev, ok := diff.V2RevisionElement(); ok {
-		fce = rev
-	}
-	if err := tx.UpdateContractElements(fce); err != nil {
-		return fmt.Errorf("failed to update contract element: %w", err)
-	}
-
-	return nil
-}
-
-func (m *ContractManager) revertChainUpdate(tx *updateTx, cru chain.RevertUpdate) error {
-	for _, diff := range cru.V2FileContractElementDiffs() {
+func (m *ContractManager) revertV2ContractDiffs(tx *updateTx, diffs []consensus.V2FileContractElementDiff) error {
+	var reverted []types.FileContractID
+	var updated []types.V2FileContractElement
+	for _, diff := range diffs {
 		if known, err := tx.IsKnownContract(diff.V2FileContractElement.ID); err != nil {
 			return fmt.Errorf("failed to determine whether contract is known: %w", err)
 		} else if !known {
 			continue // ignore unknown contracts
 		}
-		if err := m.revertContractDiff(tx, diff); err != nil {
-			return fmt.Errorf("failed to revert contract diff: %w", err)
-		}
-	}
-	return updateContractElementProofs(tx, cru)
-}
 
-func (m *ContractManager) revertContractDiff(tx *updateTx, diff consensus.V2FileContractElementDiff) error {
-	// update contract state
-	if diff.Resolution != nil || diff.Created {
-		var state ContractState
 		switch {
 		case diff.Created:
-			state = ContractStatePending
+			// contract no longer exists
+			reverted = append(reverted, diff.V2FileContractElement.ID)
+			if err := tx.UpdateContractState(diff.V2FileContractElement.ID, ContractStatePending); err != nil {
+				return fmt.Errorf("failed to update contract state for %v: %w", diff.V2FileContractElement.ID, err)
+			}
 		case diff.Resolution != nil:
-			state = ContractStateActive
-			if _, ok := diff.Resolution.(*types.V2FileContractRenewal); ok {
+			// contract is now active again
+			updated = append(updated, diff.V2FileContractElement)
+			if err := tx.UpdateContractState(diff.V2FileContractElement.ID, ContractStateActive); err != nil {
+				return fmt.Errorf("failed to update contract state for %v: %w", diff.V2FileContractElement.ID, err)
+			} else if _, ok := diff.Resolution.(*types.V2FileContractRenewal); ok {
+				// clear renewed to for renewals
 				if err := tx.UpdateContractRenewedTo(diff.V2FileContractElement.ID, nil); err != nil {
 					return fmt.Errorf("failed to null renewed to for %v: %w", diff.V2FileContractElement.ID, err)
 				}
 			}
 		default:
-			panic("unknown state") // unreachable
+			updated = append(updated, diff.V2FileContractElement)
 		}
-		if err := tx.UpdateContractState(diff.V2FileContractElement.ID, state); err != nil {
-			return fmt.Errorf("failed to update contract state for %v: %w", diff.V2FileContractElement.ID, err)
-		}
-		m.log.Info("contract state changed", zap.Stringer("contractID", diff.V2FileContractElement.ID),
-			zap.Stringer("state", state))
 	}
 
-	// update contract elements
-	fce := diff.V2FileContractElement
-	if err := tx.UpdateContractElements(fce); err != nil {
-		return fmt.Errorf("failed to update contract element: %w", err)
+	if len(reverted) > 0 {
+		// remove reverted contract elements
+		if err := tx.DeleteContractElements(reverted...); err != nil {
+			return fmt.Errorf("failed to revert deleted contract elements: %w", err)
+		}
 	}
 
+	if len(updated) > 0 {
+		// revert updated contract elements
+		if err := tx.UpdateContractElements(updated...); err != nil {
+			return fmt.Errorf("failed to revert updated contract elements: %w", err)
+		}
+	}
 	return nil
+}
+
+func (m *ContractManager) revertChainUpdate(tx *updateTx, cru chain.RevertUpdate) error {
+	if err := m.revertV2ContractDiffs(tx, cru.V2FileContractElementDiffs()); err != nil {
+		return fmt.Errorf("failed to revert contract diffs: %w", err)
+	}
+	// update state element proofs
+	return updateContractElementProofs(tx, cru)
 }
 
 func (m *ContractManager) broadcastExpiredContracts() error {

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -479,6 +479,13 @@ func (tx *mockUpdateTx) RenewedTo(contractID types.FileContractID) *types.FileCo
 	return renewedTo
 }
 
+func (tx *mockUpdateTx) DeleteContractElements(contractIDs ...types.FileContractID) error {
+	for _, contractID := range contractIDs {
+		delete(tx.contracts, contractID)
+	}
+	return nil
+}
+
 func (tx *mockUpdateTx) Contract(contractID types.FileContractID) (types.V2FileContractElement, ContractState) {
 	fce, ok := tx.contracts[contractID]
 	if !ok {
@@ -491,8 +498,16 @@ func (tx *mockUpdateTx) Contract(contractID types.FileContractID) (types.V2FileC
 	return fce, state
 }
 
+func (tx *mockUpdateTx) ContractState(contractID types.FileContractID) ContractState {
+	state, ok := tx.state[contractID]
+	if !ok {
+		panic("contract state not found")
+	}
+	return state
+}
+
 func (tx *mockUpdateTx) IsKnownContract(contractID types.FileContractID) (bool, error) {
-	_, ok := tx.contracts[contractID]
+	_, ok := tx.state[contractID]
 	return ok, nil
 }
 
@@ -513,7 +528,8 @@ func (tx *mockUpdateTx) UpdateContractElementProofs(updater wallet.ProofUpdater)
 }
 
 func (tx *mockUpdateTx) UpdateContractState(contractID types.FileContractID, state ContractState) error {
-	if _, ok := tx.contracts[contractID]; !ok {
+	// checking state, not contract since resolved elements are removed from the map
+	if _, ok := tx.state[contractID]; !ok {
 		return errors.New("contract not found")
 	}
 	tx.state[contractID] = state
@@ -521,7 +537,8 @@ func (tx *mockUpdateTx) UpdateContractState(contractID types.FileContractID, sta
 }
 
 func (tx *mockUpdateTx) UpdateContractRenewedTo(contractID types.FileContractID, renewedTo *types.FileContractID) error {
-	if _, ok := tx.contracts[contractID]; !ok {
+	// checking state, not contract since resolved elements are removed from the map
+	if _, ok := tx.state[contractID]; !ok {
 		return errors.New("contract not found")
 	}
 	tx.renewedTo[contractID] = renewedTo
@@ -646,16 +663,24 @@ func TestApplyRevertDiff(t *testing.T) {
 	// helper to apply/revert diff
 	applyDiff := func(diff consensus.V2FileContractElementDiff) {
 		t.Helper()
-		err := contracts.applyContractDiff(updateTx, diff)
+		err := contracts.applyV2ContractDiffs(updateTx, []consensus.V2FileContractElementDiff{diff})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 	revertDiff := func(diff consensus.V2FileContractElementDiff) {
 		t.Helper()
-		err := contracts.revertContractDiff(updateTx, diff)
+		err := contracts.revertV2ContractDiffs(updateTx, []consensus.V2FileContractElementDiff{diff})
 		if err != nil {
 			t.Fatal(err)
+		}
+	}
+
+	assertContractState := func(state ContractState) {
+		t.Helper()
+		storedState := mock.ContractState(contractID)
+		if storedState != state {
+			t.Fatalf("expected state %v, got %v", state, storedState)
 		}
 	}
 
@@ -696,7 +721,7 @@ func TestApplyRevertDiff(t *testing.T) {
 		V2FileContractElement: fce,
 		Resolution:            &types.V2StorageProof{},
 	})
-	assertContract(ContractStateResolved)
+	assertContractState(ContractStateResolved)
 
 	// revert resolution
 	fce.V2FileContract.RevisionNumber--
@@ -720,7 +745,7 @@ func TestApplyRevertDiff(t *testing.T) {
 		Created:               true,
 		V2FileContractElement: fce,
 	})
-	assertContract(ContractStatePending)
+	assertContractState(ContractStatePending)
 }
 
 func TestUpdateContractElementProofs(t *testing.T) {
@@ -836,30 +861,38 @@ func TestApplyRevertRenewedTo(t *testing.T) {
 	// helper to apply/revert diff
 	applyDiff := func(diff consensus.V2FileContractElementDiff) {
 		t.Helper()
-		err := contracts.applyContractDiff(updateTx, diff)
+		err := contracts.applyV2ContractDiffs(updateTx, []consensus.V2FileContractElementDiff{diff})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 	revertDiff := func(diff consensus.V2FileContractElementDiff) {
 		t.Helper()
-		err := contracts.revertContractDiff(updateTx, diff)
+		err := contracts.revertV2ContractDiffs(updateTx, []consensus.V2FileContractElementDiff{diff})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	assertContract := func(fce types.V2FileContractElement, state ContractState, renewedTo *types.FileContractID) {
+	assertContractState := func(contractID types.FileContractID, state ContractState, renewedTo *types.FileContractID) {
 		t.Helper()
-		storedFCE, storedState := mock.Contract(fce.ID)
-		storedRenewedTo := mock.RenewedTo(fce.ID)
+		storedState := mock.ContractState(contractID)
 		if storedState != state {
 			t.Fatalf("expected state %v, got %v", state, storedState)
-		} else if !reflect.DeepEqual(storedFCE, fce) {
-			t.Fatalf("expected contract %v, got %v", fce, storedFCE)
-		} else if !reflect.DeepEqual(storedRenewedTo, renewedTo) {
-			t.Fatalf("expected renewed to %v, got %v", storedRenewedTo, renewedTo)
 		}
+		storedRenewedTo := mock.RenewedTo(contractID)
+		if !reflect.DeepEqual(storedRenewedTo, renewedTo) {
+			t.Fatalf("expected renewed to %v, got %v", renewedTo, storedRenewedTo)
+		}
+	}
+
+	assertContract := func(fce types.V2FileContractElement, state ContractState, renewedTo *types.FileContractID) {
+		t.Helper()
+		storedFCE, _ := mock.Contract(fce.ID)
+		if !reflect.DeepEqual(storedFCE, fce) {
+			t.Fatalf("expected contract %v, got %v", fce, storedFCE)
+		}
+		assertContractState(fce.ID, state, renewedTo)
 	}
 
 	// initial state
@@ -883,6 +916,7 @@ func TestApplyRevertRenewedTo(t *testing.T) {
 		V2FileContractElement: fce,
 		Resolution:            &types.V2FileContractRenewal{},
 	})
+	assertContractState(fce.ID, ContractStateResolved, &newFCE.ID)
 
 	mock.AddContract(newFCE)
 	assertContract(newFCE, ContractStatePending, nil)
@@ -892,7 +926,7 @@ func TestApplyRevertRenewedTo(t *testing.T) {
 		V2FileContractElement: newFCE,
 	})
 
-	assertContract(fce, ContractStateResolved, &newFCE.ID)
+	assertContractState(fce.ID, ContractStateResolved, &newFCE.ID)
 	assertContract(newFCE, ContractStateActive, nil)
 
 	// revert resolution
@@ -906,7 +940,7 @@ func TestApplyRevertRenewedTo(t *testing.T) {
 		V2FileContractElement: newFCE,
 	})
 	assertContract(fce, ContractStateActive, nil)
-	assertContract(newFCE, ContractStatePending, nil)
+	assertContractState(newFCE.ID, ContractStatePending, nil)
 
 	applyDiff(consensus.V2FileContractElementDiff{
 		V2FileContractElement: fce,
@@ -917,6 +951,6 @@ func TestApplyRevertRenewedTo(t *testing.T) {
 		V2FileContractElement: newFCE,
 	})
 
-	assertContract(fce, ContractStateResolved, &newFCE.ID)
+	assertContractState(fce.ID, ContractStateResolved, &newFCE.ID)
 	assertContract(newFCE, ContractStateActive, nil)
 }

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -625,6 +625,14 @@ func (tx *updateTx) ContractElements() ([]types.V2FileContractElement, error) {
 	return fces, rows.Err()
 }
 
+func (tx *updateTx) DeleteContractElements(contractIDs ...types.FileContractID) error {
+	batch := &pgx.Batch{}
+	for _, contractID := range contractIDs {
+		batch.Queue(`DELETE FROM contract_elements WHERE contract_id = $1`, sqlHash256(contractID))
+	}
+	return tx.tx.SendBatch(tx.ctx, batch).Close()
+}
+
 func (tx *updateTx) IsKnownContract(contractID types.FileContractID) (bool, error) {
 	var exists bool
 	err := tx.tx.QueryRow(tx.ctx, `SELECT EXISTS (SELECT 1 FROM contracts WHERE contract_id = $1)`, sqlHash256(contractID)).


### PR DESCRIPTION
Fixes a panic when trying to update the proof for a contract element that has been reverted and cleans up the logic to make each state transition explicit over deduplicating a few lines. Also deletes resolved contracts from the elements table so they don't continue to accumulate indefinitely.

```
panic: cannot update an element that is not present in the accumulator
goroutine 243 [running]:
go.sia.tech/core/consensus.(*elementRevertUpdate).updateElementProof(0xc0035b0900?, 0x7f38800e4600?)
	go.sia.tech/core@v0.19.0/consensus/merkle.go:481 +0xac
go.sia.tech/core/consensus.RevertUpdate.UpdateElementProof(...)
	go.sia.tech/core@v0.19.0/consensus/application.go:882
go.sia.tech/indexd/contracts.updateContractElementProofs(0xc00365f8d0, {0x1af02c0, 0xc00359f308})
	go.sia.tech/indexd/contracts/chain.go:255 +0x76
go.sia.tech/indexd/contracts.(*ContractManager).revertChainUpdate(_, _, {{{0xc003648008, 0x1e, 0x23}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...}, ...})
	go.sia.tech/indexd/contracts/chain.go:167 +0x1ee
go.sia.tech/indexd/contracts.(*ContractManager).UpdateChainState(0xc000594120, {0x7f38800fc020, 0xc0036206c0}, {0xc003649308, 0x1, 0x7f38c97cb210?}, {0xc0036b4008, 0x2, 0xc0036206c0?})
	go.sia.tech/indexd/contracts/chain.go:88 +0x12e
go.sia.tech/indexd/subscriber.(*Subscriber).Sync.func1({0x1b074e8, 0xc0036206c0})
	go.sia.tech/indexd/subscriber/subscriber.go:187 +0x165
go.sia.tech/indexd/persist/postgres.(*Store).UpdateChainState.func1({0x1afd818, 0x5e2c660}, 0xc0036206a8)
	go.sia.tech/indexd/persist/postgres/chain.go:39 +0x85
go.sia.tech/indexd/persist/postgres.(*Store).transaction(0xc000228060, 0xc00365fb60)
	go.sia.tech/indexd/persist/postgres/store.go:49 +0x38f
go.sia.tech/indexd/persist/postgres.(*Store).UpdateChainState(0x87cb2?, 0x100000000000000?)
	go.sia.tech/indexd/persist/postgres/chain.go:38 +0x29
go.sia.tech/indexd/subscriber.(*Subscriber).Sync(0xc000034780, {0x1afdfb0?, 0xc000043450?})
	go.sia.tech/indexd/subscriber/subscriber.go:184 +0xac6
go.sia.tech/indexd/subscriber.New.func3()
	go.sia.tech/indexd/subscriber/subscriber.go:125 +0xed
created by go.sia.tech/indexd/subscriber.New in goroutine 1
	go.sia.tech/indexd/subscriber/subscriber.go:120 +0x43c
```