### PR TITLE
Split maintenance up into multiple loops

### DIFF
--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -21,11 +21,6 @@ const (
 	AccountFundBatch = proto.MaxAccountBatchSize
 	// AccountFundInterval is how often we will fund host accounts.
 	AccountFundInterval = time.Hour
-	// AccountExpBackoffMaxMinutes represents the maximum interval there can be
-	// between two funding attempts for a host.  If a funding attempt fails,
-	// repeatedly there is exponential backoff capped at
-	// AccountExpBackoffMaxMinutes minutes.
-	AccountExpBackoffMaxMinutes = 128
 	// AccountActivityThreshold is the threshold for determining whether an
 	// account has been active recently for the purposes of contract funding.
 	// An account is considered active if it has been used within the threshold
@@ -162,7 +157,7 @@ func (m *AccountManager) ServiceAccounts(hk types.PublicKey) []HostAccount {
 // UpdateFundedAccounts marks in-place the first `n` accounts as having a
 // successful funding and applies the exponential backoff penalty to the
 // accounts after the first `n`.
-func UpdateFundedAccounts(accounts []HostAccount, n int) {
+func UpdateFundedAccounts(accounts []HostAccount, n int, maxBackoff time.Duration) {
 	if n > len(accounts) {
 		panic("illegal number of funded accounts") // developer error
 	}
@@ -172,7 +167,7 @@ func UpdateFundedAccounts(accounts []HostAccount, n int) {
 	}
 	for i := n; i < len(accounts); i++ {
 		accounts[i].ConsecutiveFailedFunds++
-		accounts[i].NextFund = time.Now().Add(time.Duration(min(math.Pow(2, float64(accounts[i].ConsecutiveFailedFunds)), AccountExpBackoffMaxMinutes)) * time.Minute)
+		accounts[i].NextFund = time.Now().Add(min(time.Duration(math.Pow(2, float64(accounts[i].ConsecutiveFailedFunds)))*time.Minute, maxBackoff))
 	}
 }
 

--- a/accounts/manager_test.go
+++ b/accounts/manager_test.go
@@ -30,6 +30,7 @@ func newTestStore(t testing.TB) testStore {
 // and next fund time are updated correctly based on the number of funded
 // accounts.
 func TestUpdateFundedAccounts(t *testing.T) {
+	maxBackoff := 128 * time.Minute
 	tests := []struct {
 		name   string
 		accs   []accounts.HostAccount
@@ -80,12 +81,12 @@ func TestUpdateFundedAccounts(t *testing.T) {
 						t.Errorf("expected panic but function did not panic")
 					}
 				}()
-				accounts.UpdateFundedAccounts(tc.accs, tc.funded)
+				accounts.UpdateFundedAccounts(tc.accs, tc.funded, maxBackoff)
 				return
 			}
 
 			updated := slices.Clone(tc.accs)
-			accounts.UpdateFundedAccounts(updated, tc.funded)
+			accounts.UpdateFundedAccounts(updated, tc.funded, maxBackoff)
 
 			for i, acc := range updated {
 				// calculate expected values
@@ -96,7 +97,7 @@ func TestUpdateFundedAccounts(t *testing.T) {
 					wantNextFund = time.Now().Add(accounts.AccountFundInterval)
 				} else {
 					wantConsecFailures = tc.accs[i].ConsecutiveFailedFunds + 1
-					wantNextFund = time.Now().Add(time.Duration(min(math.Pow(2, float64(wantConsecFailures)), accounts.AccountExpBackoffMaxMinutes)) * time.Minute)
+					wantNextFund = time.Now().Add(min(time.Duration(math.Pow(2, float64(wantConsecFailures)))*time.Minute, maxBackoff))
 				}
 
 				// assert updates

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -54,8 +54,6 @@ type (
 	// to ensure the account is funded as soon as possible.
 	ContractManager interface {
 		TriggerAccountFunding(force bool) error
-		TriggerContractPruning() error
-		TriggerMaintenance()
 
 		MaintenanceSettings(ctx context.Context) (contracts.MaintenanceSettings, error)
 		UpdateMaintenanceSettings(ctx context.Context, ms contracts.MaintenanceSettings) error
@@ -285,7 +283,6 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 	// debug endpoints
 	if a.debug {
 		routes["GET /debug/pprof/:handler"] = a.handleGETPProf
-		routes["POST /debug/trigger/:action"] = a.handlePOSTTrigger
 	}
 
 	return jape.Mux(routes)
@@ -325,32 +322,6 @@ func (a *admin) handleGETPProf(jc jape.Context) {
 	default:
 		pprof.Index(jc.ResponseWriter, jc.Request)
 	}
-}
-
-func (a *admin) handlePOSTTrigger(jc jape.Context) {
-	var action string
-	if jc.DecodeParam("action", &action) != nil {
-		return
-	}
-
-	switch action {
-	case "funding":
-		err := a.contracts.TriggerAccountFunding(true)
-		if jc.Check("failed to trigger account funding", err) != nil {
-			return
-		}
-	case "maintenance":
-		a.contracts.TriggerMaintenance()
-	case "pruning":
-		a.contracts.TriggerContractPruning()
-	case "scanning":
-		a.hosts.TriggerHostScanning()
-	default:
-		jc.Error(fmt.Errorf("unknown action: %q, available actions are 'funding', 'maintenance', 'pruning' or 'scanning'", action), http.StatusBadRequest)
-		return
-	}
-
-	jc.Encode(nil)
 }
 
 func (a *admin) handleGETAppConnectKeys(jc jape.Context) {

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -310,13 +310,6 @@ func (c *Client) SettingsPricePinningUpdate(ctx context.Context, s pins.PinnedSe
 	return
 }
 
-// TriggerAction triggers an action on the indexer. The action must be one of
-// the following values: 'funding', 'maintenance' or 'scanning'.
-func (c *Client) TriggerAction(ctx context.Context, action string) (err error) {
-	err = c.c.POST(ctx, fmt.Sprintf("/debug/trigger/%s", action), nil, nil)
-	return
-}
-
 // Wallet returns the state of the wallet.
 func (c *Client) Wallet(ctx context.Context) (resp WalletResponse, err error) {
 	err = c.c.GET(ctx, "/wallet", &resp)

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -26,6 +26,7 @@ import (
 	"go.sia.tech/indexd/subscriber"
 	"go.sia.tech/indexd/testutils"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"lukechampine.com/frand"
 )
 
@@ -142,7 +143,7 @@ func uploadRandomSlab(t testing.TB, client *client.Client, sk types.PrivateKey, 
 func TestApplicationAPI(t *testing.T) {
 	ctx := t.Context()
 	// create cluster with three hosts
-	logger := zap.NewNop()
+	logger := zaptest.NewLogger(t)
 	cluster := testutils.NewCluster(t, testutils.WithHosts(10), testutils.WithLogger(logger))
 	indexer := cluster.Indexer
 	adminClient := indexer.Admin

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -119,6 +119,17 @@ func uploadRandomSlab(t testing.TB, client *client.Client, sk types.PrivateKey, 
 		var sector [proto.SectorSize]byte
 		frand.Read(sector[:])
 
+		// wait for account to be funded
+		for i := 0; i < 10; i++ {
+			balance, err := client.AccountBalance(context.Background(), h.PublicKey, proto.Account(sk.PublicKey()))
+			if err != nil {
+				t.Fatal("failed to obtain account balance:", err)
+			} else if !balance.IsZero() {
+				break // funded
+			}
+			time.Sleep(time.Second)
+		}
+
 		// upload sector
 		hk := h.PublicKey
 		if result, err := client.WriteSector(context.Background(), sk, hk, sector[:]); err != nil {

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -104,6 +104,8 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 		t.Fatal("expected app to be authenticated")
 	}
 
+	// wait for account to be funded
+	cluster.WaitForAccountFunding(t, proto.Account(sk.PublicKey()))
 	return sk, key
 }
 
@@ -118,17 +120,6 @@ func uploadRandomSlab(t testing.TB, client *client.Client, sk types.PrivateKey, 
 		// prepare sector data
 		var sector [proto.SectorSize]byte
 		frand.Read(sector[:])
-
-		// wait for account to be funded
-		for i := 0; i < 10; i++ {
-			balance, err := client.AccountBalance(context.Background(), h.PublicKey, proto.Account(sk.PublicKey()))
-			if err != nil {
-				t.Fatal("failed to obtain account balance:", err)
-			} else if !balance.IsZero() {
-				break // funded
-			}
-			time.Sleep(time.Second)
-		}
 
 		// upload sector
 		hk := h.PublicKey

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -144,7 +144,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	rev := contracts.NewRevisionManager(client, cm, store, contracts.DefaultRevisionSubmissionBuffer, log.Named("revision"))
 	cl := contracts.NewContractLocker()
 	f := contracts.NewFunder(client, cl, rev, signer, cm, log.Named("funder"))
-	contracts, err := contracts.NewManager(walletKey, am, f, cm, store, client, signer, rev, hm, s, wm, contracts.WithLogger(log.Named("contracts")))
+	contracts, err := contracts.NewManager(walletKey, am, f, cm, store, client, signer, rev, cl, hm, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)
 	}

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -142,7 +142,8 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	defer am.Close()
 
 	rev := contracts.NewRevisionManager(client, cm, store, contracts.DefaultRevisionSubmissionBuffer, log.Named("revision"))
-	f := contracts.NewFunder(client, rev, signer, cm, log.Named("funder"))
+	cl := contracts.NewContractLocker()
+	f := contracts.NewFunder(client, cl, rev, signer, cm, log.Named("funder"))
 	contracts, err := contracts.NewManager(walletKey, am, f, cm, store, client, signer, rev, hm, s, wm, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		return fmt.Errorf("failed to create contracts manager: %w", err)

--- a/contracts/broadcast_test.go
+++ b/contracts/broadcast_test.go
@@ -18,7 +18,7 @@ func TestBroadcastContractRevisions(t *testing.T) {
 	walletMock := &walletMock{}
 	store := newTestStore(t)
 
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, nil, nil, nil, nil, syncerMock, walletMock)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, nil, nil, nil, contracts.NewContractLocker(), nil, syncerMock, walletMock)
 	cm.SetRevisionBroadcastInterval(time.Minute)
 
 	// add host

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -406,8 +406,8 @@ func (ts testStore) hostAccounts(t testing.TB) (result []accounts.HostAccount) {
 	return
 }
 
-// scheduleContractsForPruningHelper marks all contracts as ready for pruning (test helper).
-func (ts testStore) scheduleContractsForPruningHelper(t testing.TB) {
+// scheduleContractsForPruning marks all contracts as ready for pruning.
+func (ts testStore) scheduleContractsForPruning(t testing.TB) {
 	t.Helper()
 
 	// set next_prune to past so ContractsForPruning (next_prune < NOW()) returns them

--- a/contracts/chain_test.go
+++ b/contracts/chain_test.go
@@ -648,7 +648,7 @@ func (w *walletMock) ReleaseInputs(txns []types.Transaction, v2txns []types.V2Tr
 func (w *walletMock) SignV2Inputs(txn *types.V2Transaction, toSign []int)                  {}
 
 func TestApplyRevertDiff(t *testing.T) {
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, nil, nil, nil, nil, nil, contracts.NewContractLocker(), nil, nil, nil)
 
 	// create a contract
 	contractID := types.FileContractID{1, 2, 3}
@@ -797,7 +797,7 @@ func TestProcessActions(t *testing.T) {
 	cmMock := newChainManagerMock()
 	syncerMock := &syncerMock{}
 	walletMock := &walletMock{}
-	cm := contracts.NewTestContractManager(types.PublicKey{}, amMock, nil, cmMock, store, nil, nil, nil, nil, syncerMock, walletMock)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, amMock, nil, cmMock, store, nil, nil, nil, contracts.NewContractLocker(), nil, syncerMock, walletMock)
 
 	contract := types.V2FileContractElement{
 		ID: types.FileContractID{1},
@@ -860,7 +860,7 @@ func TestProcessActions(t *testing.T) {
 }
 
 func TestApplyRevertRenewedTo(t *testing.T) {
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, nil, nil, nil, nil, nil, contracts.NewContractLocker(), nil, nil, nil)
 
 	// create a contract
 	contractID := types.FileContractID{1, 2, 3}

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -173,12 +173,11 @@ func TestContractPruning(t *testing.T) {
 	time.Sleep(time.Second)
 	assertRoots()
 
-	// unpin the 3rd slab and trigger pruning
+	// unpin the 3rd slab
 	if err := indexer.App.UnpinSlab(t.Context(), sk, slabIDs[2]); err != nil {
 		t.Fatal(err)
-	} else if err = indexer.Contracts().TriggerContractPruning(); err != nil {
-		t.Fatal(err)
 	}
+	time.Sleep(time.Second)
 
 	// remove the 3rd slab's roots from the expected roots (swap and pop)
 	for hk := range expectedRoots {

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -177,7 +177,10 @@ func TestContractPruning(t *testing.T) {
 	if err := indexer.App.UnpinSlab(t.Context(), sk, slabIDs[2]); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(time.Second)
+	_, err = indexer.Store().Exec(t.Context(), "UPDATE contracts SET next_prune = NOW()")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// remove the 3rd slab's roots from the expected roots (swap and pop)
 	for hk := range expectedRoots {

--- a/contracts/form.go
+++ b/contracts/form.go
@@ -155,13 +155,17 @@ func (cm *ContractManager) refreshContract(ctx context.Context, contract Contrac
 		}
 
 		duration := contract.ExpirationHeight - host.Settings.Prices.TipHeight
-		allowance, collateral := contractFunding(host.Settings, contract.Size, fundTarget, duration)
+
+		lc, unlock := cm.cl.LockContract(contract.ID)
+		defer unlock()
 
 		var res rhp.RPCRefreshContractResult
-		err := cm.rev.WithRevision(refreshCtx, contract.ID, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+		err := cm.rev.WithRevision(refreshCtx, lc, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 			if host.Settings.ProtocolVersion.Cmp(rhp.ProtocolVersion500) < 0 {
 				return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("host does not support contract refresh, protocol version %s < %s", host.Settings.ProtocolVersion, rhp.ProtocolVersion500)
 			}
+
+			allowance, collateral := contractFunding(host.Settings, rev.Revision.Filesize, fundTarget, duration)
 
 			cappedCollateral := collateral
 			var totalCollateral types.Currency

--- a/contracts/form_test.go
+++ b/contracts/form_test.go
@@ -480,7 +480,7 @@ func TestPerformContractFormation(t *testing.T) {
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	cm := contracts.NewTestContractManager(renterKey, amMock, nil, cmMock, store, mock, nil, rev, hm, syncerMock, wallet)
+	cm := contracts.NewTestContractManager(renterKey, amMock, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hm, syncerMock, wallet)
 
 	assertGoodContracts := func(goodCount, formations, refreshes int) {
 		t.Helper()

--- a/contracts/fund_test.go
+++ b/contracts/fund_test.go
@@ -99,7 +99,7 @@ func TestPerformAccountFunding(t *testing.T) {
 	funderMock := &accountFunderMock{}
 	store := newTestStore(t)
 	hmMock := newHostManagerMock(store)
-	cm := contracts.NewTestContractManager(types.PublicKey{}, amMock, funderMock, nil, store, nil, nil, nil, hmMock, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, amMock, funderMock, nil, store, nil, nil, nil, contracts.NewContractLocker(), hmMock, nil, nil)
 
 	// fund accounts
 	err := cm.PerformAccountFunding(context.Background(), false, zap.NewNop())

--- a/contracts/funder.go
+++ b/contracts/funder.go
@@ -69,58 +69,63 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 
 	// iterate over contracts
 	for _, contractID := range contractIDs {
-		contractLog := log.With(zap.Stringer("contractID", contractID))
+		done, err := func() (bool, error) {
+			contractLog := log.With(zap.Stringer("contractID", contractID))
 
-		lc, unlock := f.locker.TryLockContract(contractID)
-		if lc == nil {
-			contractLog.Debug("ignoring locked contract for funding")
-			continue
-		}
-		defer unlock()
-
-		var res rhp.RPCReplenishAccountsResult
-		var err error
-		err = f.rev.WithRevision(ctx, lc, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
-			if contract.Revision.RenterOutput.Value.Cmp(target) < 0 {
-				return rhp.ContractRevision{}, proto.Usage{}, ErrContractInsufficientFunds
+			lc, unlock := f.locker.TryLockContract(contractID)
+			if lc == nil {
+				contractLog.Debug("ignoring locked contract for funding")
+				return false, nil
 			}
+			defer unlock()
 
-			batchSize := int(max(1, min(contract.Revision.RenterOutput.Value.Div(target).Big().Uint64(), proto.MaxAccountBatchSize)))
-			maxEnd := min(len(accountKeys), funded+batchSize)
-			// execute replenish RPC
-			res, err = f.client.ReplenishAccounts(ctx, f.signer, f.chain, rhp.RPCReplenishAccountsParams{
-				Accounts: accountKeys[funded:maxEnd],
-				Target:   target,
-				Contract: contract,
+			var res rhp.RPCReplenishAccountsResult
+			var err error
+			err = f.rev.WithRevision(ctx, lc, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+				if contract.Revision.RenterOutput.Value.Cmp(target) < 0 {
+					return rhp.ContractRevision{}, proto.Usage{}, ErrContractInsufficientFunds
+				}
+
+				batchSize := int(max(1, min(contract.Revision.RenterOutput.Value.Div(target).Big().Uint64(), proto.MaxAccountBatchSize)))
+				maxEnd := min(len(accountKeys), funded+batchSize)
+				// execute replenish RPC
+				res, err = f.client.ReplenishAccounts(ctx, f.signer, f.chain, rhp.RPCReplenishAccountsParams{
+					Accounts: accountKeys[funded:maxEnd],
+					Target:   target,
+					Contract: contract,
+				})
+				if err != nil {
+					return rhp.ContractRevision{}, proto.Usage{}, err
+				}
+				funded = maxEnd
+				return rhp.ContractRevision{
+					ID:       contractID,
+					Revision: res.Revision,
+				}, res.Usage, nil
 			})
-			if err != nil {
-				return rhp.ContractRevision{}, proto.Usage{}, err
+			if errors.Is(err, ErrContractInsufficientFunds) {
+				contractLog.Debug("contract has insufficient funds", zap.Error(err))
+				drained++
+				return false, nil
+			} else if errors.Is(err, ErrContractNotRevisable) {
+				contractLog.Debug("contract is not revisable", zap.Error(err)) // sanity check
+				drained++
+				return false, nil
+			} else if err != nil {
+				contractLog.Debug("failed to replenish accounts", zap.Error(err))
+				return false, nil
+			} else if res.Revision.RemainingAllowance().Cmp(target) < 0 {
+				contractLog.Debug("contract was drained by replenish RPC",
+					zap.Stringer("remainingAllowance", res.Revision.RemainingAllowance()),
+					zap.Stringer("target", target))
+				drained++
 			}
-			funded = maxEnd
-			return rhp.ContractRevision{
-				ID:       contractID,
-				Revision: res.Revision,
-			}, res.Usage, nil
-		})
-		if errors.Is(err, ErrContractInsufficientFunds) {
-			contractLog.Debug("contract has insufficient funds", zap.Error(err))
-			drained++
-			continue
-		} else if errors.Is(err, ErrContractNotRevisable) {
-			contractLog.Debug("contract is not revisable", zap.Error(err)) // sanity check
-			drained++
-			continue
-		} else if err != nil {
-			contractLog.Debug("failed to replenish accounts", zap.Error(err))
-			continue
-		} else if res.Revision.RemainingAllowance().Cmp(target) < 0 {
-			contractLog.Debug("contract was drained by replenish RPC",
-				zap.Stringer("remainingAllowance", res.Revision.RemainingAllowance()),
-				zap.Stringer("target", target))
-			drained++
-		}
 
-		if funded == len(accountKeys) {
+			return funded == len(accountKeys), nil
+		}()
+		if err != nil {
+			return 0, 0, err
+		} else if done {
 			break
 		}
 	}

--- a/contracts/funder.go
+++ b/contracts/funder.go
@@ -23,6 +23,7 @@ type (
 	// Funder dials a host and replenish a set of ephemeral accounts.
 	Funder struct {
 		client FunderHostClient
+		locker *ContractLocker
 		signer rhp.ContractSigner
 		chain  ChainManager
 		rev    *RevisionManager
@@ -32,9 +33,10 @@ type (
 )
 
 // NewFunder creates a new Funder.
-func NewFunder(client FunderHostClient, rev *RevisionManager, signer rhp.ContractSigner, chain ChainManager, log *zap.Logger) *Funder {
+func NewFunder(client FunderHostClient, cl *ContractLocker, rev *RevisionManager, signer rhp.ContractSigner, chain ChainManager, log *zap.Logger) *Funder {
 	return &Funder{
 		client: client,
+		locker: cl,
 		signer: signer,
 		chain:  chain,
 		rev:    rev,
@@ -69,9 +71,16 @@ func (f *Funder) FundAccounts(ctx context.Context, host hosts.Host, contractIDs 
 	for _, contractID := range contractIDs {
 		contractLog := log.With(zap.Stringer("contractID", contractID))
 
+		lc, unlock := f.locker.TryLockContract(contractID)
+		if lc == nil {
+			contractLog.Debug("ignoring locked contract for funding")
+			continue
+		}
+		defer unlock()
+
 		var res rhp.RPCReplenishAccountsResult
 		var err error
-		err = f.rev.WithRevision(ctx, contractID, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+		err = f.rev.WithRevision(ctx, lc, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 			if contract.Revision.RenterOutput.Value.Cmp(target) < 0 {
 				return rhp.ContractRevision{}, proto.Usage{}, ErrContractInsufficientFunds
 			}

--- a/contracts/funder_test.go
+++ b/contracts/funder_test.go
@@ -112,7 +112,8 @@ func TestFunder(t *testing.T) {
 
 	// prepare funder
 	rev := NewRevisionManager(hc, &mockChainManager{}, &mockStore{target: target}, 1, zap.NewNop())
-	f := NewFunder(hc, rev, nil, &mockChainManager{}, zap.NewNop())
+	cl := NewContractLocker()
+	f := NewFunder(hc, cl, rev, nil, &mockChainManager{}, zap.NewNop())
 
 	// assert contract is marked as drained if it is out of funds
 	funded, drained, err := f.FundAccounts(context.Background(), host, []types.FileContractID{{1}}, accs, target, zap.NewNop())

--- a/contracts/funding.go
+++ b/contracts/funding.go
@@ -93,7 +93,7 @@ OUTER:
 			}
 
 			// update funded accounts
-			accounts.UpdateFundedAccounts(accs, funded)
+			accounts.UpdateFundedAccounts(accs, funded, cm.maxAccountFundingBackoff)
 			err = cm.accounts.UpdateHostAccounts(accs)
 			if err != nil {
 				return fmt.Errorf("failed to update accounts: %w", err)

--- a/contracts/funding_test.go
+++ b/contracts/funding_test.go
@@ -70,7 +70,7 @@ func TestFunding(t *testing.T) {
 	}
 	defer hm.Close()
 
-	cm, err := contracts.NewManager(types.GeneratePrivateKey(), am, f, chain.NewManager(dbstore, tipState), s, nil, nil, nil, hm, nil, nil, contracts.WithLogger(log.Named("contracts")))
+	cm, err := contracts.NewManager(types.GeneratePrivateKey(), am, f, chain.NewManager(dbstore, tipState), s, nil, nil, nil, contracts.NewContractLocker(), hm, nil, nil, contracts.WithLogger(log.Named("contracts")))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/contracts/locking.go
+++ b/contracts/locking.go
@@ -1,0 +1,90 @@
+package contracts
+
+import (
+	"sync"
+
+	"go.sia.tech/core/types"
+)
+
+type ContractLocker struct {
+	mu              sync.Mutex
+	lockedContracts map[types.FileContractID]*LockedContract
+}
+
+// LockedContract represents a contract that is currently locked. A locked
+// contract can be obtained by calling lockContract or tryLockContract on the
+// ContractManager. The contract is unlocked by calling the function returned by
+// those methods.
+// Methods that operate on a locked contract should accept a *LockedContract as
+// an argument to make sure it can never be called without locking the contract
+// first.
+type LockedContract struct {
+	id types.FileContractID
+	mu sync.Mutex // used to acquire contract
+
+	refcount int // locked by ContractManager.lockedContractsMu
+}
+
+// NewContractLocker creates a new ContractLocker.
+func NewContractLocker() *ContractLocker {
+	return &ContractLocker{
+		lockedContracts: make(map[types.FileContractID]*LockedContract),
+	}
+}
+
+// LockContract locks the contract with the given ID and returns a function to
+// unlock it. If the contract is already locked, it blocks until it can acquire
+// the lock.
+func (cl *ContractLocker) LockContract(contractID types.FileContractID) (*LockedContract, func()) {
+	cl.mu.Lock()
+	lc, exists := cl.lockedContracts[contractID]
+	if !exists {
+		lc = &LockedContract{
+			id: contractID,
+		}
+		cl.lockedContracts[contractID] = lc
+	}
+	lc.refcount++
+	cl.mu.Unlock()
+
+	lc.mu.Lock()
+	return lc, func() {
+		lc.mu.Unlock()
+
+		cl.mu.Lock()
+		lc.refcount--
+		if lc.refcount == 0 {
+			delete(cl.lockedContracts, contractID)
+		}
+		cl.mu.Unlock()
+	}
+}
+
+// TryLockContract tries to lock the contract with the given ID and returns a
+// function to unlock it. If the contract is already locked, it returns nil and
+// does not block.
+func (cl *ContractLocker) TryLockContract(contractID types.FileContractID) (*LockedContract, func()) {
+	cl.mu.Lock()
+	_, exists := cl.lockedContracts[contractID]
+	if exists {
+		return nil, nil
+	}
+	lc := &LockedContract{
+		id:       contractID,
+		refcount: 1,
+	}
+	lc.mu.Lock()
+	cl.lockedContracts[contractID] = lc
+	cl.mu.Unlock()
+
+	return lc, func() {
+		lc.mu.Unlock()
+
+		cl.mu.Lock()
+		lc.refcount--
+		if lc.refcount == 0 {
+			delete(cl.lockedContracts, contractID)
+		}
+		cl.mu.Unlock()
+	}
+}

--- a/contracts/locking.go
+++ b/contracts/locking.go
@@ -6,6 +6,8 @@ import (
 	"go.sia.tech/core/types"
 )
 
+// ContractLocker manages locks for contracts. It allows locking a contract by
+// its ID and ensures that only one lock can be held for a contract at a time.
 type ContractLocker struct {
 	mu              sync.Mutex
 	lockedContracts map[types.FileContractID]*LockedContract

--- a/contracts/locking.go
+++ b/contracts/locking.go
@@ -67,6 +67,7 @@ func (cl *ContractLocker) TryLockContract(contractID types.FileContractID) (*Loc
 	cl.mu.Lock()
 	_, exists := cl.lockedContracts[contractID]
 	if exists {
+		cl.mu.Unlock()
 		return nil, nil
 	}
 	lc := &LockedContract{

--- a/contracts/locking.go
+++ b/contracts/locking.go
@@ -24,7 +24,7 @@ type LockedContract struct {
 	id types.FileContractID
 	mu sync.Mutex // used to acquire contract
 
-	refcount int // locked by ContractManager.lockedContractsMu
+	refcount int // locked by ContractLocker.mu
 }
 
 // NewContractLocker creates a new ContractLocker.

--- a/contracts/locking_test.go
+++ b/contracts/locking_test.go
@@ -1,0 +1,161 @@
+package contracts
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/types"
+)
+
+func TestContractLockerLockUnlock(t *testing.T) {
+	cl := NewContractLocker()
+	id := types.FileContractID{1}
+
+	// lock and unlock
+	lc, unlock := cl.LockContract(id)
+	if lc == nil {
+		t.Fatal("expected non-nil LockedContract")
+	}
+	unlock()
+
+	// after unlock the map should be empty
+	cl.mu.Lock()
+	if len(cl.lockedContracts) != 0 {
+		t.Fatal("expected no locked contracts after unlock")
+	}
+	cl.mu.Unlock()
+}
+
+func TestContractLockerLockBlocks(t *testing.T) {
+	cl := NewContractLocker()
+	id := types.FileContractID{2}
+
+	_, unlock1 := cl.LockContract(id)
+
+	acquired := make(chan struct{})
+	go func() {
+		_, unlock2 := cl.LockContract(id)
+		close(acquired)
+		unlock2()
+	}()
+
+	// the second lock should be blocked
+	select {
+	case <-acquired:
+		t.Fatal("second LockContract should block while first is held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// unlock first, second should proceed
+	unlock1()
+
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second LockContract should have acquired after first unlock")
+	}
+
+	// map should be clean
+	cl.mu.Lock()
+	if len(cl.lockedContracts) != 0 {
+		t.Fatal("expected no locked contracts")
+	}
+	cl.mu.Unlock()
+}
+
+func TestContractLockerDifferentContracts(t *testing.T) {
+	cl := NewContractLocker()
+	id1 := types.FileContractID{1}
+	id2 := types.FileContractID{2}
+
+	// locking different contracts should not block each other
+	_, unlock1 := cl.LockContract(id1)
+	_, unlock2 := cl.LockContract(id2)
+
+	unlock1()
+	unlock2()
+}
+
+func TestTryLockContract(t *testing.T) {
+	cl := NewContractLocker()
+	id := types.FileContractID{3}
+
+	// try lock on unlocked contract should succeed
+	lc, unlock := cl.TryLockContract(id)
+	if lc == nil {
+		t.Fatal("expected non-nil LockedContract")
+	}
+
+	unlock()
+
+	// map should be clean after unlock
+	cl.mu.Lock()
+	if len(cl.lockedContracts) != 0 {
+		t.Fatal("expected no locked contracts after unlock")
+	}
+	cl.mu.Unlock()
+}
+
+func TestTryLockContractAlreadyLocked(t *testing.T) {
+	cl := NewContractLocker()
+	id := types.FileContractID{4}
+
+	// lock with LockContract first
+	_, unlock := cl.LockContract(id)
+
+	// TryLockContract on same ID should fail
+	lc, tryUnlock := cl.TryLockContract(id)
+	if lc != nil || tryUnlock != nil {
+		t.Fatal("expected TryLockContract to return nil when contract is locked")
+	}
+
+	unlock()
+}
+
+func TestContractLockerConcurrent(t *testing.T) {
+	cl := NewContractLocker()
+	id := types.FileContractID{5}
+
+	const n = 100
+	var wg sync.WaitGroup
+	counter := 0
+
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, unlock := cl.LockContract(id)
+			counter++ // protected by the contract lock
+			unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	if counter != n {
+		t.Fatalf("expected counter %d, got %d", n, counter)
+	}
+
+	cl.mu.Lock()
+	if len(cl.lockedContracts) != 0 {
+		t.Fatal("expected no locked contracts")
+	}
+	cl.mu.Unlock()
+}
+
+func TestTryLockAfterUnlock(t *testing.T) {
+	cl := NewContractLocker()
+	id := types.FileContractID{6}
+
+	// lock and unlock
+	_, unlock := cl.LockContract(id)
+	unlock()
+
+	// try lock should succeed after unlock
+	lc, tryUnlock := cl.TryLockContract(id)
+	if lc == nil {
+		t.Fatal("expected TryLockContract to succeed after unlock")
+	}
+	tryUnlock()
+}

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -137,6 +137,10 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 			case <-t.C:
 				log.Debug("starting scheduled contract maintenance")
 			}
+			walletLog := log.Named("wallet")
+			if err := cm.performWalletMaintenance(ctx, walletLog); err != nil {
+				log.Debug("maintenance failed", zap.Error(err)) // wallet maintenance is best-effort
+			}
 			maintenanceLog := log.Named("contracts")
 			logError(cm.performContractMaintenance(ctx, maintenanceLog), maintenanceLog)
 		}
@@ -165,13 +169,6 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 				log.Debug("starting scheduled maintenance")
 			}
 
-			// this is done first so that fragmenting the wallet can be prioritized before
-			// being used for other maintenance tasks
-			walletLog := log.Named("wallet")
-			if err := cm.performWalletMaintenance(ctx, walletLog); err != nil {
-				log.Debug("maintenance failed", zap.Error(err)) // wallet maintenance is best-effort
-			}
-
 			pruningLog := log.Named("pruning")
 			logError(cm.performContractPruning(ctx, false, pruningLog), pruningLog)
 			pinningLog := log.Named("pinning")
@@ -180,7 +177,6 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 			unpinnableLog := log.Named("unpinnable")
 			threshold := time.Now().Add(-unpinnableSectorThreshold)
 			logError(cm.store.MarkSectorsUnpinnable(threshold), unpinnableLog)
-			t.Reset(cm.maintenanceFrequency)
 			log.Debug("maintenance complete")
 		}
 	})

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -162,7 +162,7 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 			}
 
 			pruningLog := log.Named("pruning")
-			logError(cm.performContractPruning(ctx, false, pruningLog), pruningLog)
+			logError(cm.performContractPruning(ctx, pruningLog), pruningLog)
 			pinningLog := log.Named("pinning")
 			logError(cm.performSectorPinning(ctx, pinningLog), pinningLog)
 

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -157,14 +157,6 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-cm.triggerPruningChan:
-				log.Debug("triggering contract pruning")
-				if err := cm.performContractPruning(ctx, true, log); err != nil {
-					log.Error("contract pruning failed", zap.Error(err))
-				}
-				continue
-			case <-cm.triggerMaintenanceChan:
-				log.Debug("triggering maintenance")
 			case <-t.C:
 				log.Debug("starting scheduled maintenance")
 			}

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -103,7 +103,7 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 
 	// account funding loop
 	wg.Go(func() {
-		t := time.NewTimer(cm.maintenanceFrequency)
+		t := time.NewTicker(cm.maintenanceFrequency)
 		defer t.Stop()
 		for {
 			if !cm.waitUntilSynced(ctx, log) {
@@ -125,7 +125,7 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 
 	// contract maintenance loop
 	wg.Go(func() {
-		t := time.NewTimer(cm.maintenanceFrequency)
+		t := time.NewTicker(cm.maintenanceFrequency)
 		defer t.Stop()
 		for {
 			if !cm.waitUntilSynced(ctx, log) {
@@ -146,7 +146,7 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 
 	// remaining maintenance loop
 	wg.Go(func() {
-		t := time.NewTimer(cm.maintenanceFrequency)
+		t := time.NewTicker(cm.maintenanceFrequency)
 		defer t.Stop()
 		for {
 			if !cm.waitUntilSynced(ctx, log) {

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -134,8 +134,6 @@ func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-cm.triggerMaintenanceChan:
-				log.Debug("triggering scheduled contract maintenance")
 			case <-t.C:
 				log.Debug("starting scheduled contract maintenance")
 			}

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -98,58 +98,94 @@ func (cm *ContractManager) performContractMaintenance(ctx context.Context, log *
 // to perform on contracts
 func (cm *ContractManager) maintenanceLoop(ctx context.Context) {
 	log := cm.log.Named("maintenance")
-	t := time.NewTimer(cm.maintenanceFrequency)
-	defer t.Stop()
+	var wg sync.WaitGroup
+	defer wg.Wait()
 
-	for {
-		if !cm.waitUntilSynced(ctx, log) {
-			log.Debug("shutting down maintenance loop")
-			return
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case force := <-cm.triggerFundingChan:
-			log.Debug("triggering account funding", zap.Bool("force", force))
-			if err := cm.performAccountFunding(ctx, force, log); err != nil {
-				log.Error("account funding failed", zap.Error(err))
+	// account funding loop
+	wg.Go(func() {
+		t := time.NewTimer(cm.maintenanceFrequency)
+		defer t.Stop()
+		for {
+			if !cm.waitUntilSynced(ctx, log) {
+				return
 			}
-			continue
-		case <-cm.triggerPruningChan:
-			log.Debug("triggering contract pruning")
-			if err := cm.performContractPruning(ctx, true, log); err != nil {
-				log.Error("contract pruning failed", zap.Error(err))
+			var force bool
+			select {
+			case <-ctx.Done():
+				return
+			case force = <-cm.triggerFundingChan:
+				log.Debug("triggering scheduled account funding", zap.Bool("force", force))
+			case <-t.C:
+				log.Debug("starting scheduled funding")
 			}
-			continue
-		case <-cm.triggerMaintenanceChan:
-			log.Debug("triggering maintenance")
-		case <-t.C:
-			log.Debug("starting scheduled maintenance")
+			fundingLog := log.Named("accounts")
+			logError(cm.performAccountFunding(ctx, force, fundingLog), fundingLog)
 		}
+	})
 
-		// this is done first so that fragmenting the wallet can be prioritized before
-		// being used for other maintenance tasks
-		walletLog := log.Named("wallet")
-		if err := cm.performWalletMaintenance(ctx, walletLog); err != nil {
-			log.Debug("maintenance failed", zap.Error(err)) // wallet maintenance is best-effort
+	// contract maintenance loop
+	wg.Go(func() {
+		t := time.NewTimer(cm.maintenanceFrequency)
+		defer t.Stop()
+		for {
+			if !cm.waitUntilSynced(ctx, log) {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-cm.triggerMaintenanceChan:
+				log.Debug("triggering scheduled contract maintenance")
+			case <-t.C:
+				log.Debug("starting scheduled contract maintenance")
+			}
+			maintenanceLog := log.Named("contracts")
+			logError(cm.performContractMaintenance(ctx, maintenanceLog), maintenanceLog)
 		}
+	})
 
-		contractMaintenanceLog := log.Named("contracts")
-		logError(cm.performContractMaintenance(ctx, contractMaintenanceLog), contractMaintenanceLog)
-		fundingLog := log.Named("accounts")
-		logError(cm.performAccountFunding(ctx, false, fundingLog), fundingLog)
-		pruningLog := log.Named("pruning")
-		logError(cm.performContractPruning(ctx, false, pruningLog), pruningLog)
-		pinningLog := log.Named("pinning")
-		logError(cm.performSectorPinning(ctx, pinningLog), pinningLog)
+	// remaining maintenance loop
+	wg.Go(func() {
+		t := time.NewTimer(cm.maintenanceFrequency)
+		defer t.Stop()
+		for {
+			if !cm.waitUntilSynced(ctx, log) {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-cm.triggerPruningChan:
+				log.Debug("triggering contract pruning")
+				if err := cm.performContractPruning(ctx, true, log); err != nil {
+					log.Error("contract pruning failed", zap.Error(err))
+				}
+				continue
+			case <-cm.triggerMaintenanceChan:
+				log.Debug("triggering maintenance")
+			case <-t.C:
+				log.Debug("starting scheduled maintenance")
+			}
 
-		unpinnableLog := log.Named("unpinnable")
-		threshold := time.Now().Add(-unpinnableSectorThreshold)
-		logError(cm.store.MarkSectorsUnpinnable(threshold), unpinnableLog)
-		t.Reset(cm.maintenanceFrequency)
-		log.Debug("maintenance complete")
-	}
+			// this is done first so that fragmenting the wallet can be prioritized before
+			// being used for other maintenance tasks
+			walletLog := log.Named("wallet")
+			if err := cm.performWalletMaintenance(ctx, walletLog); err != nil {
+				log.Debug("maintenance failed", zap.Error(err)) // wallet maintenance is best-effort
+			}
+
+			pruningLog := log.Named("pruning")
+			logError(cm.performContractPruning(ctx, false, pruningLog), pruningLog)
+			pinningLog := log.Named("pinning")
+			logError(cm.performSectorPinning(ctx, pinningLog), pinningLog)
+
+			unpinnableLog := log.Named("unpinnable")
+			threshold := time.Now().Add(-unpinnableSectorThreshold)
+			logError(cm.store.MarkSectorsUnpinnable(threshold), unpinnableLog)
+			t.Reset(cm.maintenanceFrequency)
+			log.Debug("maintenance complete")
+		}
+	})
 }
 
 func (cm *ContractManager) performWalletMaintenance(ctx context.Context, log *zap.Logger) error {

--- a/contracts/maintenance_test.go
+++ b/contracts/maintenance_test.go
@@ -71,7 +71,6 @@ func TestWalletMaintenance(t *testing.T) {
 	if err := sub.Sync(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	contracts.TriggerMaintenance()
 	time.Sleep(time.Second) // wait for maintenance to run
 
 	events, err := w.UnconfirmedEvents()
@@ -94,8 +93,7 @@ func TestWalletMaintenance(t *testing.T) {
 		t.Fatalf("expected 100 UTXOs, got %d", len(utxos))
 	}
 
-	// trigger maintenance again and ensure no new split is created
-	contracts.TriggerMaintenance()
+	// wait for maintenance and ensure no new split is created
 	time.Sleep(time.Second)
 
 	events, err = w.UnconfirmedEvents()

--- a/contracts/maintenance_test.go
+++ b/contracts/maintenance_test.go
@@ -53,7 +53,7 @@ func TestWalletMaintenance(t *testing.T) {
 	}
 	defer hm.Close()
 
-	contracts, err := contracts.NewManager(sk, nil, nil, cm, store, nil, nil, nil, hm, s, w, contracts.WithLogger(log.Named("contracts")), contracts.WithSyncPollInterval(250*time.Millisecond))
+	contracts, err := contracts.NewManager(sk, nil, nil, cm, store, nil, nil, nil, contracts.NewContractLocker(), hm, s, w, contracts.WithLogger(log.Named("contracts")), contracts.WithSyncPollInterval(250*time.Millisecond))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/contracts/maintenance_test.go
+++ b/contracts/maintenance_test.go
@@ -53,7 +53,10 @@ func TestWalletMaintenance(t *testing.T) {
 	}
 	defer hm.Close()
 
-	contracts, err := contracts.NewManager(sk, nil, nil, cm, store, nil, nil, nil, contracts.NewContractLocker(), hm, s, w, contracts.WithLogger(log.Named("contracts")), contracts.WithSyncPollInterval(250*time.Millisecond))
+	contracts, err := contracts.NewManager(sk, nil, nil, cm, store, nil, nil, nil, contracts.NewContractLocker(), hm, s, w,
+		contracts.WithLogger(log.Named("contracts")),
+		contracts.WithSyncPollInterval(250*time.Millisecond),
+		contracts.WithMaintenanceFrequency(50*time.Millisecond))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -470,7 +470,7 @@ func (cm *ContractManager) Close() error {
 	return nil
 }
 
-func newContractManager(renterKey types.PublicKey, accounts AccountManager, accountFunder AccountFunder, chain ChainManager, store Store, client HostClient, signer rhp.FormContractSigner, rev *RevisionManager, hosts HostManager, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
+func newContractManager(renterKey types.PublicKey, accounts AccountManager, accountFunder AccountFunder, chain ChainManager, store Store, client HostClient, signer rhp.FormContractSigner, rev *RevisionManager, cl *ContractLocker, hosts HostManager, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) *ContractManager {
 	cm := &ContractManager{
 		accounts:      accounts,
 		accountFunder: accountFunder,
@@ -482,7 +482,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, acco
 		store:  store,
 
 		client: client,
-		cl:     NewContractLocker(),
+		cl:     cl,
 		signer: signer,
 		rev:    rev,
 
@@ -516,8 +516,8 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, acco
 // NewManager creates a new contract manager. It is responsible for forming and
 // renewing contracts as well as any interactions with hosts that require
 // contracts.
-func NewManager(renterKey types.PrivateKey, accountManager AccountManager, accountFunder AccountFunder, chainManager ChainManager, store Store, client HostClient, signer rhp.FormContractSigner, rev *RevisionManager, hm HostManager, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
-	cm := newContractManager(renterKey.PublicKey(), accountManager, accountFunder, chainManager, store, client, signer, rev, hm, syncer, wallet, opts...)
+func NewManager(renterKey types.PrivateKey, accountManager AccountManager, accountFunder AccountFunder, chainManager ChainManager, store Store, client HostClient, signer rhp.FormContractSigner, rev *RevisionManager, cl *ContractLocker, hm HostManager, syncer Syncer, wallet Wallet, opts ...ContractManagerOpt) (*ContractManager, error) {
+	cm := newContractManager(renterKey.PublicKey(), accountManager, accountFunder, chainManager, store, client, signer, rev, cl, hm, syncer, wallet, opts...)
 
 	ctx, cancel, err := cm.tg.AddContext(context.Background())
 	if err != nil {

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -128,7 +128,6 @@ type (
 		PruneContractSectorsMap(maxBlocksSinceExpiry uint64) error
 		RejectPendingContracts(maxFormation time.Time) error
 		ScheduleAccountForFunding(hostKey types.PublicKey, account proto.Account) error
-		ScheduleContractsForPruning() error
 		UnpinnedSectors(hostKey types.PublicKey, limit int) ([]types.Hash256, error)
 		UpdateContractRevision(contract rhp.ContractRevision, usage proto.Usage) error
 		UpdateNextPrune(contractID types.FileContractID, nextPrune time.Time) error
@@ -256,6 +255,14 @@ func WithMaxAccountFundingBackoff(backoff time.Duration) ContractManagerOpt {
 func WithMinHostDistance(km float64) ContractManagerOpt {
 	return func(cm *ContractManager) {
 		cm.minHostDistanceKm = km
+	}
+}
+
+// WithPruneIntervalSuccess sets the interval for retrying contract pruning
+// after a successful prune. The default is 24 hours.
+func WithPruneIntervalSuccess(interval time.Duration) ContractManagerOpt {
+	return func(cm *ContractManager) {
+		cm.pruneIntervalSuccess = interval
 	}
 }
 

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -207,9 +207,7 @@ type (
 		rev       *RevisionManager
 		renterKey types.PublicKey
 
-		triggerFundingChan     chan bool
-		triggerMaintenanceChan chan struct{}
-		triggerPruningChan     chan struct{}
+		triggerFundingChan chan bool
 
 		log *zap.Logger
 		tg  *threadgroup.ThreadGroup
@@ -367,32 +365,6 @@ func (cm *ContractManager) TriggerAccountFunding(force bool) error {
 	return nil
 }
 
-// TriggerContractPruning triggers contract pruning for all active contracts
-// that are marked good.
-func (cm *ContractManager) TriggerContractPruning() error {
-	ctx, cancel, err := cm.tg.AddContext(context.Background())
-	if err != nil {
-		return err
-	}
-	go func() {
-		defer cancel()
-
-		select {
-		case <-ctx.Done():
-		case cm.triggerPruningChan <- struct{}{}:
-		}
-	}()
-	return nil
-}
-
-// TriggerMaintenance triggers the maintenance loop to run immediately.
-func (cm *ContractManager) TriggerMaintenance() {
-	select {
-	case cm.triggerMaintenanceChan <- struct{}{}:
-	default:
-	}
-}
-
 // Contract retrieves a contract by its ID.
 func (cm *ContractManager) Contract(ctx context.Context, id types.FileContractID) (Contract, error) {
 	return cm.store.Contract(id)
@@ -488,9 +460,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, acco
 
 		renterKey: renterKey,
 
-		triggerFundingChan:     make(chan bool, 1),
-		triggerMaintenanceChan: make(chan struct{}, 1),
-		triggerPruningChan:     make(chan struct{}, 1),
+		triggerFundingChan: make(chan bool, 1),
 
 		log: zap.NewNop(),
 		tg:  threadgroup.New(),

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -217,6 +217,7 @@ type (
 		expiredContractPruneBuffer        uint64
 		expiredContractSectorsPruneBuffer uint64
 		maintenanceFrequency              time.Duration
+		maxAccountFundingBackoff          time.Duration
 		minHostDistanceKm                 float64
 		pruneIntervalSuccess              time.Duration
 		pruneIntervalFailure              time.Duration
@@ -238,6 +239,14 @@ func WithLogger(l *zap.Logger) ContractManagerOpt {
 func WithMaintenanceFrequency(frequency time.Duration) ContractManagerOpt {
 	return func(cm *ContractManager) {
 		cm.maintenanceFrequency = frequency
+	}
+}
+
+// WithMaxAccountFundingBackoff sets the maximum backoff duration for account
+// funding retries. The default is 2 hours.
+func WithMaxAccountFundingBackoff(backoff time.Duration) ContractManagerOpt {
+	return func(cm *ContractManager) {
+		cm.maxAccountFundingBackoff = backoff
 	}
 }
 
@@ -470,6 +479,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, acco
 		expiredContractPruneBuffer:        144,           // 144 blocks after broadcast
 		expiredContractSectorsPruneBuffer: 36,            // 36 blocks (~6 hours) after expiration
 		maintenanceFrequency:              2 * time.Minute,
+		maxAccountFundingBackoff:          2 * time.Hour,
 		minHostDistanceKm:                 10,                 // 10km
 		pruneIntervalSuccess:              24 * time.Hour,     // 1 day
 		pruneIntervalFailure:              3 * time.Hour,      // 3 hours

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -196,6 +196,7 @@ type (
 		accounts      AccountManager
 		accountFunder AccountFunder
 		chain         ChainManager
+		cl            *ContractLocker
 		hosts         HostManager
 		syncer        Syncer
 		wallet        Wallet
@@ -481,6 +482,7 @@ func newContractManager(renterKey types.PublicKey, accounts AccountManager, acco
 		store:  store,
 
 		client: client,
+		cl:     NewContractLocker(),
 		signer: signer,
 		rev:    rev,
 

--- a/contracts/manager_test.go
+++ b/contracts/manager_test.go
@@ -14,7 +14,7 @@ import (
 func TestBlockBadHosts(t *testing.T) {
 	store := newTestStore(t)
 	hmMock := newHostManagerMock(store)
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, nil, store, nil, nil, nil, hmMock, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, nil, store, nil, nil, nil, contracts.NewContractLocker(), hmMock, nil, nil)
 
 	goodHost := hosts.Host{PublicKey: types.PublicKey{1}, Usability: hosts.GoodUsability, Settings: goodSettings}
 	badHost := hosts.Host{PublicKey: types.PublicKey{2}, Usability: hosts.Usability{}, Settings: goodSettings}

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -118,114 +118,120 @@ func (cm *ContractManager) pinSectors(ctx context.Context, hostKey types.PublicK
 		if len(sectors) == 0 {
 			break
 		}
-		log := log.With(zap.Stringer("contractID", contractID))
 
-		lc, unlock := cm.cl.LockContract(contractID)
-		defer unlock()
+		if err := func() error {
+			log := log.With(zap.Stringer("contractID", contractID))
 
-		prices, err := cm.client.Prices(ctx, hostKey)
-		if err != nil {
-			log.Debug("failed to get host prices", zap.Error(err))
-			continue
-		}
+			lc, unlock := cm.cl.LockContract(contractID)
+			defer unlock()
 
-		var res rhp.RPCAppendSectorsResult
-		var attempted int
-		err = cm.rev.WithRevision(ctx, lc, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
-			if contract.Revision.Filesize >= maxSize {
-				return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d: %w", contract.Revision.Filesize, maxSize, ErrContractMaxSize)
-			}
-
-			// calculate the maximum number of sectors we can append based on the
-			// contract's remaining capacity and collateral
-			maxRemainingSectors := (maxSize - contract.Revision.Filesize) / proto.SectorSize
-			maxAppendSectors := (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
-
-			if contract.Revision.ExpirationHeight <= prices.TipHeight {
-				return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract has expired at height %d, current height is %d", contract.Revision.ExpirationHeight, prices.TipHeight)
-			}
-
-			duration := contract.Revision.ExpirationHeight - prices.TipHeight
-			appendSectorCost := prices.RPCAppendSectorsCost(1, duration)
-
-			sectorCollateralCost := appendSectorCost.RiskedCollateral
-			if sectorCollateralCost.IsZero() {
-				sectorCollateralCost = types.NewCurrency64(1) // avoid division by zero
-			}
-			sectorRenterCost := appendSectorCost.RenterCost()
-			if sectorRenterCost.IsZero() {
-				sectorRenterCost = types.NewCurrency64(1) // avoid division by zero
-			}
-
-			maxSectorsByCollateral := contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
-			maxSectorsByAllowance := contract.Revision.RemainingAllowance().Div(sectorRenterCost).Big().Uint64()
-			maxAppendSectors += min(maxSectorsByAllowance, maxSectorsByCollateral)
-
-			// ensure the maximum contract size is not exceeded
-			maxAppendSectors = min(maxAppendSectors, maxRemainingSectors)
-
-			if maxAppendSectors == 0 {
-				switch {
-				case maxSectorsByAllowance == 0:
-					return rhp.ContractRevision{}, proto.Usage{}, ErrContractOutOfFunds
-				case maxSectorsByCollateral == 0:
-					return rhp.ContractRevision{}, proto.Usage{}, ErrContractOutOfCollateral
-				case maxRemainingSectors == 0:
-					return rhp.ContractRevision{}, proto.Usage{}, ErrContractMaxSize
-				}
-				return rhp.ContractRevision{}, proto.Usage{}, errors.New("maxAppendSectors is zero for unknown reason") // unreachable
-			}
-
-			// only attempt to append up to the calculated maximum number of sectors
-			attemptedSectors := sectors
-			if uint64(len(attemptedSectors)) > maxAppendSectors {
-				attemptedSectors = attemptedSectors[:maxAppendSectors]
-			}
-			res, err = cm.client.AppendSectors(ctx, cm.signer, cm.chain, contract, attemptedSectors)
+			prices, err := cm.client.Prices(ctx, hostKey)
 			if err != nil {
-				return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("failed to append sectors: %w", err)
+				log.Debug("failed to get host prices", zap.Error(err))
+				return nil
 			}
-			attempted = len(attemptedSectors)
-			contract.Revision = res.Revision
-			return contract, res.Usage, nil
-		})
-		if err != nil {
-			log.Debug("failed to pin sectors", zap.Error(err))
-			continue
-		}
-		// if the RPC returned, regardless of how many sectors were pinned,
-		// consider it a success as we made progress towards pinning unpinned
-		// sectors.
-		success = true
 
-		// Only the sectors that were attempted should be marked
-		// as missing. So sectors that were not part of the append
-		// call can be pinned to other contracts.
-		if len(res.Sectors) != attempted {
-			lookup := make(map[types.Hash256]struct{}, attempted)
-			for _, sector := range sectors[:attempted] {
-				lookup[sector] = struct{}{}
-			}
-			for _, sector := range res.Sectors {
-				delete(lookup, sector)
-			}
-			missing := slices.Collect(maps.Keys(lookup))
-			if err := cm.store.MarkSectorsLost(hostKey, missing); err != nil {
-				return fmt.Errorf("failed to mark sectors as lost: %w", err)
-			}
-			log = log.With(zap.Int("missing", len(missing)))
-		}
+			var res rhp.RPCAppendSectorsResult
+			var attempted int
+			err = cm.rev.WithRevision(ctx, lc, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
+				if contract.Revision.Filesize >= maxSize {
+					return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d: %w", contract.Revision.Filesize, maxSize, ErrContractMaxSize)
+				}
 
-		if err := cm.store.PinSectors(contractID, res.Sectors); err != nil {
-			// log unexpected database error
-			if !errors.Is(err, ErrNotFound) {
-				log.Error("failed to pin sectors", zap.Stringer("contractID", contractID), zap.Error(err))
-			}
-			return fmt.Errorf("failed to pin sectors: %w", err)
-		}
+				// calculate the maximum number of sectors we can append based on the
+				// contract's remaining capacity and collateral
+				maxRemainingSectors := (maxSize - contract.Revision.Filesize) / proto.SectorSize
+				maxAppendSectors := (contract.Revision.Capacity - contract.Revision.Filesize) / proto.SectorSize
 
-		sectors = sectors[attempted:] // pin the remaining sectors
-		log.Debug("pinned sectors", zap.Int("pinned", len(res.Sectors)), zap.Int("attempted", attempted))
+				if contract.Revision.ExpirationHeight <= prices.TipHeight {
+					return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract has expired at height %d, current height is %d", contract.Revision.ExpirationHeight, prices.TipHeight)
+				}
+
+				duration := contract.Revision.ExpirationHeight - prices.TipHeight
+				appendSectorCost := prices.RPCAppendSectorsCost(1, duration)
+
+				sectorCollateralCost := appendSectorCost.RiskedCollateral
+				if sectorCollateralCost.IsZero() {
+					sectorCollateralCost = types.NewCurrency64(1) // avoid division by zero
+				}
+				sectorRenterCost := appendSectorCost.RenterCost()
+				if sectorRenterCost.IsZero() {
+					sectorRenterCost = types.NewCurrency64(1) // avoid division by zero
+				}
+
+				maxSectorsByCollateral := contract.Revision.RemainingCollateral().Div(sectorCollateralCost).Big().Uint64()
+				maxSectorsByAllowance := contract.Revision.RemainingAllowance().Div(sectorRenterCost).Big().Uint64()
+				maxAppendSectors += min(maxSectorsByAllowance, maxSectorsByCollateral)
+
+				// ensure the maximum contract size is not exceeded
+				maxAppendSectors = min(maxAppendSectors, maxRemainingSectors)
+
+				if maxAppendSectors == 0 {
+					switch {
+					case maxSectorsByAllowance == 0:
+						return rhp.ContractRevision{}, proto.Usage{}, ErrContractOutOfFunds
+					case maxSectorsByCollateral == 0:
+						return rhp.ContractRevision{}, proto.Usage{}, ErrContractOutOfCollateral
+					case maxRemainingSectors == 0:
+						return rhp.ContractRevision{}, proto.Usage{}, ErrContractMaxSize
+					}
+					return rhp.ContractRevision{}, proto.Usage{}, errors.New("maxAppendSectors is zero for unknown reason") // unreachable
+				}
+
+				// only attempt to append up to the calculated maximum number of sectors
+				attemptedSectors := sectors
+				if uint64(len(attemptedSectors)) > maxAppendSectors {
+					attemptedSectors = attemptedSectors[:maxAppendSectors]
+				}
+				res, err = cm.client.AppendSectors(ctx, cm.signer, cm.chain, contract, attemptedSectors)
+				if err != nil {
+					return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("failed to append sectors: %w", err)
+				}
+				attempted = len(attemptedSectors)
+				contract.Revision = res.Revision
+				return contract, res.Usage, nil
+			})
+			if err != nil {
+				log.Debug("failed to pin sectors", zap.Error(err))
+				return nil
+			}
+			// if the RPC returned, regardless of how many sectors were pinned,
+			// consider it a success as we made progress towards pinning unpinned
+			// sectors.
+			success = true
+
+			// Only the sectors that were attempted should be marked
+			// as missing. So sectors that were not part of the append
+			// call can be pinned to other contracts.
+			if len(res.Sectors) != attempted {
+				lookup := make(map[types.Hash256]struct{}, attempted)
+				for _, sector := range sectors[:attempted] {
+					lookup[sector] = struct{}{}
+				}
+				for _, sector := range res.Sectors {
+					delete(lookup, sector)
+				}
+				missing := slices.Collect(maps.Keys(lookup))
+				if err := cm.store.MarkSectorsLost(hostKey, missing); err != nil {
+					return fmt.Errorf("failed to mark sectors as lost: %w", err)
+				}
+				log = log.With(zap.Int("missing", len(missing)))
+			}
+
+			if err := cm.store.PinSectors(contractID, res.Sectors); err != nil {
+				// log unexpected database error
+				if !errors.Is(err, ErrNotFound) {
+					log.Error("failed to pin sectors", zap.Stringer("contractID", contractID), zap.Error(err))
+				}
+				return fmt.Errorf("failed to pin sectors: %w", err)
+			}
+
+			sectors = sectors[attempted:] // pin the remaining sectors
+			log.Debug("pinned sectors", zap.Int("pinned", len(res.Sectors)), zap.Int("attempted", attempted))
+			return nil
+		}(); err != nil {
+			return err
+		}
 	}
 	if !success {
 		return errors.New("all contracts failed to pin sectors")

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -120,6 +120,9 @@ func (cm *ContractManager) pinSectors(ctx context.Context, hostKey types.PublicK
 		}
 		log := log.With(zap.Stringer("contractID", contractID))
 
+		lc, unlock := cm.cl.LockContract(contractID)
+		defer unlock()
+
 		prices, err := cm.client.Prices(ctx, hostKey)
 		if err != nil {
 			log.Debug("failed to get host prices", zap.Error(err))
@@ -128,7 +131,7 @@ func (cm *ContractManager) pinSectors(ctx context.Context, hostKey types.PublicK
 
 		var res rhp.RPCAppendSectorsResult
 		var attempted int
-		err = cm.rev.WithRevision(ctx, contractID, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
+		err = cm.rev.WithRevision(ctx, lc, func(contract rhp.ContractRevision) (_ rhp.ContractRevision, _ proto.Usage, err error) {
 			if contract.Revision.Filesize >= maxSize {
 				return rhp.ContractRevision{}, proto.Usage{}, fmt.Errorf("contract is too large, %d > %d: %w", contract.Revision.Filesize, maxSize, ErrContractMaxSize)
 			}

--- a/contracts/pinning_test.go
+++ b/contracts/pinning_test.go
@@ -91,7 +91,7 @@ func TestPerformSectorPinningOnHost(t *testing.T) {
 
 	// prepare contract manager
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, hmMock, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hmMock, nil, nil)
 
 	assertSectorsContract := func(roots []types.Hash256, contractID *types.FileContractID) {
 		t.Helper()
@@ -203,7 +203,7 @@ func TestPerformSectorPinningOnHostOverflow(t *testing.T) {
 
 	// prepare contract manager
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, hmMock, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hmMock, nil, nil)
 
 	assertSectorsContract := func(roots []types.Hash256, contractID *types.FileContractID) {
 		t.Helper()

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -14,16 +14,8 @@ import (
 	"go.uber.org/zap"
 )
 
-func (cm *ContractManager) performContractPruning(ctx context.Context, force bool, log *zap.Logger) error {
+func (cm *ContractManager) performContractPruning(ctx context.Context, log *zap.Logger) error {
 	start := time.Now()
-
-	// if force is true, schedule all (active and good) contracts for pruning
-	if force {
-		err := cm.store.ScheduleContractsForPruning()
-		if err != nil {
-			return fmt.Errorf("failed to schedule contracts for pruning: %w", err)
-		}
-	}
 
 	// fetch hosts for pruning, a host is eligible for pruning if it is not
 	// blocked and has active contracts that haven't been pruned in the last 24

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -114,6 +114,11 @@ loop:
 func (cm *ContractManager) pruneContract(ctx context.Context, contractID types.FileContractID) (int, error) {
 	const dbRootsBatchSize = 10000
 
+	// lock contract first before doing anything else to avoid anything else
+	// modifying the contract while we loop over offsets and roots
+	lc, unlock := cm.cl.LockContract(contractID)
+	defer unlock()
+
 	contract, renewed, err := cm.store.ContractRevision(contractID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch contract revision: %w", err)
@@ -128,7 +133,7 @@ func (cm *ContractManager) pruneContract(ctx context.Context, contractID types.F
 		length := min(cm.sectorRootsBatchSize, contractSectors-offset)
 
 		var roots []types.Hash256
-		err = cm.rev.WithRevision(ctx, contractID, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+		err = cm.rev.WithRevision(ctx, lc, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 			res, err := cm.client.SectorRoots(ctx, cm.signer, cm.chain, rev, offset, length)
 			if err != nil {
 				return rhp.ContractRevision{}, proto.Usage{}, err
@@ -165,7 +170,7 @@ func (cm *ContractManager) pruneContract(ctx context.Context, contractID types.F
 			continue
 		}
 
-		err = cm.rev.WithRevision(ctx, contractID, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+		err = cm.rev.WithRevision(ctx, lc, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 			res, err := cm.client.FreeSectors(ctx, cm.signer, cm.chain, rev, indices)
 			if err != nil {
 				return rhp.ContractRevision{}, proto.Usage{}, err

--- a/contracts/pruning_test.go
+++ b/contracts/pruning_test.go
@@ -142,7 +142,7 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 	store.setRevisionFilesize(t, fcid4, proto.SectorSize*uint64(len(h5Mock.sectorRoots[fcid4])))
 
 	// schedule contracts for pruning
-	store.scheduleContractsForPruningHelper(t)
+	store.scheduleContractsForPruning(t)
 
 	// prepare contract manager
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
@@ -296,7 +296,7 @@ func TestPruneContractBatchBoundary(t *testing.T) {
 
 	store.setContractSize(t, fcid, proto.SectorSize*7)
 	store.setRevisionFilesize(t, fcid, proto.SectorSize*7)
-	store.scheduleContractsForPruningHelper(t)
+	store.scheduleContractsForPruning(t)
 
 	// use batch size 3 so the contract spans multiple batches; after
 	// FreeSectors removes sectors in the first batch, subsequent batches must

--- a/contracts/pruning_test.go
+++ b/contracts/pruning_test.go
@@ -146,7 +146,7 @@ func TestPerformContractPruningOnHost(t *testing.T) {
 
 	// prepare contract manager
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, hmMock, nil, nil)
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hmMock, nil, nil)
 
 	// prune contracts on h1
 	err := cm.PerformContractPruningOnHost(context.Background(), h1, zap.NewNop())
@@ -303,7 +303,7 @@ func TestPruneContractBatchBoundary(t *testing.T) {
 	// account for the reduced sector count to avoid requesting out-of-bounds
 	// ranges from the host
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, hmMock, nil, nil, contracts.WithSectorRootsBatchSize(3))
+	cm := contracts.NewTestContractManager(types.PublicKey{}, nil, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hmMock, nil, nil, contracts.WithSectorRootsBatchSize(3))
 
 	err := cm.PerformContractPruningOnHost(context.Background(), h, zap.NewNop())
 	if err != nil {

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -64,8 +64,11 @@ func (cm *ContractManager) renewContract(ctx context.Context, contract Contract,
 		renewCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 		defer cancel()
 
+		lc, unlock := cm.cl.LockContract(contract.ID)
+		defer unlock()
+
 		var res rhp.RPCRenewContractResult
-		err = cm.rev.WithRevision(renewCtx, contract.ID, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+		err = cm.rev.WithRevision(renewCtx, lc, func(rev rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 			cappedCollateral := collateral
 			estimatedRenewal, _ := proto.RenewContract(rev.Revision, settings.Prices, proto.RPCRenewContractParams{
 				Allowance:   allowance,

--- a/contracts/renew_test.go
+++ b/contracts/renew_test.go
@@ -57,7 +57,7 @@ func TestPerformContractRenewals(t *testing.T) {
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	contractsMgr := contracts.NewTestContractManager(renterKey, amMock, nil, cmMock, store, mock, nil, rev, hmMock, syncerMock, wallet)
+	contractsMgr := contracts.NewTestContractManager(renterKey, amMock, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hmMock, syncerMock, wallet)
 
 	assertRenewal := func(renewedFrom types.FileContractID, proofHeight uint64, call renewContractCall) {
 		t.Helper()
@@ -165,7 +165,7 @@ func TestRenewalAllowance(t *testing.T) {
 	renterKey := types.PublicKey{1, 2, 3, 4, 5}
 	wallet := &walletMock{}
 	rev := contracts.NewRevisionManager(mock, cmMock, store, 1, zaptest.NewLogger(t))
-	cm := contracts.NewTestContractManager(renterKey, amMock, nil, cmMock, store, mock, nil, rev, hmMock, syncerMock, wallet)
+	cm := contracts.NewTestContractManager(renterKey, amMock, nil, cmMock, store, mock, nil, rev, contracts.NewContractLocker(), hmMock, syncerMock, wallet)
 
 	assertRenewal := func(allowance types.Currency, call renewContractCall) {
 		t.Helper()

--- a/contracts/revision.go
+++ b/contracts/revision.go
@@ -124,12 +124,14 @@ func (rm *RevisionManager) syncRevision(ctx context.Context, contractID types.Fi
 	return resp.Contract, resp.Renewed, nil
 }
 
-// WithRevision retrieves the current revision of the specified contract ID from
-// the database and executes the provided revise function with it. If the host
-// reports an invalid signature, suggesting the local revision is out of sync,
-// it will synchronize with the host and retry the function using the updated
-// revision. Therefore, the revise function must be idempotent.
-func (rm *RevisionManager) WithRevision(ctx context.Context, lc *LockedContract, reviseFn func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error)) error {
+// WithRevision retrieves the current revision of the specified locked contract
+// from the database and executes the provided revise function with it. If the
+// host reports an invalid signature, suggesting the local revision is out of
+// sync, it will synchronize with the host and retry the function using the
+// updated revision. Therefore, the revise function must be idempotent.
+func (rm *RevisionManager) WithRevision(ctx context.Context, lc *LockedContract,
+	reviseFn func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage,
+		error)) error {
 	cs := rm.chain.TipState()
 	bh := cs.Index.Height
 	contractID := lc.id

--- a/contracts/revision.go
+++ b/contracts/revision.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -72,10 +71,6 @@ type (
 		store  RevisionStore
 		buffer uint64
 		log    *zap.Logger
-
-		// revision locking
-		mu    sync.Mutex
-		locks map[types.FileContractID]*sync.Mutex
 	}
 )
 

--- a/contracts/revision.go
+++ b/contracts/revision.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -71,6 +72,10 @@ type (
 		store  RevisionStore
 		buffer uint64
 		log    *zap.Logger
+
+		// revision locking
+		mu    sync.Mutex
+		locks map[types.FileContractID]*sync.Mutex
 	}
 )
 
@@ -129,9 +134,10 @@ func (rm *RevisionManager) syncRevision(ctx context.Context, contractID types.Fi
 // reports an invalid signature, suggesting the local revision is out of sync,
 // it will synchronize with the host and retry the function using the updated
 // revision. Therefore, the revise function must be idempotent.
-func (rm *RevisionManager) WithRevision(ctx context.Context, contractID types.FileContractID, reviseFn func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error)) error {
+func (rm *RevisionManager) WithRevision(ctx context.Context, lc *LockedContract, reviseFn func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error)) error {
 	cs := rm.chain.TipState()
 	bh := cs.Index.Height
+	contractID := lc.id
 
 	// fetch revision from database
 	contract, renewed, err := rm.store.ContractRevision(contractID)

--- a/contracts/revision_test.go
+++ b/contracts/revision_test.go
@@ -81,19 +81,25 @@ func TestWithRevision(t *testing.T) {
 	}
 
 	// assert ErrContractRenewed is returned for a renewed contract
-	err := rm.WithRevision(context.Background(), fcid1, noopFn)
+	lc := contracts.NewContractLocker()
+	lock := func(fcid types.FileContractID) *contracts.LockedContract {
+		lockedContract, unlock := lc.LockContract(fcid)
+		unlock() // immediately unlock since we don't need the lock for this test
+		return lockedContract
+	}
+	err := rm.WithRevision(context.Background(), lock(fcid1), noopFn)
 	if !errors.Is(err, contracts.ErrContractRenewed) {
 		t.Fatalf("expected ErrContractRenewed, got: %v", err)
 	}
 
 	// assert ErrContractNotRevisable is returned for a contract that can't be revised
-	err = rm.WithRevision(context.Background(), fcid2, noopFn)
+	err = rm.WithRevision(context.Background(), lock(fcid2), noopFn)
 	if !errors.Is(err, contracts.ErrContractNotRevisable) {
 		t.Fatalf("expected ErrContractNotRevisable, got: %v", err)
 	}
 
 	// assert withRevision errors out if the revision can't be found
-	err = rm.WithRevision(context.Background(), types.FileContractID{4, 0, 4}, noopFn)
+	err = rm.WithRevision(context.Background(), lock(types.FileContractID{4, 0, 4}), noopFn)
 	if err == nil || !errors.Is(err, contracts.ErrNotFound) {
 		t.Fatalf("expected error for non-existent contract, got: %v", err)
 	}
@@ -103,7 +109,7 @@ func TestWithRevision(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = rm.WithRevision(context.Background(), fcid3, func(rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	err = rm.WithRevision(context.Background(), lock(fcid3), func(rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		return rhp.ContractRevision{ID: fcid3, Revision: rev3.Revision}, proto.Usage{}, nil
 	})
 	if err != nil {
@@ -120,7 +126,7 @@ func TestWithRevision(t *testing.T) {
 	// assert withRevision errors out if the revise function returns an unexpected error
 	addContract(fcid4)
 	errUnexpected := errors.New("unexpected error")
-	if err := rm.WithRevision(context.Background(), fcid4, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	if err := rm.WithRevision(context.Background(), lock(fcid4), func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		return rhp.ContractRevision{}, proto.Usage{}, errUnexpected
 	}); err != errUnexpected {
 		t.Fatalf("expected unexpected error, got: %v", err)
@@ -128,7 +134,7 @@ func TestWithRevision(t *testing.T) {
 
 	// assert withRevision persists the revision if no error occurs and we don't need to sync the revision
 	update := frand.Uint64n(math.MaxInt32)
-	err = rm.WithRevision(context.Background(), fcid4, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	err = rm.WithRevision(context.Background(), lock(fcid4), func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		contract.Revision.RevisionNumber = update
 		return contract, proto.Usage{}, nil
 	})
@@ -148,7 +154,7 @@ func TestWithRevision(t *testing.T) {
 	addContract(fcid5)
 	errStore := &persistErrorStore{testStore: store, errorContractID: fcid5}
 	rmErr := contracts.NewRevisionManager(latest, chain, errStore, revisionSubmissionBuffer, zaptest.NewLogger(t))
-	err = rmErr.WithRevision(context.Background(), fcid5, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	err = rmErr.WithRevision(context.Background(), lock(fcid5), func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		contract.Revision.RevisionNumber = update
 		return contract, proto.Usage{}, nil
 	})
@@ -162,7 +168,7 @@ func TestWithRevision(t *testing.T) {
 		return proto.RPCLatestRevisionResponse{}, errors.New("latest revision not found")
 	}
 	addContract(types.FileContractID{6})
-	err = rm.WithRevision(context.Background(), types.FileContractID{6}, invalidSigFn)
+	err = rm.WithRevision(context.Background(), lock(types.FileContractID{6}), invalidSigFn)
 	if err == nil || !strings.Contains(err.Error(), "latest revision not found") {
 		t.Fatal("unexpected error", err)
 	}
@@ -181,7 +187,7 @@ func TestWithRevision(t *testing.T) {
 			Renewed:   false,
 		}, nil
 	}
-	err = rm.WithRevision(context.Background(), fcid7, invalidSigFn)
+	err = rm.WithRevision(context.Background(), lock(fcid7), invalidSigFn)
 	if err == nil || !strings.Contains(err.Error(), "local revision is newer than host revision") {
 		t.Fatal("unexpected error", err)
 	} else if contract, err := store.Contract(fcid7); err != nil {
@@ -205,7 +211,7 @@ func TestWithRevision(t *testing.T) {
 			Renewed:   false,
 		}, nil
 	}
-	err = rm.WithRevision(context.Background(), fcid8, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	err = rm.WithRevision(context.Background(), lock(fcid8), func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		if contract.Revision.RevisionNumber != update {
 			return rhp.ContractRevision{}, proto.Usage{}, proto.ErrInvalidSignature
 		}
@@ -241,7 +247,7 @@ func TestWithRevision(t *testing.T) {
 	}
 	fcid9 := types.FileContractID{9}
 	addContract(fcid9)
-	err = rm.WithRevision(context.Background(), fcid9, invalidSigFn)
+	err = rm.WithRevision(context.Background(), lock(fcid9), invalidSigFn)
 	if !errors.Is(err, contracts.ErrContractRenewed) {
 		t.Fatalf("expected ErrContractRenewed, got: %v", err)
 	}
@@ -256,7 +262,7 @@ func TestWithRevision(t *testing.T) {
 	}
 	fcid10 := types.FileContractID{10}
 	addContract(fcid10)
-	err = rm.WithRevision(context.Background(), fcid10, invalidSigFn)
+	err = rm.WithRevision(context.Background(), lock(fcid10), invalidSigFn)
 	if !errors.Is(err, contracts.ErrContractNotRevisable) {
 		t.Fatalf("expected ErrContractNotRevisable, got: %v", err)
 	}
@@ -264,7 +270,7 @@ func TestWithRevision(t *testing.T) {
 	// assert withRevision doesn't persist the revision if the revise function renewed the contract
 	fcid11 := types.FileContractID{11}
 	addContract(fcid11)
-	err = rm.WithRevision(context.Background(), fcid11, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	err = rm.WithRevision(context.Background(), lock(fcid11), func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		return contract, proto.Usage{}, nil
 	})
 	if err != nil {
@@ -285,7 +291,7 @@ func TestWithRevision(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = rm.WithRevision(context.Background(), types.FileContractID{12}, func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
+	err = rm.WithRevision(context.Background(), lock(types.FileContractID{12}), func(contract rhp.ContractRevision) (rhp.ContractRevision, proto.Usage, error) {
 		contract.Revision.RevisionNumber++
 		return contract, proto.Usage{RPC: types.NewCurrency64(1)}, nil
 	})

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -826,46 +826,6 @@ paths:
                 type: string
                 format: binary
 
-  /debug/trigger/{action}:
-    post:
-      tags:
-        - debug
-      summary: Trigger a specific debug action
-      description: >
-        Triggers a specific action such as contract maintenance or pruning.
-        This is useful for testing and debugging purposes. This route is only
-        available in debug mode.
-
-      operationId: triggerDebugAction
-      parameters:
-        - name: action
-          in: path
-          required: true
-          schema:
-            type: string
-            enum: [funding, maintenance, pruning, scanning]
-      responses:
-        "204":
-          description: Action triggered successfully
-        "400":
-          description: Invalid action specified
-      x-codeSamples:
-        - lang: Go
-          label: Go
-          source: |
-            package main
-
-            import (
-              "context"
-              admin "go.sia.tech/indexd/admin"
-            )
-
-            func main() {
-              c := admin.NewClient("http://localhost:9980", "your-admin-password")
-              err := c.TriggerAction(context.Background(), "maintenance")
-              // ...
-            }
-
   /explorer/exchange-rate/siacoin/{currency}:
     get:
       tags:
@@ -1649,7 +1609,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HostsStatsResponse"
-
 
   /stats/sectors:
     get:

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -871,18 +871,6 @@ func (s *Store) PrunableContractRoots(contractID types.FileContractID, roots []t
 	return prunable, nil
 }
 
-// ScheduleContractsForPruning schedules contracts for pruning by updating their
-// next prune time to the current time.
-func (s *Store) ScheduleContractsForPruning() error {
-	return s.transaction(func(ctx context.Context, tx *txn) error {
-		_, err := tx.Exec(ctx, `UPDATE contracts SET next_prune = NOW() WHERE good = TRUE AND state <= $1`, sqlContractState(contracts.ContractStateActive))
-		if err != nil {
-			return fmt.Errorf("failed to schedule contracts for pruning: %w", err)
-		}
-		return nil
-	})
-}
-
 func (tx *updateTx) UpdateContractElements(fces ...types.V2FileContractElement) error {
 	for _, fce := range fces {
 		_, err := tx.tx.Exec(tx.ctx, `

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -256,7 +256,7 @@ func TestRecordIntegrityCheck(t *testing.T) {
 		err := store.pool.QueryRow(t.Context(), "SELECT next_integrity_check, consecutive_failed_checks FROM sectors WHERE sector_root = $1", sqlHash256(root)).Scan(&nextCheck, &consecutiveFailures)
 		if err != nil {
 			t.Fatal(err)
-		} else if expectedNextCheck != nextCheck {
+		} else if !expectedNextCheck.Equal(nextCheck) {
 			t.Fatalf("expected next check %v, got %v", expectedNextCheck, nextCheck)
 		} else if consecutiveFailures != expectedConsecutiveFailures {
 			t.Fatalf("expected %d consecutive failures, got %d", expectedConsecutiveFailures, consecutiveFailures)

--- a/testutils/cluster.go
+++ b/testutils/cluster.go
@@ -190,6 +190,8 @@ func (c *Cluster) NewHosts(t testing.TB, n int) []*Host {
 	return hosts
 }
 
+// WaitForAccountFunding waits until the given account is funded on every host
+// in the cluster.
 func (c *Cluster) WaitForAccountFunding(t *testing.T, pk proto.Account) {
 	t.Helper()
 	for _, h := range c.Hosts {

--- a/testutils/cluster.go
+++ b/testutils/cluster.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/consensus"
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/indexd/contracts"
@@ -187,6 +188,26 @@ func (c *Cluster) NewHosts(t testing.TB, n int) []*Host {
 		hosts = append(hosts, cn.NewHost(t, pk, c.log.Named("host-"+pk.PublicKey().String())))
 	}
 	return hosts
+}
+
+func (c *Cluster) WaitForAccountFunding(t *testing.T, pk proto.Account) {
+	t.Helper()
+	for _, h := range c.Hosts {
+		var funded bool
+		for i := 0; i < 10; i++ {
+			b, err := c.Indexer.Client().AccountBalance(t.Context(), h.PublicKey(), pk)
+			if err != nil {
+				t.Fatal("failed to get account balance:", err)
+			} else if !b.IsZero() {
+				funded = true
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+		if !funded {
+			t.Fatalf("account not funded on host %v", h.PublicKey())
+		}
+	}
 }
 
 // WaitForContracts waits until a contract is formed with every host in the cluster

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -91,6 +91,7 @@ func defaultIndexerCfg(log *zap.Logger) *indexerCfg {
 			contracts.WithSyncPollInterval(500 * time.Millisecond),
 			contracts.WithSectorRootsBatchSize(5),     // small batch size for testing
 			contracts.WithMaxAccountFundingBackoff(0), // retry immediately
+			contracts.WithPruneIntervalSuccess(500 * time.Millisecond),
 		},
 		slabOpts: []slabs.Option{
 			slabs.WithLogger(log.Named("slabs")),

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -182,7 +182,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	rev := contracts.NewRevisionManager(client, c.cm, store, 1, log.Named("revision"))
 	cl := contracts.NewContractLocker()
 	f := contracts.NewFunder(client, cl, rev, signer, c.cm, log.Named("funder"))
-	contracts, err := contracts.NewManager(walletKey, am, f, c.cm, store, client, signer, rev, hm, s, wm, cfg.contractOpts...)
+	contracts, err := contracts.NewManager(walletKey, am, f, c.cm, store, client, signer, rev, cl, hm, s, wm, cfg.contractOpts...)
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)
 	}

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -86,7 +86,7 @@ func defaultIndexerCfg(log *zap.Logger) *indexerCfg {
 		maintenanceSettings: MaintenanceSettings,
 		contractOpts: []contracts.ContractManagerOpt{
 			contracts.WithLogger(log.Named("contracts")),
-			contracts.WithMaintenanceFrequency(100 * time.Millisecond),
+			contracts.WithMaintenanceFrequency(500 * time.Millisecond),
 			contracts.WithMinHostDistance(0), // disable location checks in tests
 			contracts.WithSyncPollInterval(500 * time.Millisecond),
 			contracts.WithSectorRootsBatchSize(5), // small batch size for testing

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -180,7 +180,8 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	}
 
 	rev := contracts.NewRevisionManager(client, c.cm, store, 1, log.Named("revision"))
-	f := contracts.NewFunder(client, rev, signer, c.cm, log.Named("funder"))
+	cl := contracts.NewContractLocker()
+	f := contracts.NewFunder(client, cl, rev, signer, c.cm, log.Named("funder"))
 	contracts, err := contracts.NewManager(walletKey, am, f, c.cm, store, client, signer, rev, hm, s, wm, cfg.contractOpts...)
 	if err != nil {
 		t.Fatalf("failed to create contract manager: %v", err)

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -89,7 +89,8 @@ func defaultIndexerCfg(log *zap.Logger) *indexerCfg {
 			contracts.WithMaintenanceFrequency(100 * time.Millisecond),
 			contracts.WithMinHostDistance(0), // disable location checks in tests
 			contracts.WithSyncPollInterval(500 * time.Millisecond),
-			contracts.WithSectorRootsBatchSize(5), // small batch size for testing
+			contracts.WithSectorRootsBatchSize(5),     // small batch size for testing
+			contracts.WithMaxAccountFundingBackoff(0), // retry immediately
 		},
 		slabOpts: []slabs.Option{
 			slabs.WithLogger(log.Named("slabs")),

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -86,7 +86,7 @@ func defaultIndexerCfg(log *zap.Logger) *indexerCfg {
 		maintenanceSettings: MaintenanceSettings,
 		contractOpts: []contracts.ContractManagerOpt{
 			contracts.WithLogger(log.Named("contracts")),
-			contracts.WithMaintenanceFrequency(500 * time.Millisecond),
+			contracts.WithMaintenanceFrequency(100 * time.Millisecond),
 			contracts.WithMinHostDistance(0), // disable location checks in tests
 			contracts.WithSyncPollInterval(500 * time.Millisecond),
 			contracts.WithSectorRootsBatchSize(5), // small batch size for testing


### PR DESCRIPTION
This splits up the maintenance in
1. account funding loop
2. contract maintenance loop 
3. remaining maintenance loop (pruning, pinning etc)

They all use the same frequency right now which currently is 2 minutes.

Closes https://github.com/SiaFoundation/indexd/issues/844
Closes https://github.com/SiaFoundation/indexd/issues/845