### PR TITLE
Include renew period in collateral calculation logic

### DIFF
--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -195,8 +195,13 @@ func (c Contract) GoodForAppend(prices proto.HostPrices, renewWindow, height uin
 }
 
 // GoodForRefresh indicates whether a contract is likely to succeed refreshing.
-func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.Currency, renewWindow, height, period uint64) error {
-	_, collateral := contractFunding(settings, c.Size, fundTarget, period)
+func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.Currency, renewWindow, height uint64) error {
+	if c.inRenewWindow(renewWindow, height) {
+		return fmt.Errorf("contract is in renew window")
+	}
+
+	duration := c.ExpirationHeight - height
+	_, collateral := contractFunding(settings, c.Size, fundTarget, duration)
 	var totalCollateral types.Currency
 	if settings.ProtocolVersion.Cmp(rhp.ProtocolVersion502) >= 0 {
 		totalCollateral = c.UsedCollateral.Add(collateral)
@@ -210,8 +215,6 @@ func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.C
 		return fmt.Errorf("contract has reached maximum size")
 	case c.ProofHeight <= height:
 		return fmt.Errorf("contract is not revisable")
-	case c.inRenewWindow(renewWindow, height):
-		return fmt.Errorf("contract is in renew window")
 	case totalCollateral.Cmp(settings.MaxCollateral) > 0:
 		return fmt.Errorf("host's max collateral %s is less than estimated collateral %s for refresh", settings.MaxCollateral, totalCollateral)
 	default:

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -100,8 +100,8 @@ func (cm *ContractManager) formContract(ctx context.Context, host types.PublicKe
 		if !host.IsGood() {
 			return errors.New("host is not good")
 		}
-		allowance, collateral := contractFunding(host.Settings, 0, fundTarget, period)
-		formationCtx, cancel := context.WithTimeout(ctx, 5*time.Minute) // note: broadcasting on the host-side can block for up to a minute by default
+		allowance, collateral := contractFunding(host.Settings, 0, fundTarget, period+proto.ProofWindow) // duration should be extended until expiration height
+		formationCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)                                  // note: broadcasting on the host-side can block for up to a minute by default
 		defer cancel()
 		hc, err := cm.dialer.DialHost(formationCtx, host.PublicKey, host.RHP4Addrs())
 		if err != nil {
@@ -142,7 +142,7 @@ func (cm *ContractManager) formContract(ctx context.Context, host types.PublicKe
 	})
 }
 
-func (cm *ContractManager) refreshContract(ctx context.Context, contract Contract, height uint64, fundTarget types.Currency, log *zap.Logger) error {
+func (cm *ContractManager) refreshContract(ctx context.Context, contract Contract, fundTarget types.Currency, log *zap.Logger) error {
 	return cm.hosts.WithScannedHost(ctx, contract.HostKey, func(host hosts.Host) error {
 		if !host.IsGood() {
 			return errors.New("host is not good")
@@ -150,7 +150,11 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 		refreshCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
 
-		duration := contract.ExpirationHeight - height
+		if contract.ProofHeight <= host.Settings.Prices.TipHeight {
+			return fmt.Errorf("contract is expired and cannot be refreshed")
+		}
+
+		duration := contract.ExpirationHeight - host.Settings.Prices.TipHeight
 		allowance, collateral := contractFunding(host.Settings, contract.Size, fundTarget, duration)
 		hc, err := cm.dialer.DialHost(refreshCtx, host.PublicKey, host.RHP4Addrs())
 		if err != nil {
@@ -237,7 +241,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, setting
 			candidate := candidateContract{
 				host:           host,
 				contract:       contract,
-				goodForRefresh: contract.GoodForRefresh(host.Settings, accountFundTarget, settings.RenewWindow, height, settings.Period),
+				goodForRefresh: contract.GoodForRefresh(host.Settings, accountFundTarget, settings.RenewWindow, height),
 				goodForFunding: contract.GoodForAccountFunding(accountFundTarget),
 				goodForAppend:  contract.GoodForAppend(host.Settings.Prices, settings.RenewWindow, height),
 			}
@@ -300,7 +304,7 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, setting
 			return false
 		}
 		// fund target is multiplied by 2 to have buffer for less frequent refreshes
-		err = cm.refreshContract(ctx, contract, cm.chain.TipState().Index.Height, accountFundTarget.Mul64(2), log)
+		err = cm.refreshContract(ctx, contract, accountFundTarget.Mul64(2), log)
 		switch {
 		case err == nil:
 			refreshed++

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"go.sia.tech/core/rhp/v4"
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -30,7 +30,7 @@ func (cm *ContractManager) performContractRenewals(ctx context.Context, period, 
 			}
 
 			log := log.With(zap.Stringer("contractID", contract.ID), zap.Stringer("host", contract.HostKey))
-			if err := cm.renewContract(ctx, contract, newProofHeight, period, log); err != nil {
+			if err := cm.renewContract(ctx, contract, newProofHeight, log); err != nil {
 				log.Error("failed to renew contract", zap.Error(err))
 			}
 		}
@@ -43,16 +43,21 @@ func (cm *ContractManager) performContractRenewals(ctx context.Context, period, 
 	return nil
 }
 
-func (cm *ContractManager) renewContract(ctx context.Context, contract Contract, proofHeight, period uint64, log *zap.Logger) error {
+func (cm *ContractManager) renewContract(ctx context.Context, contract Contract, proofHeight uint64, log *zap.Logger) error {
 	return cm.hosts.WithScannedHost(ctx, contract.HostKey, func(host hosts.Host) error {
 		// calculate funding target
 		minAllowance, err := cm.ContractFundTarget(ctx, host, minAllowance)
 		if err != nil {
 			return fmt.Errorf("failed to get fund target: %w", err)
 		}
+		settings := host.Settings
+		if settings.Prices.TipHeight > proofHeight {
+			return fmt.Errorf("cannot renew contract with proof height %d before tip height %d", proofHeight, settings.Prices.TipHeight)
+		}
+		duration := proofHeight + proto.ProofWindow - settings.Prices.TipHeight
 
 		// allowance is doubled to allow for two account funding cycles before next refresh
-		allowance, collateral := contractFunding(host.Settings, contract.Size, minAllowance.Mul64(2), period)
+		allowance, collateral := contractFunding(settings, contract.Size, minAllowance.Mul64(2), duration)
 		renewCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 		defer cancel()
 
@@ -63,7 +68,7 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 		}
 		defer hc.Close()
 
-		res, err := hc.RenewContract(renewCtx, host.Settings, rhp.RPCRenewContractParams{
+		res, err := hc.RenewContract(renewCtx, settings, proto.RPCRenewContractParams{
 			Allowance:   allowance,
 			Collateral:  collateral,
 			ContractID:  contract.ID,


### PR DESCRIPTION
Fixes contract renewal and refreshes to use the host's height for duration calculations instead of an abstract `period` to match RHP4 calculations.
