### PR TITLE
Update shouldReplaceContract

### DIFF
--- a/contracts/form.go
+++ b/contracts/form.go
@@ -469,27 +469,18 @@ func shouldReplaceContract(current, candidate candidateContract) bool {
 	case current.goodForAppend == nil && current.goodForFunding == nil:
 		// current contract is already good for both uploading and funding
 		return false
-	case candidate.goodForAppend == nil && candidate.goodForFunding == nil:
-		// candidate contract is good for both uploading and funding
-		return true
-	case current.goodForRefresh == nil && candidate.goodForRefresh != nil:
-		// current contract can be refreshed to become good, but candidate cannot
+	case current.goodForRefresh == nil && candidate.goodForRefresh != nil && (candidate.goodForAppend != nil || candidate.goodForFunding != nil):
+		// current contract can be refreshed to become good, candidate cannot
+		// and is not good for both upload and funding.
 		return false
-	case current.goodForRefresh != nil && candidate.goodForRefresh == nil:
-		// candidate contract can be refreshed to become good, but current cannot
-		return true
-	case current.goodForAppend == nil && candidate.goodForAppend != nil:
-		// current contract is good for uploading, but candidate is not
+	case current.goodForAppend == nil && candidate.goodForAppend != nil && candidate.goodForRefresh != nil:
+		// current contract is only good for uploading, candidate is not and
+		// can't be refreshed.
 		return false
-	case current.goodForAppend != nil && candidate.goodForAppend == nil:
-		// candidate contract is good for uploading, but current is not
-		return true
-	case current.goodForFunding == nil && candidate.goodForFunding != nil:
-		// current contract is good for funding, but candidate is not
+	case current.goodForFunding == nil && candidate.goodForFunding != nil && candidate.goodForRefresh != nil:
+		// current contract is only good for funding, candidate is not and can't
+		// be refreshed.
 		return false
-	case current.goodForFunding != nil && candidate.goodForFunding == nil:
-		// candidate contract is good for funding, but current is not
-		return true
 	}
-	return false
+	return true
 }

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -212,30 +212,6 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, setting
 		}
 	}
 
-	// helper to determine if the candidate contract is better
-	// than the current best candidate for this host.
-	// The priority is to have a contract that is as good as possible
-	// for both uploading and funding. A contract that can be refreshed
-	// is preferred over one that cannot to prevent forming unnecessary
-	// extra contracts.
-	shouldReplaceContract := func(current, candidate candidateContract) bool {
-		switch {
-		case current.goodForAppend == nil && current.goodForFunding == nil:
-			// current contract is already good for both uploading and funding
-			return false
-		case current.goodForRefresh == nil && candidate.goodForRefresh != nil:
-			// current contract can be refreshed to become good, but candidate cannot
-			return false
-		case current.goodForAppend == nil && candidate.goodForAppend != nil:
-			// current contract is good for uploading, but candidate is not
-			return false
-		case current.goodForFunding == nil && candidate.goodForFunding != nil:
-			// current contract is good for funding, but candidate is not
-			return false
-		}
-		return true
-	}
-
 	// evaluate all existing contracts to see which hosts do not
 	// currently have a contract that is both good for uploading and
 	// funding and determine the best candidate for refreshing.
@@ -481,4 +457,39 @@ func contractFunding(settings proto.HostSettings, existingData uint64, minAllowa
 		collateral = minHostCollateral // ensure we have at least the minimum collateral
 	}
 	return
