### PR TITLE
Add endpoint to prune orphaned slabs from an account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 .DS_Store
 .vscode
 indexd.yml
+CLAUDE.md

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -623,6 +623,7 @@ func (a *admin) handleDELETEAccountPrune(jc jape.Context) {
 		jc.Error(err, http.StatusInternalServerError)
 		return
 	}
+	jc.Encode(nil)
 }
 
 func (a *admin) handlePATCHAccount(jc jape.Context) {

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -127,6 +127,7 @@ type (
 
 		DeleteContract(contractID types.FileContractID) error
 		LastScannedIndex() (types.ChainIndex, error)
+		PruneSlabs(account proto.Account) error
 	}
 
 	// A Syncer can connect to other peers and synchronize the blockchain.
@@ -210,8 +211,9 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 		// accounts endpoints
 		"GET    /accounts":            a.handleGETAccounts,
 		"GET    /account/:accountkey": a.handleGETAccount,
-		"DELETE /account/:accountkey": a.handleDELETEAccount,
-		"PATCH  /account/:accountkey": a.handlePATCHAccount,
+		"DELETE /account/:accountkey":       a.handleDELETEAccount,
+		"DELETE /account/:accountkey/prune": a.handleDELETEAccountPrune,
+		"PATCH  /account/:accountkey":       a.handlePATCHAccount,
 
 		// alerts endpoints
 		"GET    /alerts":         a.handleGETAlerts,
@@ -605,6 +607,16 @@ func (a *admin) handleDELETEAccount(jc jape.Context) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if jc.Check("failed to delete account", err) != nil {
+		return
+	}
+}
+
+func (a *admin) handleDELETEAccountPrune(jc jape.Context) {
+	var ak proto.Account
+	if jc.DecodeParam("accountkey", &ak) != nil {
+		return
+	}
+	if jc.Check("failed to prune slabs", a.store.PruneSlabs(ak)) != nil {
 		return
 	}
 }

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -209,11 +209,11 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 		"GET /consensus/network": a.handleGETConsensusNetwork,
 
 		// accounts endpoints
-		"GET    /accounts":                  a.handleGETAccounts,
-		"GET    /account/:accountkey":       a.handleGETAccount,
-		"DELETE /account/:accountkey":       a.handleDELETEAccount,
-		"DELETE /account/:accountkey/prune": a.handleDELETEAccountPrune,
-		"PATCH  /account/:accountkey":       a.handlePATCHAccount,
+		"GET    /accounts":                        a.handleGETAccounts,
+		"GET    /account/:accountkey":             a.handleGETAccount,
+		"DELETE /account/:accountkey":             a.handleDELETEAccount,
+		"POST   /account/:accountkey/slabs/prune": a.handlePOSTAccountPrune,
+		"PATCH  /account/:accountkey":             a.handlePATCHAccount,
 
 		// alerts endpoints
 		"GET    /alerts":         a.handleGETAlerts,
@@ -611,7 +611,7 @@ func (a *admin) handleDELETEAccount(jc jape.Context) {
 	}
 }
 
