### PR TITLE
Fix TestSharedObjects NDF

### DIFF
--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -645,17 +645,17 @@ func TestSharedObjects(t *testing.T) {
 			// prepare sector data
 			var sector [proto.SectorSize]byte
 			frand.Read(sector[:])
-			root := proto.SectorRoot(&sector)
 
 			// upload sector
 			hk := h.PublicKey
-			if _, err = client.WriteSector(t.Context(), sk1, hk, sector[:]); err != nil {
+			if result, err := client.WriteSector(ctx, sk1, hk, sector[:]); err != nil {
 				t.Fatal(err)
+			} else {
+				sectors = append(sectors, slabs.PinnedSector{
+					Root:    result.Root,
+					HostKey: hk,
+				})
 			}
-			sectors = append(sectors, slabs.PinnedSector{
-				Root:    root,
-				HostKey: hk,
-			})
 		}
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -18,7 +18,9 @@ import (
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/app"
+	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/geoip"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/subscriber"
 	"go.sia.tech/indexd/testutils"
@@ -587,6 +589,10 @@ func TestSharedObjects(t *testing.T) {
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
 
+	// create client
+	client := client.New(client.NewProvider(hosts.NewHostStore(cluster.Indexer.Store())))
+	defer client.Close()
+
 	// wait for contracts to be formed
 	cluster.WaitForContracts(t)
 
@@ -633,20 +639,31 @@ func TestSharedObjects(t *testing.T) {
 
 	// helper to generate slab pin parameters
 	randomSlab := func() slabs.SlabPinParams {
+		// prepare sectors
+		var sectors []slabs.PinnedSector
+		for _, h := range hosts {
+			// prepare sector data
+			var sector [proto.SectorSize]byte
+			frand.Read(sector[:])
+			root := proto.SectorRoot(&sector)
+
+			// upload sector
+			hk := h.PublicKey
+			if _, err = client.WriteSector(t.Context(), sk1, hk, sector[:]); err != nil {
+				t.Fatal(err)
+			}
+			sectors = append(sectors, slabs.PinnedSector{
+				Root:    root,
+				HostKey: hk,
+			})
+		}
 		return slabs.SlabPinParams{
 			EncryptionKey: frand.Entropy256(),
 			MinShards:     1,
-			Sectors: func() (s []slabs.PinnedSector) {
-				for _, h := range hosts {
-					s = append(s, slabs.PinnedSector{
-						Root:    frand.Entropy256(),
-						HostKey: h.PublicKey,
-					})
-				}
-				return s
-			}(),
+			Sectors:       sectors,
 		}
 	}
+
 	// generate and pin a slab
 	slab1Params := randomSlab()
 	_, err = client1.PinSlabs(ctx, sk1, slab1Params)


### PR DESCRIPTION
The test fails because we are trying to pin sectors that were never uploaded to hosts. That marks them as lost, causing the host key to be unset causing the shared object to have zeroed out host keys which failed the assertion. There's a couple of ways to fix this, one is to allow disabling the pinning of sectors in the maintenance loop, but I figured it's probably best to upload the sectors to the test hosts. I ran it 20 times locally while it would otherwise fail consistently at least one out of 10 runs. 

Fixes https://github.com/SiaFoundation/indexd/issues/766