### PR TITLE
Fix TestE2E NDF

### DIFF
--- a/testutils/cluster.go
+++ b/testutils/cluster.go
@@ -217,9 +217,9 @@ func (c *Cluster) WaitForContracts(t *testing.T) {
 		formed = max(formed, len(seen))
 		t.Logf("formed contracts with %d/%d hosts", formed, len(required))
 
-		// ensure they are all confirmed
-		c.ConsensusNode.MineBlocks(t, types.VoidAddress, 1)
 		if len(seen) == len(required) {
+			// mine a block to confirm all pending contracts
+			c.ConsensusNode.MineBlocks(t, types.VoidAddress, 1)
 			time.Sleep(time.Second) // wait for indexing
 			return
 		}


### PR DESCRIPTION
Close #807

Passed:
```
POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres POSTGRES_DB=postgres go test ./sdk -v -run="TestE2E" -count=20
```
multiple times for me.

I think mining blocks every time in `WaitForContracts` can interfere with the maintenance loop when it is creating contract formation transactions.