### PR TITLE
Expose PinObject

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -224,11 +224,11 @@ func (s *SDK) DeleteObject(ctx context.Context, key types.Hash256) error {
 	return s.client.DeleteObject(ctx, s.appKey, key)
 }
 
-// Upload uploads the data to hosts and pins it to the indexer.
+// Upload uploads the data to hosts.
 //
 // Appends the metadata of the slabs that were uploaded to the given object.
-// After uploading the object, the caller must call SaveObject to save the
-// object metadata to the indexer.
+// After uploading the object, the caller must call PinObject to pin the
+// slabs and save the object metadata to the indexer.
 func (s *SDK) Upload(ctx context.Context, obj *Object, r io.Reader, opts ...UploadOption) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -281,11 +281,7 @@ top:
 			}
 
 			totalShards := uo.dataShards + uo.parityShards
-			params := slabs.SlabPinParams{
-				EncryptionKey: slab.encryptionKey,
-				MinShards:     uint(uo.dataShards),
-				Sectors:       make([]slabs.PinnedSector, totalShards),
-			}
+			sectors := make([]slabs.PinnedSector, totalShards)
 
 			// collect all shards
 			for n := totalShards; n > 0; n-- {
@@ -296,25 +292,20 @@ top:
 					if shard.err != nil {
 						return fmt.Errorf("failed to upload slab: shard upload failed: %w", shard.err)
 					}
-					params.Sectors[shard.index] = slabs.PinnedSector{
+					sectors[shard.index] = slabs.PinnedSector{
 						HostKey: shard.host,
 						Root:    shard.root,
 					}
 				}
 			}
 
-			expectedSlabID := params.Digest()
-
-			slabIDs, err := s.client.PinSlabs(ctx, s.appKey, params)
-			if err != nil {
-				return fmt.Errorf("failed to pin slab %d: %w", slab.slabIndex, err)
-			}
-			slabID := slabIDs[0]
-
-			if slabID != expectedSlabID {
-				return fmt.Errorf("pinned slab %d id %s does not match expected id %s", slab.slabIndex, slabID.String(), expectedSlabID.String())
-			}
-			uploaded = append(uploaded, params.Slice(0, slab.length))
+			uploaded = append(uploaded, slabs.SlabSlice{
+				EncryptionKey: slab.encryptionKey,
+				MinShards:     uint(uo.dataShards),
+				Sectors:       sectors,
+				Offset:        0,
+				Length:        slab.length,
+			})
 			uploadedIndices = append(uploadedIndices, slab.slabIndex)
 		}
 	}
@@ -389,8 +380,29 @@ func (s *SDK) Close() error {
 	return s.hosts.Close()
 }
 
