### PR TITLE
Add quotas for app connect keys

### DIFF
--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -50,7 +50,7 @@ type (
 	ConnectKey struct {
 		Key           string    `json:"key"`
 		Description   string    `json:"description"`
-		Quota         Quota     `json:"quota"`
+		Quota         string    `json:"quota"`
 		RemainingUses int       `json:"remainingUses"`
 		DateCreated   time.Time `json:"dateCreated"`
 		LastUpdated   time.Time `json:"lastUpdated"`

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -25,6 +25,10 @@ var (
 	// ErrQuotaNotFound is returned when a quota is not found.
 	ErrQuotaNotFound = errors.New("quota not found")
 
+	// ErrQuotaInUse is returned when deleting a quota with connect keys
+	// associated to it.
+	ErrQuotaInUse = errors.New("quota in use")
+
 	// ErrAppKeyStorageLimitExceeded is returned when an operation fails due to
 	// the connect key exceeding its storage limit.    We use the term "account
 	// storage limit" here because from the user's perspective, the app connect
@@ -75,6 +79,13 @@ type (
 		LogoURL     string        `json:"logoURL"`
 		ServiceURL  string        `json:"serviceURL"`
 	}
+
+	// PutQuotaRequest is the request type for creating or updating a quota.
+	PutQuotaRequest struct {
+		Description   string `json:"description"`
+		MaxPinnedData uint64 `json:"maxPinnedData"`
+		TotalUses     int    `json:"totalUses"`
+	}
 )
 
 // AddAppConnectKey adds a new app connect key.
@@ -117,6 +128,27 @@ func (m *AccountManager) RegisterAppKey(key string, pk types.PublicKey, meta App
 // returns [ErrKeyNotFound].
 func (m *AccountManager) ValidAppConnectKey(ctx context.Context, key string) (bool, error) {
 	return m.store.ValidAppConnectKey(key)
+}
+
+// PutQuota creates or updates a quota.
+func (m *AccountManager) PutQuota(ctx context.Context, key string, req PutQuotaRequest) (Quota, error) {
+	return m.store.PutQuota(key, req)
+}
+
+// DeleteQuota deletes an existing quota. If the quota does not exist, it returns [ErrQuotaNotFound].
+// If the quota is in use by connect keys, it returns [ErrQuotaInUse].
+func (m *AccountManager) DeleteQuota(ctx context.Context, key string) error {
+	return m.store.DeleteQuota(key)
+}
+
+// Quota returns the quota with the given key. If the quota does not exist, it returns [ErrQuotaNotFound].
+func (m *AccountManager) Quota(ctx context.Context, key string) (Quota, error) {
+	return m.store.Quota(key)
+}
+
+// Quotas returns a list of quotas.
+func (m *AccountManager) Quotas(ctx context.Context, offset, limit int) ([]Quota, error) {
+	return m.store.Quotas(offset, limit)
 }
 
 // AppSecret derives a unique application secret using a stored user secret

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -131,7 +131,7 @@ func (m *AccountManager) ValidAppConnectKey(ctx context.Context, key string) (bo
 }
 
 // PutQuota creates or updates a quota.
-func (m *AccountManager) PutQuota(ctx context.Context, key string, req PutQuotaRequest) (Quota, error) {
+func (m *AccountManager) PutQuota(ctx context.Context, key string, req PutQuotaRequest) error {
 	return m.store.PutQuota(key, req)
 }
 

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -22,6 +22,9 @@ var (
 	// associated to it.
 	ErrKeyInUse = errors.New("key in use")
 
+	// ErrQuotaNotFound is returned when a quota is not found.
+	ErrQuotaNotFound = errors.New("quota not found")
+
 	// ErrAppKeyStorageLimitExceeded is returned when an operation fails due to
 	// the connect key exceeding its storage limit.    We use the term "account
 	// storage limit" here because from the user's perspective, the app connect
@@ -30,34 +33,39 @@ var (
 )
 
 type (
+	// Quota represents a usage quota for connect keys.
+	Quota struct {
+		Key           string `json:"key"`
+		Description   string `json:"description"`
+		MaxPinnedData uint64 `json:"maxPinnedData"`
+		TotalUses     int    `json:"totalUses"`
+	}
+
 	// A ConnectKey represents a key used to authenticate
 	// when connecting a new application.
 	ConnectKey struct {
 		Key           string    `json:"key"`
 		Description   string    `json:"description"`
-		TotalUses     int       `json:"totalUses"`
+		Quota         Quota     `json:"quota"`
 		RemainingUses int       `json:"remainingUses"`
 		DateCreated   time.Time `json:"dateCreated"`
 		LastUpdated   time.Time `json:"lastUpdated"`
 		LastUsed      time.Time `json:"lastUsed"`
 		PinnedData    uint64    `json:"pinnedData"`
-		MaxPinnedData uint64    `json:"maxPinnedData"`
 	}
 
 	// AddConnectKeyRequest is the request type for adding a new app connect key.
 	AddConnectKeyRequest struct {
-		Description   string `json:"description"`
-		MaxPinnedData uint64 `json:"maxPinnedData,omitempty"`
-		RemainingUses int    `json:"remainingUses"`
+		Description string `json:"description"`
+		Quota       string `json:"quota"`
 	}
 
 	// UpdateAppConnectKey represents a request to add or update
 	// an app connect key.
 	UpdateAppConnectKey struct {
-		Key           string `json:"key"`
-		Description   string `json:"description"`
-		MaxPinnedData uint64 `json:"maxPinnedData,omitempty"`
-		RemainingUses int    `json:"remainingUses"`
+		Key         string `json:"key"`
+		Description string `json:"description"`
+		Quota       string `json:"quota"`
 	}
 
 	// AppMeta contains additional metadata associated with an account.

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -60,6 +60,11 @@ type (
 		AppConnectKey(key string) (ConnectKey, error)
 		AppConnectKeys(offset, limit int) ([]ConnectKey, error)
 
+		PutQuota(key string, req PutQuotaRequest) (Quota, error)
+		DeleteQuota(key string) error
+		Quota(key string) (Quota, error)
+		Quotas(offset, limit int) ([]Quota, error)
+
 		PruneAccounts(limit int) error
 		ActiveAccounts(threshold time.Time) (uint64, error)
 		Account(types.PublicKey) (Account, error)

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -60,7 +60,7 @@ type (
 		AppConnectKey(key string) (ConnectKey, error)
 		AppConnectKeys(offset, limit int) ([]ConnectKey, error)
 
-		PutQuota(key string, req PutQuotaRequest) (Quota, error)
+		PutQuota(key string, req PutQuotaRequest) error
 		DeleteQuota(key string) error
 		Quota(key string) (Quota, error)
 		Quotas(offset, limit int) ([]Quota, error)

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -385,9 +385,16 @@ func (a *admin) handlePUTAppConnectKeys(jc jape.Context) {
 	if jc.Decode(&key) != nil {
 		return
 	}
+	if key.Quota == "" {
+		jc.Error(errors.New("quota is required"), http.StatusBadRequest)
+		return
+	}
 
 	_, err := a.accounts.UpdateAppConnectKey(jc.Request.Context(), key)
 	if errors.Is(err, accounts.ErrKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if errors.Is(err, accounts.ErrQuotaNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if jc.Check("failed to update app connect key", err) != nil {
@@ -478,6 +485,10 @@ func (a *admin) handlePUTQuota(jc jape.Context) {
 
 	var req accounts.PutQuotaRequest
 	if jc.Decode(&req) != nil {
+		return
+	}
+	if req.TotalUses < 0 {
+		jc.Error(errors.New("totalUses must be non-negative"), http.StatusBadRequest)
 		return
 	}
 

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"net/http"
+	"strings"
 
 	"errors"
 	"fmt"
@@ -101,6 +102,11 @@ type (
 		DeleteAppConnectKey(context.Context, string) error
 		AppConnectKey(ctx context.Context, key string) (accounts.ConnectKey, error)
 		AppConnectKeys(ctx context.Context, offset, limit int) ([]accounts.ConnectKey, error)
+
+		PutQuota(ctx context.Context, key string, req accounts.PutQuotaRequest) (accounts.Quota, error)
+		DeleteQuota(ctx context.Context, key string) error
+		Quota(ctx context.Context, key string) (accounts.Quota, error)
+		Quotas(ctx context.Context, offset, limit int) ([]accounts.Quota, error)
 	}
 
 	// A Store is a persistent store for the indexer.
@@ -244,6 +250,12 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 		"PUT    /apps/connect/keys":      a.handlePUTAppConnectKeys,
 		"GET    /apps/connect/keys/:key": a.handleGETAppConnectKeysKey,
 		"DELETE /apps/connect/keys/:key": a.handleDELETEAppConnectKeys,
+
+		// quota endpoints
+		"GET    /quotas":      a.handleGETQuotas,
+		"PUT    /quotas/:key": a.handlePUTQuota,
+		"GET    /quotas/:key": a.handleGETQuota,
+		"DELETE /quotas/:key": a.handleDELETEQuota,
 
 		// wallet endpoints
 		"GET /wallet":            a.handleGETWallet,
@@ -415,6 +427,83 @@ func (a *admin) handleDELETEAppConnectKeys(jc jape.Context) {
 		return
 	}
 	jc.Encode(nil)
+}
+
+func (a *admin) handleGETQuotas(jc jape.Context) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	quotas, err := a.accounts.Quotas(jc.Request.Context(), offset, limit)
+	if jc.Check("failed to get quotas", err) != nil {
+		return
+	}
+	jc.Encode(quotas)
+}
+
+func (a *admin) handleGETQuota(jc jape.Context) {
+	var key string
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	quota, err := a.accounts.Quota(jc.Request.Context(), key)
+	if errors.Is(err, accounts.ErrQuotaNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to get quota", err) != nil {
+		return
+	}
+	jc.Encode(quota)
+}
+
+func (a *admin) handlePUTQuota(jc jape.Context) {
+	var key string
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	// validate key
+	if key == "" {
+		jc.Error(errors.New("key cannot be empty"), http.StatusBadRequest)
+		return
+	} else if len(key) > 32 {
+		jc.Error(errors.New("key cannot be longer than 32 characters"), http.StatusBadRequest)
+		return
+	} else if strings.Contains(key, " ") {
+		jc.Error(errors.New("key cannot contain spaces"), http.StatusBadRequest)
+		return
+	}
+
+	var req accounts.PutQuotaRequest
+	if jc.Decode(&req) != nil {
+		return
+	}
+
+	quota, err := a.accounts.PutQuota(jc.Request.Context(), key, req)
+	if jc.Check("failed to put quota", err) != nil {
+		return
+	}
+	jc.Encode(quota)
+}
+
+func (a *admin) handleDELETEQuota(jc jape.Context) {
+	var key string
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	err := a.accounts.DeleteQuota(jc.Request.Context(), key)
+	if errors.Is(err, accounts.ErrQuotaNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if errors.Is(err, accounts.ErrQuotaInUse) {
+		jc.Error(err, http.StatusConflict)
+		return
+	} else if jc.Check("failed to delete quota", err) != nil {
+		return
+	}
 }
 
 func (a *admin) handleGETAccount(jc jape.Context) {

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -475,11 +475,8 @@ func (a *admin) handlePUTQuota(jc jape.Context) {
 	if key == "" {
 		jc.Error(errors.New("key cannot be empty"), http.StatusBadRequest)
 		return
-	} else if len(key) > 32 {
-		jc.Error(errors.New("key cannot be longer than 32 characters"), http.StatusBadRequest)
-		return
 	} else if !isValidQuotaKey(key) {
-		jc.Error(errors.New("key must only contain letters, digits, hyphens, and underscores"), http.StatusBadRequest)
+		jc.Error(errors.New("key must only contain letters, digits, hyphens, underscores and be between 1 and 32 characters long"), http.StatusBadRequest)
 		return
 	}
 
@@ -1149,7 +1146,7 @@ func writeResponse(jc jape.Context, resp prometheus.Marshaller) {
 	}
 }
 
-var validQuotaKey = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+var validQuotaKey = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,32}$`)
 
 func isValidQuotaKey(key string) bool {
 	return validQuotaKey.MatchString(key)

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"net/http"
-	"strings"
+	"regexp"
 
 	"errors"
 	"fmt"
@@ -471,8 +471,8 @@ func (a *admin) handlePUTQuota(jc jape.Context) {
 	} else if len(key) > 32 {
 		jc.Error(errors.New("key cannot be longer than 32 characters"), http.StatusBadRequest)
 		return
-	} else if strings.Contains(key, " ") {
-		jc.Error(errors.New("key cannot contain spaces"), http.StatusBadRequest)
+	} else if !isValidQuotaKey(key) {
+		jc.Error(errors.New("key must only contain letters, digits, hyphens, and underscores"), http.StatusBadRequest)
 		return
 	}
 
@@ -1138,4 +1138,10 @@ func writeResponse(jc jape.Context, resp prometheus.Marshaller) {
 	default:
 		jc.Encode(resp)
 	}
+}
+
+var validQuotaKey = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func isValidQuotaKey(key string) bool {
+	return validQuotaKey.MatchString(key)
 }

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -349,17 +349,20 @@ func (a *admin) handlePOSTAppConnectKeys(jc jape.Context) {
 	if jc.Decode(&req) != nil {
 		return
 	}
-	if req.MaxPinnedData == 0 {
-		req.MaxPinnedData = 1e12 // default to 1TB
+	if req.Quota == "" {
+		jc.Error(errors.New("quota is required"), http.StatusBadRequest)
+		return
 	}
 
 	created, err := a.accounts.AddAppConnectKey(jc.Request.Context(), accounts.UpdateAppConnectKey{
-		Key:           hex.EncodeToString(frand.Bytes(32)),
-		Description:   req.Description,
-		MaxPinnedData: req.MaxPinnedData,
-		RemainingUses: req.RemainingUses,
+		Key:         hex.EncodeToString(frand.Bytes(32)),
+		Description: req.Description,
+		Quota:       req.Quota,
 	})
-	if jc.Check("failed to update app connect key", err) != nil {
+	if errors.Is(err, accounts.ErrQuotaNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to add app connect key", err) != nil {
 		return
 	}
 	jc.Encode(created)

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -103,7 +103,7 @@ type (
 		AppConnectKey(ctx context.Context, key string) (accounts.ConnectKey, error)
 		AppConnectKeys(ctx context.Context, offset, limit int) ([]accounts.ConnectKey, error)
 
-		PutQuota(ctx context.Context, key string, req accounts.PutQuotaRequest) (accounts.Quota, error)
+		PutQuota(ctx context.Context, key string, req accounts.PutQuotaRequest) error
 		DeleteQuota(ctx context.Context, key string) error
 		Quota(ctx context.Context, key string) (accounts.Quota, error)
 		Quotas(ctx context.Context, offset, limit int) ([]accounts.Quota, error)
@@ -481,11 +481,9 @@ func (a *admin) handlePUTQuota(jc jape.Context) {
 		return
 	}
 
-	quota, err := a.accounts.PutQuota(jc.Request.Context(), key, req)
-	if jc.Check("failed to put quota", err) != nil {
+	if jc.Check("failed to put quota", a.accounts.PutQuota(jc.Request.Context(), key, req)) != nil {
 		return
 	}
-	jc.Encode(quota)
 }
 
 func (a *admin) handleDELETEQuota(jc jape.Context) {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -72,8 +72,10 @@ func TestAppConnectKeys(t *testing.T) {
 			t.Fatal(err)
 		case len(created.Key) != 64:
 			t.Fatalf("expected key to be %d, got %d", 64, len(created.Key))
-		case created.RemainingUses != created.Quota.TotalUses:
-			t.Fatal("expected remaining uses to match quota total uses")
+		case created.RemainingUses != 5:
+			t.Fatalf("expected remaining uses to be 5, got %d", created.RemainingUses)
+		case created.Quota != "default":
+			t.Fatalf("expected quota to be 'default', got %q", created.Quota)
 		case !created.LastUsed.IsZero():
 			t.Fatal("expected last used to be zero")
 		case created.DateCreated.IsZero():
@@ -122,7 +124,7 @@ func TestAppConnectKeys(t *testing.T) {
 	err = adminClient.UpdateAppConnectKey(context.Background(), accounts.UpdateAppConnectKey{
 		Key:         key.Key,
 		Description: key.Description,
-		Quota:       key.Quota.Key,
+		Quota:       key.Quota,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -158,6 +158,128 @@ func TestAppConnectKeys(t *testing.T) {
 	}
 }
 
+func TestQuotasAPI(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+	adminClient := indexer.Admin
+
+	// list quotas - should have the default quota
+	quotas, err := adminClient.Quotas(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(quotas) != 1 {
+		t.Fatal("expected 1 default quota, got", len(quotas))
+	} else if quotas[0].Key != "default" {
+		t.Fatal("expected default quota")
+	}
+
+	// create a new quota
+	err = adminClient.PutQuota(context.Background(), "test-quota", accounts.PutQuotaRequest{
+		Description:   "Test quota",
+		MaxPinnedData: 1000,
+		TotalUses:     10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get the quota
+	quota, err := adminClient.Quota(context.Background(), "test-quota")
+	if err != nil {
+		t.Fatal(err)
+	} else if quota.Key != "test-quota" {
+		t.Fatalf("expected key to be 'test-quota', got %q", quota.Key)
+	} else if quota.Description != "Test quota" {
+		t.Fatalf("expected description to be 'Test quota', got %q", quota.Description)
+	} else if quota.MaxPinnedData != 1000 {
+		t.Fatalf("expected max pinned data to be 1000, got %d", quota.MaxPinnedData)
+	} else if quota.TotalUses != 10 {
+		t.Fatalf("expected total uses to be 10, got %d", quota.TotalUses)
+	}
+
+	// list quotas - should now have 2
+	quotas, err = adminClient.Quotas(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(quotas) != 2 {
+		t.Fatal("expected 2 quotas, got", len(quotas))
+	}
+
+	// update the quota (upsert)
+	err = adminClient.PutQuota(context.Background(), "test-quota", accounts.PutQuotaRequest{
+		Description:   "Updated description",
+		MaxPinnedData: 2000,
+		TotalUses:     20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the update
+	quota, err = adminClient.Quota(context.Background(), "test-quota")
+	if err != nil {
+		t.Fatal(err)
+	} else if quota.Description != "Updated description" {
+		t.Fatalf("expected description to be 'Updated description', got %q", quota.Description)
+	} else if quota.MaxPinnedData != 2000 {
+		t.Fatalf("expected max pinned data to be 2000, got %d", quota.MaxPinnedData)
+	} else if quota.TotalUses != 20 {
+		t.Fatalf("expected total uses to be 20, got %d", quota.TotalUses)
+	}
+
+	// delete the quota
+	err = adminClient.DeleteQuota(context.Background(), "test-quota")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// verify it's deleted
+	_, err = adminClient.Quota(context.Background(), "test-quota")
+	if err == nil {
+		t.Fatal("expected error when getting deleted quota")
+	}
+
+	// list quotas - should be back to 1
+	quotas, err = adminClient.Quotas(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(quotas) != 1 {
+		t.Fatal("expected 1 quota after deletion, got", len(quotas))
+	}
+
+	// test deleting non-existent quota
+	err = adminClient.DeleteQuota(context.Background(), "non-existent")
+	if err == nil {
+		t.Fatal("expected error when deleting non-existent quota")
+	}
+
+	// test that a quota in use cannot be deleted
+	// first create a quota
+	err = adminClient.PutQuota(context.Background(), "in-use-quota", accounts.PutQuotaRequest{
+		Description:   "Quota in use",
+		MaxPinnedData: 1000,
+		TotalUses:     10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create a connect key using this quota
+	_, err = adminClient.AddAppConnectKey(context.Background(), accounts.AddConnectKeyRequest{
+		Description: "Test key",
+		Quota:       "in-use-quota",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// try to delete the quota - should fail
+	err = adminClient.DeleteQuota(context.Background(), "in-use-quota")
+	if err == nil {
+		t.Fatal("expected error when deleting quota in use")
+	}
+}
+
 func TestAccountsAPI(t *testing.T) {
 	c := testutils.NewConsensusNode(t, zap.NewNop())
 	indexer := testutils.NewIndexer(t, c, zap.NewNop())

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -63,20 +63,17 @@ func TestAppConnectKeys(t *testing.T) {
 	var generated []accounts.ConnectKey
 	for i := range 100 {
 		description := fmt.Sprintf("key %d", i)
-		uses := frand.Intn(1000) + 1
 		created, err := adminClient.AddAppConnectKey(context.Background(), accounts.AddConnectKeyRequest{
-			Description:   description,
-			RemainingUses: uses,
+			Description: description,
+			Quota:       "default",
 		})
 		switch {
 		case err != nil:
 			t.Fatal(err)
 		case len(created.Key) != 64:
 			t.Fatalf("expected key to be %d, got %d", 64, len(created.Key))
-		case created.RemainingUses != uses:
-			t.Fatal("expected remaining uses to match")
-		case created.TotalUses != 0:
-			t.Fatal("expected total uses to be 0")
+		case created.RemainingUses != created.Quota.TotalUses:
+			t.Fatal("expected remaining uses to match quota total uses")
 		case !created.LastUsed.IsZero():
 			t.Fatal("expected last used to be zero")
 		case created.DateCreated.IsZero():
@@ -121,13 +118,11 @@ func TestAppConnectKeys(t *testing.T) {
 
 	key := generated[0]
 	key.Description = "foobar"
-	key.MaxPinnedData = 32
 
 	err = adminClient.UpdateAppConnectKey(context.Background(), accounts.UpdateAppConnectKey{
-		Key:           key.Key,
-		Description:   key.Description,
-		RemainingUses: key.RemainingUses,
-		MaxPinnedData: key.MaxPinnedData,
+		Key:         key.Key,
+		Description: key.Description,
+		Quota:       key.Quota.Key,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -136,7 +131,10 @@ func TestAppConnectKeys(t *testing.T) {
 	keys, err = adminClient.AppConnectKeys(context.Background(), 0, 10)
 	if err != nil {
 		t.Fatal(err)
-	} else if !reflect.DeepEqual(keys[0], key) {
+	}
+	// update expected key's LastUpdated since it changed
+	key.LastUpdated = keys[0].LastUpdated
+	if !reflect.DeepEqual(keys[0], key) {
 		t.Fatal("unexpected key", keys[0], key)
 	}
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -97,6 +97,32 @@ func (c *Client) UpdateAppConnectKey(ctx context.Context, req accounts.UpdateApp
 	return c.c.PUT(ctx, "/apps/connect/keys", req)
 }
 
+// Quotas retrieves a paginated list of quotas.
+func (c *Client) Quotas(ctx context.Context, offset, limit int) (quotas []accounts.Quota, err error) {
+	values := url.Values{}
+	values.Set("offset", fmt.Sprintf("%d", offset))
+	values.Set("limit", fmt.Sprintf("%d", limit))
+	err = c.c.GET(ctx, "/quotas?"+values.Encode(), &quotas)
+	return
+}
+
+// Quota retrieves a single quota by its key.
+func (c *Client) Quota(ctx context.Context, key string) (quota accounts.Quota, err error) {
+	err = c.c.GET(ctx, fmt.Sprintf("/quotas/%s", key), &quota)
+	return
+}
+
+// PutQuota creates or updates a quota.
+func (c *Client) PutQuota(ctx context.Context, key string, req accounts.PutQuotaRequest) error {
+	return c.c.PUT(ctx, fmt.Sprintf("/quotas/%s", key), req)
+}
+
+// DeleteQuota deletes a quota by its key.
+func (c *Client) DeleteQuota(ctx context.Context, key string) (err error) {
+	err = c.c.DELETE(ctx, fmt.Sprintf("/quotas/%s", key))
+	return
+}
+
 // Account returns the account with the given public key.
 func (c *Client) Account(ctx context.Context, ak types.PublicKey) (account accounts.Account, err error) {
 	err = c.c.GET(ctx, fmt.Sprintf("/account/%s", ak), &account)

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -108,18 +108,18 @@ func (c *Client) Quotas(ctx context.Context, offset, limit int) (quotas []accoun
 
 // Quota retrieves a single quota by its key.
 func (c *Client) Quota(ctx context.Context, key string) (quota accounts.Quota, err error) {
-	err = c.c.GET(ctx, fmt.Sprintf("/quotas/%s", key), &quota)
+	err = c.c.GET(ctx, fmt.Sprintf("/quotas/%s", url.PathEscape(key)), &quota)
 	return
 }
 
 // PutQuota creates or updates a quota.
 func (c *Client) PutQuota(ctx context.Context, key string, req accounts.PutQuotaRequest) error {
-	return c.c.PUT(ctx, fmt.Sprintf("/quotas/%s", key), req)
+	return c.c.PUT(ctx, fmt.Sprintf("/quotas/%s", url.PathEscape(key)), req)
 }
 
 // DeleteQuota deletes a quota by its key.
 func (c *Client) DeleteQuota(ctx context.Context, key string) (err error) {
-	err = c.c.DELETE(ctx, fmt.Sprintf("/quotas/%s", key))
+	err = c.c.DELETE(ctx, fmt.Sprintf("/quotas/%s", url.PathEscape(key)))
 	return
 }
 

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -137,8 +137,8 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("expected 1 key, got", len(keys))
 	case keys[0].Key != key.Key:
 		t.Fatal("expected key to match", keys[0].Key, key.Key)
-	case keys[0].RemainingUses != keys[0].Quota.TotalUses-1:
-		t.Fatalf("expected remaining uses to be %d, got %d", keys[0].Quota.TotalUses-1, keys[0].RemainingUses)
+	case keys[0].RemainingUses != 4:
+		t.Fatalf("expected remaining uses to be 4, got %d", keys[0].RemainingUses)
 	case keys[0].LastUsed.IsZero():
 		t.Fatal("expected last used to be set, got", keys[0].LastUsed)
 	}

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -63,7 +63,7 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 	client := indexer.App(sk)
 
 	key, err := indexer.Admin.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
-		RemainingUses: 1,
+		Quota: "default",
 	})
 	if err != nil {
 		t.Fatal("failed to add app connect key:", err)
@@ -137,10 +137,8 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("expected 1 key, got", len(keys))
 	case keys[0].Key != key.Key:
 		t.Fatal("expected key to match", keys[0].Key, key.Key)
-	case keys[0].RemainingUses != 0:
-		t.Fatal("expected remaining uses to be 0, got", keys[0].RemainingUses)
-	case keys[0].TotalUses != 1:
-		t.Fatal("expected total uses to be 1, got", keys[0].TotalUses)
+	case keys[0].RemainingUses != keys[0].Quota.TotalUses-1:
+		t.Fatalf("expected remaining uses to be %d, got %d", keys[0].Quota.TotalUses-1, keys[0].RemainingUses)
 	case keys[0].LastUsed.IsZero():
 		t.Fatal("expected last used to be set, got", keys[0].LastUsed)
 	}
@@ -458,8 +456,8 @@ func TestAppConnect(t *testing.T) {
 	adminClient := indexer.Admin
 
 	connectKey, err := adminClient.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
-		Description:   "hello world",
-		RemainingUses: 2,
+		Description: "hello world",
+		Quota:       "default",
 	})
 	if err != nil {
 		t.Fatal("failed to add app connect key:", err)
@@ -610,7 +608,7 @@ func TestSharedObjects(t *testing.T) {
 		client := indexer.App(sk)
 
 		key, err := adminClient.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
-			RemainingUses: 1,
+			Quota: "default",
 		})
 		if err != nil {
 			t.Fatal("failed to add app connect key:", err)

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -380,8 +380,8 @@ func (ts testStore) setActiveAccountsCount(t testing.TB, n uint64) {
 	// create a connect key for the dummy accounts
 	var connectKeyID int64
 	err = ts.QueryRow(t.Context(), `
-		INSERT INTO app_connect_keys (app_key, user_secret, use_description, remaining_uses, max_pinned_data)
-		VALUES ('test-connect-key', $1, 'test connect key', 0, 1000000000000)
+		INSERT INTO app_connect_keys (app_key, user_secret, use_description, quota_name)
+		VALUES ('test-connect-key', $1, 'test connect key', 'default')
 		ON CONFLICT (app_key) DO UPDATE SET app_key = EXCLUDED.app_key
 		RETURNING id
 	`, frand.Bytes(32)).Scan(&connectKeyID)

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -390,7 +390,7 @@ func (ts testStore) setActiveAccountsCount(t testing.TB, n uint64) {
 	}
 
 	// insert n dummy accounts
-	for i := uint64(0); i < n; i++ {
+	for i := range n {
 		pk := types.PublicKey{byte(i % 256), byte(i / 256)}
 		_, err := ts.Exec(t.Context(), `
 			INSERT INTO accounts (public_key, connect_key_id, last_used, pinned_data, max_pinned_data)

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -45,6 +45,9 @@ tags:
   - name: apps
     description: Manage app connect keys.
 
+  - name: quotas
+    description: Manage quotas for app connect keys.
+
 paths:
   /state:
     get:
@@ -252,6 +255,109 @@ paths:
           description: Connect key deleted successfully
         "404":
           description: Connect key not found
+
+  /quotas:
+    get:
+      tags:
+        - quotas
+      summary: Get all quotas
+      description: Returns a list of all quotas.
+      operationId: getQuotas
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of quotas to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: The number of quotas to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: A list of quotas
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Quota"
+
+  /quotas/{key}:
+    get:
+      tags:
+        - quotas
+      summary: Get a quota by key
+      description: Returns a single quota by its key.
+      operationId: getQuota
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: The unique key of the quota
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The quota
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Quota"
+        "404":
+          description: Quota not found
+    put:
+      tags:
+        - quotas
+      summary: Create or update a quota
+      description: Creates a new quota or updates an existing one with the given key.
+      operationId: putQuota
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: The unique key of the quota
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PutQuotaRequest"
+      responses:
+        "200":
+          description: Quota created or updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Quota"
+    delete:
+      tags:
+        - quotas
+      summary: Delete a quota
+      description: Deletes a quota by its key. Fails if the quota is in use by any connect keys.
+      operationId: deleteQuota
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: The unique key of the quota
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Quota deleted successfully
+        "404":
+          description: Quota not found
+        "409":
+          description: Quota is in use by connect keys
 
   /accounts:
     get:
@@ -1809,6 +1915,10 @@ components:
       $ref: "./components.yml#/components/schemas/UpdateAppConnectKey"
     AddConnectKeyRequest:
       $ref: "./components.yml#/components/schemas/AddConnectKeyRequest"
+    Quota:
+      $ref: "./components.yml#/components/schemas/Quota"
+    PutQuotaRequest:
+      $ref: "./components.yml#/components/schemas/PutQuotaRequest"
     ContractsStatsResponse:
       $ref: "./components.yml#/components/schemas/ContractsStatsResponse"
     HostsStatsResponse:

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -302,7 +302,7 @@ paths:
           required: true
           description: The unique key of the quota
           schema:
-            type: string
+            $ref: "#/components/schemas/QuotaKey"
       responses:
         "200":
           description: The quota
@@ -324,7 +324,7 @@ paths:
           required: true
           description: The unique key of the quota
           schema:
-            type: string
+            $ref: "#/components/schemas/QuotaKey"
       requestBody:
         required: true
         content:
@@ -346,7 +346,7 @@ paths:
           required: true
           description: The unique key of the quota
           schema:
-            type: string
+            $ref: "#/components/schemas/QuotaKey"
       responses:
         "204":
           description: Quota deleted successfully
@@ -1911,6 +1911,8 @@ components:
       $ref: "./components.yml#/components/schemas/UpdateAppConnectKey"
     AddConnectKeyRequest:
       $ref: "./components.yml#/components/schemas/AddConnectKeyRequest"
+    QuotaKey:
+      $ref: "./components.yml#/components/schemas/QuotaKey"
     Quota:
       $ref: "./components.yml#/components/schemas/Quota"
     PutQuotaRequest:

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -332,12 +332,8 @@ paths:
             schema:
               $ref: "#/components/schemas/PutQuotaRequest"
       responses:
-        "200":
+        "204":
           description: Quota created or updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Quota"
     delete:
       tags:
         - quotas

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -971,6 +971,7 @@ components:
           description: Maximum number of bytes that may be pinned by accounts using this quota
         totalUses:
           type: integer
+          minimum: 0
           description: Total number of accounts that can be created using connect keys with this quota
 
     ConnectKey:
@@ -1007,6 +1008,8 @@ components:
 
     UpdateAppConnectKey:
       type: object
+      required:
+        - quota
       properties:
         key:
           type: string
@@ -1016,14 +1019,18 @@ components:
           description: App description
         quota:
           type: string
+          minLength: 1
           description: The key of the quota to use for this connect key
 
     AddConnectKeyRequest:
       type: object
+      required:
+        - quota
       properties:
         description:
           type: string
           description: App description
         quota:
           type: string
+          minLength: 1
           description: The key of the quota to use for this connect key

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -942,12 +942,18 @@ components:
           format: int64
           description: Number of sectors that have had failed integrity checks.
 
+    QuotaKey:
+      type: string
+      description: Unique identifier for a quota
+      pattern: "^[a-zA-Z0-9_-]{1,32}$"
+      minLength: 1
+      maxLength: 32
+
     Quota:
       type: object
       properties:
         key:
-          type: string
-          description: Unique identifier for the quota
+          $ref: "#/components/schemas/QuotaKey"
         description:
           type: string
           description: Human-readable description of the quota
@@ -984,8 +990,7 @@ components:
           type: string
           description: App description
         quota:
-          type: string
-          description: The key of the quota associated with this connect key
+          $ref: "#/components/schemas/QuotaKey"
         remainingUses:
           type: integer
           description: Remaining number of times this key can be used to create accounts
@@ -1018,9 +1023,7 @@ components:
           type: string
           description: App description
         quota:
-          type: string
-          minLength: 1
-          description: The key of the quota to use for this connect key
+          $ref: "#/components/schemas/QuotaKey"
 
     AddConnectKeyRequest:
       type: object
@@ -1031,6 +1034,4 @@ components:
           type: string
           description: App description
         quota:
-          type: string
-          minLength: 1
-          description: The key of the quota to use for this connect key
+          $ref: "#/components/schemas/QuotaKey"

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -942,6 +942,37 @@ components:
           format: int64
           description: Number of sectors that have had failed integrity checks.
 
+    Quota:
+      type: object
+      properties:
+        key:
+          type: string
+          description: Unique identifier for the quota
+        description:
+          type: string
+          description: Human-readable description of the quota
+        maxPinnedData:
+          type: integer
+          format: uint64
+          description: Maximum number of bytes that may be pinned by accounts using this quota
+        totalUses:
+          type: integer
+          description: Total number of accounts that can be created using connect keys with this quota
+
+    PutQuotaRequest:
+      type: object
+      properties:
+        description:
+          type: string
+          description: Human-readable description of the quota
+        maxPinnedData:
+          type: integer
+          format: uint64
+          description: Maximum number of bytes that may be pinned by accounts using this quota
+        totalUses:
+          type: integer
+          description: Total number of accounts that can be created using connect keys with this quota
+
     ConnectKey:
       type: object
       properties:
@@ -951,12 +982,11 @@ components:
         description:
           type: string
           description: App description
-        totalUses:
-          type: integer
-          description: Total number of times this key has been used
+        quota:
+          $ref: "#/components/schemas/Quota"
         remainingUses:
           type: integer
-          description: Remaining number of times this key can be used
+          description: Remaining number of times this key can be used to create accounts
         dateCreated:
           type: string
           format: date-time
@@ -973,10 +1003,6 @@ components:
           type: integer
           format: uint64
           description: Sum of all the pinned data of the accounts associated with this key
-        maxPinnedData:
-          type: integer
-          format: uint64
-          description: Maximum number of bytes that may be pinned at once with this key
 
     UpdateAppConnectKey:
       type: object
@@ -987,13 +1013,9 @@ components:
         description:
           type: string
           description: App description
-        maxPinnedData:
-          type: integer
-          format: uint64
-          description: Maximum number of bytes that may be pinned at once with this key
-        remainingUses:
-          type: integer
-          description: Remaining number of times this key can be used
+        quota:
+          type: string
+          description: The key of the quota to use for this connect key
 
     AddConnectKeyRequest:
       type: object
@@ -1001,10 +1023,6 @@ components:
         description:
           type: string
           description: App description
-        maxPinnedData:
-          type: integer
-          format: uint64
-          description: Maximum number of bytes that may be pinned at once with this key
-        remainingUses:
-          type: integer
-          description: Remaining number of times this key can be used
+        quota:
+          type: string
+          description: The key of the quota to use for this connect key

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -983,7 +983,8 @@ components:
           type: string
           description: App description
         quota:
-          $ref: "#/components/schemas/Quota"
+          type: string
+          description: The key of the quota associated with this connect key
         remainingUses:
           type: integer
           description: Remaining number of times this key can be used to create accounts

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -46,6 +46,7 @@ func (s *Store) Accounts(offset, limit int, opts ...accounts.QueryAccountsOpt) (
 			INNER JOIN app_connect_keys ak ON ak.id = a.connect_key_id
 			WHERE a.deleted_at IS NULL AND
 			($1::integer IS NULL OR connect_key_id = $1::integer)
+			ORDER BY a.id
 			LIMIT $2 OFFSET $3
 		`, connectKeyID, limit, offset)
 		if err != nil {
@@ -112,18 +113,11 @@ func (s *Store) ActiveAccounts(threshold time.Time) (count uint64, err error) {
 // DeleteAccount deletes the account in the database with given account key.
 func (s *Store) DeleteAccount(acc proto.Account) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
-		var connectKeyID int64
-		err := tx.QueryRow(ctx, `UPDATE accounts SET deleted_at = NOW() WHERE public_key = $1 AND deleted_at IS NULL RETURNING connect_key_id`, sqlPublicKey(acc)).Scan(&connectKeyID)
-		if errors.Is(err, sql.ErrNoRows) {
-			return accounts.ErrNotFound
-		} else if err != nil {
-			return fmt.Errorf("failed to delete account: %w", err)
-		}
-
-		// increment remaining uses on the connect key since this account no longer counts
-		_, err = tx.Exec(ctx, `UPDATE app_connect_keys SET remaining_uses = remaining_uses + 1 WHERE id = $1`, connectKeyID)
+		res, err := tx.Exec(ctx, `UPDATE accounts SET deleted_at = NOW() WHERE public_key = $1 AND deleted_at IS NULL`, sqlPublicKey(acc))
 		if err != nil {
-			return fmt.Errorf("failed to increment connect key remaining uses: %w", err)
+			return fmt.Errorf("failed to delete account: %w", err)
+		} else if res.RowsAffected() == 0 {
+			return accounts.ErrNotFound
 		}
 		return nil
 	})

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -21,10 +21,9 @@ import (
 func (s *Store) addTestAccount(t testing.TB, ak types.PublicKey, opts ...accounts.AddAccountOption) {
 	connectKey := fmt.Sprintf("test-connect-key-%x", frand.Bytes(8))
 	_, err := s.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           connectKey,
-		Description:   "test connect key",
-		MaxPinnedData: math.MaxInt64,
-		RemainingUses: 1,
+		Key:         connectKey,
+		Description: "test connect key",
+		Quota:       "default",
 	})
 	if err != nil {
 		t.Fatalf("failed to add app connect key: %v", err)
@@ -71,11 +70,14 @@ func TestAccounts(t *testing.T) {
 	assertAccount(t, accs[1], pk3, 100)
 
 	// add accounts associated with connect key
+	// create a test quota with specific limits
+	store.addTestQuota(t, "test-100", 100, 10)
+
 	const connectKey = "foobar"
 	if _, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           connectKey,
-		MaxPinnedData: 100,
-		RemainingUses: 10,
+		Key:         connectKey,
+		Description: "test connect key",
+		Quota:       "test-100",
 	}); err != nil {
 		t.Fatal("failed to add app connect key:", err)
 	}
@@ -150,10 +152,9 @@ func TestAddAccount(t *testing.T) {
 	t.Run("user account", func(t *testing.T) {
 		connectKey := fmt.Sprintf("test-connect-key-%x", frand.Bytes(8))
 		_, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-			Key:           connectKey,
-			Description:   "test connect key",
-			MaxPinnedData: math.MaxInt64,
-			RemainingUses: 10,
+			Key:         connectKey,
+			Description: "test connect key",
+			Quota:       "default",
 		})
 		if err != nil {
 			t.Fatal("failed to add app connect key:", err)
@@ -536,10 +537,9 @@ func BenchmarkHostAccountsForFunding(b *testing.B) {
 
 	// create a connect key for benchmark accounts
 	connectKey, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           "benchmark-connect-key",
-		Description:   "benchmark connect key",
-		MaxPinnedData: math.MaxInt64,
-		RemainingUses: math.MaxInt32,
+		Key:         "benchmark-connect-key",
+		Description: "benchmark connect key",
+		Quota:       "default",
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -628,10 +628,9 @@ func BenchmarkUpdateHostAccounts(b *testing.B) {
 
 	// create a connect key for benchmark accounts
 	connectKey, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           "benchmark-connect-key",
-		Description:   "benchmark connect key",
-		MaxPinnedData: math.MaxInt64,
-		RemainingUses: math.MaxInt32,
+		Key:         "benchmark-connect-key",
+		Description: "benchmark connect key",
+		Quota:       "default",
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -814,10 +813,9 @@ func TestActiveAccounts(t *testing.T) {
 
 	// create a connect key for test accounts
 	connectKey, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           "test-connect-key",
-		Description:   "test connect key",
-		MaxPinnedData: math.MaxInt64,
-		RemainingUses: 10,
+		Key:         "test-connect-key",
+		Description: "test connect key",
+		Quota:       "default",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -884,10 +882,9 @@ func BenchmarkActiveAccounts(b *testing.B) {
 
 	// create a connect key for benchmark accounts
 	connectKey, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           "benchmark-connect-key",
-		Description:   "benchmark connect key",
-		MaxPinnedData: math.MaxInt64,
-		RemainingUses: math.MaxInt32,
+		Key:         "benchmark-connect-key",
+		Description: "benchmark connect key",
+		Quota:       "default",
 	})
 	if err != nil {
 		b.Fatal(err)
@@ -926,10 +923,9 @@ func BenchmarkPruneAccounts(b *testing.B) {
 
 	// create a connect key for benchmark accounts
 	connectKey, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           "benchmark-connect-key",
-		Description:   "benchmark connect key",
-		MaxPinnedData: math.MaxInt64,
-		RemainingUses: math.MaxInt32,
+		Key:         "benchmark-connect-key",
+		Description: "benchmark connect key",
+		Quota:       "default",
 	})
 	if err != nil {
 		b.Fatal(err)

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -66,14 +66,6 @@ func (s *Store) UpdateAppConnectKey(meta accounts.UpdateAppConnectKey) (key acco
 		return accounts.ConnectKey{}, fmt.Errorf("quota is required")
 	}
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
-		// verify quota exists
-		var exists bool
-		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quotas WHERE name = $1)`, meta.Quota).Scan(&exists); err != nil {
-			return fmt.Errorf("failed to check quota: %w", err)
-		} else if !exists {
-			return accounts.ErrQuotaNotFound
-		}
-
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
 			UPDATE app_connect_keys ack SET (use_description, quota_name) = ($2, $3) WHERE app_key = $1
 			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -20,10 +20,7 @@ func scanConnectKey(s scanner) (key accounts.ConnectKey, err error) {
 		&key.LastUpdated,
 		&lastUsed,
 		&key.PinnedData,
-		&key.Quota.Key,
-		&key.Quota.Description,
-		&key.Quota.MaxPinnedData,
-		&key.Quota.TotalUses,
+		&key.Quota,
 		&key.RemainingUses,
 	)
 	if lastUsed.Valid {
@@ -48,15 +45,15 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 
 		userSecret := frand.Bytes(32)
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
-			INSERT INTO app_connect_keys (app_key, user_secret, use_description, quota_name)
+			INSERT INTO app_connect_keys ack (app_key, user_secret, use_description, quota_name)
 			VALUES ($1, $2, $3, $4)
 			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,
-				(SELECT name FROM quotas WHERE name = quota_name),
-				(SELECT description FROM quotas WHERE name = quota_name),
-				(SELECT max_pinned_data FROM quotas WHERE name = quota_name),
-				(SELECT total_uses FROM quotas WHERE name = quota_name),
-				(SELECT total_uses FROM quotas WHERE name = quota_name);
+				quota_name,
+				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
 		`, meta.Key, userSecret, meta.Description, meta.Quota))
+		if errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyNotFound
+		}
 		return err
 	})
 	return
@@ -80,12 +77,12 @@ func (s *Store) UpdateAppConnectKey(meta accounts.UpdateAppConnectKey) (key acco
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
 			UPDATE app_connect_keys ack SET (use_description, quota_name) = ($2, $3) WHERE app_key = $1
 			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,
-				(SELECT name FROM quotas WHERE name = quota_name),
-				(SELECT description FROM quotas WHERE name = quota_name),
-				(SELECT max_pinned_data FROM quotas WHERE name = quota_name),
-				(SELECT total_uses FROM quotas WHERE name = quota_name),
-				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id));
+				quota_name,
+				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
 		`, meta.Key, meta.Description, meta.Quota))
+		if errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyNotFound
+		}
 		return err
 	})
 	return
@@ -115,7 +112,7 @@ func (s *Store) AppConnectKey(key string) (connectKey accounts.ConnectKey, err e
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
 		connectKey, err = scanConnectKey(tx.QueryRow(ctx, `
 			SELECT ack.app_key, ack.use_description, ack.created_at, ack.updated_at, ack.last_used, ack.pinned_data,
-				q.name, q.description, q.max_pinned_data, q.total_uses,
+				ack.quota_name,
 				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
 			FROM app_connect_keys ack
 			INNER JOIN quotas q ON q.name = ack.quota_name
@@ -133,7 +130,7 @@ func (s *Store) AppConnectKeys(offset, limit int) (keys []accounts.ConnectKey, e
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
 			SELECT ack.app_key, ack.use_description, ack.created_at, ack.updated_at, ack.last_used, ack.pinned_data,
-				q.name, q.description, q.max_pinned_data, q.total_uses,
+				ack.quota_name,
 				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
 			FROM app_connect_keys ack
 			INNER JOIN quotas q ON q.name = ack.quota_name
@@ -206,7 +203,7 @@ func (s *Store) RegisterAppKey(connectKey string, appKey types.PublicKey, meta a
 			UPDATE app_connect_keys ack SET last_used = NOW()
 			FROM quotas q
 			WHERE ack.app_key = $1 AND q.name = ack.quota_name
-			RETURNING q.total_uses - (SELECT COUNT(*) FROM accounts a WHERE a.connect_key_id = ack.id), q.max_pinned_data
+			RETURNING GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts a WHERE a.connect_key_id = ack.id)), q.max_pinned_data
 		`, connectKey).Scan(&remainingUses, &storageLimit)
 		if errors.Is(err, sql.ErrNoRows) {
 			return accounts.ErrKeyNotFound

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -16,13 +16,15 @@ func scanConnectKey(s scanner) (key accounts.ConnectKey, err error) {
 	err = s.Scan(
 		&key.Key,
 		&key.Description,
-		&key.RemainingUses,
-		&key.TotalUses,
 		&key.DateCreated,
 		&key.LastUpdated,
 		&lastUsed,
 		&key.PinnedData,
-		&key.MaxPinnedData,
+		&key.Quota.Key,
+		&key.Quota.Description,
+		&key.Quota.MaxPinnedData,
+		&key.Quota.TotalUses,
+		&key.RemainingUses,
 	)
 	if lastUsed.Valid {
 		key.LastUsed = lastUsed.Time
@@ -32,17 +34,29 @@ func scanConnectKey(s scanner) (key accounts.ConnectKey, err error) {
 
 // AddAppConnectKey adds or updates an application connection key in the database.
 func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key accounts.ConnectKey, err error) {
-	if meta.RemainingUses <= 0 {
-		return accounts.ConnectKey{}, accounts.ErrKeyExhausted
-	} else if meta.MaxPinnedData == 0 {
-		return accounts.ConnectKey{}, fmt.Errorf("max pinned data must be greater than 0")
+	if meta.Quota == "" {
+		return accounts.ConnectKey{}, fmt.Errorf("quota is required")
 	}
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		// verify quota exists
+		var exists bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quotas WHERE name = $1)`, meta.Quota).Scan(&exists); err != nil {
+			return fmt.Errorf("failed to check quota: %w", err)
+		} else if !exists {
+			return accounts.ErrQuotaNotFound
+		}
+
 		userSecret := frand.Bytes(32)
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
-			INSERT INTO app_connect_keys (app_key, user_secret, use_description, remaining_uses, max_pinned_data) VALUES ($1, $2, $3, $4, $5)
-			RETURNING app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used, pinned_data, max_pinned_data;
-		`, meta.Key, userSecret, meta.Description, meta.RemainingUses, meta.MaxPinnedData))
+			INSERT INTO app_connect_keys (app_key, user_secret, use_description, quota_name)
+			VALUES ($1, $2, $3, $4)
+			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,
+				(SELECT name FROM quotas WHERE name = quota_name),
+				(SELECT description FROM quotas WHERE name = quota_name),
+				(SELECT max_pinned_data FROM quotas WHERE name = quota_name),
+				(SELECT total_uses FROM quotas WHERE name = quota_name),
+				(SELECT total_uses FROM quotas WHERE name = quota_name);
+		`, meta.Key, userSecret, meta.Description, meta.Quota))
 		return err
 	})
 	return
@@ -51,16 +65,27 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 // UpdateAppConnectKey updates an existing application connection key in the database.
 // If the key does not exist, it returns [app.ErrKeyNotFound].
 func (s *Store) UpdateAppConnectKey(meta accounts.UpdateAppConnectKey) (key accounts.ConnectKey, err error) {
-	if meta.RemainingUses <= 0 {
-		return accounts.ConnectKey{}, accounts.ErrKeyExhausted
-	} else if meta.MaxPinnedData == 0 {
-		return accounts.ConnectKey{}, fmt.Errorf("max pinned data must be greater than 0")
+	if meta.Quota == "" {
+		return accounts.ConnectKey{}, fmt.Errorf("quota is required")
 	}
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		// verify quota exists
+		var exists bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quotas WHERE name = $1)`, meta.Quota).Scan(&exists); err != nil {
+			return fmt.Errorf("failed to check quota: %w", err)
+		} else if !exists {
+			return accounts.ErrQuotaNotFound
+		}
+
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
-			UPDATE app_connect_keys SET (use_description, remaining_uses, max_pinned_data) = ($2, $3, $4) WHERE app_key = $1
-			RETURNING app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used, pinned_data, max_pinned_data;
-		`, meta.Key, meta.Description, meta.RemainingUses, meta.MaxPinnedData))
+			UPDATE app_connect_keys ack SET (use_description, quota_name) = ($2, $3) WHERE app_key = $1
+			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,
+				(SELECT name FROM quotas WHERE name = quota_name),
+				(SELECT description FROM quotas WHERE name = quota_name),
+				(SELECT max_pinned_data FROM quotas WHERE name = quota_name),
+				(SELECT total_uses FROM quotas WHERE name = quota_name),
+				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id));
+		`, meta.Key, meta.Description, meta.Quota))
 		return err
 	})
 	return
@@ -68,27 +93,33 @@ func (s *Store) UpdateAppConnectKey(meta accounts.UpdateAppConnectKey) (key acco
 
 // ValidAppConnectKey checks if an application connection key is valid.
 func (s *Store) ValidAppConnectKey(key string) (bool, error) {
-	var uses int
+	var remainingUses int
 	err := s.transaction(func(ctx context.Context, tx *txn) error {
 		return tx.QueryRow(ctx, `
-			SELECT remaining_uses FROM app_connect_keys WHERE app_key = $1
-		`, key).Scan(&uses)
+			SELECT GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+			FROM app_connect_keys ack
+			INNER JOIN quotas q ON q.name = ack.quota_name
+			WHERE ack.app_key = $1
+		`, key).Scan(&remainingUses)
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, accounts.ErrKeyNotFound
 	} else if err != nil {
 		return false, err
 	}
-	return uses > 0, nil
+	return remainingUses > 0, nil
 }
 
 // AppConnectKey retrieves an application connection key from the database.
 func (s *Store) AppConnectKey(key string) (connectKey accounts.ConnectKey, err error) {
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
 		connectKey, err = scanConnectKey(tx.QueryRow(ctx, `
-			SELECT app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used, pinned_data, max_pinned_data
-			FROM app_connect_keys
-			WHERE app_key = $1`, key))
+			SELECT ack.app_key, ack.use_description, ack.created_at, ack.updated_at, ack.last_used, ack.pinned_data,
+				q.name, q.description, q.max_pinned_data, q.total_uses,
+				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+			FROM app_connect_keys ack
+			INNER JOIN quotas q ON q.name = ack.quota_name
+			WHERE ack.app_key = $1`, key))
 		if errors.Is(err, sql.ErrNoRows) {
 			return accounts.ErrKeyNotFound
 		}
@@ -101,9 +132,12 @@ func (s *Store) AppConnectKey(key string) (connectKey accounts.ConnectKey, err e
 func (s *Store) AppConnectKeys(offset, limit int) (keys []accounts.ConnectKey, err error) {
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
 		rows, err := tx.Query(ctx, `
-			SELECT app_key, use_description, remaining_uses, total_uses, created_at, updated_at, last_used, pinned_data, max_pinned_data
-			FROM app_connect_keys
-			ORDER BY created_at DESC
+			SELECT ack.app_key, ack.use_description, ack.created_at, ack.updated_at, ack.last_used, ack.pinned_data,
+				q.name, q.description, q.max_pinned_data, q.total_uses,
+				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+			FROM app_connect_keys ack
+			INNER JOIN quotas q ON q.name = ack.quota_name
+			ORDER BY ack.created_at DESC
 			LIMIT $1 OFFSET $2
 		`, limit, offset)
 		if err != nil {
@@ -161,23 +195,25 @@ func (s *Store) AppConnectKeyUserSecret(connectKey string) (secret types.Hash256
 	return
 }
 
-// RegisterAppKey decrements the remaining uses of a connect key
-// and adds the app account. It returns the user secret associated
-// with the connect key. This secret must never be exposed to the user.
+// RegisterAppKey uses a connect key to register a new app account.
+// It returns the user secret associated with the connect key.
+// This secret must never be exposed to the user.
 func (s *Store) RegisterAppKey(connectKey string, appKey types.PublicKey, meta accounts.AppMeta) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
-		var uses int
+		var remainingUses int
 		var storageLimit uint64
 		err := tx.QueryRow(ctx, `
-			UPDATE app_connect_keys SET (remaining_uses, total_uses, last_used) = (remaining_uses - 1, total_uses + 1, NOW())
-			WHERE app_key = $1 RETURNING remaining_uses, max_pinned_data
-		`, connectKey).Scan(&uses, &storageLimit)
+			UPDATE app_connect_keys ack SET last_used = NOW()
+			FROM quotas q
+			WHERE ack.app_key = $1 AND q.name = ack.quota_name
+			RETURNING q.total_uses - (SELECT COUNT(*) FROM accounts a WHERE a.connect_key_id = ack.id), q.max_pinned_data
+		`, connectKey).Scan(&remainingUses, &storageLimit)
 		if errors.Is(err, sql.ErrNoRows) {
 			return accounts.ErrKeyNotFound
 		} else if err != nil {
 			return fmt.Errorf("failed to update app connect key %q: %w", connectKey, err)
-		} else if uses < 0 {
-			// uses is returned after updating, -1 would mean the key is exhausted
+		} else if remainingUses <= 0 {
+			// check remaining uses before adding the account
 			return accounts.ErrKeyExhausted
 		}
 

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -45,15 +45,12 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 
 		userSecret := frand.Bytes(32)
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
-			INSERT INTO app_connect_keys ack (app_key, user_secret, use_description, quota_name)
+			INSERT INTO app_connect_keys (app_key, user_secret, use_description, quota_name)
 			VALUES ($1, $2, $3, $4)
 			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,
 				quota_name,
-				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+				(SELECT total_uses FROM quotas WHERE name = quota_name)
 		`, meta.Key, userSecret, meta.Description, meta.Quota))
-		if errors.Is(err, sql.ErrNoRows) {
-			return accounts.ErrKeyNotFound
-		}
 		return err
 	})
 	return
@@ -70,7 +67,7 @@ func (s *Store) UpdateAppConnectKey(meta accounts.UpdateAppConnectKey) (key acco
 			UPDATE app_connect_keys ack SET (use_description, quota_name) = ($2, $3) WHERE app_key = $1
 			RETURNING app_key, use_description, created_at, updated_at, last_used, pinned_data,
 				quota_name,
-				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+				GREATEST(0, (SELECT total_uses FROM quotas WHERE name = quota_name) - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id AND deleted_at IS NULL))
 		`, meta.Key, meta.Description, meta.Quota))
 		if errors.Is(err, sql.ErrNoRows) {
 			return accounts.ErrKeyNotFound
@@ -85,7 +82,7 @@ func (s *Store) ValidAppConnectKey(key string) (bool, error) {
 	var remainingUses int
 	err := s.transaction(func(ctx context.Context, tx *txn) error {
 		return tx.QueryRow(ctx, `
-			SELECT GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+			SELECT GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id AND deleted_at IS NULL))
 			FROM app_connect_keys ack
 			INNER JOIN quotas q ON q.name = ack.quota_name
 			WHERE ack.app_key = $1
@@ -105,7 +102,7 @@ func (s *Store) AppConnectKey(key string) (connectKey accounts.ConnectKey, err e
 		connectKey, err = scanConnectKey(tx.QueryRow(ctx, `
 			SELECT ack.app_key, ack.use_description, ack.created_at, ack.updated_at, ack.last_used, ack.pinned_data,
 				ack.quota_name,
-				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id AND deleted_at IS NULL))
 			FROM app_connect_keys ack
 			INNER JOIN quotas q ON q.name = ack.quota_name
 			WHERE ack.app_key = $1`, key))
@@ -123,9 +120,15 @@ func (s *Store) AppConnectKeys(offset, limit int) (keys []accounts.ConnectKey, e
 		rows, err := tx.Query(ctx, `
 			SELECT ack.app_key, ack.use_description, ack.created_at, ack.updated_at, ack.last_used, ack.pinned_data,
 				ack.quota_name,
-				GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts WHERE connect_key_id = ack.id))
+				GREATEST(0, q.total_uses - COALESCE(ac.cnt, 0))
 			FROM app_connect_keys ack
 			INNER JOIN quotas q ON q.name = ack.quota_name
+			LEFT JOIN (
+				SELECT connect_key_id, COUNT(*) AS cnt
+				FROM accounts
+				WHERE deleted_at IS NULL
+				GROUP BY connect_key_id
+			) ac ON ac.connect_key_id = ack.id
 			ORDER BY ack.created_at DESC
 			LIMIT $1 OFFSET $2
 		`, limit, offset)
@@ -195,7 +198,7 @@ func (s *Store) RegisterAppKey(connectKey string, appKey types.PublicKey, meta a
 			UPDATE app_connect_keys ack SET last_used = NOW()
 			FROM quotas q
 			WHERE ack.app_key = $1 AND q.name = ack.quota_name
-			RETURNING GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts a WHERE a.connect_key_id = ack.id)), q.max_pinned_data
+			RETURNING GREATEST(0, q.total_uses - (SELECT COUNT(*) FROM accounts a WHERE a.connect_key_id = ack.id AND a.deleted_at IS NULL)), q.max_pinned_data
 		`, connectKey).Scan(&remainingUses, &storageLimit)
 		if errors.Is(err, sql.ErrNoRows) {
 			return accounts.ErrKeyNotFound

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -90,8 +90,8 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatalf("expected 1 app connect key, got %d", len(keys))
 	} else if keys[0].LastUsed.IsZero() {
 		t.Fatal("expected app connect key's last used field to be set")
-	} else if keys[0].Quota.MaxPinnedData != 10 {
-		t.Fatalf("expected app connect key's max pinned data to be 10, got %d", keys[0].Quota.MaxPinnedData)
+	} else if keys[0].Quota != "test-1-use" {
+		t.Fatalf("expected app connect key's quota to be 'test-1-use', got %q", keys[0].Quota)
 	}
 
 	// try again on an exhausted key
@@ -114,8 +114,8 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("failed to update app connect key:", err)
 	} else if updated.Key != connectKey || updated.Description != "updated key" {
 		t.Fatalf("unexpected updated app connect key: %+v", updated)
-	} else if updated.Quota.MaxPinnedData != 20 {
-		t.Fatalf("expected updated app connect key's max pinned data to be 20, got %d", updated.Quota.MaxPinnedData)
+	} else if updated.Quota != "test-20-data" {
+		t.Fatalf("expected updated app connect key's quota to be 'test-20-data', got %q", updated.Quota)
 	}
 
 	// key should still be invalid since remaining_uses is not updated by UpdateAppConnectKey

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -15,12 +14,11 @@ import (
 // addTestQuota creates a test quota with the given parameters
 func (s *Store) addTestQuota(t testing.TB, name string, maxPinnedData uint64, totalUses int) {
 	t.Helper()
-	err := s.transaction(func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, `INSERT INTO quotas (name, description, max_pinned_data, total_uses) VALUES ($1, $2, $3, $4) ON CONFLICT (name) DO NOTHING`,
-			name, "test quota", maxPinnedData, totalUses)
-		return err
-	})
-	if err != nil {
+	if _, err := s.PutQuota(name, accounts.PutQuotaRequest{
+		Description:   "test quota",
+		MaxPinnedData: maxPinnedData,
+		TotalUses:     totalUses,
+	}); err != nil {
 		t.Fatalf("failed to add test quota: %v", err)
 	}
 }

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -14,7 +14,7 @@ import (
 // addTestQuota creates a test quota with the given parameters
 func (s *Store) addTestQuota(t testing.TB, name string, maxPinnedData uint64, totalUses int) {
 	t.Helper()
-	if _, err := s.PutQuota(name, accounts.PutQuotaRequest{
+	if err := s.PutQuota(name, accounts.PutQuotaRequest{
 		Description:   "test quota",
 		MaxPinnedData: maxPinnedData,
 		TotalUses:     totalUses,
@@ -118,7 +118,8 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatalf("expected updated app connect key's quota to be 'test-20-data', got %q", updated.Quota)
 	}
 
-	// key should still be invalid since remaining_uses is not updated by UpdateAppConnectKey
+	// key should still be invalid since UpdateAppConnectKey does not reset
+	// usage or make an exhausted key valid
 	if ok, err := store.ValidAppConnectKey(connectKey); err != nil {
 		t.Fatal("failed to validate app connect key:", err)
 	} else if ok {
@@ -138,20 +139,30 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyInUse, err)
 	}
 
-	// delete account
+	// soft-delete account
 	if err := store.DeleteAccount(proto.Account(acc)); err != nil {
-		t.Fatal(err)
-	} else if err := store.PruneAccounts(1); err != nil {
 		t.Fatal(err)
 	}
 
-	// verify that remaining uses was incremented after account deletion
+	// verify that soft-deleted accounts don't count towards the quota
 	key, err := store.AppConnectKey(connectKey)
 	if err != nil {
 		t.Fatal("failed to get app connect key:", err)
 	} else if key.RemainingUses != 1 {
-		// was 0 after RegisterAppKey, then +1 after prune
-		t.Fatalf("expected remaining uses to be 1 after account deletion, got %d", key.RemainingUses)
+		t.Fatalf("expected remaining uses to be 1 after soft deletion, got %d", key.RemainingUses)
+	}
+
+	// prune the soft-deleted account
+	if err := store.PruneAccounts(1); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify remaining uses is still 1 after hard deletion
+	key, err = store.AppConnectKey(connectKey)
+	if err != nil {
+		t.Fatal("failed to get app connect key:", err)
+	} else if key.RemainingUses != 1 {
+		t.Fatalf("expected remaining uses to be 1 after hard deletion, got %d", key.RemainingUses)
 	}
 
 	// try deleting key again now that it's not in use

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -11,6 +12,19 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+// addTestQuota creates a test quota with the given parameters
+func (s *Store) addTestQuota(t testing.TB, name string, maxPinnedData uint64, totalUses int) {
+	t.Helper()
+	err := s.transaction(func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `INSERT INTO quotas (name, description, max_pinned_data, total_uses) VALUES ($1, $2, $3, $4) ON CONFLICT (name) DO NOTHING`,
+			name, "test quota", maxPinnedData, totalUses)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("failed to add test quota: %v", err)
+	}
+}
+
 func TestAppConnectKeys(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
@@ -18,12 +32,15 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
 
+	// create test quotas
+	store.addTestQuota(t, "test-1-use", 10, 1)
+	store.addTestQuota(t, "test-20-data", 20, 1)
+
 	const connectKey = "foobar"
 	if key, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           connectKey,
-		Description:   "test key",
-		MaxPinnedData: 10,
-		RemainingUses: 1,
+		Key:         connectKey,
+		Description: "test key",
+		Quota:       "test-1-use",
 	}); err != nil {
 		t.Fatal("failed to add app connect key:", err)
 	} else if key.Key != connectKey || key.Description != "test key" || key.RemainingUses != 1 {
@@ -44,7 +61,7 @@ func TestAppConnectKeys(t *testing.T) {
 		} else if account.PinnedData != pinned {
 			t.Fatalf("expected %d pinned data for account %v, got %d", pinned, acc, account.PinnedData)
 		} else if account.MaxPinnedData != maxPinned {
-			t.Fatalf("expected max pinned data to be 10, got %d", account.MaxPinnedData)
+			t.Fatalf("expected max pinned data to be %d, got %d", maxPinned, account.MaxPinnedData)
 		} else if account.App.Description != desc {
 			t.Fatalf("expected description to be %q, got %q", desc, account.App.Description)
 		} else if account.App.LogoURL != logo {
@@ -75,8 +92,8 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatalf("expected 1 app connect key, got %d", len(keys))
 	} else if keys[0].LastUsed.IsZero() {
 		t.Fatal("expected app connect key's last used field to be set")
-	} else if keys[0].MaxPinnedData != 10 {
-		t.Fatalf("expected app connect key's max pinned data to be 10, got %d", keys[0].MaxPinnedData)
+	} else if keys[0].Quota.MaxPinnedData != 10 {
+		t.Fatalf("expected app connect key's max pinned data to be 10, got %d", keys[0].Quota.MaxPinnedData)
 	}
 
 	// try again on an exhausted key
@@ -90,23 +107,24 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("expected app connect key to be invalid")
 	}
 
+	// update to a different quota with more data
 	if updated, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           connectKey,
-		Description:   "updated key",
-		MaxPinnedData: 20,
-		RemainingUses: 1,
+		Key:         connectKey,
+		Description: "updated key",
+		Quota:       "test-20-data",
 	}); err != nil {
-		t.Fatal("failed to add app connect key:", err)
-	} else if updated.Key != connectKey || updated.Description != "updated key" || updated.RemainingUses != 1 {
+		t.Fatal("failed to update app connect key:", err)
+	} else if updated.Key != connectKey || updated.Description != "updated key" {
 		t.Fatalf("unexpected updated app connect key: %+v", updated)
-	} else if updated.MaxPinnedData != 20 {
-		t.Fatalf("expected updated app connect key's max pinned data to be 20, got %d", updated.MaxPinnedData)
+	} else if updated.Quota.MaxPinnedData != 20 {
+		t.Fatalf("expected updated app connect key's max pinned data to be 20, got %d", updated.Quota.MaxPinnedData)
 	}
 
+	// key should still be invalid since remaining_uses is not updated by UpdateAppConnectKey
 	if ok, err := store.ValidAppConnectKey(connectKey); err != nil {
 		t.Fatal("failed to validate app connect key:", err)
-	} else if !ok {
-		t.Fatal("expected app connect key to be valid")
+	} else if ok {
+		t.Fatal("expected app connect key to be invalid")
 	}
 
 	stats, err := store.AccountStats()
@@ -133,9 +151,9 @@ func TestAppConnectKeys(t *testing.T) {
 	key, err := store.AppConnectKey(connectKey)
 	if err != nil {
 		t.Fatal("failed to get app connect key:", err)
-	} else if key.RemainingUses != 2 {
-		// was set to 1 via UpdateAppConnectKey, then +1 after prune
-		t.Fatalf("expected remaining uses to be 2 after account deletion, got %d", key.RemainingUses)
+	} else if key.RemainingUses != 1 {
+		// was 0 after RegisterAppKey, then +1 after prune
+		t.Fatalf("expected remaining uses to be 1 after account deletion, got %d", key.RemainingUses)
 	}
 
 	// try deleting key again now that it's not in use
@@ -156,11 +174,12 @@ func TestAppConnectKeys(t *testing.T) {
 func TestAppConnectKey(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
+	store.addTestQuota(t, "test-quota", 10, 1)
+
 	key, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           "foobar",
-		Description:   "test key",
-		MaxPinnedData: 10,
-		RemainingUses: 1,
+		Key:         "foobar",
+		Description: "test key",
+		Quota:       "test-quota",
 	})
 	if err != nil {
 		t.Fatal("failed to add app connect key:", err)

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -1,16 +1,26 @@
+CREATE TABLE quotas (
+    name TEXT PRIMARY KEY CHECK (LENGTH(name) > 0 AND LENGTH(name) <= 32), -- unique, human-readable key
+    description TEXT NOT NULL,
+    max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0), -- max pinned data in bytes
+    total_uses INTEGER NOT NULL CHECK (total_uses >= 0)
+);
+
+-- insert default quota: 1TB max data, 5 total uses
+INSERT INTO quotas (name, description, max_pinned_data, total_uses)
+VALUES ('default', 'Default quota', 1000000000000, 5);
+
 CREATE TABLE app_connect_keys (
     id SERIAL PRIMARY KEY,
     user_secret BYTEA UNIQUE NOT NULL CHECK (LENGTH(user_secret) = 32),
     app_key TEXT UNIQUE NOT NULL,
     use_description TEXT NOT NULL,
-    remaining_uses INTEGER NOT NULL,
-    total_uses INTEGER NOT NULL DEFAULT 0,
+    quota_name TEXT NOT NULL REFERENCES quotas(name),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     last_used TIMESTAMP WITH TIME ZONE,
-    pinned_data BIGINT NOT NULL DEFAULT 0 CHECK (pinned_data >= 0), -- total pinned data in bytes
-    max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0)
+    pinned_data BIGINT NOT NULL DEFAULT 0 CHECK (pinned_data >= 0) -- total pinned data in bytes
 );
+CREATE INDEX app_connect_keys_quota_name_idx ON app_connect_keys(quota_name);
 
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -679,4 +679,46 @@ CREATE INDEX hosts_stuck_since_idx ON hosts(stuck_since) WHERE stuck_since IS NO
 		_, err = tx.Exec(ctx, `ALTER TABLE accounts ALTER COLUMN connect_key_id SET NOT NULL`)
 		return err
 	},
+	// add quotas table and migrate app_connect_keys
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		// create quotas table
+		_, err := tx.Exec(ctx, `
+CREATE TABLE quotas (
+    name TEXT PRIMARY KEY CHECK (LENGTH(name) > 0 AND LENGTH(name) <= 32),
+    description TEXT NOT NULL,
+    max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0),
+    total_uses INTEGER NOT NULL CHECK (total_uses >= 0)
+);
+
+-- insert default quota: 1TB max data, 5 total uses
+INSERT INTO quotas (name, description, max_pinned_data, total_uses)
+VALUES ('default', 'Default quota', 1000000000000, 5);
+`)
+		if err != nil {
+			return fmt.Errorf("failed to create quotas table: %w", err)
+		}
+
+		// add quota_name column to app_connect_keys with default value
+		_, err = tx.Exec(ctx, `
+ALTER TABLE app_connect_keys ADD COLUMN quota_name TEXT REFERENCES quotas(name);
+UPDATE app_connect_keys SET quota_name = 'default';
+ALTER TABLE app_connect_keys ALTER COLUMN quota_name SET NOT NULL;
+CREATE INDEX app_connect_keys_quota_name_idx ON app_connect_keys(quota_name);
+`)
+		if err != nil {
+			return fmt.Errorf("failed to add quota_name column: %w", err)
+		}
+
+		// drop old columns
+		_, err = tx.Exec(ctx, `
+ALTER TABLE app_connect_keys DROP COLUMN max_pinned_data;
+ALTER TABLE app_connect_keys DROP COLUMN total_uses;
+ALTER TABLE app_connect_keys DROP COLUMN remaining_uses;
+`)
+		if err != nil {
+			return fmt.Errorf("failed to drop old columns: %w", err)
+		}
+
+		return nil
+	},
 }

--- a/persist/postgres/quotas.go
+++ b/persist/postgres/quotas.go
@@ -75,6 +75,8 @@ func (s *Store) Quota(key string) (quota accounts.Quota, err error) {
 // Quotas retrieves a list of quotas from the database.
 func (s *Store) Quotas(offset, limit int) (quotas []accounts.Quota, err error) {
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		quotas = quotas[:0] // reset in case of retry
+
 		rows, err := tx.Query(ctx, `
 			SELECT name, description, max_pinned_data, total_uses
 			FROM quotas

--- a/persist/postgres/quotas.go
+++ b/persist/postgres/quotas.go
@@ -1,0 +1,101 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/indexd/accounts"
+)
+
+func scanQuota(s scanner) (quota accounts.Quota, err error) {
+	err = s.Scan(&quota.Key, &quota.Description, &quota.MaxPinnedData, &quota.TotalUses)
+	return
+}
+
+// PutQuota creates or updates a quota in the database.
+func (s *Store) PutQuota(key string, req accounts.PutQuotaRequest) (quota accounts.Quota, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		quota, err = scanQuota(tx.QueryRow(ctx, `
+			INSERT INTO quotas (name, description, max_pinned_data, total_uses)
+			VALUES ($1, $2, $3, $4)
+			ON CONFLICT (name) DO UPDATE SET
+				description = EXCLUDED.description,
+				max_pinned_data = EXCLUDED.max_pinned_data,
+				total_uses = EXCLUDED.total_uses
+			RETURNING name, description, max_pinned_data, total_uses
+		`, key, req.Description, req.MaxPinnedData, req.TotalUses))
+		return err
+	})
+	return
+}
+
+// DeleteQuota deletes a quota from the database.
+// If the quota does not exist, it returns [accounts.ErrQuotaNotFound].
+// If the quota is in use by connect keys, it returns [accounts.ErrQuotaInUse].
+func (s *Store) DeleteQuota(key string) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		// check if quota exists
+		var exists bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quotas WHERE name = $1)`, key).Scan(&exists); err != nil {
+			return fmt.Errorf("failed to check quota: %w", err)
+		} else if !exists {
+			return accounts.ErrQuotaNotFound
+		}
+
+		// check if quota is in use
+		var inUse bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM app_connect_keys WHERE quota_name = $1)`, key).Scan(&inUse); err != nil {
+			return fmt.Errorf("failed to check if quota in use: %w", err)
+		} else if inUse {
+			return accounts.ErrQuotaInUse
+		}
+
+		_, err := tx.Exec(ctx, `DELETE FROM quotas WHERE name = $1`, key)
+		return err
+	})
+}
+
+// Quota retrieves a quota from the database.
+// If the quota does not exist, it returns [accounts.ErrQuotaNotFound].
+func (s *Store) Quota(key string) (quota accounts.Quota, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		quota, err = scanQuota(tx.QueryRow(ctx, `
+			SELECT name, description, max_pinned_data, total_uses
+			FROM quotas
+			WHERE name = $1
+		`, key))
+		if errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrQuotaNotFound
+		}
+		return err
+	})
+	return
+}
+
+// Quotas retrieves a list of quotas from the database.
+func (s *Store) Quotas(offset, limit int) (quotas []accounts.Quota, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		rows, err := tx.Query(ctx, `
+			SELECT name, description, max_pinned_data, total_uses
+			FROM quotas
+			ORDER BY name
+			LIMIT $1 OFFSET $2
+		`, limit, offset)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			quota, err := scanQuota(rows)
+			if err != nil {
+				return err
+			}
+			quotas = append(quotas, quota)
+		}
+		return rows.Err()
+	})
+	return
+}

