### PR TITLE
Fix edge case where slab sector link isn't created correctly

### DIFF
--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -493,12 +493,21 @@ func TestContractsAPI(t *testing.T) {
 
 	// assert contract was renewed - we don't pass the option here to asserts
 	// the contracts API returns only revisable contracts by default
-	if contracts, err := adminClient.Contracts(context.Background()); err != nil {
+	contracts, err := adminClient.Contracts(context.Background())
+	if err != nil {
 		t.Fatal(err)
-	} else if len(contracts) < 2 {
-		t.Fatal("expected at least 2 contracts, got", len(contracts))
-	} else if contracts[0].RenewedFrom != contract.ID && contracts[1].RenewedFrom != contract.ID {
-		t.Fatal("expected contract to be renewed", contracts[0].RenewedFrom, contracts[1].RenewedFrom, contract.ID)
+	} else if len(contracts) < 1 {
+		t.Fatal("expected at least 1 contract, got", len(contracts))
+	}
+	var renewed bool
+	for _, c := range contracts {
+		if c.RenewedFrom == contract.ID {
+			renewed = true
+			break
+		}
+	}
+	if !renewed {
+		t.Fatal("expected contract to be renewed")
 	}
 
 	// assert usage is being tracked

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -495,8 +495,8 @@ func TestContractsAPI(t *testing.T) {
 	// the contracts API returns only revisable contracts by default
 	if contracts, err := adminClient.Contracts(context.Background()); err != nil {
 		t.Fatal(err)
-	} else if len(contracts) < 1 {
-		t.Fatal("expected at least 1 contract, got", len(contracts))
+	} else if len(contracts) < 2 {
+		t.Fatal("expected at least 2 contracts, got", len(contracts))
 	} else if contracts[0].RenewedFrom != contract.ID && contracts[1].RenewedFrom != contract.ID {
 		t.Fatal("expected contract to be renewed", contracts[0].RenewedFrom, contracts[1].RenewedFrom, contract.ID)
 	}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -339,19 +339,19 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 				if err := incrementNumUnpinnedSectors(ctx, tx, unpinned); err != nil {
 					return fmt.Errorf("failed to increment number of unpinned sectors: %w", err)
 				}
+			}
 
-				// insert slab sectors into join table
-				batch = &pgx.Batch{}
-				for i, sectorID := range sectorIDs {
-					batch.Queue(`
+			// insert slab sectors into join table
+			batch = &pgx.Batch{}
+			for i, sectorID := range sectorIDs {
+				batch.Queue(`
 				INSERT INTO slab_sectors (slab_id, slab_index, sector_id)
 				VALUES ($1, $2, $3)
 				ON CONFLICT (slab_id, slab_index) DO NOTHING
 			`, slabID, i, sectorID)
-				}
-				if err = tx.Tx.SendBatch(ctx, batch).Close(); err != nil {
-					return fmt.Errorf("failed to insert slab sectors: %w", err)
-				}
+			}
+			if err = tx.Tx.SendBatch(ctx, batch).Close(); err != nil {
+				return fmt.Errorf("failed to insert slab sectors: %w", err)
 			}
 		}
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -785,6 +785,94 @@ func TestPinSlabs(t *testing.T) {
 	assertUnpinnedSectors(4)
 }
 
+// TestPinSlabsSameSectorDifferentEncryptionKey tests that pinning a slab with
+// sectors that already exist (from another slab) correctly creates the
+// slab_sectors entries.
+func TestPinSlabsSameSectorDifferentEncryptionKey(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// add account
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+
+	// add two hosts with contracts
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	store.addTestContract(t, hk1)
+	store.addTestContract(t, hk2)
+
+	// create two sector roots that will be shared between slabs
+	sectorRoot1 := frand.Entropy256()
+	sectorRoot2 := frand.Entropy256()
+
+	// pin first slab with these sectors
+	slab1 := slabs.SlabPinParams{
+		EncryptionKey: slabs.EncryptionKey{1}, // unique encryption key
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{
+			{Root: sectorRoot1, HostKey: hk1},
+			{Root: sectorRoot2, HostKey: hk2},
+		},
+	}
+
+	nextCheck := time.Now().Add(time.Hour)
+	slab1IDs, err := store.PinSlabs(account, nextCheck, slab1)
+	if err != nil {
+		t.Fatal("failed to pin slab1:", err)
+	}
+
+	// verify slab1 can be fetched with all sectors
+	fetched1, err := store.Slabs(account, slab1IDs)
+	if err != nil {
+		t.Fatal("failed to fetch slab1:", err)
+	} else if len(fetched1) != 1 {
+		t.Fatalf("expected 1 slab, got %d", len(fetched1))
+	} else if len(fetched1[0].Sectors) != 2 {
+		t.Fatalf("expected 2 sectors in slab1, got %d", len(fetched1[0].Sectors))
+	}
+
+	// pin second slab with the SAME sector roots but different encryption key
+	// this creates a different slab (different digest) but reuses existing sectors
+	slab2 := slabs.SlabPinParams{
+		EncryptionKey: slabs.EncryptionKey{2}, // different encryption key = different slab
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{
+			{Root: sectorRoot1, HostKey: hk1},
+			{Root: sectorRoot2, HostKey: hk2},
+		},
+	}
+
+	slab2IDs, err := store.PinSlabs(account, nextCheck, slab2)
+	if err != nil {
+		t.Fatal("failed to pin slab2:", err)
+	}
+
+	// verify slab2 is a different slab than slab1
+	if slab2IDs[0] == slab1IDs[0] {
+		t.Fatal("expected slab2 to have different ID than slab1")
+	}
+
+	// verify slab2 can be fetched with all sectors
+	// this is the regression test - if slab_sectors entries weren't created,
+	// this will fail with 0 sectors
+	fetched2, err := store.Slabs(account, slab2IDs)
+	if err != nil {
+		t.Fatal("failed to fetch slab2:", err)
+	} else if len(fetched2) != 1 {
+		t.Fatalf("expected 1 slab, got %d", len(fetched2))
+	} else if len(fetched2[0].Sectors) != 2 {
+		t.Fatalf("expected 2 sectors in slab2, got %d", len(fetched2[0].Sectors))
+	}
+
+	// verify the sectors have correct roots
+	if fetched2[0].Sectors[0].Root != sectorRoot1 {
+		t.Fatalf("expected sector root %x, got %x", sectorRoot1, fetched2[0].Sectors[0].Root)
+	}
+	if fetched2[0].Sectors[1].Root != sectorRoot2 {
+		t.Fatalf("expected sector root %x, got %x", sectorRoot2, fetched2[0].Sectors[1].Root)
+	}
+}
+
 func TestPinSlabsStorageLimit(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 


### PR DESCRIPTION
Ran into this edge case when looking into why the docker image hasn't been updated in a few days due to the CI failing to NDFs.

When pinning a slab with sectors that are already pinned by another slab that doesn't have the same slab id, the join table isn't populated correctly. That leads to us silently dropping sectors when fetching the salb from the API.

While this isn't something that should happen when using the SDK, nothing prevents a user from doing this. 