### PR TITLE
add aria labels to auth page

### DIFF
--- a/api/app/auth.html
+++ b/api/app/auth.html
@@ -299,13 +299,14 @@
       <input
         type="password"
         id="appPassword"
+        aria-label="app-password"
         placeholder="Enter your app password"
         required
       />
 
       <div class="actions">
         <button id="rejectButton" class="btn btn-danger">Reject</button>
-        <button id="acceptButton" class="btn btn-primary">Accept</button>
+        <button id="acceptButton" aria-label="accept-button" class="btn btn-primary">Accept</button>
       </div>
     </div>
 


### PR DESCRIPTION
- Slightly different labels may be required for mobile test automation, still confirming.