### PR TITLE
Fix ndf in TestApplicationAPI

### DIFF
--- a/accounts/accounts_test.go
+++ b/accounts/accounts_test.go
@@ -22,7 +22,7 @@ func TestAccountFunding(t *testing.T) {
 	indexer := cluster.Indexer
 
 	// create an app
-	app, sk := cluster.App(t)
+	sk := cluster.AddAccount(t)
 
 	// assert we have one usable host
 	time.Sleep(time.Second)
@@ -52,7 +52,7 @@ func TestAccountFunding(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// fetch account
-	acc, err := app.Account(t.Context(), sk)
+	acc, err := indexer.App.Account(t.Context(), sk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1171,7 +1171,7 @@ func TestSectorStatsAPI(t *testing.T) {
 	// pin a slab
 	account := types.GeneratePrivateKey()
 	indexer.Store().AddTestAccount(t, account.PublicKey())
-	slabIDs, err := indexer.App().PinSlabs(context.Background(), account, slabs.SlabPinParams{
+	slabIDs, err := indexer.App.PinSlabs(context.Background(), account, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{1},
 		MinShards:     1,
 		Sectors: func() (s []slabs.PinnedSector) {
@@ -1195,7 +1195,7 @@ func TestSectorStatsAPI(t *testing.T) {
 	}
 
 	// unpin the slab
-	if err := indexer.App().UnpinSlab(context.Background(), account, slabID); err != nil {
+	if err := indexer.App.UnpinSlab(context.Background(), account, slabID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1171,7 +1171,7 @@ func TestSectorStatsAPI(t *testing.T) {
 	// pin a slab
 	account := types.GeneratePrivateKey()
 	indexer.Store().AddTestAccount(t, account.PublicKey())
-	slabIDs, err := indexer.App(account).PinSlabs(context.Background(), account, slabs.SlabPinParams{
+	slabIDs, err := indexer.App().PinSlabs(context.Background(), account, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{1},
 		MinShards:     1,
 		Sectors: func() (s []slabs.PinnedSector) {
@@ -1195,7 +1195,7 @@ func TestSectorStatsAPI(t *testing.T) {
 	}
 
 	// unpin the slab
-	if err := indexer.App(account).UnpinSlab(context.Background(), account, slabID); err != nil {
+	if err := indexer.App().UnpinSlab(context.Background(), account, slabID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -60,7 +60,7 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 	indexer := cluster.Indexer
 
 	sk := types.GeneratePrivateKey()
-	client := indexer.App()
+	client := indexer.App
 
 	key, err := indexer.Admin.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
 		Quota: "default",
@@ -162,7 +162,7 @@ func TestApplicationAPI(t *testing.T) {
 	sk, key := newAccount(t, cluster)
 	sk2, key2 := newAccount(t, cluster)
 
-	client := indexer.App()
+	client := indexer.App
 
 	// check that the key has been used
 	keys, err := adminClient.AppConnectKeys(ctx, 0, 2)
@@ -487,7 +487,7 @@ func TestAppConnect(t *testing.T) {
 	}
 
 	sk := types.GeneratePrivateKey()
-	appClient := indexer.App()
+	appClient := indexer.App
 
 	connected, err := appClient.CheckAppAuth(ctx, sk)
 	if err != nil {
@@ -628,7 +628,7 @@ func TestSharedObjects(t *testing.T) {
 	// prepare accounts
 	sk1, _ := newAccount(t, cluster)
 	sk2, _ := newAccount(t, cluster)
-	appClient := indexer.App()
+	appClient := indexer.App
 
 	// generate and pin a slab
 	slab1Params := uploadRandomSlab(t, client, sk1, hosts)
@@ -689,7 +689,7 @@ func TestSharedObjects(t *testing.T) {
 		t.Fatal("shared object mismatch")
 	}
 
-	// make sure appClient has no objects
+	// make sure appClient returns no objects
 	if objs, err := appClient.ListObjects(ctx, sk2, slabs.Cursor{}, 100); err != nil {
 		t.Fatal(err)
 	} else if len(objs) != 0 {

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -60,7 +60,7 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 	indexer := cluster.Indexer
 
 	sk := types.GeneratePrivateKey()
-	client := indexer.App(sk)
+	client := indexer.App()
 
 	key, err := indexer.Admin.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
 		Quota: "default",
@@ -105,6 +105,36 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 	return sk, key
 }
 
+// uploadRandomSlab uploads a slab with random data to the provided hosts and
+// returns the corresponding SlabPinParams.
+func uploadRandomSlab(t testing.TB, client *client.Client, sk types.PrivateKey, hosts []hosts.Host) slabs.SlabPinParams {
+	t.Helper()
+
+	// prepare sectors
+	var sectors []slabs.PinnedSector
+	for _, h := range hosts {
+		// prepare sector data
+		var sector [proto.SectorSize]byte
+		frand.Read(sector[:])
+
+		// upload sector
+		hk := h.PublicKey
+		if result, err := client.WriteSector(context.Background(), sk, hk, sector[:]); err != nil {
+			t.Fatal(err)
+		} else {
+			sectors = append(sectors, slabs.PinnedSector{
+				Root:    result.Root,
+				HostKey: hk,
+			})
+		}
+	}
+	return slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors:       sectors,
+	}
+}
+
 func TestApplicationAPI(t *testing.T) {
 	ctx := t.Context()
 	// create cluster with three hosts
@@ -112,6 +142,10 @@ func TestApplicationAPI(t *testing.T) {
 	cluster := testutils.NewCluster(t, testutils.WithHosts(10), testutils.WithLogger(logger))
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin
+
+	// create host client
+	hc := client.New(client.NewProvider(hosts.NewHostStore(cluster.Indexer.Store())))
+	defer hc.Close()
 
 	// wait for contracts to be formed
 	cluster.WaitForContracts(t)
@@ -126,7 +160,7 @@ func TestApplicationAPI(t *testing.T) {
 
 	// prepare account
 	sk, key := newAccount(t, cluster)
-	client := indexer.App(sk)
+	client := indexer.App()
 
 	// check that the key has been used
 	keys, err := adminClient.AppConnectKeys(ctx, 0, 1)
@@ -143,25 +177,8 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("expected last used to be set, got", keys[0].LastUsed)
 	}
 
-	// helper to generate slab pin parameters
-	params := func() slabs.SlabPinParams {
-		return slabs.SlabPinParams{
-			EncryptionKey: frand.Entropy256(),
-			MinShards:     1,
-			Sectors: func() (s []slabs.PinnedSector) {
-				for _, host := range hosts {
-					s = append(s, slabs.PinnedSector{
-						Root:    frand.Entropy256(),
-						HostKey: host.PublicKey,
-					})
-				}
-				return s
-			}(),
-		}
-	}
-
 	// pin the slab
-	slabIDs, err := client.PinSlabs(context.Background(), sk, params())
+	slabIDs, err := client.PinSlabs(context.Background(), sk, uploadRandomSlab(t, hc, sk, hosts))
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}
@@ -173,7 +190,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// assert minimum redundancy is enforced
-	p := params()
+	p := uploadRandomSlab(t, hc, sk, hosts)
 	p.Sectors = p.Sectors[:2]
 	_, err = client.PinSlabs(context.Background(), sk, p)
 	if err == nil || !strings.Contains(err.Error(), "not enough redundancy") {
@@ -288,8 +305,8 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// pin 2 slabs
-	slab1Params := params()
-	slab2Params := params()
+	slab1Params := uploadRandomSlab(t, hc, sk, hosts)
+	slab2Params := uploadRandomSlab(t, hc, sk, hosts)
 	slabIDs1, err := client.PinSlabs(context.Background(), sk, slab1Params)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
@@ -426,9 +443,9 @@ func TestApplicationAPI(t *testing.T) {
 	// ourselves.
 	// Pin a slab on a second account
 	sk2, _ := newAccount(t, cluster)
-	client2 := indexer.App(sk2)
+	client2 := indexer.App()
 
-	p2 := params()
+	p2 := uploadRandomSlab(t, hc, sk, hosts)
 	slabIDs, err = client2.PinSlabs(context.Background(), sk2, p2)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
@@ -466,7 +483,7 @@ func TestAppConnect(t *testing.T) {
 	}
 
 	sk := types.GeneratePrivateKey()
-	appClient := indexer.App(sk)
+	appClient := indexer.App()
 
 	connected, err := appClient.CheckAppAuth(ctx, sk)
 	if err != nil {
@@ -605,74 +622,19 @@ func TestSharedObjects(t *testing.T) {
 	}
 
 	// prepare accounts
-	prepareAcccount := func(t *testing.T) (*app.Client, types.PrivateKey) {
-		sk := types.GeneratePrivateKey()
-		client := indexer.App(sk)
-
-		key, err := adminClient.AddAppConnectKey(ctx, accounts.AddConnectKeyRequest{
-			Quota: "default",
-		})
-		if err != nil {
-			t.Fatal("failed to add app connect key:", err)
-		}
-
-		connectResp, err := client.RequestAppConnection(ctx, app.RegisterAppRequest{
-			AppID:       frand.Entropy256(),
-			Name:        "Test App",
-			Description: "A test application",
-			LogoURL:     "foo",
-			ServiceURL:  "bar",
-		})
-		if err != nil {
-			t.Fatal("failed to request app connection:", err)
-		}
-
-		respondToAppConnection(t, connectResp.ResponseURL, key.Key, true)
-		if err = client.RegisterApp(ctx, connectResp.RegisterURL, sk); err != nil {
-			t.Fatal("failed to register app:", err)
-		}
-		return client, sk
-	}
-
-	client1, sk1 := prepareAcccount(t)
-	client2, sk2 := prepareAcccount(t)
-
-	// helper to generate slab pin parameters
-	randomSlab := func() slabs.SlabPinParams {
-		// prepare sectors
-		var sectors []slabs.PinnedSector
-		for _, h := range hosts {
-			// prepare sector data
-			var sector [proto.SectorSize]byte
-			frand.Read(sector[:])
-
-			// upload sector
-			hk := h.PublicKey
-			if result, err := client.WriteSector(ctx, sk1, hk, sector[:]); err != nil {
-				t.Fatal(err)
-			} else {
-				sectors = append(sectors, slabs.PinnedSector{
-					Root:    result.Root,
-					HostKey: hk,
-				})
-			}
-		}
-		return slabs.SlabPinParams{
-			EncryptionKey: frand.Entropy256(),
-			MinShards:     1,
-			Sectors:       sectors,
-		}
-	}
+	sk1, _ := newAccount(t, cluster)
+	sk2, _ := newAccount(t, cluster)
+	appClient := indexer.App()
 
 	// generate and pin a slab
-	slab1Params := randomSlab()
-	_, err = client1.PinSlabs(ctx, sk1, slab1Params)
+	slab1Params := uploadRandomSlab(t, client, sk1, hosts)
+	_, err = appClient.PinSlabs(ctx, sk1, slab1Params)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}
 
-	slab2Params := randomSlab()
-	_, err = client1.PinSlabs(ctx, sk1, slab2Params)
+	slab2Params := uploadRandomSlab(t, client, sk1, hosts)
+	_, err = appClient.PinSlabs(ctx, sk1, slab2Params)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}
@@ -694,12 +656,12 @@ func TestSharedObjects(t *testing.T) {
 		},
 	}
 	obj.Sign(sk1)
-	if err := client1.SaveObject(ctx, sk1, obj); err != nil {
+	if err := appClient.SaveObject(ctx, sk1, obj); err != nil {
 		t.Fatal(err)
 	}
 
 	// populate the object's created and updated fields
-	obj, err = client1.Object(ctx, sk1, obj.ID())
+	obj, err = appClient.Object(ctx, sk1, obj.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,13 +670,13 @@ func TestSharedObjects(t *testing.T) {
 	encryptionKey := frand.Bytes(32)
 
 	// create a shared URL for the object
-	shareURL, err := client1.CreateSharedObjectURL(ctx, sk1, obj.ID(), encryptionKey, time.Now().Add(2*time.Second))
+	shareURL, err := appClient.CreateSharedObjectURL(ctx, sk1, obj.ID(), encryptionKey, time.Now().Add(2*time.Second))
 	if err != nil {
 		t.Fatal("failed to create shared object URL:", err)
 	}
 
-	// try to retrieve the object with client2
-	sharedObj, key, err := client2.SharedObject(ctx, shareURL)
+	// try to retrieve the object with appClient
+	sharedObj, key, err := appClient.SharedObject(ctx, shareURL)
 	if err != nil {
 		t.Fatal("failed to retrieve shared object:", err)
 	} else if !bytes.Equal(key, encryptionKey) {
@@ -723,8 +685,8 @@ func TestSharedObjects(t *testing.T) {
 		t.Fatal("shared object mismatch")
 	}
 
-	// make sure client2 has no objects
-	if objs, err := client2.ListObjects(ctx, sk2, slabs.Cursor{}, 100); err != nil {
+	// make sure appClient has no objects
+	if objs, err := appClient.ListObjects(ctx, sk2, slabs.Cursor{}, 100); err != nil {
 		t.Fatal(err)
 	} else if len(objs) != 0 {
 		t.Fatalf("expected 0 objects, got %d", len(objs))
@@ -732,7 +694,7 @@ func TestSharedObjects(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 	// try to retrieve the object again, should be expired
-	_, _, err = client1.SharedObject(ctx, shareURL)
+	_, _, err = appClient.SharedObject(ctx, shareURL)
 	if err == nil {
 		t.Fatal("expected error when creating shared URL with past expiry")
 	}

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -158,23 +158,30 @@ func TestApplicationAPI(t *testing.T) {
 		t.Fatal("expected 10 hosts, got", len(hosts))
 	}
 
-	// prepare account
+	// prepare accounts for the test
 	sk, key := newAccount(t, cluster)
+	sk2, key2 := newAccount(t, cluster)
+
 	client := indexer.App()
 
 	// check that the key has been used
-	keys, err := adminClient.AppConnectKeys(ctx, 0, 1)
-	switch {
-	case err != nil:
+	keys, err := adminClient.AppConnectKeys(ctx, 0, 2)
+	if err != nil {
 		t.Fatal(err)
-	case len(keys) != 1:
-		t.Fatal("expected 1 key, got", len(keys))
-	case keys[0].Key != key.Key:
-		t.Fatal("expected key to match", keys[0].Key, key.Key)
-	case keys[0].RemainingUses != 4:
-		t.Fatalf("expected remaining uses to be 4, got %d", keys[0].RemainingUses)
-	case keys[0].LastUsed.IsZero():
-		t.Fatal("expected last used to be set, got", keys[0].LastUsed)
+	} else if len(keys) != 2 {
+		t.Fatal("expected 2 keys, got", len(keys))
+	} else if keys[0] == keys[1] {
+		t.Fatal("expected different keys")
+	}
+	for _, k := range keys {
+		switch {
+		case k.Key != key.Key && k.Key != key2.Key:
+			t.Fatalf("unexpected key: %s", k.Key)
+		case k.RemainingUses != 4:
+			t.Fatalf("expected remaining uses to be 4, got %d", k.RemainingUses)
+		case k.LastUsed.IsZero():
+			t.Fatal("expected last used to be set, got", k.LastUsed)
+		}
 	}
 
 	// pin the slab
@@ -442,11 +449,8 @@ func TestApplicationAPI(t *testing.T) {
 	// We are not allowed to create objects using slabs that we have not pinned
 	// ourselves.
 	// Pin a slab on a second account
-	sk2, _ := newAccount(t, cluster)
-	client2 := indexer.App()
-
-	p2 := uploadRandomSlab(t, hc, sk, hosts)
-	slabIDs, err = client2.PinSlabs(context.Background(), sk2, p2)
+	p2 := uploadRandomSlab(t, hc, sk2, hosts)
+	slabIDs, err = client.PinSlabs(context.Background(), sk2, p2)
 	if err != nil {
 		t.Fatal("failed to pin slab:", err)
 	}

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -34,8 +34,8 @@ func TestContractPruning(t *testing.T) {
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(nHosts), testutils.WithIndexer(testutils.WithContractOptions(contracts.WithSectorRootsBatchSize(batchSize))))
 	indexer := cluster.Indexer
 
-	// create an app
-	app, sk := cluster.App(t)
+	// create an account
+	sk := cluster.AddAccount(t)
 
 	// wait for contracts
 	cluster.WaitForContracts(t)
@@ -83,7 +83,7 @@ func TestContractPruning(t *testing.T) {
 	}
 
 	// pin the slabs
-	slabIDs, err := app.PinSlabs(t.Context(), sk, pinParams...)
+	slabIDs, err := indexer.App.PinSlabs(t.Context(), sk, pinParams...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestContractPruning(t *testing.T) {
 	assertRoots()
 
 	// unpin the 3rd slab and trigger pruning
-	if err := app.UnpinSlab(t.Context(), sk, slabIDs[2]); err != nil {
+	if err := indexer.App.UnpinSlab(t.Context(), sk, slabIDs[2]); err != nil {
 		t.Fatal(err)
 	} else if err = indexer.Contracts().TriggerContractPruning(); err != nil {
 		t.Fatal(err)
@@ -196,7 +196,7 @@ func TestSectorPinning(t *testing.T) {
 	indexer := cluster.Indexer
 
 	// create an app
-	app, sk := cluster.App(t)
+	sk := cluster.AddAccount(t)
 
 	// wait for contracts to be formed
 	cluster.WaitForContracts(t)
@@ -229,14 +229,14 @@ func TestSectorPinning(t *testing.T) {
 	}
 
 	// pin the slab
-	slabIDs, err := app.PinSlabs(context.Background(), sk, params)
+	slabIDs, err := indexer.App.PinSlabs(context.Background(), sk, params)
 	if err != nil {
 		t.Fatal(err)
 	}
 	slabID := slabIDs[0]
 
 	// fetch account
-	acc, err := app.Account(t.Context(), sk)
+	acc, err := indexer.App.Account(t.Context(), sk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestSectorPinning(t *testing.T) {
 	}
 
 	// unpin the slab
-	if err := app.UnpinSlab(context.Background(), sk, slabID); err != nil {
+	if err := indexer.App.UnpinSlab(context.Background(), sk, slabID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/slabs/e2e_test.go
+++ b/slabs/e2e_test.go
@@ -20,8 +20,8 @@ func TestMigrations(t *testing.T) {
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(11))
 	indexer := cluster.Indexer
 
-	// create an app
-	app, sk := cluster.App(t)
+	// create an account
+	sk := cluster.AddAccount(t)
 
 	// create some more utxos
 	cluster.ConsensusNode.MineBlocks(t, indexer.WalletAddr(), 11)
@@ -40,7 +40,7 @@ func TestMigrations(t *testing.T) {
 	}
 
 	// pin the slab
-	slabIDs, err := app.PinSlabs(context.Background(), sk, slabs.SlabPinParams{
+	slabIDs, err := indexer.App.PinSlabs(context.Background(), sk, slabs.SlabPinParams{
 		EncryptionKey: encryptionKey,
 		MinShards:     1,
 		Sectors: []slabs.PinnedSector{
@@ -98,7 +98,7 @@ func TestMigrations(t *testing.T) {
 
 	// assert sector was migrated
 	if err := retry(300, 100*time.Millisecond, func() error {
-		if pinned, err := app.Slab(context.Background(), sk, slabID); err != nil {
+		if pinned, err := indexer.App.Slab(context.Background(), sk, slabID); err != nil {
 			t.Fatal(err)
 		} else if len(pinned.Sectors) != 10 {
 			return fmt.Errorf("expected 10 pinned sectors, got %d", len(pinned.Sectors))
@@ -116,8 +116,8 @@ func TestUpdateLastUsed(t *testing.T) {
 	logger := zap.NewNop()
 	cluster := testutils.NewCluster(t, testutils.WithLogger(logger), testutils.WithHosts(10), testutils.WithIndexer())
 
-	// create an app
-	app, sk := cluster.App(t)
+	// create an account
+	sk := cluster.AddAccount(t)
 
 	// create some more utxos
 	indexer := cluster.Indexer
@@ -141,7 +141,7 @@ func TestUpdateLastUsed(t *testing.T) {
 
 	// last used time should be around account creation and thus should predate
 	// `now` timestamp
-	account, err := app.Account(context.Background(), sk)
+	account, err := indexer.App.Account(context.Background(), sk)
 	if err != nil {
 		t.Fatal(err)
 	} else if !account.LastUsed.Before(now) {
@@ -149,7 +149,7 @@ func TestUpdateLastUsed(t *testing.T) {
 	}
 
 	// pin the slab
-	slabIDs, err := app.PinSlabs(context.Background(), sk, slabs.SlabPinParams{
+	slabIDs, err := indexer.App.PinSlabs(context.Background(), sk, slabs.SlabPinParams{
 		EncryptionKey: encryptionKey,
 		MinShards:     1,
 		Sectors: func() (s []slabs.PinnedSector) {
@@ -166,7 +166,7 @@ func TestUpdateLastUsed(t *testing.T) {
 
 	// last used time should be time of PinSlab invocation and thus should be
 	// after `now` timestamp
-	account, err = app.Account(context.Background(), sk)
+	account, err = indexer.App.Account(context.Background(), sk)
 	if err != nil {
 		t.Fatal(err)
 	} else if !account.LastUsed.After(now) {
@@ -176,14 +176,14 @@ func TestUpdateLastUsed(t *testing.T) {
 
 	// assert sectors were pinned
 	time.Sleep(time.Second)
-	if _, err := app.Slab(context.Background(), sk, slabID); err != nil {
+	if _, err := indexer.App.Slab(context.Background(), sk, slabID); err != nil {
 		t.Fatal(err)
 	}
 
 	// last used time should be time of Slab invocation (which causes the server
 	// to call PinnedSlab) and thus should be after the timestamp from when
 	// PinSlab was invoked
-	account, err = app.Account(context.Background(), sk)
+	account, err = indexer.App.Account(context.Background(), sk)
 	if err != nil {
 		t.Fatal(err)
 	} else if !account.LastUsed.After(now) {
@@ -191,12 +191,12 @@ func TestUpdateLastUsed(t *testing.T) {
 	}
 	now = account.LastUsed
 
-	if err := app.UnpinSlab(context.Background(), sk, slabID); err != nil {
+	if err := indexer.App.UnpinSlab(context.Background(), sk, slabID); err != nil {
 		t.Fatal(err)
 	}
 
 	// last used time should not have changed as a result of UnpinSlab
-	account, err = app.Account(context.Background(), sk)
+	account, err = indexer.App.Account(context.Background(), sk)
 	if err != nil {
 		t.Fatal(err)
 	} else if !account.LastUsed.Equal(now) {

--- a/testutils/cluster.go
+++ b/testutils/cluster.go
@@ -9,7 +9,6 @@ import (
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/testutil"
-	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/contracts"
 	"go.uber.org/zap"
 )
@@ -109,12 +108,10 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	return cluster
 }
 
-// App adds a new test account and returns an app client for it.
-func (c *Cluster) App(t testing.TB) (*app.Client, types.PrivateKey) {
-	t.Helper()
+func (c *Cluster) AddAccount(t testing.TB) types.PrivateKey {
 	sk := types.GeneratePrivateKey()
 	c.Indexer.Store().AddTestAccount(t, sk.PublicKey())
-	return c.Indexer.App(), sk
+	return sk
 }
 
 // AddHosts adds the given hosts to the cluster.

--- a/testutils/cluster.go
+++ b/testutils/cluster.go
@@ -108,6 +108,7 @@ func NewCluster(t testing.TB, opts ...ClusterOpt) *Cluster {
 	return cluster
 }
 
+// AddAccount adds a new account to the indexer and returns the private key.
 func (c *Cluster) AddAccount(t testing.TB) types.PrivateKey {
 	sk := types.GeneratePrivateKey()
 	c.Indexer.Store().AddTestAccount(t, sk.PublicKey())

--- a/testutils/cluster.go
+++ b/testutils/cluster.go
@@ -114,7 +114,7 @@ func (c *Cluster) App(t testing.TB) (*app.Client, types.PrivateKey) {
 	t.Helper()
 	sk := types.GeneratePrivateKey()
 	c.Indexer.Store().AddTestAccount(t, sk.PublicKey())
-	return c.Indexer.App(sk), sk
+	return c.Indexer.App(), sk
 }
 
 // AddHosts adds the given hosts to the cluster.

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -55,7 +55,7 @@ type (
 		appApiAddr string
 
 		Admin *admin.Client
-		App   func() *app.Client
+		App   *app.Client
 
 		cm        *chain.Manager
 		dialer    *client.Dialer
@@ -294,9 +294,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		appApiAddr: appAPIAddr,
 
 		Admin: admin.NewClient(adminAPIAddr, password),
-		App: func() *app.Client {
-			return app.NewClient(appAPIAddr)
-		},
+		App:   app.NewClient(appAPIAddr),
 
 		cm:        c.cm,
 		accounts:  am,

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -55,7 +55,7 @@ type (
 		appApiAddr string
 
 		Admin *admin.Client
-		App   func(types.PrivateKey) *app.Client
+		App   func() *app.Client
 
 		cm        *chain.Manager
 		dialer    *client.Dialer
@@ -294,7 +294,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		appApiAddr: appAPIAddr,
 
 		Admin: admin.NewClient(adminAPIAddr, password),
-		App: func(appKey types.PrivateKey) *app.Client {
+		App: func() *app.Client {
 			return app.NewClient(appAPIAddr)
 		},
 


### PR DESCRIPTION
Also removes an unused parameter from `App()`.

The issue is that sectors sometimes get marked as lost from hosts because we didn't actually upload them. Same as `TestSharedObjects` before.