### PR TITLE
Handle violations in UpdateAppConnectKey

### DIFF
--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	//  ErrKeyAlreadyExists is returned when trying to add an app connect key
-	//  with an app key that already exists.
+	// ErrKeyAlreadyExists is returned when trying to add an app connect key
+	// with an app key that already exists.
 	ErrKeyAlreadyExists = errors.New("key already exists")
 
 	// ErrKeyExhausted is returned when an app connect key has

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -11,6 +11,10 @@ import (
 )
 
 var (
+	//  ErrKeyAlreadyExists is returned when trying to add an app connect key
+	//  with an app key that already exists.
+	ErrKeyAlreadyExists = errors.New("key already exists")
+
 	// ErrKeyExhausted is returned when an app connect key has
 	// no remaining uses.
 	ErrKeyExhausted = errors.New("key has no remaining uses")

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -46,10 +46,13 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 				(SELECT total_uses FROM quotas WHERE name = quota_name)
 		`, meta.Key, userSecret, meta.Description, meta.Quota))
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.ForeignKeyViolation {
-			return accounts.ErrQuotaNotFound
-		} else if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
-			return accounts.ErrKeyAlreadyExists
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case pgerrcode.ForeignKeyViolation:
+				return accounts.ErrQuotaNotFound
+			case pgerrcode.UniqueViolation:
+				return accounts.ErrKeyAlreadyExists
+			}
 		}
 		return err
 	})

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -48,6 +48,8 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.ForeignKeyViolation {
 			return accounts.ErrQuotaNotFound
+		} else if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return accounts.ErrKeyAlreadyExists
 		}
 		return err
 	})

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
 	"lukechampine.com/frand"
@@ -35,14 +37,6 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 		return accounts.ConnectKey{}, fmt.Errorf("quota is required")
 	}
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
-		// verify quota exists
-		var exists bool
-		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM quotas WHERE name = $1)`, meta.Quota).Scan(&exists); err != nil {
-			return fmt.Errorf("failed to check quota: %w", err)
-		} else if !exists {
-			return accounts.ErrQuotaNotFound
-		}
-
 		userSecret := frand.Bytes(32)
 		key, err = scanConnectKey(tx.QueryRow(ctx, `
 			INSERT INTO app_connect_keys (app_key, user_secret, use_description, quota_name)
@@ -51,6 +45,10 @@ func (s *Store) AddAppConnectKey(meta accounts.UpdateAppConnectKey) (key account
 				quota_name,
 				(SELECT total_uses FROM quotas WHERE name = quota_name)
 		`, meta.Key, userSecret, meta.Description, meta.Quota))
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.ForeignKeyViolation {
+			return accounts.ErrQuotaNotFound
+		}
 		return err
 	})
 	return
@@ -71,6 +69,10 @@ func (s *Store) UpdateAppConnectKey(meta accounts.UpdateAppConnectKey) (key acco
 		`, meta.Key, meta.Description, meta.Quota))
 		if errors.Is(err, sql.ErrNoRows) {
 			return accounts.ErrKeyNotFound
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.ForeignKeyViolation {
+			return accounts.ErrQuotaNotFound
 		}
 		return err
 	})

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -211,7 +211,8 @@ func TestAppConnectKey(t *testing.T) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyAlreadyExists, err)
 	}
 
-	// assert ErrQuotaNotFound is returned when updating to unknown quota
+	// assert ErrQuotaNotFound is returned when adding a key with an unknown
+	// quota
 	if _, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
 		Key:         "bar baz",
 		Description: "test key",

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -105,15 +105,6 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("expected app connect key to be invalid")
 	}
 
-	// try update to a non-existent quota
-	if _, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
-		Key:         connectKey,
-		Description: "updated key",
-		Quota:       "i-dont-exist",
-	}); !errors.Is(err, accounts.ErrQuotaNotFound) {
-		t.Fatalf("expected err %q, got %q", accounts.ErrQuotaNotFound, err)
-	}
-
 	// update to a different quota with more data
 	if updated, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
 		Key:         connectKey,
@@ -208,5 +199,69 @@ func TestAppConnectKey(t *testing.T) {
 		t.Fatal("failed to validate app connect key:", err)
 	} else if !reflect.DeepEqual(key, got) {
 		t.Fatalf("expected app connect key %v, got %v", key, got)
+	}
+
+	// assert ErrKeyAlreadyExists is returned when adding an existing key
+	_, err = store.AddAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "foobar",
+		Description: "test key",
+		Quota:       "test-quota",
+	})
+	if !errors.Is(err, accounts.ErrKeyAlreadyExists) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrKeyAlreadyExists, err)
+	}
+
+	// assert ErrQuotaNotFound is returned when updating to unknown quota
+	if _, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "bar baz",
+		Description: "test key",
+		Quota:       "i-dont-exist",
+	}); !errors.Is(err, accounts.ErrQuotaNotFound) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrQuotaNotFound, err)
+	}
+}
+
+func TestUpdateConnectKey(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	store.addTestQuota(t, "test-quota", 10, 1)
+	store.addTestQuota(t, "updated-quota", 10, 1)
+
+	key, err := store.AddAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "foobar",
+		Description: "test key",
+		Quota:       "test-quota",
+	})
+	if err != nil {
+		t.Fatal("failed to add app connect key:", err)
+	}
+
+	updated, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "foobar",
+		Description: "updated key",
+		Quota:       "updated-quota",
+	})
+	if err != nil {
+		t.Fatal("failed to update app connect key:", err)
+	} else if updated.Key != key.Key || updated.Description != "updated key" || updated.Quota != "updated-quota" {
+		t.Fatalf("expected updated app connect key %v, got %v", key, updated)
+	}
+
+	// assert ErrQuotaNotFound is returned when updating to unknown quota
+	if _, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "foobar",
+		Description: "updated key",
+		Quota:       "i-dont-exist",
+	}); !errors.Is(err, accounts.ErrQuotaNotFound) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrQuotaNotFound, err)
+	}
+
+	// assert ErrKeyNotFound is returned when updating a non-existent key
+	if _, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         "i-dont-exist",
+		Description: "updated key",
+		Quota:       "updated-quota",
+	}); !errors.Is(err, accounts.ErrKeyNotFound) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
 	}
 }

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -105,6 +105,15 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("expected app connect key to be invalid")
 	}
 
+	// try update to a non-existent quota
+	if _, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
+		Key:         connectKey,
+		Description: "updated key",
+		Quota:       "i-dont-exist",
+	}); !errors.Is(err, accounts.ErrQuotaNotFound) {
+		t.Fatalf("expected err %q, got %q", accounts.ErrQuotaNotFound, err)
+	}
+
 	// update to a different quota with more data
 	if updated, err := store.UpdateAppConnectKey(accounts.UpdateAppConnectKey{
 		Key:         connectKey,


### PR DESCRIPTION
This PR adds handling of unique constraint violation and foreign key constraint violation. I've updated `AddAppConnectKey` to handle it in a similar fashion so the implementations are consistent.