-// SaveObject saves the given object to the indexer.
-func (s *SDK) SaveObject(ctx context.Context, obj Object) error {
+// PinObject pins the object's slabs and saves the object metadata to the
+// indexer.
+func (s *SDK) PinObject(ctx context.Context, obj Object) error {
+	params := make([]slabs.SlabPinParams, len(obj.slabs))
+	for i, slab := range obj.slabs {
+		params[i] = slabs.SlabPinParams{
+			EncryptionKey: slab.EncryptionKey,
+			MinShards:     slab.MinShards,
+			Sectors:       slab.Sectors,
+		}
+	}
+
+	slabIDs, err := s.client.PinSlabs(ctx, s.appKey, params...)
+	if err != nil {
+		return fmt.Errorf("failed to pin slabs: %w", err)
+	}
+
+	for i, slab := range obj.slabs {
+		if expected := slab.Digest(); slabIDs[i] != expected {
+			return fmt.Errorf("slab %d: pinned id %s does not match expected id %s", i, slabIDs[i], expected)
+		}
+	}
+
 	return s.client.SaveObject(ctx, s.appKey, obj.Seal(s.appKey).SealedObject)
 }
 

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -255,7 +255,7 @@ func TestE2E(t *testing.T) {
 			t.Fatalf("failed to save object: %v", err)
 		} else if _, err := client.Object(t.Context(), obj.ID()); err != nil {
 			t.Fatalf("failed to get object: %v", err)
-		} else if err := client.Download(context.Background(), buf, obj); err != nil {
+		} else if err := client.Download(t.Context(), buf, obj); err != nil {
 			t.Fatalf("failed to download: %v", err)
 		} else if !bytes.Equal(buf.Bytes(), data) {
 			t.Fatal("data mismatch")
@@ -293,11 +293,11 @@ func TestE2E(t *testing.T) {
 	defer packed.Close()
 
 	data1 := frand.Bytes(3000)
-	if _, err := packed.Add(context.Background(), bytes.NewReader(data1)); err != nil {
+	if _, err := packed.Add(t.Context(), bytes.NewReader(data1)); err != nil {
 		t.Fatalf("failed to add first object: %v", err)
 	}
 	data2 := frand.Bytes(5000)
-	if _, err := packed.Add(context.Background(), bytes.NewReader(data2)); err != nil {
+	if _, err := packed.Add(t.Context(), bytes.NewReader(data2)); err != nil {
 		t.Fatalf("failed to add second object: %v", err)
 	}
 
@@ -319,11 +319,11 @@ func TestE2E(t *testing.T) {
 	defer packedL.Close()
 
 	data3 := frand.Bytes(5 * 1 << 20) // 5 MiB
-	if _, err := packedL.Add(context.Background(), bytes.NewReader(data3)); err != nil {
+	if _, err := packedL.Add(t.Context(), bytes.NewReader(data3)); err != nil {
 		t.Fatalf("failed to add first large object: %v", err)
 	}
 	data4 := frand.Bytes(5 * 1 << 20) // 5 MiB
-	if _, err := packedL.Add(context.Background(), bytes.NewReader(data4)); err != nil {
+	if _, err := packedL.Add(t.Context(), bytes.NewReader(data4)); err != nil {
 		t.Fatalf("failed to add second large object: %v", err)
 	}
 

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -246,6 +246,35 @@ func TestE2E(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertShareable := func(obj Object, data []byte) {
+		t.Helper()
+
+		// assert we can download the object
+		buf := bytes.NewBuffer(nil)
+		if err := client.SaveObject(t.Context(), obj); err != nil {
+			t.Fatalf("failed to save object: %v", err)
+		} else if _, err := client.Object(t.Context(), obj.ID()); err != nil {
+			t.Fatalf("failed to get object: %v", err)
+		} else if err := client.Download(context.Background(), buf, obj); err != nil {
+			t.Fatalf("failed to download: %v", err)
+		} else if !bytes.Equal(buf.Bytes(), data) {
+			t.Fatal("data mismatch")
+		}
+
+		// assert we can share the object
+		sharedURL, err := client.CreateSharedObjectURL(t.Context(), obj.ID(), time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("failed to create shared object URL: %v", err)
+		}
+		buf.Reset()
+		if err := client.DownloadSharedObject(t.Context(), buf, sharedURL); err != nil {
+			t.Fatalf("failed to download shared object: %v", err)
+		} else if !bytes.Equal(buf.Bytes(), data) {
+			t.Fatal("data mismatch")
+		}
+	}
+
+	// regular object upload
 	data := frand.Bytes(4096)
 	obj := NewEmptyObject()
 	err = client.Upload(t.Context(), &obj, bytes.NewReader(data), WithRedundancy(2, 8))
@@ -253,20 +282,60 @@ func TestE2E(t *testing.T) {
 		t.Fatalf("failed to upload: %v", err)
 	} else if _, err := client.Object(t.Context(), obj.ID()); err == nil || !strings.Contains(err.Error(), slabs.ErrObjectNotFound.Error()) {
 		t.Fatal("object should not be pinned yet")
-	} else if err := client.SaveObject(t.Context(), obj); err != nil {
-		t.Fatal(err)
-	} else if _, err := client.Object(t.Context(), obj.ID()); err != nil {
-		t.Fatal(err)
+	}
+	assertShareable(obj, data)
+
+	// packed upload
+	packed, err := client.UploadPacked(WithRedundancy(2, 8))
+	if err != nil {
+		t.Fatalf("failed to create packed upload: %v", err)
+	}
+	defer packed.Close()
+
+	data1 := frand.Bytes(3000)
+	if _, err := packed.Add(context.Background(), bytes.NewReader(data1)); err != nil {
+		t.Fatalf("failed to add first object: %v", err)
+	}
+	data2 := frand.Bytes(5000)
+	if _, err := packed.Add(context.Background(), bytes.NewReader(data2)); err != nil {
+		t.Fatalf("failed to add second object: %v", err)
 	}
 
-	buf := bytes.NewBuffer(nil)
-	if err := client.Download(t.Context(), buf, obj); err != nil {
-		t.Fatalf("failed to download: %v", err)
-	} else if !bytes.Equal(buf.Bytes(), data) {
-		t.Log(data[:64])
-		t.Log(buf.Bytes()[:64])
-		t.Fatal("data mismatch")
+	objects, err := packed.Finalize(t.Context())
+	if err != nil {
+		t.Fatalf("failed to finalize packed upload: %v", err)
+	} else if len(objects) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objects))
 	}
+
+	assertShareable(objects[0], data1)
+	assertShareable(objects[1], data2)
+
+	// packed upload spanning multiple slabs
+	packedL, err := client.UploadPacked(WithRedundancy(2, 8))
+	if err != nil {
+		t.Fatalf("failed to create multi-slab packed upload: %v", err)
+	}
+	defer packedL.Close()
+
+	data3 := frand.Bytes(5 * 1 << 20) // 5 MiB
+	if _, err := packedL.Add(context.Background(), bytes.NewReader(data3)); err != nil {
+		t.Fatalf("failed to add first large object: %v", err)
+	}
+	data4 := frand.Bytes(5 * 1 << 20) // 5 MiB
+	if _, err := packedL.Add(context.Background(), bytes.NewReader(data4)); err != nil {
+		t.Fatalf("failed to add second large object: %v", err)
+	}
+
+	objects2, err := packedL.Finalize(t.Context())
+	if err != nil {
+		t.Fatalf("failed to finalize multi-slab packed upload: %v", err)
+	} else if len(objects2) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objects2))
+	}
+
+	assertShareable(objects2[0], data3)
+	assertShareable(objects2[1], data4)
 }
 
 func BenchmarkUpload(b *testing.B) {

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -133,9 +133,9 @@ func TestDownload(t *testing.T) {
 		t.Fatalf("failed to upload: %v", err)
 	}
 
-	err = s.client.SaveObject(t.Context(), appKey, obj.Seal(appKey).SealedObject)
+	err = s.PinObject(t.Context(), obj)
 	if err != nil {
-		t.Fatalf("failed to save object to mock client: %v", err)
+		t.Fatalf("failed to pin object: %v", err)
 	}
 
 	sharedURL, err := s.CreateSharedObjectURL(t.Context(), obj.ID(), time.Now().Add(time.Hour))
@@ -251,8 +251,8 @@ func TestE2E(t *testing.T) {
 
 		// assert we can download the object
 		buf := bytes.NewBuffer(nil)
-		if err := client.SaveObject(t.Context(), obj); err != nil {
-			t.Fatalf("failed to save object: %v", err)
+		if err := client.PinObject(t.Context(), obj); err != nil {
+			t.Fatalf("failed to pin object: %v", err)
 		} else if _, err := client.Object(t.Context(), obj.ID()); err != nil {
 			t.Fatalf("failed to get object: %v", err)
 		} else if err := client.Download(t.Context(), buf, obj); err != nil {

--- a/sdk/packing.go
+++ b/sdk/packing.go
@@ -35,9 +35,6 @@ type (
 		dataShards   uint8
 		parityShards uint8
 
-		// pin function, set by SDK
-		pinResultFn pinResultFn
-
 		// upload state
 		reader  *io.PipeReader
 		writer  *io.PipeWriter
@@ -62,33 +59,7 @@ type (
 		slabs []slabs.SlabSlice
 		err   error
 	}
-
-	pinResultFn func(ctx context.Context, result packedResult) error
 )
-
-func (pr packedResult) PinParams() []slabs.SlabPinParams {
-	params := make([]slabs.SlabPinParams, len(pr.slabs))
-	for i, slab := range pr.slabs {
-		params[i] = slabs.SlabPinParams{
-			EncryptionKey: slab.EncryptionKey,
-			MinShards:     slab.MinShards,
-			Sectors:       slab.Sectors,
-		}
-	}
-	return params
-}
-
-func (pr packedResult) VerifySlabIDs(uploaded []slabs.SlabID) error {
-	if len(pr.slabs) != len(uploaded) {
-		return fmt.Errorf("unexpected number of slabs: got %d, expected %d", len(uploaded), len(pr.slabs))
-	}
-	for i, slab := range pr.slabs {
-		if slab.Digest() != uploaded[i] {
-			return fmt.Errorf("slab %d: unexpected slab ID: got %s, expected %s", i, uploaded[i], slab.Digest())
-		}
-	}
-	return nil
-}
 
 // Add adds a new object to the upload. The data will be read until EOF and
 // packed into the upload. The caller must call Finalize to get the resulting
@@ -159,11 +130,11 @@ func (u *PackedUpload) Close() error {
 	return nil
 }
 
-// Finalize finalizes the upload, pins the resulting slabs, and returns the
-// resulting objects. This will wait for all slabs to be uploaded before
-// returning. The resulting objects will contain the metadata needed to
-// download the objects. The caller must call SaveObject for each returned
-// object to persist it to the indexer.
+// Finalize finalizes the upload and returns the resulting objects. This will
+// wait for all slabs to be uploaded before returning. The resulting objects
+// will contain the metadata needed to download the objects. The caller must
+// call PinObject for each returned object to pin the slabs and save the
+// object metadata to the indexer.
 func (u *PackedUpload) Finalize(ctx context.Context) ([]Object, error) {
 	// close the writer to signal EOF to the uploader
 	_ = u.writer.Close()
@@ -176,11 +147,6 @@ func (u *PackedUpload) Finalize(ctx context.Context) ([]Object, error) {
 		if u.result.err != nil {
 			return nil, u.result.err
 		}
-	}
-
-	// pin slabs
-	if err := u.pinResultFn(ctx, u.result); err != nil {
-		return nil, err
 	}
 
 	// build objects
@@ -289,14 +255,6 @@ func (s *SDK) UploadPacked(opts ...UploadOption) (*PackedUpload, error) {
 	u := &PackedUpload{
 		dataShards:   uo.dataShards,
 		parityShards: uo.parityShards,
-
-		pinResultFn: func(ctx context.Context, result packedResult) error {
-			slabIDs, err := s.client.PinSlabs(ctx, s.appKey, result.PinParams()...)
-			if err != nil {
-				return fmt.Errorf("failed to pin slabs: %w", err)
-			}
-			return result.VerifySlabIDs(slabIDs)
-		},
 
 		reader: reader,
 		writer: writer,

--- a/sdk/packing.go
+++ b/sdk/packing.go
@@ -35,6 +35,9 @@ type (
 		dataShards   uint8
 		parityShards uint8
 
+		// pin function, set by SDK
+		pinResultFn pinResultFn
+
 		// upload state
 		reader  *io.PipeReader
 		writer  *io.PipeWriter
@@ -59,7 +62,33 @@ type (
 		slabs []slabs.SlabSlice
 		err   error
 	}
+
+	pinResultFn func(ctx context.Context, result packedResult) error
 )
+
+func (pr packedResult) PinParams() []slabs.SlabPinParams {
+	params := make([]slabs.SlabPinParams, len(pr.slabs))
+	for i, slab := range pr.slabs {
+		params[i] = slabs.SlabPinParams{
+			EncryptionKey: slab.EncryptionKey,
+			MinShards:     slab.MinShards,
+			Sectors:       slab.Sectors,
+		}
+	}
+	return params
+}
+
+func (pr packedResult) VerifySlabIDs(uploaded []slabs.SlabID) error {
+	if len(pr.slabs) != len(uploaded) {
+		return fmt.Errorf("unexpected number of slabs: got %d, expected %d", len(uploaded), len(pr.slabs))
+	}
+	for i, slab := range pr.slabs {
+		if slab.Digest() != uploaded[i] {
+			return fmt.Errorf("slab %d: unexpected slab ID: got %s, expected %s", i, uploaded[i], slab.Digest())
+		}
+	}
+	return nil
+}
 
 // Add adds a new object to the upload. The data will be read until EOF and
 // packed into the upload. The caller must call Finalize to get the resulting
@@ -130,12 +159,11 @@ func (u *PackedUpload) Close() error {
 	return nil
 }
 
-// Finalize finalizes the upload and returns the resulting objects. This will
-// wait for all slabs to be uploaded before returning. The resulting objects
-// will contain the metadata needed to download the objects.
-//
-// The caller must pin the resulting objects to the indexer when ready. Finalize
-// is idempotent and can be called multiple times.
+// Finalize finalizes the upload, pins the resulting slabs, and returns the
+// resulting objects. This will wait for all slabs to be uploaded before
+// returning. The resulting objects will contain the metadata needed to
+// download the objects. The caller must call SaveObject for each returned
+// object to persist it to the indexer.
 func (u *PackedUpload) Finalize(ctx context.Context) ([]Object, error) {
 	// close the writer to signal EOF to the uploader
 	_ = u.writer.Close()
@@ -148,6 +176,11 @@ func (u *PackedUpload) Finalize(ctx context.Context) ([]Object, error) {
 		if u.result.err != nil {
 			return nil, u.result.err
 		}
+	}
+
+	// pin slabs
+	if err := u.pinResultFn(ctx, u.result); err != nil {
+		return nil, err
 	}
 
 	// build objects
@@ -256,6 +289,14 @@ func (s *SDK) UploadPacked(opts ...UploadOption) (*PackedUpload, error) {
 	u := &PackedUpload{
 		dataShards:   uo.dataShards,
 		parityShards: uo.parityShards,
+
+		pinResultFn: func(ctx context.Context, result packedResult) error {
+			slabIDs, err := s.client.PinSlabs(ctx, s.appKey, result.PinParams()...)
+			if err != nil {
+				return fmt.Errorf("failed to pin slabs: %w", err)
+			}
+			return result.VerifySlabIDs(slabIDs)
+		},
 
 		reader: reader,
 		writer: writer,


### PR DESCRIPTION
The Go SDK pins slabs in `Upload` (and not in `UploadPacked`) so it's internally inconsistent. The Rust SDK does not pin slabs for both regular and packed uploads but instead exposes `PinObject`. This PR makes the Go SDK consistent with the Rust SDK.
