### PR TITLE
Fix stats race

### DIFF
--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -739,17 +739,10 @@ func (s *Store) DeleteContract(contractID types.FileContractID) error {
 			return fmt.Errorf("failed to get contract sectors map ID: %w", err)
 		}
 
-		// count the number of sectors pinned to this contract
-		var pinned, hostID int64
-		err = tx.QueryRow(ctx, `SELECT COUNT(*), any_value(host_id) FROM sectors WHERE contract_sectors_map_id = $1`, contractMapID).Scan(&pinned, &hostID)
-		if err != nil {
-			return fmt.Errorf("failed to count pinned sectors: %w", err)
-		}
-
 		// unpin all sectors by setting contract_sectors_map_id to NULL and
 		// updating uploaded_at to prevent MarkSectorsUnpinnable from immediately
 		// marking them as unpinnable
-		_, err = tx.Exec(ctx, `UPDATE sectors SET contract_sectors_map_id = NULL, uploaded_at = NOW() WHERE contract_sectors_map_id = $1`, contractMapID)
+		res, err := tx.Exec(ctx, `UPDATE sectors SET contract_sectors_map_id = NULL, uploaded_at = NOW() WHERE contract_sectors_map_id = $1`, contractMapID)
 		if err != nil {
 			return fmt.Errorf("failed to unpin sectors: %w", err)
 		}
@@ -761,7 +754,13 @@ func (s *Store) DeleteContract(contractID types.FileContractID) error {
 		}
 
 		// update stats
-		if pinned > 0 {
+		if pinned := res.RowsAffected(); pinned > 0 {
+			var hostID int64
+			err = tx.QueryRow(ctx, `SELECT host_id FROM contracts WHERE contract_id = $1`, sqlHash256(contractID)).Scan(&hostID)
+			if err != nil {
+				return fmt.Errorf("failed to get host ID: %w", err)
+			}
+
 			if err := incrementNumPinnedSectors(ctx, tx, -pinned); err != nil {
 				return fmt.Errorf("failed to update pinned sectors stat: %w", err)
 			} else if err := incrementNumUnpinnedSectors(ctx, tx, pinned); err != nil {

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -744,4 +744,44 @@ ALTER TABLE app_connect_keys DROP COLUMN remaining_uses;
 
 		return nil
 	},
+	// reset stats
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		if _, err := tx.Exec(ctx, `
+		WITH counts AS (
+			SELECT
+				COUNT(*) FILTER (WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NOT NULL)::bigint AS pinned,
+				COUNT(*) FILTER (WHERE host_id IS NOT NULL AND contract_sectors_map_id IS NULL)::bigint     AS unpinned,
+				COUNT(*) FILTER (WHERE host_id IS NULL     AND contract_sectors_map_id IS NULL)::bigint     AS unpinnable
+			FROM sectors
+		)
+		UPDATE stats s
+		SET
+			num_pinned_sectors     = counts.pinned,
+			num_unpinned_sectors   = counts.unpinned,
+			num_unpinnable_sectors = counts.unpinnable
+		FROM counts`); err != nil {
+			return fmt.Errorf("failed to reset sector stats: %w", err)
+		}
+
+		_, err := tx.Exec(ctx, `
+			UPDATE hosts h
+			SET unpinned_sectors = COALESCE(sub.cnt, 0)
+			FROM (
+				SELECT host_id, COUNT(*) as cnt
+				FROM sectors
+				WHERE contract_sectors_map_id IS NULL
+				GROUP BY host_id
+			) sub
+			WHERE h.id = sub.host_id;
+
+			UPDATE hosts
+			SET unpinned_sectors = 0
+			WHERE id NOT IN (
+				SELECT DISTINCT host_id
+				FROM sectors
+				WHERE contract_sectors_map_id IS NULL
+			);
+		`)
+		return err
+	},
 }

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -769,7 +769,7 @@ ALTER TABLE app_connect_keys DROP COLUMN remaining_uses;
 			FROM (
 				SELECT host_id, COUNT(*) as cnt
 				FROM sectors
-				WHERE contract_sectors_map_id IS NULL
+				WHERE contract_sectors_map_id IS NULL AND host_id IS NOT NULL
 				GROUP BY host_id
 			) sub
 			WHERE h.id = sub.host_id;