-func (a *admin) handleDELETEAccountPrune(jc jape.Context) {
+func (a *admin) handlePOSTAccountPrune(jc jape.Context) {
 	var ak proto.Account
 	if jc.DecodeParam("accountkey", &ak) != nil {
 		return

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -209,8 +209,8 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 		"GET /consensus/network": a.handleGETConsensusNetwork,
 
 		// accounts endpoints
-		"GET    /accounts":            a.handleGETAccounts,
-		"GET    /account/:accountkey": a.handleGETAccount,
+		"GET    /accounts":                  a.handleGETAccounts,
+		"GET    /account/:accountkey":       a.handleGETAccount,
 		"DELETE /account/:accountkey":       a.handleDELETEAccount,
 		"DELETE /account/:accountkey/prune": a.handleDELETEAccountPrune,
 		"PATCH  /account/:accountkey":       a.handlePATCHAccount,
@@ -616,7 +616,11 @@ func (a *admin) handleDELETEAccountPrune(jc jape.Context) {
 	if jc.DecodeParam("accountkey", &ak) != nil {
 		return
 	}
-	if jc.Check("failed to prune slabs", a.store.PruneSlabs(ak)) != nil {
+	if err := a.store.PruneSlabs(ak); errors.Is(err, accounts.ErrNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
 		return
 	}
 }

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1455,6 +1455,83 @@ func TestAccountStatsAPI(t *testing.T) {
 	}
 }
 
+func TestPruneSlabs(t *testing.T) {
+	cluster := testutils.NewCluster(t, testutils.WithHosts(1))
+	indexer := cluster.Indexer
+	adminClient := indexer.Admin
+	store := indexer.Store()
+
+	cluster.WaitForContracts(t)
+
+	hk := cluster.Hosts[0].PublicKey()
+
+	// create an account
+	account := types.GeneratePrivateKey().PublicKey()
+	store.AddTestAccount(t, account)
+	acc := proto.Account(account)
+
+	// pin two slabs
+	slab1 := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    frand.Entropy256(),
+			HostKey: hk,
+		}},
+	}
+	slab2 := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    frand.Entropy256(),
+			HostKey: hk,
+		}},
+	}
+	if _, err := store.PinSlabs(acc, time.Time{}, slab1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.PinSlabs(acc, time.Time{}, slab2); err != nil {
+		t.Fatal(err)
+	}
+
+	// create an object that references only slab1
+	obj := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: frand.Bytes(72),
+		Slabs: []slabs.SlabSlice{
+			slab1.Slice(0, 100),
+		},
+		DataSignature:     types.Signature(frand.Bytes(64)),
+		MetadataSignature: types.Signature(frand.Bytes(64)),
+	}
+	if err := store.SaveObject(acc, obj); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify both slabs exist
+	slabIDs, err := store.SlabIDs(acc, 0, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(slabIDs) != 2 {
+		t.Fatalf("expected 2 slabs, got %d", len(slabIDs))
+	}
+
+	// prune slabs via admin API
+	if err := adminClient.PruneSlabs(context.Background(), account); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify only slab1 (referenced by object) remains
+	slabIDs, err = store.SlabIDs(acc, 0, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(slabIDs) != 1 {
+		t.Fatalf("expected 1 slab after prune, got %d", len(slabIDs))
+	} else if slabIDs[0] != slab1.Digest() {
+		t.Fatal("expected slab1 to remain")
+	}
+}
+
 // newTestLogger creates a console logger used for testing.
 func newTestLogger(enable bool) *zap.Logger {
 	if !enable {

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -146,6 +146,12 @@ func (c *Client) UpdateAccount(ctx context.Context, ak types.PublicKey, updates 
 	return c.c.PATCH(ctx, fmt.Sprintf("/account/%s", ak), updates, nil)
 }
 
+// PruneSlabs prunes all pinned slabs of the given account not currently
+// connected to an object.
+func (c *Client) PruneSlabs(ctx context.Context, ak types.PublicKey) error {
+	return c.c.DELETE(ctx, fmt.Sprintf("/account/%s/prune", ak))
+}
+
 // Accounts returns all accounts registered in the indexer.
 func (c *Client) Accounts(ctx context.Context, opts ...api.URLQueryParameterOption) (accounts []accounts.Account, err error) {
 	values := url.Values{}

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -149,7 +149,7 @@ func (c *Client) UpdateAccount(ctx context.Context, ak types.PublicKey, updates 
 // PruneSlabs prunes all pinned slabs of the given account not currently
 // connected to an object.
 func (c *Client) PruneSlabs(ctx context.Context, ak types.PublicKey) error {
-	return c.c.DELETE(ctx, fmt.Sprintf("/account/%s/prune", ak))
+	return c.c.POST(ctx, fmt.Sprintf("/account/%s/slabs/prune", ak), nil, nil)
 }
 
 // Accounts returns all accounts registered in the indexer.

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -537,8 +537,8 @@ paths:
         "404":
           description: Account not found
 
-  /account/{accountkey}/prune:
-    delete:
+  /account/{accountkey}/slabs/prune:
+    post:
       tags:
         - accounts
       summary: Prune orphaned slabs

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -551,7 +551,7 @@ paths:
           schema:
             type: string
       responses:
-        "200":
+        "204":
           description: Slabs pruned successfully
         "404":
           description: Account not found

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -537,6 +537,27 @@ paths:
         "404":
           description: Account not found
 
+  /account/{accountkey}/prune:
+    delete:
+      tags:
+        - accounts
+      summary: Prune orphaned slabs
+      description: Prune all pinned slabs of the given account that are not currently referenced by any object.
+      operationId: pruneAccountSlabs
+      parameters:
+        - name: accountkey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Slabs pruned successfully
+        "404":
+          description: Account not found
+        "500":
+          description: Internal server error
+
   /alerts:
     get:
       tags:


### PR DESCRIPTION
This will allow us to provide a dashboard function that users can use to prune garbage data from their accounts without having to go through their apps. 

It's also nice for manually pruning deleted objects. Our test server has a few lost slabs without objects that should be pruned. 