+}
+
+// Helper to determine if a candidate contract is better than the current best
+// candidate for this host. The priority is to have a contract that is as good
+// as possible for both uploading and funding. A contract that can be refreshed
+// is preferred over one that cannot to prevent forming unnecessary extra
+// contracts.
+func shouldReplaceContract(current, candidate candidateContract) bool {
+	switch {
+	case current.goodForAppend == nil && current.goodForFunding == nil:
+		// current contract is already good for both uploading and funding
+		return false
+	case candidate.goodForAppend == nil && candidate.goodForFunding == nil:
+		// candidate contract is good for both uploading and funding
+		return true
+	case current.goodForRefresh == nil && candidate.goodForRefresh != nil:
+		// current contract can be refreshed to become good, but candidate cannot
+		return false
+	case current.goodForRefresh != nil && candidate.goodForRefresh == nil:
+		// candidate contract can be refreshed to become good, but current cannot
+		return true
+	case current.goodForAppend == nil && candidate.goodForAppend != nil:
+		// current contract is good for uploading, but candidate is not
+		return false
+	case current.goodForAppend != nil && candidate.goodForAppend == nil:
+		// candidate contract is good for uploading, but current is not
+		return true
+	case current.goodForFunding == nil && candidate.goodForFunding != nil:
+		// current contract is good for funding, but candidate is not
+		return false
+	case current.goodForFunding != nil && candidate.goodForFunding == nil:
+		// candidate contract is good for funding, but current is not
+		return true
+	}
+	return false
 }

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -774,7 +774,7 @@ func TestShouldReplaceContract(t *testing.T) {
 	assertShouldReplace(goodContracts, anyContracts, false)
 
 	// a contract that is not good should be replaced by any good contract
-	badContracts := slices.DeleteFunc(slices.Clone(goodContracts), func(c candidateContract) bool {
+	badContracts := slices.DeleteFunc(slices.Clone(anyContracts), func(c candidateContract) bool {
 		return c.goodForAppend == nil && c.goodForFunding == nil
 	})
 	assertShouldReplace(badContracts, goodContracts, true)

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -699,6 +699,12 @@ func TestShouldReplaceContract(t *testing.T) {
 			should:    true,
 		},
 		{
+			name:      "current refreshable < candidate good",
+			current:   contract(false, false, true),
+			candidate: contract(true, true, false),
+			should:    true,
+		},
+		{
 			name:      "current append > not append",
 			current:   contract(true, true, false),
 			candidate: contract(false, true, false),
@@ -726,7 +732,7 @@ func TestShouldReplaceContract(t *testing.T) {
 			name:      "both equally bad",
 			current:   contract(false, false, false),
 			candidate: contract(false, false, false),
-			should:    false,
+			should:    true,
 		},
 	}
 	for _, test := range tests {

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -743,4 +743,43 @@ func TestShouldReplaceContract(t *testing.T) {
 			}
 		})
 	}
+
+	// run exhaustive combinations for important cases
+	enumerate := func(gfa, gff, gfr []bool) (candidates []candidateContract) {
+		t.Helper()
+		for _, gfa := range gfa {
+			for _, gff := range gff {
+				for _, gfr := range gfr {
+					candidates = append(candidates, contract(gfa, gff, gfr))
+				}
+			}
+		}
+		return
+	}
+
+	assertShouldReplace := func(current []candidateContract, candidates []candidateContract, shouldReplace bool) {
+		t.Helper()
+		for _, current := range current {
+			for _, candidate := range candidates {
+				if replaces := shouldReplaceContract(current, candidate); replaces != shouldReplace {
+					t.Fatalf("expected replace=%v for candidate gfa=%v, gff=%v, gfr=%v, got %v", shouldReplace, candidate.goodForAppend == nil, candidate.goodForFunding == nil, candidate.goodForRefresh == nil, replaces)
+				}
+			}
+		}
+	}
+
+	// a good contract should never be replaced
+	goodContracts := enumerate([]bool{true}, []bool{true}, []bool{true, false})
+	anyContracts := enumerate([]bool{true, false}, []bool{true, false}, []bool{true, false})
+	assertShouldReplace(goodContracts, anyContracts, false)
+
+	// a contract that is not good should be replaced by any good contract
+	badContracts := slices.DeleteFunc(slices.Clone(goodContracts), func(c candidateContract) bool {
+		return c.goodForAppend == nil && c.goodForFunding == nil
+	})
+	assertShouldReplace(badContracts, goodContracts, true)
+
+	// a bad contract should be replaced by any contract that is good for refresh
+	goodForRefreshContracts := enumerate([]bool{true, false}, []bool{true, false}, []bool{true})
+	assertShouldReplace(badContracts, goodForRefreshContracts, true)
 }

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -654,15 +654,15 @@ func TestContractFunding(t *testing.T) {
 }
 
 func TestShouldReplaceContract(t *testing.T) {
-	contract := func(append, funding, refresh bool) (cc candidateContract) {
+	contract := func(gfa, gff, gfr bool) (cc candidateContract) {
 		t.Helper()
-		if !append {
+		if !gfa {
 			cc.goodForAppend = fmt.Errorf("not good for append")
 		}
-		if !funding {
+		if !gff {
 			cc.goodForFunding = fmt.Errorf("not good for funding")
 		}
-		if !refresh {
+		if !gfr {
 			cc.goodForRefresh = fmt.Errorf("not good for refresh")
 		}
 		return cc

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -652,3 +652,89 @@ func TestContractFunding(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldReplaceContract(t *testing.T) {
+	contract := func(append, funding, refresh bool) (cc candidateContract) {
+		t.Helper()
+		if !append {
+			cc.goodForAppend = fmt.Errorf("not good for append")
+		}
+		if !funding {
+			cc.goodForFunding = fmt.Errorf("not good for funding")
+		}
+		if !refresh {
+			cc.goodForRefresh = fmt.Errorf("not good for refresh")
+		}
+		return cc
+	}
+
+	tests := []struct {
+		name      string
+		current   candidateContract
+		candidate candidateContract
+		should    bool
+	}{
+		{
+			name:      "current good for upload and funding",
+			current:   contract(true, true, false),
+			candidate: contract(true, true, true),
+			should:    false,
+		},
+		{
+			name:      "candidate good for upload and funding",
+			current:   contract(true, false, false),
+			candidate: contract(true, true, false),
+			should:    true,
+		},
+		{
+			name:      "current refreshed > not refreshed",
+			current:   contract(true, false, true),
+			candidate: contract(true, false, false),
+			should:    false,
+		},
+		{
+			name:      "candidate refreshed > not refreshed",
+			current:   contract(true, false, false),
+			candidate: contract(true, false, true),
+			should:    true,
+		},
+		{
+			name:      "current append > not append",
+			current:   contract(true, true, false),
+			candidate: contract(false, true, false),
+			should:    false,
+		},
+		{
+			name:      "candidate append > not append",
+			current:   contract(false, true, false),
+			candidate: contract(true, true, false),
+			should:    true,
+		},
+		{
+			name:      "current funding > not funding",
+			current:   contract(false, true, false),
+			candidate: contract(false, false, false),
+			should:    false,
+		},
+		{
+			name:      "candidate funding > not funding",
+			current:   contract(false, false, false),
+			candidate: contract(false, true, false),
+			should:    true,
+		},
+		{
+			name:      "both equally bad",
+			current:   contract(false, false, false),
+			candidate: contract(false, false, false),
+			should:    false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := shouldReplaceContract(test.current, test.candidate)
+			if result != test.should {
+				t.Fatalf("expected %v but got %v", test.should, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/SiaFoundation/indexd/issues/743

We were running into an edge case where we would pick the wrong candidate when a contract is up for renewal. Because the `current` contract ends up being not good for append or refresh but good for funding. While the candidate (which was drained) ended up being not good for append, not good for funding but good for refresh. So we always kept the current contract which wasn't good for refreshing, realized it's bad and formed a new contract instead of trying to refresh the refreshable candidate.

This PR fixes that and adds a test.