--- a/persist/postgres/quotas.go
+++ b/persist/postgres/quotas.go
@@ -15,20 +15,18 @@ func scanQuota(s scanner) (quota accounts.Quota, err error) {
 }
 
 // PutQuota creates or updates a quota in the database.
-func (s *Store) PutQuota(key string, req accounts.PutQuotaRequest) (quota accounts.Quota, err error) {
-	err = s.transaction(func(ctx context.Context, tx *txn) error {
-		quota, err = scanQuota(tx.QueryRow(ctx, `
+func (s *Store) PutQuota(key string, req accounts.PutQuotaRequest) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `
 			INSERT INTO quotas (name, description, max_pinned_data, total_uses)
 			VALUES ($1, $2, $3, $4)
 			ON CONFLICT (name) DO UPDATE SET
 				description = EXCLUDED.description,
 				max_pinned_data = EXCLUDED.max_pinned_data,
 				total_uses = EXCLUDED.total_uses
-			RETURNING name, description, max_pinned_data, total_uses
-		`, key, req.Description, req.MaxPinnedData, req.TotalUses))
+		`, key, req.Description, req.MaxPinnedData, req.TotalUses)
 		return err
 	})
-	return
 }
 
 // DeleteQuota deletes a quota from the database.

--- a/persist/postgres/quotas_test.go
+++ b/persist/postgres/quotas_test.go
@@ -51,6 +51,25 @@ func TestQuotas(t *testing.T) {
 		t.Fatalf("expected 2 quotas (including default), got %d", len(quotas))
 	}
 
+	// test offset and limit
+	quotas, err = store.Quotas(0, 1)
+	if err != nil {
+		t.Fatal("failed to list quotas:", err)
+	} else if len(quotas) != 1 {
+		t.Fatalf("expected 1 quota, got %d", len(quotas))
+	} else if quotas[0].Key != "default" {
+		t.Fatalf("expected first quota to be 'default', got %q", quotas[0].Key)
+	}
+
+	quotas, err = store.Quotas(1, 1)
+	if err != nil {
+		t.Fatal("failed to list quotas:", err)
+	} else if len(quotas) != 1 {
+		t.Fatalf("expected 1 quota, got %d", len(quotas))
+	} else if quotas[0].Key != "test-quota" {
+		t.Fatalf("expected first quota to be 'test-quota', got %q", quotas[0].Key)
+	}
+
 	// update the test quota
 	if err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
 		Description:   "Updated description",

--- a/persist/postgres/quotas_test.go
+++ b/persist/postgres/quotas_test.go
@@ -1,0 +1,126 @@
+package postgres
+
+import (
+	"testing"
+
+	"go.sia.tech/indexd/accounts"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestQuotas(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// create a quota
+	created, err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
+		Description:   "Test quota",
+		MaxPinnedData: 1000,
+		TotalUses:     10,
+	})
+	if err != nil {
+		t.Fatal("failed to create quota:", err)
+	} else if created.Key != "test-quota" {
+		t.Fatalf("expected key to be 'test-quota', got %q", created.Key)
+	} else if created.Description != "Test quota" {
+		t.Fatalf("expected description to be 'Test quota', got %q", created.Description)
+	} else if created.MaxPinnedData != 1000 {
+		t.Fatalf("expected max pinned data to be 1000, got %d", created.MaxPinnedData)
+	} else if created.TotalUses != 10 {
+		t.Fatalf("expected total uses to be 10, got %d", created.TotalUses)
+	}
+
+	// get the quota
+	got, err := store.Quota("test-quota")
+	if err != nil {
+		t.Fatal("failed to get quota:", err)
+	} else if got != created {
+		t.Fatalf("expected quota %+v, got %+v", created, got)
+	}
+
+	// list quotas - should include default and test-quota
+	quotas, err := store.Quotas(0, 100)
+	if err != nil {
+		t.Fatal("failed to list quotas:", err)
+	}
+	var found bool
+	for _, q := range quotas {
+		if q.Key == "test-quota" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected to find test-quota in list")
+	} else if len(quotas) != 2 {
+		t.Fatalf("expected 2 quotas (including default), got %d", len(quotas))
+	}
+
+	// update the test quota
+	updated, err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
+		Description:   "Updated description",
+		MaxPinnedData: 2000,
+		TotalUses:     20,
+	})
+	if err != nil {
+		t.Fatal("failed to update quota:", err)
+	} else if updated.Description != "Updated description" {
+		t.Fatalf("expected description to be 'Updated description', got %q", updated.Description)
+	} else if updated.MaxPinnedData != 2000 {
+		t.Fatalf("expected max pinned data to be 2000, got %d", updated.MaxPinnedData)
+	} else if updated.TotalUses != 20 {
+		t.Fatalf("expected total uses to be 20, got %d", updated.TotalUses)
+	}
+
+	// delete the quota
+	if err := store.DeleteQuota("test-quota"); err != nil {
+		t.Fatal("failed to delete quota:", err)
+	}
+
+	// verify it's deleted
+	if _, err := store.Quota("test-quota"); err != accounts.ErrQuotaNotFound {
+		t.Fatalf("expected ErrQuotaNotFound, got %v", err)
+	}
+
+	// test deleting non-existent quota
+	if err := store.DeleteQuota("non-existent"); err != accounts.ErrQuotaNotFound {
+		t.Fatalf("expected ErrQuotaNotFound, got %v", err)
+	}
+}
+
+func TestQuotaInUse(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// create a quota
+	_, err := store.PutQuota("in-use-quota", accounts.PutQuotaRequest{
+		Description:   "Quota that will be in use",
+		MaxPinnedData: 1000,
+		TotalUses:     10,
+	})
+	if err != nil {
+		t.Fatal("failed to create quota:", err)
+	}
+
+	// create a connect key using this quota
+	_, err = store.AddAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "test-connect-key",
+		Description: "Test connect key",
+		Quota:       "in-use-quota",
+	})
+	if err != nil {
+		t.Fatal("failed to create connect key:", err)
+	}
+
+	// try to delete the quota - should fail
+	if err := store.DeleteQuota("in-use-quota"); err != accounts.ErrQuotaInUse {
+		t.Fatalf("expected ErrQuotaInUse, got %v", err)
+	}
+
+	// delete the connect key
+	if err := store.DeleteAppConnectKey("test-connect-key"); err != nil {
+		t.Fatal("failed to delete connect key:", err)
+	}
+
+	// now we should be able to delete the quota
+	if err := store.DeleteQuota("in-use-quota"); err != nil {
+		t.Fatal("failed to delete quota:", err)
+	}
+}