@@ -779,7 +779,7 @@ ALTER TABLE app_connect_keys DROP COLUMN remaining_uses;
 			WHERE id NOT IN (
 				SELECT DISTINCT host_id
 				FROM sectors
-				WHERE contract_sectors_map_id IS NULL
+				WHERE contract_sectors_map_id IS NULL AND host_id IS NOT NULL
 			);
 		`)
 		return err

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -851,7 +851,9 @@ func (s *Store) MigrateSector(root types.Hash256, hostKey types.PublicKey) (migr
 		err := tx.QueryRow(ctx, `
 			SELECT id, host_id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = $1`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
+			WHERE sector_root = $1
+			FOR UPDATE
+		`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // not migrated
 		} else if err != nil {

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -851,8 +851,7 @@ func (s *Store) MigrateSector(root types.Hash256, hostKey types.PublicKey) (migr
 		err := tx.QueryRow(ctx, `
 			SELECT id, host_id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = $1
-			FOR UPDATE`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
+			WHERE sector_root = $1`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // not migrated
 		} else if err != nil {

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -683,7 +683,21 @@ func (s *Store) PinSectors(contractID types.FileContractID, roots []types.Hash25
 // MarkSectorsUnpinnable sets the host ID for sectors that haven't been pinned
 // by the threshold time to NULL.
 func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
+	const batchSize = 1000
+	for {
+		done, err := s.markSectorsUnpinnableBatch(threshold, batchSize)
+		if err != nil {
+			return err
+		} else if done {
+			return nil
+		}
+	}
+}
+
+func (s *Store) markSectorsUnpinnableBatch(threshold time.Time, limit uint64) (bool, error) {
+	var done bool
 	err := s.transaction(func(ctx context.Context, tx *txn) error {
+		done = false // reset on retry
 		rows, err := tx.Query(ctx, `
 			WITH selected AS (
 				SELECT id, host_id
@@ -691,6 +705,7 @@ func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
 				WHERE host_id IS NOT NULL
 					AND contract_sectors_map_id IS NULL
 					AND uploaded_at <= $1
+				LIMIT $2
 				FOR UPDATE
 			), updated AS (
 				UPDATE sectors s
@@ -699,7 +714,7 @@ func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
 				WHERE s.id = selected.id
 				RETURNING selected.host_id
 			)
-			SELECT host_id, COUNT(*) FROM updated GROUP BY host_id`, threshold)
+			SELECT host_id, COUNT(*) FROM updated GROUP BY host_id`, threshold, limit)
 		if err != nil {
 			return fmt.Errorf("failed to prune unpinnable sectors: %w", err)
 		}
@@ -718,6 +733,7 @@ func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
 		if err := rows.Err(); err != nil {
 			return err
 		} else if totalUnpinnable == 0 {
+			done = true
 			return nil
 		}
 
@@ -730,7 +746,7 @@ func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
 		}
 		return nil
 	})
-	return err
+	return done, err
 }
 
 // UnpinnedSectors returns up to 'limit' sectors which have been uploaded to a host but

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -47,7 +47,8 @@ func (s *Store) MarkSectorsLost(hostKey types.PublicKey, roots []types.Hash256) 
 		rows, err := tx.Query(ctx, `
 			SELECT id, contract_sectors_map_id
 			FROM sectors
-			WHERE host_id = $1 AND sector_root = ANY($2)`, hostID, sqlRoots)
+			WHERE host_id = $1 AND sector_root = ANY($2)
+			FOR UPDATE`, hostID, sqlRoots)
 		if err != nil {
 			return fmt.Errorf("failed to query sectors: %w", err)
 		}
@@ -185,6 +186,7 @@ func (s *Store) markFailingSectorsLostBatch(hostKey types.PublicKey, maxChecks, 
 			FROM sectors
 			WHERE host_id = $1 AND consecutive_failed_checks >= $2
 			LIMIT $3
+			FOR UPDATE
 		`, hostID, maxChecks, batchSize)
 		if err != nil {
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
@@ -648,7 +650,8 @@ func (s *Store) PinSectors(contractID types.FileContractID, roots []types.Hash25
 		rows, err := tx.Query(ctx, `
 			SELECT id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = ANY($1) AND (contract_sectors_map_id IS NULL OR contract_sectors_map_id != $2)`, sqlRoots, contractMapID)
+			WHERE sector_root = ANY($1) AND (contract_sectors_map_id IS NULL OR contract_sectors_map_id != $2)
+			FOR UPDATE`, sqlRoots, contractMapID)
 		if err != nil {
 			return fmt.Errorf("failed to query sectors: %w", err)
 		}
@@ -688,6 +691,7 @@ func (s *Store) MarkSectorsUnpinnable(threshold time.Time) error {
 				WHERE host_id IS NOT NULL
 					AND contract_sectors_map_id IS NULL
 					AND uploaded_at <= $1
+				FOR UPDATE
 			), updated AS (
 				UPDATE sectors s
 				SET host_id = NULL, consecutive_failed_checks = 0
@@ -847,7 +851,8 @@ func (s *Store) MigrateSector(root types.Hash256, hostKey types.PublicKey) (migr
 		err := tx.QueryRow(ctx, `
 			SELECT id, host_id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = $1`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
+			WHERE sector_root = $1
+			FOR UPDATE`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // not migrated
 		} else if err != nil {


### PR DESCRIPTION
I ran into a few of these on Zeus:

```
{"level":"debug","ts":"2026-02-18T09:39:20Z","logger":"slabs.integrity","caller":"slabs/dataintegrity.go:77","msg":"performed integrity checks","hostKey":"ed25519:4489f1744948a981035f901217976bb407bbdc7cf8b913b7003708a49d055699","lost":0,"failed":0,"successful":1000}
```

The problem was probably caused by a host being blocked, triggering a huge update of unpinnable sectors. Looking at PostgreSQLs default transaction read isolation level it probably stems from selecting a lot of rows we want to update matching certain conditions (e.g. host_id IT NOT NULL) and then updating these rows without them being locked.

There are 2 options to fix this which this PR makes use of:
1. avoid select followed by an update by using `UPDATE ... RETURNING` 
2. when 1. doesn't work use `SELECT ... FOR UPDATE` before the actual `UPDATE` call