### PR TITLE
Round result of maxRenewableContractSize down to multiple of SectorSize

### DIFF
--- a/contracts/contract.go
+++ b/contracts/contract.go
@@ -290,5 +290,11 @@ func maxRenewableContractSize(hostSettings proto.HostSettings, period uint64) ui
 	if maxSectorsSize.IsUint64() {
 		maxSize = min(maxSize, maxSectorsSize.Uint64())
 	}
-	return maxSize * 8 / 10 // 20% safety margin
+
+	// 20% safety margin
+	maxSize = maxSize * 8 / 10
+
+	// round down to a multiple of the sector size
+	maxSize = (maxSize / proto.SectorSize) * proto.SectorSize
+	return maxSize
 }

--- a/contracts/contract_test.go
+++ b/contracts/contract_test.go
@@ -28,7 +28,8 @@ func TestMaxRenewableContractSize(t *testing.T) {
 				collateral := types.Siacoins(100).Div64(1e12).Div64(4320)
 				sectorCollateral := collateral.Mul64(proto.SectorSize).Mul64(period + proto.ProofWindow)
 				maxSectors := maxCollateral.Div(sectorCollateral).Big().Uint64()
-				return maxSectors * proto.SectorSize * 8 / 10 // 20% safety margin
+				maxSize := maxSectors * proto.SectorSize * 8 / 10      // 20% safety margin
+				return (maxSize / proto.SectorSize) * proto.SectorSize // round down
 			}(),
 		},
 		{


### PR DESCRIPTION
I noticed the unpinned data not going down anymore and when looking into it I noticed a very interesting edge case.

The client computes the number of sectors it can append before reaching the max size and ended up with 0.
`GoodForAppend` directly compares the size. 

In theory that is fine but `maxRenewableContractSize` returned a size that isn't a multiple of sector size. So we ended up with 0 sectors being append able while at the same time being under the size due to rounding errors.

Tried this on Zeus and as expected a new contract formed immediately and pinning continued.