--- a/persist/postgres/quotas_test.go
+++ b/persist/postgres/quotas_test.go
@@ -11,29 +11,26 @@ func TestQuotas(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// create a quota
-	created, err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
+	if err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
 		Description:   "Test quota",
 		MaxPinnedData: 1000,
 		TotalUses:     10,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal("failed to create quota:", err)
-	} else if created.Key != "test-quota" {
-		t.Fatalf("expected key to be 'test-quota', got %q", created.Key)
-	} else if created.Description != "Test quota" {
-		t.Fatalf("expected description to be 'Test quota', got %q", created.Description)
-	} else if created.MaxPinnedData != 1000 {
-		t.Fatalf("expected max pinned data to be 1000, got %d", created.MaxPinnedData)
-	} else if created.TotalUses != 10 {
-		t.Fatalf("expected total uses to be 10, got %d", created.TotalUses)
 	}
 
 	// get the quota
 	got, err := store.Quota("test-quota")
 	if err != nil {
 		t.Fatal("failed to get quota:", err)
-	} else if got != created {
-		t.Fatalf("expected quota %+v, got %+v", created, got)
+	} else if got.Key != "test-quota" {
+		t.Fatalf("expected key to be 'test-quota', got %q", got.Key)
+	} else if got.Description != "Test quota" {
+		t.Fatalf("expected description to be 'Test quota', got %q", got.Description)
+	} else if got.MaxPinnedData != 1000 {
+		t.Fatalf("expected max pinned data to be 1000, got %d", got.MaxPinnedData)
+	} else if got.TotalUses != 10 {
+		t.Fatalf("expected total uses to be 10, got %d", got.TotalUses)
 	}
 
 	// list quotas - should include default and test-quota
