### PR TITLE
Introduce `maxRenewableContractSize`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,8 +17,6 @@ import (
 )
 
 const (
-	maxContractSize = 10 * 1 << 40 // 10TB
-
 	// defaultRevisionSubmissionBuffer is a buffer that mainnet hosts apply on
 	// the contract's proof height before they consider a contract revisable, so
 	// if the current block height plus the buffer exceed the proof height, the

--- a/client/client.go
+++ b/client/client.go
@@ -120,7 +120,7 @@ func (c *HostClient) AccountBalance(ctx context.Context, account proto.Account) 
 // The integer returned does not indicate the number of sectors that were
 // appended, but rather the number of sectors that were attempted. Check the
 // result for the actual number of sectors that were appended.
-func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxSize uint64) (res rhp.RPCAppendSectorsResult, attempted int, err error) {
+func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxContractSize uint64) (res rhp.RPCAppendSectorsResult, attempted int, err error) {
 	// sanity check
 	if len(sectors) > proto.MaxSectorBatchSize {
 		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
@@ -128,14 +128,14 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 
 	// append sectors
 	err = c.withRevision(ctx, contractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
-		if contract.Revision.Filesize >= maxSize {
-			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d", contract.Revision.Filesize, maxSize)
+		if contract.Revision.Filesize >= maxContractSize {
+			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d", contract.Revision.Filesize, maxContractSize)
 		} else if contract.Revision.ExpirationHeight <= hostPrices.TipHeight {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract has expired at height %d, current height is %d", contract.Revision.ExpirationHeight, hostPrices.TipHeight)
 		}
 		// calculate the maximum number of sectors we can append based on the
 		// contract's remaining capacity and collateral
-		maxRemainingSectors := (maxSize - contract.Revision.Filesize) / proto.SectorSize
+		maxRemainingSectors := (maxContractSize - contract.Revision.Filesize) / proto.SectorSize
 		maxAppendSectors := (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
 		duration := contract.Revision.ExpirationHeight - hostPrices.TipHeight
 		appendSectorCost := hostPrices.RPCAppendSectorsCost(1, duration)

--- a/client/client.go
+++ b/client/client.go
@@ -122,7 +122,7 @@ func (c *HostClient) AccountBalance(ctx context.Context, account proto.Account) 
 // The integer returned does not indicate the number of sectors that were
 // appended, but rather the number of sectors that were attempted. Check the
 // result for the actual number of sectors that were appended.
-func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (res rhp.RPCAppendSectorsResult, attempted int, err error) {
+func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxSize uint64) (res rhp.RPCAppendSectorsResult, attempted int, err error) {
 	// sanity check
 	if len(sectors) > proto.MaxSectorBatchSize {
 		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("too many sectors, %d > %d", len(sectors), proto.MaxSectorBatchSize) // developer error
@@ -130,14 +130,14 @@ func (c *HostClient) AppendSectors(ctx context.Context, hostPrices proto.HostPri
 
 	// append sectors
 	err = c.withRevision(ctx, contractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
-		if contract.Revision.Filesize >= maxContractSize {
-			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d", contract.Revision.Filesize, maxContractSize)
+		if contract.Revision.Filesize >= maxSize {
+			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d", contract.Revision.Filesize, maxSize)
 		} else if contract.Revision.ExpirationHeight <= hostPrices.TipHeight {
 			return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract has expired at height %d, current height is %d", contract.Revision.ExpirationHeight, hostPrices.TipHeight)
 		}
 		// calculate the maximum number of sectors we can append based on the
 		// contract's remaining capacity and collateral
-		maxRemainingSectors := (maxContractSize - contract.Revision.Filesize) / proto.SectorSize
+		maxRemainingSectors := (maxSize - contract.Revision.Filesize) / proto.SectorSize
 		maxAppendSectors := (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
 		duration := contract.Revision.ExpirationHeight - hostPrices.TipHeight
 		appendSectorCost := hostPrices.RPCAppendSectorsCost(1, duration)

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -274,3 +274,21 @@ func (s *ContractState) UnmarshalText(b []byte) error {
 		return fmt.Errorf("unknown contract state %v", s)
 	}
 }
+
+// maxRenewableContractSize returns the maximum size a contract can have to
+// still be renewable
+func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) uint64 {
+	maxCollateral := hostSettings.MaxCollateral
+	sectorUsage := hostSettings.Prices.RPCAppendSectorsCost(1, period+proto.ProofWindow)
+	sectorCollateral := sectorUsage.HostRiskedCollateral()
+	if sectorCollateral.IsZero() {
+		sectorCollateral = types.NewCurrency64(1)
+	}
+	maxSectors := maxCollateral.Div(sectorCollateral)
+	maxSectorsSize := maxSectors.Mul64(proto.SectorSize).Big()
+	maxSize := uint64(maxContractSize)
+	if maxSectorsSize.IsUint64() {
+		maxSize = min(maxSize, maxSectorsSize.Uint64())
+	}
+	return maxSize * 8 / 10 // 20% safety margin
+}

--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -169,12 +169,14 @@ func (c Contract) inRenewWindow(renewWindow, height uint64) bool {
 }
 
 // GoodForAppend indicates whether a contract can be used to append sectors
-func (c Contract) GoodForAppend(prices proto.HostPrices, renewWindow, height uint64) error {
+func (c Contract) GoodForAppend(settings proto.HostSettings, renewWindow, height, period uint64) error {
+	prices := settings.Prices
+	maxRenewableSize := maxRenewableContractSize(settings, period)
 	switch {
 	case !c.Good:
 		return fmt.Errorf("contract is not good")
-	case c.Size >= maxContractSize:
-		return fmt.Errorf("contract has reached maximum size")
+	case c.Size >= maxRenewableSize:
+		return fmt.Errorf("contract has reached maximum renewable size: %d >= %d", c.Size, maxRenewableSize)
 	case c.ProofHeight <= height:
 		return fmt.Errorf("contract is not revisable")
 	case c.inRenewWindow(renewWindow, height):
@@ -195,7 +197,7 @@ func (c Contract) GoodForAppend(prices proto.HostPrices, renewWindow, height uin
 }
 
 // GoodForRefresh indicates whether a contract is likely to succeed refreshing.
-func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.Currency, renewWindow, height uint64) error {
+func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.Currency, renewWindow, height, period uint64) error {
 	if c.inRenewWindow(renewWindow, height) {
 		return fmt.Errorf("contract is in renew window")
 	}
@@ -208,11 +210,12 @@ func (c Contract) GoodForRefresh(settings proto.HostSettings, fundTarget types.C
 	} else {
 		totalCollateral = c.TotalCollateral.Add(collateral)
 	}
+	maxRenewableSize := maxRenewableContractSize(settings, period)
 	switch {
 	case !c.Good:
 		return fmt.Errorf("contract is not good")
-	case c.Size >= maxContractSize:
-		return fmt.Errorf("contract has reached maximum size")
+	case c.Size >= maxRenewableSize:
+		return fmt.Errorf("contract has reached maximum renewable size: %d >= %d", c.Size, maxRenewableSize)
 	case c.ProofHeight <= height:
 		return fmt.Errorf("contract is not revisable")
 	case totalCollateral.Cmp(settings.MaxCollateral) > 0:

--- a/contracts/contract_test.go
+++ b/contracts/contract_test.go
@@ -1,0 +1,64 @@
+package contracts
+
+import (
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+)
+
+func TestMaxRenewableContractSize(t *testing.T) {
+	const period = 144 * 30 // 30 days
+
+	tests := []struct {
+		name          string
+		maxCollateral types.Currency
+		collateral    types.Currency
+		expected      uint64
+	}{
+		{
+			name:          "collateral limited",
+			maxCollateral: types.Siacoins(1000),
+			collateral:    types.Siacoins(100).Div64(1e12).Div64(4320), // 100 SC / TB / month
+			expected: func() uint64 {
+				// maxCollateral / (collateral * sectorSize * (period + proofWindow))
+				// = 1000 SC / (100 SC/TB/month * 4MiB * (30 days + proofWindow))
+				maxCollateral := types.Siacoins(1000)
+				collateral := types.Siacoins(100).Div64(1e12).Div64(4320)
+				sectorCollateral := collateral.Mul64(proto.SectorSize).Mul64(period + proto.ProofWindow)
+				maxSectors := maxCollateral.Div(sectorCollateral).Big().Uint64()
+				return maxSectors * proto.SectorSize * 8 / 10 // 20% safety margin
+			}(),
+		},
+		{
+			name:          "max contract size limited",
+			maxCollateral: types.MaxCurrency, // extremely high collateral
+			collateral:    types.NewCurrency64(1),
+			expected:      maxContractSize * 8 / 10, // limited by maxContractSize with 20% safety margin
+		},
+		{
+			name:          "zero collateral",
+			maxCollateral: types.Siacoins(1000),
+			collateral:    types.ZeroCurrency,       // zero collateral per sector
+			expected:      maxContractSize * 8 / 10, // should use maxContractSize with safety margin
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			settings := proto.HostSettings{
+				MaxCollateral: tc.maxCollateral,
+				Prices: proto.HostPrices{
+					Collateral: tc.collateral,
+					ValidUntil: time.Now().Add(time.Hour),
+				},
+			}
+
+			result := maxRenewableContractSize(settings, period)
+			if result != tc.expected {
+				t.Errorf("expected %d, got %d", tc.expected, result)
+			}
+		})
+	}
+}

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -241,9 +241,9 @@ func (cm *ContractManager) performContractFormation(ctx context.Context, setting
 			candidate := candidateContract{
 				host:           host,
 				contract:       contract,
-				goodForRefresh: contract.GoodForRefresh(host.Settings, accountFundTarget, settings.RenewWindow, height),
+				goodForRefresh: contract.GoodForRefresh(host.Settings, accountFundTarget, settings.RenewWindow, height, settings.Period),
 				goodForFunding: contract.GoodForAccountFunding(accountFundTarget),
-				goodForAppend:  contract.GoodForAppend(host.Settings.Prices, settings.RenewWindow, height),
+				goodForAppend:  contract.GoodForAppend(host.Settings, settings.RenewWindow, height, settings.Period),
 			}
 
 			// determine which contract to use for maintenance with this host.

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -552,6 +552,9 @@ func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) ui
 	maxCollateral := hostSettings.MaxCollateral
 	sectorUsage := hostSettings.Prices.RPCAppendSectorsCost(1, period)
 	sectorCollateral := sectorUsage.HostRiskedCollateral()
+	if sectorCollateral.IsZero() {
+		sectorCollateral = types.NewCurrency64(1)
+	}
 	maxSectors := maxCollateral.Div(sectorCollateral)
 	maxSectorsSize := maxSectors.Mul64(proto.SectorSize).Big()
 	maxSize := uint64(maxContractSize)

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -77,7 +77,7 @@ type (
 		// The integer returned does not indicate the number of sectors that were
 		// appended, but rather the number of sectors that were attempted. Check the
 		// result for the actual number of sectors that were appended.
-		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxSize uint64) (rhp.RPCAppendSectorsResult, int, error)
+		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxContractSize uint64) (rhp.RPCAppendSectorsResult, int, error)
 		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
 		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
 		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
@@ -544,22 +544,4 @@ func NewManager(renterKey types.PrivateKey, accountManager AccountManager, accou
 		cm.maintenanceLoop(ctx)
 	}()
 	return cm, nil
-}
-
-// maxRenewableContractSize returns the maximum size a contract can have to
-// still be renewable
-func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) uint64 {
-	maxCollateral := hostSettings.MaxCollateral
-	sectorUsage := hostSettings.Prices.RPCAppendSectorsCost(1, period+proto.ProofWindow)
-	sectorCollateral := sectorUsage.HostRiskedCollateral()
-	if sectorCollateral.IsZero() {
-		sectorCollateral = types.NewCurrency64(1)
-	}
-	maxSectors := maxCollateral.Div(sectorCollateral)
-	maxSectorsSize := maxSectors.Mul64(proto.SectorSize).Big()
-	maxSize := uint64(maxContractSize)
-	if maxSectorsSize.IsUint64() {
-		maxSize = min(maxSize, maxSectorsSize.Uint64())
-	}
-	return maxSize * 8 / 10 // 20% safety margin
 }

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -550,7 +550,7 @@ func NewManager(renterKey types.PrivateKey, accountManager AccountManager, accou
 // still be renewable
 func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) uint64 {
 	maxCollateral := hostSettings.MaxCollateral
-	sectorUsage := hostSettings.Prices.RPCAppendSectorsCost(1, period)
+	sectorUsage := hostSettings.Prices.RPCAppendSectorsCost(1, period+proto.ProofWindow)
 	sectorCollateral := sectorUsage.HostRiskedCollateral()
 	if sectorCollateral.IsZero() {
 		sectorCollateral = types.NewCurrency64(1)

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -558,5 +558,5 @@ func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) ui
 	if maxSectorsSize.IsUint64() {
 		maxSize = min(maxSize, maxSectorsSize.Uint64())
 	}
-	return maxSize
+	return maxSize * 8 / 10 // 20% safety margin
 }

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -77,7 +77,7 @@ type (
 		// The integer returned does not indicate the number of sectors that were
 		// appended, but rather the number of sectors that were attempted. Check the
 		// result for the actual number of sectors that were appended.
-		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, int, error)
+		AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxSize uint64) (rhp.RPCAppendSectorsResult, int, error)
 		FormContract(ctx context.Context, settings proto.HostSettings, params proto.RPCFormContractParams) (rhp.RPCFormContractResult, error)
 		FreeSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, indices []uint64) (rhp.RPCFreeSectorsResult, error)
 		RefreshContract(ctx context.Context, settings proto.HostSettings, params proto.RPCRefreshContractParams) (rhp.RPCRefreshContractResult, error)
@@ -436,7 +436,7 @@ func (cm *ContractManager) ContractsForAppend() (good []Contract, err error) {
 		return nil, fmt.Errorf("failed to fetch maintenance settings: %w", err)
 	}
 
-	hostsMap := make(map[types.PublicKey]proto.HostPrices)
+	hostsMap := make(map[types.PublicKey]proto.HostSettings)
 
 	const batchSize = 50
 	for offset := 0; ; offset += batchSize {
@@ -450,17 +450,17 @@ func (cm *ContractManager) ContractsForAppend() (good []Contract, err error) {
 		height := cm.chain.TipState().Index.Height
 
 		for _, c := range batch {
-			hostPrices, ok := hostsMap[c.HostKey]
+			hostSettings, ok := hostsMap[c.HostKey]
 			if !ok {
 				host, err := cm.hosts.Host(context.Background(), c.HostKey)
 				if err != nil {
 					return nil, fmt.Errorf("failed to fetch host %s: %w", c.HostKey.String(), err)
 				}
-				hostPrices = host.Settings.Prices
-				hostsMap[c.HostKey] = hostPrices
+				hostSettings = host.Settings
+				hostsMap[c.HostKey] = hostSettings
 			}
 
-			if c.GoodForAppend(hostPrices, settings.RenewWindow, height) == nil {
+			if c.GoodForAppend(hostSettings, settings.RenewWindow, height, settings.Period) == nil {
 				good = append(good, c)
 			}
 		}
@@ -544,4 +544,19 @@ func NewManager(renterKey types.PrivateKey, accountManager AccountManager, accou
 		cm.maintenanceLoop(ctx)
 	}()
 	return cm, nil
+}
+
+// maxRenewableContractSize returns the maximum size a contract can have to
+// still be renewable
+func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) uint64 {
+	maxCollateral := hostSettings.MaxCollateral
+	sectorUsage := hostSettings.Prices.RPCAppendSectorsCost(1, period)
+	sectorCollateral := sectorUsage.HostRiskedCollateral()
+	maxSectors := maxCollateral.Div(sectorCollateral)
+	maxSectorsSize := maxSectors.Mul64(proto.SectorSize).Big()
+	maxSize := uint64(maxContractSize)
+	if maxSectorsSize.IsUint64() {
+		maxSize = min(maxSize, maxSectorsSize.Uint64())
+	}
+	return maxSize
 }

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -75,8 +75,14 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 	}
 	defer client.Close()
 
+	ms, err := cm.store.MaintenanceSettings()
+	if err != nil {
+		return fmt.Errorf("failed to fetch maintenance settings for sector pinning: %w", err)
+	}
+	maxRenewableSize := maxRenewableContractSize(host.Settings, ms.Period)
+
 	// fetch contract ids
-	contractIDs, err := cm.store.ContractsForPinning(host.PublicKey, maxContractSize)
+	contractIDs, err := cm.store.ContractsForPinning(host.PublicKey, maxRenewableSize)
 	if err != nil {
 		return fmt.Errorf("failed to fetch contracts for pinning: %w", err)
 	} else if len(contractIDs) == 0 {
@@ -92,7 +98,7 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 			exhausted = true
 		}
 
-		if err := cm.pinSectors(ctx, client, host.PublicKey, host.Settings.Prices, contractIDs, roots, log); err != nil {
+		if err := cm.pinSectors(ctx, client, host.PublicKey, host.Settings.Prices, contractIDs, roots, maxRenewableSize, log); err != nil {
 			return fmt.Errorf("failed to pin sectors: %w", err)
 		}
 	}
@@ -104,7 +110,7 @@ func (cm *ContractManager) performSectorPinningOnHost(ctx context.Context, host 
 // attempt to pin all sectors, but may not be able to if the contracts run out of
 // space. It will try to pin sectors using the contracts in the order they are
 // provided. If the host refuses to pin a sector, it will be marked as lost.
-func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, hostKey types.PublicKey, hostPrices proto.HostPrices, contractIDs []types.FileContractID, sectors []types.Hash256, log *zap.Logger) error {
+func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, hostKey types.PublicKey, hostPrices proto.HostPrices, contractIDs []types.FileContractID, sectors []types.Hash256, maxSize uint64, log *zap.Logger) error {
 	// NOTE: this is necessary to avoid looping forever
 	// when [AppendSectors] returns an error for all contracts.
 	var success bool
@@ -115,7 +121,7 @@ func (cm *ContractManager) pinSectors(ctx context.Context, client HostClient, ho
 		log := log.With(zap.Stringer("contractID", contractID))
 
 		// try to pin sectors to the contract
-		res, attempted, err := client.AppendSectors(ctx, hostPrices, contractID, sectors)
+		res, attempted, err := client.AppendSectors(ctx, hostPrices, contractID, sectors, maxSize)
 		if err != nil {
 			log.Debug("failed to pin sectors", zap.Error(err))
 			continue

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -24,7 +24,7 @@ type appendSectorCall struct {
 	sectors    []types.Hash256
 }
 
-func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxSize uint64) (rhp.RPCAppendSectorsResult, int, error) {
+func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxContractSize uint64) (rhp.RPCAppendSectorsResult, int, error) {
 	if c.failsRPCs {
 		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("mocked error")
 	}
@@ -32,7 +32,7 @@ func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.Hos
 	c.appendSectorCalls = append(c.appendSectorCalls, appendSectorCall{
 		hostPrices: hostPrices,
 		contractID: contractID,
-		maxSize:    maxSize,
+		maxSize:    maxContractSize,
 		sectors:    slices.Clone(sectors),
 	})
 

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -20,10 +20,11 @@ import (
 type appendSectorCall struct {
 	hostPrices proto.HostPrices
 	contractID types.FileContractID
+	maxSize    uint64
 	sectors    []types.Hash256
 }
 
-func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256) (rhp.RPCAppendSectorsResult, int, error) {
+func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.HostPrices, contractID types.FileContractID, sectors []types.Hash256, maxSize uint64) (rhp.RPCAppendSectorsResult, int, error) {
 	if c.failsRPCs {
 		return rhp.RPCAppendSectorsResult{}, 0, fmt.Errorf("mocked error")
 	}
@@ -31,6 +32,7 @@ func (c *hostClientMock) AppendSectors(ctx context.Context, hostPrices proto.Hos
 	c.appendSectorCalls = append(c.appendSectorCalls, appendSectorCall{
 		hostPrices: hostPrices,
 		contractID: contractID,
+		maxSize:    maxSize,
 		sectors:    slices.Clone(sectors),
 	})
 

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -13,7 +13,7 @@ import (
 func (cm *ContractManager) performContractRenewals(ctx context.Context, period, renewWindow uint64, log *zap.Logger) error {
 	bh := cm.chain.TipState().Index.Height
 	minProofHeight := bh + renewWindow
-	newProofHeight := bh + period + renewWindow
+	newProofHeight := bh + period
 
 	batchSize := 50
 	for offset := 0; ; offset += batchSize {

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -147,7 +147,7 @@ func TestPerformContractRenewals(t *testing.T) {
 			if c.RenewedFrom != (types.FileContractID{1}) {
 				t.Fatal("renewed contract should be renewed from first contract")
 			} else if c.ProofHeight != blockHeight+period {
-				t.Fatalf("renewed contract should have proof height %d, got %d", blockHeight+period+renewWindow, c.ProofHeight)
+				t.Fatalf("renewed contract should have proof height %d, got %d", blockHeight+period, c.ProofHeight)
 			} else if c.ExpirationHeight != c.ProofHeight+144 {
 				t.Fatalf("renewed contract should have expiration height %d, got %d", c.ProofHeight+144, c.ExpirationHeight)
 			} else if !c.ContractPrice.Equals(types.Siacoins(1)) {

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -124,7 +124,7 @@ func TestPerformContractRenewals(t *testing.T) {
 	} else if len(dialer.HostClient(bad.PublicKey).renewCalls) != 0 {
 		t.Fatal("expected bad host to not be dialed")
 	}
-	assertRenewal(types.FileContractID{1}, blockHeight+period+renewWindow, dialer.HostClient(good.PublicKey).renewCalls[0])
+	assertRenewal(types.FileContractID{1}, blockHeight+period, dialer.HostClient(good.PublicKey).renewCalls[0])
 
 	// assert renewal made it into the store
 	allContracts, err := store.Contracts(0, 10)
@@ -146,7 +146,7 @@ func TestPerformContractRenewals(t *testing.T) {
 		default:
 			if c.RenewedFrom != (types.FileContractID{1}) {
 				t.Fatal("renewed contract should be renewed from first contract")
-			} else if c.ProofHeight != blockHeight+period+renewWindow {
+			} else if c.ProofHeight != blockHeight+period {
 				t.Fatalf("renewed contract should have proof height %d, got %d", blockHeight+period+renewWindow, c.ProofHeight)
 			} else if c.ExpirationHeight != c.ProofHeight+144 {
 				t.Fatalf("renewed contract should have expiration height %d, got %d", c.ProofHeight+144, c.ExpirationHeight)

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -210,7 +210,7 @@ func TestSectorsToMigrate(t *testing.T) {
 			ProofHeight:      200,
 			ExpirationHeight: 300,
 		}
-		if err := c.GoodForAppend(goodSettings.Prices, 0, 0); (err == nil) != goodForUpload {
+		if err := c.GoodForAppend(goodSettings, 0, 0, 100); (err == nil) != goodForUpload {
 			// sanity check
 			t.Fatalf("contract %d: expected goodForUpload %v, got %v (%s)", contractIndex, goodForUpload, err == nil, err)
 		}


### PR DESCRIPTION
This PR does 2 things to reduce our issues with contracts not getting renewed due to too much host collateral being requested.

1. updates renewals to use the period rather than period + renew window to make sure both formations and renewals use the same duration
2. introduce a maximum contract size and enforce it

The latter is a computed maximum contract size over a full contract period. This is really just a less reliable version of a max contract size field on the host settings but since we still don't know how to best implement that this is what we can do right now.

The reason we need this is the fact that right now collateral for a sector gets cheaper as time passes. Let's assume 1 sector costs 1SC per block in collateral. If the sector is uploaded right when forming a contract with a period of 100 blocks this means 100SC of collateral for that sector. If you upload the sector right at the end it costs 1SC. 
So imagine a host has a max collateral of 50SC and we upload 50 sectors at the end of the contract. To the host this is fine but when we renew that contract we need to pay for the next 100 blocks of collateral which would be 5000SC which is above the max collateral and therefore fails.

This PR solves this by making sure we consider a contract as not good as soon as we approach that max size and form a new one and by not going above the limit.

It's not foolproof since a host might update its settings which is why I gave it a 20% safety margin until the host itself enforces a max contract size. Once we have that, `maxRenewableContractSize` basically becomes `return min(hostSettings.MaxContractSize, maxContractSize)`