### PR TITLE
Fix edge case around pinning sectors on hosts we need to resync revisions with, more `dial` context and `consecutive_failed_checks` reset

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -171,14 +171,17 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 		}
 
 		// only attempt to append up to the calculated maximum number of sectors
-		if uint64(len(sectors)) > maxAppendSectors {
-			sectors = sectors[:maxAppendSectors]
+		// NOTE: use a new variable here to avoid modifying sectors from the
+		// closure
+		attemptedSectors := sectors
+		if uint64(len(attemptedSectors)) > maxAppendSectors {
+			attemptedSectors = attemptedSectors[:maxAppendSectors]
 		}
-		attempted = len(sectors)
-		res, err = rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, contract, sectors)
+		res, err = rhp.RPCAppendSectors(ctx, c.client, c.signer, c.cm.TipState(), hostPrices, contract, attemptedSectors)
 		if err != nil {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("failed to append sectors: %w", err)
 		}
+		attempted = len(attemptedSectors)
 		contract.Revision = res.Revision
 		return contract, res.Usage, nil
 	})

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -93,6 +93,9 @@ func (t *transport) dial(ctx context.Context, hostKey types.PublicKey, addresses
 	var dialCtx, dialCancel = context.WithCancel(ctx)
 	defer dialCancel()
 
+	var connectErr error
+	var connectErrMu sync.Mutex
+
 top:
 	for _, addr := range addresses {
 		select {
@@ -117,6 +120,9 @@ top:
 			default:
 				return
 			}
+			connectErrMu.Lock()
+			connectErr = errors.Join(connectErr, err)
+			connectErrMu.Unlock()
 			if err != nil || dialCtx.Err() != nil {
 				// failed to connect or already connected elsewhere
 				if err == nil {
@@ -140,7 +146,7 @@ top:
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.tc == nil {
-		return nil, fmt.Errorf("failed to connect to host %s", hostKey.String())
+		return nil, fmt.Errorf("failed to connect to host %s (%w)", hostKey.String(), connectErr)
 	}
 	return t.tc, nil
 }

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -93,18 +93,17 @@ func (t *transport) dial(ctx context.Context, hostKey types.PublicKey, addresses
 	var dialCtx, dialCancel = context.WithCancel(ctx)
 	defer dialCancel()
 
-	var connectErr error
-	var connectErrMu sync.Mutex
+	connectErrs := make([]error, len(addresses))
 
 top:
-	for _, addr := range addresses {
+	for i, addr := range addresses {
 		select {
 		case <-dialCtx.Done():
 			break top
 		case sema <- struct{}{}:
 		}
 		wg.Add(1)
-		go func(addr chain.NetAddress) {
+		go func(i int, addr chain.NetAddress) {
 			defer func() {
 				<-sema
 				wg.Done()
@@ -120,9 +119,7 @@ top:
 			default:
 				return
 			}
-			connectErrMu.Lock()
-			connectErr = errors.Join(connectErr, err)
-			connectErrMu.Unlock()
+			connectErrs[i] = err
 			if err != nil || dialCtx.Err() != nil {
 				// failed to connect or already connected elsewhere
 				if err == nil {
@@ -138,7 +135,7 @@ top:
 				_ = transport.Close()
 			}
 			t.mu.Unlock()
-		}(addr)
+		}(i, addr)
 	}
 	// wait for all dial attempts to finish
 	wg.Wait()
@@ -146,7 +143,7 @@ top:
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.tc == nil {
-		return nil, fmt.Errorf("failed to connect to host %s (%w)", hostKey.String(), connectErr)
+		return nil, fmt.Errorf("failed to connect to host %s (%w)", hostKey.String(), errors.Join(connectErrs...))
 	}
 	return t.tc, nil
 }

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -126,14 +126,15 @@ func (s *storeMock) MarkSectorsLost(hk types.PublicKey, roots []types.Hash256) e
 		lookup[root] = struct{}{}
 	}
 
-	// mark sectors as lost
+	// mark sectors as lost by removing them from the host's sector list
 	updated, ok := s.sectors[hk]
 	if !ok {
 		panic("no host sectors found")
 	}
-	for i, sector := range updated {
-		if _, ok := lookup[sector.root]; ok {
-			updated[i].contractID = nil
+	updated = updated[:0]
+	for _, sector := range s.sectors[hk] {
+		if _, ok := lookup[sector.root]; !ok {
+			updated = append(updated, sector)
 		}
 	}
 	s.sectors[hk] = updated

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -311,7 +311,7 @@ func (s *Store) BlockHosts(hks []types.PublicKey, reasons []string) error {
 
 			res, err := tx.Exec(ctx, `
 				UPDATE sectors
-				SET host_id = NULL
+				SET host_id = NULL, consecutive_failed_checks = 0
 				WHERE host_id = $1 AND contract_sectors_map_id IS NULL`, hostID)
 			if err != nil {
 				return fmt.Errorf("failed to update sectors: %w", err)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -93,10 +93,34 @@ func TestBlockHosts(t *testing.T) {
 	hk2 := store.addTestHost(t, types.PublicKey{2})
 	hk3 := types.PublicKey{3} // not in DB
 
+	// create a sector for hk1 with a non-zero consecutive_failed_checks
+	sectorRoot := frand.Entropy256()
+	_, err := store.pool.Exec(t.Context(), `
+		INSERT INTO sectors (sector_root, host_id, next_integrity_check, consecutive_failed_checks)
+		SELECT $1, id, NOW(), 5 FROM hosts WHERE public_key = $2
+	`, sqlHash256(sectorRoot), sqlPublicKey(hk1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// update num_unpinned_sectors stat to match inserted sector
+	_, err = store.pool.Exec(t.Context(), `UPDATE stats SET num_unpinned_sectors = num_unpinned_sectors + 1`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// assert block reasons
 	reasons := []string{"a", "b"}
 	if err := store.BlockHosts([]types.PublicKey{hk1, hk2}, reasons); err != nil {
 		t.Fatal(err)
+	}
+
+	// assert consecutive_failed_checks was reset to 0
+	var consecutiveFailedChecks int
+	err = store.pool.QueryRow(t.Context(), `SELECT consecutive_failed_checks FROM sectors WHERE sector_root = $1`, sqlHash256(sectorRoot)).Scan(&consecutiveFailedChecks)
+	if err != nil {
+		t.Fatal(err)
+	} else if consecutiveFailedChecks != 0 {
+		t.Fatalf("expected consecutive_failed_checks to be 0, got %d", consecutiveFailedChecks)
 	}
 	for _, hk := range []types.PublicKey{hk1, hk2} {
 		host, err := store.Host(hk)

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -667,7 +667,7 @@ func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
 	err := s.transaction(func(ctx context.Context, tx *txn) error {
 		res, err := tx.Exec(ctx, `
             UPDATE sectors
-            SET host_id = NULL
+            SET host_id = NULL, consecutive_failed_checks = 0
             WHERE host_id IS NOT NULL
 	            AND contract_sectors_map_id IS NULL
 	            AND uploaded_at <= $1`, threshold)

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1492,8 +1492,8 @@ func TestMarkSectorsUnpinnable(t *testing.T) {
 	}
 
 	// set the uploaded timestamp to past the threshold pruning threshold date
-	// of 3 days
-	_, err = store.pool.Exec(t.Context(), "UPDATE sectors SET uploaded_at = NOW() - Interval '4 days' WHERE id = 1")
+	// of 3 days and set consecutive_failed_checks to a non-zero value
+	_, err = store.pool.Exec(t.Context(), "UPDATE sectors SET uploaded_at = NOW() - Interval '4 days', consecutive_failed_checks = 5 WHERE id = 1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1511,6 +1511,15 @@ func TestMarkSectorsUnpinnable(t *testing.T) {
 
 	if err := store.MarkSectorsUnpinnable(time.Now().Add(-3 * 24 * time.Hour)); err != nil {
 		t.Fatal(err)
+	}
+
+	// assert consecutive_failed_checks was reset to 0
+	var consecutiveFailedChecks int
+	err = store.pool.QueryRow(t.Context(), "SELECT consecutive_failed_checks FROM sectors WHERE id = 1").Scan(&consecutiveFailedChecks)
+	if err != nil {
+		t.Fatal(err)
+	} else if consecutiveFailedChecks != 0 {
+		t.Fatalf("expected consecutive_failed_checks to be 0, got %d", consecutiveFailedChecks)
 	}
 
 	// sector should have had host_id nulled out due to MarkSectorsUnpinnable


### PR DESCRIPTION
This PR includes the following changes:

1. `AppendSectors` doesn't slice the input `sectors` anymore to avoid an edge case related to the `withRevision` retry.
2. more context in `dial`
3. Blocking host and marking sectors unpinnable resets the `consecutive_failed_checks`

There seems to be some correlation between number of times a contract revision with a host had to be resynced and the number of lost sectors that host has. So maybe that edge case happens more often than I initially thought. 