@@ -55,19 +52,24 @@ func TestQuotas(t *testing.T) {
 	}
 
 	// update the test quota
-	updated, err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
+	if err := store.PutQuota("test-quota", accounts.PutQuotaRequest{
 		Description:   "Updated description",
 		MaxPinnedData: 2000,
 		TotalUses:     20,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatal("failed to update quota:", err)
-	} else if updated.Description != "Updated description" {
-		t.Fatalf("expected description to be 'Updated description', got %q", updated.Description)
-	} else if updated.MaxPinnedData != 2000 {
-		t.Fatalf("expected max pinned data to be 2000, got %d", updated.MaxPinnedData)
-	} else if updated.TotalUses != 20 {
-		t.Fatalf("expected total uses to be 20, got %d", updated.TotalUses)
+	}
+
+	// verify the update
+	got, err = store.Quota("test-quota")
+	if err != nil {
+		t.Fatal("failed to get updated quota:", err)
+	} else if got.Description != "Updated description" {
+		t.Fatalf("expected description to be 'Updated description', got %q", got.Description)
+	} else if got.MaxPinnedData != 2000 {
+		t.Fatalf("expected max pinned data to be 2000, got %d", got.MaxPinnedData)
+	} else if got.TotalUses != 20 {
+		t.Fatalf("expected total uses to be 20, got %d", got.TotalUses)
 	}
 
 	// delete the quota
@@ -90,7 +92,7 @@ func TestQuotaInUse(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
 	// create a quota
-	_, err := store.PutQuota("in-use-quota", accounts.PutQuotaRequest{
+	err := store.PutQuota("in-use-quota", accounts.PutQuotaRequest{
 		Description:   "Quota that will be in use",
 		MaxPinnedData: 1000,
 		TotalUses:     10,

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -376,7 +376,11 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 
 		// check whether adding the newly pinned data would exceed the connect
 		// key's storage limit and if not, update the connect key's pinned data
-		err = tx.QueryRow(ctx, `UPDATE app_connect_keys SET pinned_data = pinned_data + $1 WHERE id = $2 RETURNING pinned_data, max_pinned_data`, newPinnedData, connectKeyID).Scan(&pinnedData, &maxPinnedData)
+		err = tx.QueryRow(ctx, `
+			UPDATE app_connect_keys ack SET pinned_data = pinned_data + $1
+			FROM quotas q
+			WHERE ack.id = $2 AND q.name = ack.quota_name
+			RETURNING ack.pinned_data, q.max_pinned_data`, newPinnedData, connectKeyID).Scan(&pinnedData, &maxPinnedData)
 		if err != nil {
 			return fmt.Errorf("failed to update connect key's pinned data: %w", err)
 		} else if pinnedData > maxPinnedData {

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -882,11 +882,14 @@ func TestPinSlabsStorageLimit(t *testing.T) {
 	store.addTestContract(t, hk1)
 	store.addTestContract(t, hk2)
 
+	// create a test quota with specific limits
+	store.addTestQuota(t, "storage-limit-test", 2*proto.SectorSize, 2)
+
 	const connectKey = "foobar"
 	key, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:           connectKey,
-		MaxPinnedData: 2 * proto.SectorSize,
-		RemainingUses: 2,
+		Key:         connectKey,
+		Description: "test key",
+		Quota:       "storage-limit-test",
 	})
 	if err != nil {
 		t.Fatal("failed to add app connect key:", err)

--- a/sdk/connect_test.go
+++ b/sdk/connect_test.go
@@ -47,9 +47,8 @@ func TestConnect(t *testing.T) {
 	cluster := testutils.NewCluster(t, testutils.WithHosts(15), testutils.WithLogger(log.Named("cluster")), testutils.WithIndexer(testutils.WithMaintenanceSettings(ms)))
 
 	connectKey, err := cluster.Indexer.Admin.AddAppConnectKey(t.Context(), accounts.AddConnectKeyRequest{
-		Description:   "test",
-		MaxPinnedData: 1 << 40,
-		RemainingUses: 10,
+		Description: "test",
+		Quota:       "default",
 	})
 	if err != nil {
 		t.Fatal("failed to add app connect key:", err)

--- a/testutils/db.go
+++ b/testutils/db.go
@@ -125,8 +125,11 @@ func (ts TestStore) AddTestAccount(t testing.TB, ak types.PublicKey) {
 	const connectKey = "test"
 	if _, err := ts.ValidAppConnectKey(connectKey); errors.Is(err, accounts.ErrKeyNotFound) {
 		// create testing quota if it doesn't exist
-		if _, err := ts.Exec(t.Context(), `INSERT INTO quotas (name, description, max_pinned_data, total_uses) VALUES ($1, $2, $3, $4) ON CONFLICT (name) DO NOTHING`,
-			TestQuotaName, "Testing quota", uint64(1e12), 10000); err != nil {
+		if _, err := ts.PutQuota(TestQuotaName, accounts.PutQuotaRequest{
+			Description:   "Testing quota",
+			MaxPinnedData: uint64(1e12),
+			TotalUses:     10000,
+		}); err != nil {
 			t.Fatal(err)
 		}
 		_, err := ts.AddAppConnectKey(accounts.UpdateAppConnectKey{

--- a/testutils/db.go
+++ b/testutils/db.go
@@ -21,6 +21,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// TestQuotaName is the name of the quota used in tests.
+	TestQuotaName = "testing"
+)
+
 // TestStore represents a postgres database for testing with some helpers for
 // common actions in testing like adding accounts and running SQL queries.
 type TestStore struct {
@@ -119,10 +124,14 @@ func (ts TestStore) AddTestAccount(t testing.TB, ak types.PublicKey) {
 
 	const connectKey = "test"
 	if _, err := ts.ValidAppConnectKey(connectKey); errors.Is(err, accounts.ErrKeyNotFound) {
+		// create testing quota if it doesn't exist
+		if _, err := ts.Exec(t.Context(), `INSERT INTO quotas (name, description, max_pinned_data, total_uses) VALUES ($1, $2, $3, $4) ON CONFLICT (name) DO NOTHING`,
+			TestQuotaName, "Testing quota", uint64(1e12), 10000); err != nil {
+			t.Fatal(err)
+		}
 		_, err := ts.AddAppConnectKey(accounts.UpdateAppConnectKey{
-			Key:           connectKey,
-			MaxPinnedData: 1e10,
-			RemainingUses: 10000,
+			Key:   connectKey,
+			Quota: TestQuotaName,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/testutils/db.go
+++ b/testutils/db.go
@@ -125,7 +125,7 @@ func (ts TestStore) AddTestAccount(t testing.TB, ak types.PublicKey) {
 	const connectKey = "test"
 	if _, err := ts.ValidAppConnectKey(connectKey); errors.Is(err, accounts.ErrKeyNotFound) {
 		// create testing quota if it doesn't exist
-		if _, err := ts.PutQuota(TestQuotaName, accounts.PutQuotaRequest{
+		if err := ts.PutQuota(TestQuotaName, accounts.PutQuotaRequest{
 			Description:   "Testing quota",
 			MaxPinnedData: uint64(1e12),
 			TotalUses:     10000,


### PR DESCRIPTION
This PR adds a `quotas` table which contains custom settings we might want to associate with app connect keys and their associated accounts. 
Initially only the "default" quota exists which is also the quota assigned by the migration in this PR. 

What this PR doesn't do is add handling for when a user ends up exceeding their limit due to lowering their quota. We will cross that bridge when we come to it.

This is also going to be useful for suspending accounts without deleting them. A "suspended" quota would be all zero limits and lead to accounts not being funded at all. While we still migrate the data. 
