### PR TITLE
Add prune slabs method to SDK

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -47,7 +47,7 @@ type (
 		Slab(context.Context, types.PrivateKey, slabs.SlabID) (slabs.PinnedSlab, error)
 		PinSlabs(context.Context, types.PrivateKey, ...slabs.SlabPinParams) ([]slabs.SlabID, error)
 		UnpinSlab(context.Context, types.PrivateKey, slabs.SlabID) error
-		PruneSlabs(ctx context.Context, appKey types.PrivateKey) error
+		PruneSlabs(context.Context, types.PrivateKey) error
 	}
 
 	downloadOption struct {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -47,6 +47,7 @@ type (
 		Slab(context.Context, types.PrivateKey, slabs.SlabID) (slabs.PinnedSlab, error)
 		PinSlabs(context.Context, types.PrivateKey, ...slabs.SlabPinParams) ([]slabs.SlabID, error)
 		UnpinSlab(context.Context, types.PrivateKey, slabs.SlabID) error
+		PruneSlabs(ctx context.Context, appKey types.PrivateKey) error
 	}
 
 	downloadOption struct {
@@ -208,6 +209,12 @@ func (s *SDK) downloadSlab(ctx context.Context, slab slabs.SlabSlice, maxInfligh
 // the indexer.
 func (s *SDK) AppKey() types.PrivateKey {
 	return s.appKey
+}
+
+// PruneSlabs removes all slabs on the account that are not associated with
+// an object.
+func (s *SDK) PruneSlabs(ctx context.Context) error {
+	return s.client.PruneSlabs(ctx, s.appKey)
 }
 
 // Upload uploads the data to hosts and pins it to the indexer.

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -285,6 +285,26 @@ func (mc *mockAppClient) CreateSharedObjectURL(ctx context.Context, _ types.Priv
 	return hex.EncodeToString(key), nil
 }
 
+func (mc *mockAppClient) PruneSlabs(ctx context.Context, _ types.PrivateKey) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	used := make(map[slabs.SlabID]slabs.PinnedSlab)
+	for _, obj := range mc.objects {
+		for _, slab := range obj.Slabs {
+			digest := slab.Digest()
+			used[digest] = slabs.PinnedSlab{
+				ID:            digest,
+				EncryptionKey: slab.EncryptionKey,
+				MinShards:     slab.MinShards,
+				Sectors:       slab.Sectors,
+			}
+		}
+	}
+	mc.pinned = used
+	return nil
+}
+
 func newMockAppClient() *mockAppClient {
 	return &mockAppClient{
 		objects: make(map[types.Hash256]slabs.SealedObject),


### PR DESCRIPTION
Close #745

I didn't add a test because we'd basically just be testing the mock app client at that point...