### PR TITLE
Add ephemeral key to auth

### DIFF
--- a/api/app/app.go
+++ b/api/app/app.go
@@ -608,20 +608,24 @@ func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
 
 	a.mu.Lock()
 	authReq, ok := a.authRequests[requestID]
-	a.mu.Unlock()
 	if !ok || time.Now().After(authReq.Expiration) {
+		a.mu.Unlock()
 		jc.Error(fmt.Errorf("request invalid or expired"), http.StatusNotFound)
 		return
 	} else if signerKey, ok := validateURLSignature(jc, a.hostname); !ok {
+		a.mu.Unlock()
 		return
 	} else if authReq.EphemeralKey != signerKey {
+		a.mu.Unlock()
 		jc.Error(fmt.Errorf("invalid request signature"), http.StatusUnauthorized)
 		return
 	}
-	jc.Encode(AuthConnectStatusResponse{
+	resp := AuthConnectStatusResponse{
 		Approved:   authReq.Approved,
 		UserSecret: authReq.UserSecret,
-	})
+	}
+	a.mu.Unlock()
+	jc.Encode(resp)
 }
 
 // 5. app registers the public key with indexd using a request signed

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -608,24 +608,20 @@ func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
 
 	a.mu.Lock()
 	authReq, ok := a.authRequests[requestID]
+	a.mu.Unlock()
 	if !ok || time.Now().After(authReq.Expiration) {
-		a.mu.Unlock()
 		jc.Error(fmt.Errorf("request invalid or expired"), http.StatusNotFound)
 		return
 	} else if signerKey, ok := validateURLSignature(jc, a.hostname); !ok {
-		a.mu.Unlock()
 		return
 	} else if authReq.EphemeralKey != signerKey {
-		a.mu.Unlock()
 		jc.Error(fmt.Errorf("invalid request signature"), http.StatusUnauthorized)
 		return
 	}
-	resp := AuthConnectStatusResponse{
+	jc.Encode(AuthConnectStatusResponse{
 		Approved:   authReq.Approved,
 		UserSecret: authReq.UserSecret,
-	}
-	a.mu.Unlock()
-	jc.Encode(resp)
+	})
 }
 
 // 5. app registers the public key with indexd using a request signed

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -74,8 +74,10 @@ type (
 	}
 
 	authReq struct {
-		Request    RegisterAppRequest
-		Expiration time.Time
+		// EphemeralKey is the public key used to sign the initial connection request. It is used to authenticate future requests for the same connection request, so it must be unique for each connection request. It is not used for authentication after the app key is registered.
+		EphemeralKey types.PublicKey
+		Request      RegisterAppRequest
+		Expiration   time.Time
 
 		// set when the user approves the request
 		Approved   bool
@@ -124,6 +126,14 @@ type (
 		PinnedSize    uint64           `json:"pinnedSize"`
 		App           accounts.AppMeta `json:"app"`
 		LastUsed      time.Time        `json:"lastUsed"`
+	}
+
+	// RegisterAppKeyRequest is the request body for registering an application key after the user approves the connection request.
+	// The request must be signed with the app key to prove ownership of it.
+	RegisterAppKeyRequest struct {
+		AppKey types.PublicKey `json:"appKey"`
+		// Signature is a signature of the request ID signed with the app key to prove ownership
+		Signature types.Signature `json:"signature"`
 	}
 
 	app struct {
@@ -440,6 +450,13 @@ func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 
 // 1. app requests connection by POSTing to /auth/connect
 func (a *app) handleAuthRequest(jc jape.Context) {
+	// the request is required to be signed with an ephemeral key to provide authentication
+	// for future steps.
+	ephemeralKey, ok := validateURLSignature(jc, a.hostname)
+	if !ok {
+		return
+	}
+
 	var req RegisterAppRequest
 	if err := jc.Decode(&req); err != nil {
 		return
@@ -480,8 +497,9 @@ func (a *app) handleAuthRequest(jc jape.Context) {
 
 	a.mu.Lock()
 	a.authRequests[requestID] = authReq{
-		Request:    req,
-		Expiration: expiration,
+		Request:      req,
+		Expiration:   expiration,
+		EphemeralKey: ephemeralKey,
 	}
 	a.mu.Unlock()
 	time.AfterFunc(time.Until(expiration), func() {
@@ -589,10 +607,15 @@ func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
 	jc.DecodeParam("requestID", &requestID)
 
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	authReq, ok := a.authRequests[requestID]
+	a.mu.Unlock()
 	if !ok || time.Now().After(authReq.Expiration) {
 		jc.Error(fmt.Errorf("request invalid or expired"), http.StatusNotFound)
+		return
+	} else if signerKey, ok := validateURLSignature(jc, a.hostname); !ok {
+		return
+	} else if authReq.EphemeralKey != signerKey {
+		jc.Error(fmt.Errorf("invalid request signature"), http.StatusUnauthorized)
 		return
 	}
 	jc.Encode(AuthConnectStatusResponse{
@@ -625,13 +648,26 @@ func (a *app) handleAuthRegister(jc jape.Context) {
 		panic("user secret is empty for approved request") // should never happen
 	}
 
-	// check whether the request is properly signed
-	appKey, ok := validateURLSignature(jc, a.hostname, jc.Request.URL.Path)
+	// check whether the request is signed with the ephemeral key
+	ephemeralKey, ok := validateURLSignature(jc, a.hostname)
 	if !ok {
+		return
+	} else if authReq.EphemeralKey != ephemeralKey {
+		jc.Error(fmt.Errorf("invalid request signature"), http.StatusUnauthorized)
 		return
 	}
 
-	err := a.accounts.RegisterAppKey(authReq.ConnectKey, appKey, accounts.AppMeta{
+	var registerReq RegisterAppKeyRequest
+	if jc.Decode(&registerReq) != nil {
+		return
+	}
+	// verify ownership of the app key
+	if !registerReq.AppKey.VerifyHash(registerAppKeyHash(authReq.EphemeralKey, requestID), registerReq.Signature) {
+		jc.Error(fmt.Errorf("invalid signature"), http.StatusUnauthorized)
+		return
+	}
+
+	err := a.accounts.RegisterAppKey(authReq.ConnectKey, registerReq.AppKey, accounts.AppMeta{
 		ID:          authReq.Request.AppID,
 		Description: authReq.Request.Description,
 		LogoURL:     authReq.Request.LogoURL,
@@ -701,7 +737,7 @@ func NewAPI(advertiseURL string, store Store, am Accounts, contracts Contracts, 
 
 	wrapSignedAuth := func(h authedHandler) jape.Handler {
 		return func(jc jape.Context) {
-			pk, ok := validateSignedURLAuth(jc, a.hostname, jc.Request.URL.Path, am)
+			pk, ok := validateSignedURLAuth(jc, a.hostname, am)
 			if !ok {
 				return
 			}

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -72,7 +72,8 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 		t.Fatal("failed to add app connect key:", err)
 	}
 
-	connectResp, err := client.RequestAppConnection(ctx, app.RegisterAppRequest{
+	ephemeralKey := types.GeneratePrivateKey()
+	connectResp, err := client.RequestAppConnection(ctx, ephemeralKey, app.RegisterAppRequest{
 		AppID:       frand.Entropy256(),
 		Name:        "Test App",
 		Description: "A test application",
@@ -94,7 +95,7 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 	respondToAppConnection(t, connectResp.ResponseURL, key.Key, true)
 
 	// register the app key
-	if err = client.RegisterApp(ctx, connectResp.RegisterURL, sk); err != nil {
+	if err = client.RegisterApp(ctx, connectResp.RegisterURL, ephemeralKey, sk); err != nil {
 		t.Fatal("failed to register app:", err)
 	}
 
@@ -473,6 +474,57 @@ func TestApplicationAPI(t *testing.T) {
 	}
 }
 
+func TestEphemeralKeyAuth(t *testing.T) {
+	ctx := t.Context()
+	cluster := testutils.NewCluster(t, testutils.WithHosts(3), testutils.WithLogger(zap.NewNop()))
+	indexer := cluster.Indexer
+
+	connectKey, err := indexer.Admin.AddAppConnectKey(ctx, accounts.AppConnectKeyRequest{
+		Quota: "default",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ephemeralKey := types.GeneratePrivateKey()
+	wrongKey := types.GeneratePrivateKey()
+	appKey := types.GeneratePrivateKey()
+	appClient := indexer.App
+
+	connectResp, err := appClient.RequestAppConnection(ctx, ephemeralKey, app.RegisterAppRequest{
+		AppID:       frand.Entropy256(),
+		Name:        "test",
+		Description: "test",
+		ServiceURL:  "http://example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	respondToAppConnection(t, connectResp.ResponseURL, connectKey.Key, true)
+
+	if _, err := appClient.RequestStatus(ctx, wrongKey, connectResp.StatusURL); err == nil {
+		t.Fatal("expected error with wrong ephemeral key on status")
+	}
+
+	status, err := appClient.RequestStatus(ctx, ephemeralKey, connectResp.StatusURL)
+	if err != nil {
+		t.Fatal(err)
+	} else if !status.Approved {
+		t.Fatal("expected approved")
+	} else if status.UserSecret == (types.Hash256{}) {
+		t.Fatal("expected non-empty user secret")
+	}
+
+	if err := appClient.RegisterApp(ctx, connectResp.RegisterURL, wrongKey, appKey); err == nil {
+		t.Fatal("expected error with wrong ephemeral key on register")
+	}
+
+	if err := appClient.RegisterApp(ctx, connectResp.RegisterURL, ephemeralKey, appKey); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAppConnect(t *testing.T) {
 	appID := frand.Entropy256()
 
@@ -492,6 +544,7 @@ func TestAppConnect(t *testing.T) {
 	}
 
 	sk := types.GeneratePrivateKey()
+	ephemeralSK := types.GeneratePrivateKey()
 	appClient := indexer.App
 
 	connected, err := appClient.CheckAppAuth(ctx, sk)
@@ -501,7 +554,7 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("expected app to not be authenticated yet")
 	}
 
-	resp, err := appClient.RequestAppConnection(ctx, app.RegisterAppRequest{
+	resp, err := appClient.RequestAppConnection(ctx, ephemeralSK, app.RegisterAppRequest{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -511,7 +564,7 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("failed to request app connection:", err)
 	}
 
-	if status, err := appClient.RequestStatus(ctx, resp.StatusURL); err != nil {
+	if status, err := appClient.RequestStatus(ctx, ephemeralSK, resp.StatusURL); err != nil {
 		t.Fatal("failed to check request status:", err)
 	} else if status.Approved {
 		t.Fatal("expected request to not be approved")
@@ -519,23 +572,23 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("expected empty user secret")
 	}
 
-	if err := appClient.RegisterApp(ctx, resp.RegisterURL, sk); err == nil {
+	if err := appClient.RegisterApp(ctx, resp.RegisterURL, ephemeralSK, sk); err == nil {
 		t.Fatal("expected registration to fail for unapproved request")
 	}
 
 	// reject the request
 	respondToAppConnection(t, resp.ResponseURL, connectKey.Key, false)
 
-	if err := appClient.RegisterApp(ctx, resp.RegisterURL, sk); err == nil {
+	if err := appClient.RegisterApp(ctx, resp.RegisterURL, ephemeralSK, sk); err == nil {
 		t.Fatal("expected registration to fail for rejected request")
 	}
 
-	if status, err := appClient.RequestStatus(ctx, resp.StatusURL); !errors.Is(err, app.ErrUserRejected) {
+	if status, err := appClient.RequestStatus(ctx, ephemeralSK, resp.StatusURL); !errors.Is(err, app.ErrUserRejected) {
 		t.Fatalf("expected request to be rejected, got: %v %v", err, status)
 	}
 
 	// try again
-	resp, err = appClient.RequestAppConnection(ctx, app.RegisterAppRequest{
+	resp, err = appClient.RequestAppConnection(ctx, ephemeralSK, app.RegisterAppRequest{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -547,7 +600,7 @@ func TestAppConnect(t *testing.T) {
 
 	respondToAppConnection(t, resp.ResponseURL, connectKey.Key, true)
 
-	status, err := appClient.RequestStatus(ctx, resp.StatusURL)
+	status, err := appClient.RequestStatus(ctx, ephemeralSK, resp.StatusURL)
 	if err != nil {
 		t.Fatal("failed to check request status:", err)
 	} else if !status.Approved {
@@ -556,7 +609,7 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("expected non-empty user secret")
 	}
 
-	if err := appClient.RegisterApp(ctx, resp.RegisterURL, sk); err != nil {
+	if err := appClient.RegisterApp(ctx, resp.RegisterURL, ephemeralSK, sk); err != nil {
 		t.Fatal("failed to register app:", err)
 	}
 
@@ -596,7 +649,7 @@ func TestAppConnect(t *testing.T) {
 	}
 
 	// authenticate again to ensure the same user secret is returned
-	resp, err = appClient.RequestAppConnection(ctx, app.RegisterAppRequest{
+	resp, err = appClient.RequestAppConnection(ctx, ephemeralSK, app.RegisterAppRequest{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -607,7 +660,7 @@ func TestAppConnect(t *testing.T) {
 	}
 	respondToAppConnection(t, resp.ResponseURL, connectKey.Key, true)
 
-	if secondStatus, err := appClient.RequestStatus(ctx, resp.StatusURL); err != nil {
+	if secondStatus, err := appClient.RequestStatus(ctx, ephemeralSK, resp.StatusURL); err != nil {
 		t.Fatal("failed to check request status:", err)
 	} else if !secondStatus.Approved {
 		t.Fatal("expected request to be approved")
@@ -632,6 +685,7 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ephemeralKey := types.GeneratePrivateKey()
 	sk2 := types.GeneratePrivateKey()
 	appMeta := app.RegisterAppRequest{
 		AppID:       frand.Entropy256(),
@@ -640,22 +694,22 @@ func TestAppConnect(t *testing.T) {
 		ServiceURL:  "http://example.com",
 	}
 	// first connection — uses the single remaining use
-	resp, err = appClient.RequestAppConnection(ctx, appMeta)
+	resp, err = appClient.RequestAppConnection(ctx, ephemeralKey, appMeta)
 	if err != nil {
 		t.Fatal(err)
 	}
 	respondToAppConnection(t, resp.ResponseURL, oneUseKey.Key, true)
-	if err := appClient.RegisterApp(ctx, resp.RegisterURL, sk2); err != nil {
+	if err := appClient.RegisterApp(ctx, resp.RegisterURL, ephemeralKey, sk2); err != nil {
 		t.Fatal("expected first registration on 1-use key to succeed:", err)
 	}
 
 	// second connection with the same key — key is now exhausted, but re-auth should succeed
-	resp, err = appClient.RequestAppConnection(ctx, appMeta)
+	resp, err = appClient.RequestAppConnection(ctx, ephemeralKey, appMeta)
 	if err != nil {
 		t.Fatal(err)
 	}
 	respondToAppConnection(t, resp.ResponseURL, oneUseKey.Key, true)
-	if err := appClient.RegisterApp(ctx, resp.RegisterURL, sk2); err != nil {
+	if err := appClient.RegisterApp(ctx, resp.RegisterURL, ephemeralKey, sk2); err != nil {
 		t.Fatal("expected re-auth on exhausted key to succeed:", err)
 	}
 }

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -52,7 +52,7 @@ const (
 // NOTE: This function does not check if the account exists, it only validates
 // the signature and expiration. If you need to check for account existence, use
 // validateSignedURLAuth instead.
-func ValidateURLSignature(req *http.Request, hostname, path string) (types.PublicKey, error) {
+func ValidateURLSignature(req *http.Request, hostname string) (types.PublicKey, error) {
 	defer req.Body.Close()
 
 	buf, err := io.ReadAll(io.LimitReader(req.Body, maxRequestSize))
@@ -83,8 +83,8 @@ func ValidateURLSignature(req *http.Request, hostname, path string) (types.Publi
 	// check for expiration and verify the signature
 	if ts.Before(time.Now().UTC()) {
 		return types.PublicKey{}, ErrSignatureExpired
-	} else if !pk.VerifyHash(requestHash(req.Method, hostname, path, ts, buf), sig) {
-		return types.PublicKey{}, fmt.Errorf("failed to authenticate for %q host %q: %w", req.Method, filepath.Join(hostname, path), ErrSignatureInvalid)
+	} else if !pk.VerifyHash(requestHash(req.Method, hostname, req.URL.Path, ts, buf), sig) {
+		return types.PublicKey{}, fmt.Errorf("failed to authenticate for %q host %q: %w", req.Method, filepath.Join(hostname, req.URL.Path), ErrSignatureInvalid)
 	}
 	return pk, nil
 }
@@ -93,8 +93,8 @@ func ValidateURLSignature(req *http.Request, hostname, path string) (types.Publi
 // verifies the signature and expiration. If successful, it returns the public
 // key and true, otherwise it writes an error to the context and returns an
 // empty public key and false.
-func validateURLSignature(jc jape.Context, hostname, path string) (types.PublicKey, bool) {
-	acc, err := ValidateURLSignature(jc.Request, hostname, path)
+func validateURLSignature(jc jape.Context, hostname string) (types.PublicKey, bool) {
+	acc, err := ValidateURLSignature(jc.Request, hostname)
 	if err != nil {
 		jc.Error(err, http.StatusUnauthorized)
 		return types.PublicKey{}, false
@@ -106,10 +106,10 @@ func validateURLSignature(jc jape.Context, hostname, path string) (types.PublicK
 // parameters, verifying the signature and expiration, and confirming the
 // account exists. If any check fails, it writes an HTTP error and returns
 // false, otherwise it returns the public key and true.
-func validateSignedURLAuth(jc jape.Context, hostname, path string, store Accounts) (types.PublicKey, bool) {
+func validateSignedURLAuth(jc jape.Context, hostname string, store Accounts) (types.PublicKey, bool) {
 	req := jc.Request
 
-	pk, ok := validateURLSignature(jc, hostname, path)
+	pk, ok := validateURLSignature(jc, hostname)
 	if !ok {
 		return types.PublicKey{}, false
 	}
@@ -170,5 +170,13 @@ func requestHash(method string, hostname, path string, validUntil time.Time, bod
 	if body != nil {
 		h.E.Write(body)
 	}
+	return h.Sum()
+}
+
+func registerAppKeyHash(ephemeralKey types.PublicKey, requestID string) types.Hash256 {
+	h := types.NewHasher()
+	h.E.Write([]byte("registerAppKey"))
+	h.E.Write(ephemeralKey[:])
+	h.E.Write([]byte(requestID))
 	return h.Sum()
 }

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -49,14 +50,23 @@ func (s *mockAccounts) AppSecret(connectKey string, appID types.Hash256) (types.
 
 func TestAuthConnectFieldLimits(t *testing.T) {
 	s := &mockAccounts{tokens: make(map[types.PublicKey]struct{})}
-	handler, err := NewAPI("http://localhost:9982", nil, s, nil, nil)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(handler)
-	defer server.Close()
+	defer l.Close()
 
-	client := NewClient(server.URL)
+	appAPIAddr := fmt.Sprintf("http://%s", l.Addr().String())
+	handler, err := NewAPI(appAPIAddr, nil, s, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: handler}
+	defer server.Close()
+	go server.Serve(l)
+
+	ephemeralKey := types.GeneratePrivateKey()
+	client := NewClient(appAPIAddr)
 
 	// valid request should succeed
 	valid := RegisterAppRequest{
@@ -65,7 +75,7 @@ func TestAuthConnectFieldLimits(t *testing.T) {
 		Description: "A test app",
 		ServiceURL:  "http://test-app.com",
 	}
-	if _, err := client.RequestAppConnection(context.Background(), valid); err != nil {
+	if _, err := client.RequestAppConnection(context.Background(), ephemeralKey, valid); err != nil {
 		t.Fatal("expected success, got", err)
 	}
 
@@ -83,7 +93,7 @@ func TestAuthConnectFieldLimits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := valid
 			tt.modify(&req)
-			if _, err := client.RequestAppConnection(context.Background(), req); err == nil {
+			if _, err := client.RequestAppConnection(context.Background(), ephemeralKey, req); err == nil {
 				t.Fatal("expected error for oversized field")
 			}
 		})
@@ -93,14 +103,25 @@ func TestAuthConnectFieldLimits(t *testing.T) {
 func TestAuthConnectRateLimit(t *testing.T) {
 	s := &mockAccounts{tokens: make(map[types.PublicKey]struct{})}
 	rl := api.NewIPRateLimiter(10*time.Millisecond, 2, time.Minute)
-	handler, err := NewAPI("http://localhost:9982", nil, s, nil, nil, WithRateLimiter(rl))
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(handler)
-	defer server.Close()
+	defer l.Close()
 
-	client := NewClient(server.URL)
+	appAPIAddr := fmt.Sprintf("http://%s", l.Addr().String())
+	handler, err := NewAPI(appAPIAddr, nil, s, nil, nil, WithRateLimiter(rl))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: handler}
+	defer server.Close()
+	go server.Serve(l)
+
+	ephemeralKey := types.GeneratePrivateKey()
+
+	client := NewClient(appAPIAddr)
 	req := RegisterAppRequest{
 		AppID:       frand.Entropy256(),
 		Name:        "test-app",
@@ -109,14 +130,14 @@ func TestAuthConnectRateLimit(t *testing.T) {
 	}
 
 	// first 2 requests should succeed (burst)
-	for i := 0; i < 2; i++ {
-		if _, err := client.RequestAppConnection(context.Background(), req); err != nil {
+	for i := range 2 {
+		if _, err := client.RequestAppConnection(context.Background(), ephemeralKey, req); err != nil {
 			t.Fatalf("request %d: expected success, got %v", i, err)
 		}
 	}
 
 	// 3rd request should be rate limited
-	_, err = client.RequestAppConnection(context.Background(), req)
+	_, err = client.RequestAppConnection(context.Background(), ephemeralKey, req)
 	if err == nil {
 		t.Fatal("expected rate limit error")
 	}
@@ -128,8 +149,7 @@ func TestAuth(t *testing.T) {
 
 	h := func(jc jape.Context) {
 		hostname := jc.Request.Host
-		path := jc.Request.URL.Path
-		if _, ok := validateSignedURLAuth(jc, hostname, path, s); ok {
+		if _, ok := validateSignedURLAuth(jc, hostname, s); ok {
 			jc.ResponseWriter.WriteHeader(http.StatusOK)
 		}
 	}

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -31,15 +31,6 @@ type Client struct {
 	validity time.Duration
 }
 
-// helper to parse URL and panic on error
-func mustParseURL(base, path string) *url.URL {
-	u, err := url.Parse(base + path)
-	if err != nil {
-		panic(err)
-	}
-	return u
-}
-
 // sign signs the request with the appropriate headers and returns the signed URL
 // and request body.
 func sign(appKey types.PrivateKey, validUntil time.Time, method, endpointURL string, requestBuf []byte) (*url.URL, io.Reader, error) {
@@ -278,25 +269,36 @@ func (c *Client) SharedObject(ctx context.Context, sharedURL string) (slabs.Shar
 }
 
 // RequestAppConnection requests an application connection to the indexer.
-func (c *Client) RequestAppConnection(ctx context.Context, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
+func (c *Client) RequestAppConnection(ctx context.Context, ephemeralKey types.PrivateKey, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
 	requestBuf, err := json.Marshal(request)
 	if err != nil {
 		return RegisterAppResponse{}, fmt.Errorf("failed to marshal request data: %w", err)
 	}
-	body, err := doRequest(ctx, http.MethodPost, mustParseURL(c.baseURL, "/auth/connect"), bytes.NewReader(requestBuf), applicationJSON)
+
+	u, reqBody, err := sign(ephemeralKey, time.Now().Add(c.validity), http.MethodPost, fmt.Sprintf("%s/auth/connect", c.baseURL), requestBuf)
+	if err != nil {
+		return RegisterAppResponse{}, fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	respBody, err := doRequest(ctx, http.MethodPost, u, reqBody, applicationJSON)
 	if err != nil {
 		return RegisterAppResponse{}, err
 	}
-	defer io.Copy(io.Discard, body)
-	defer body.Close()
-	err = json.NewDecoder(body).Decode(&resp)
+	defer io.Copy(io.Discard, respBody)
+	defer respBody.Close()
+	err = json.NewDecoder(respBody).Decode(&resp)
 	return
 }
 
 // RequestStatus checks if an auth request has been approved.
 // If the auth request is still pending, it returns false.
-func (c *Client) RequestStatus(ctx context.Context, statusURL string) (status AuthConnectStatusResponse, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, statusURL, nil)
+func (c *Client) RequestStatus(ctx context.Context, ephemeralKey types.PrivateKey, statusURL string) (status AuthConnectStatusResponse, err error) {
+	u, _, err := sign(ephemeralKey, time.Now().Add(c.validity), http.MethodGet, statusURL, nil)
+	if err != nil {
+		return AuthConnectStatusResponse{}, fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return AuthConnectStatusResponse{}, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -323,13 +325,29 @@ func (c *Client) RequestStatus(ctx context.Context, statusURL string) (status Au
 
 // RegisterApp registers the application with the indexer using the provided
 // app key and registration URL.
-func (c *Client) RegisterApp(ctx context.Context, registerURL string, appKey types.PrivateKey) error {
+//
+// The request must be signed with the ephemeral key
+func (c *Client) RegisterApp(ctx context.Context, registerURL string, ephemeralKey, appKey types.PrivateKey) error {
 	u, err := url.Parse(registerURL)
 	if err != nil {
 		return fmt.Errorf("failed to parse register URL: %w", err)
 	}
+	// extract request ID from path
+	pathPieces := strings.Split(u.Path, "/")
+	if len(pathPieces) != 5 || pathPieces[4] != "register" {
+		return fmt.Errorf("invalid register URL path: %s", u.Path)
+	}
+	requestID := pathPieces[3]
 
-	u, body, err := sign(appKey, time.Now().Add(c.validity), http.MethodPost, u.String(), nil)
+	requestBuf, err := json.Marshal(RegisterAppKeyRequest{
+		AppKey:    appKey.PublicKey(),
+		Signature: appKey.SignHash(registerAppKeyHash(ephemeralKey.PublicKey(), requestID)),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal request data: %w", err)
+	}
+
+	u, body, err := sign(ephemeralKey, time.Now().Add(c.validity), http.MethodPost, u.String(), requestBuf)
 	if err != nil {
 		return fmt.Errorf("failed to sign request: %w", err)
 	}

--- a/contracts/locking_test.go
+++ b/contracts/locking_test.go
@@ -36,15 +36,15 @@ func TestContractLockerLockBlocks(t *testing.T) {
 	acquired := make(chan struct{})
 	go func() {
 		_, unlock2 := cl.LockContract(id)
-		close(acquired)
 		unlock2()
+		close(acquired)
 	}()
 
 	// the second lock should be blocked
 	select {
 	case <-acquired:
 		t.Fatal("second LockContract should block while first is held")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(250 * time.Millisecond):
 	}
 
 	// unlock first, second should proceed
@@ -52,7 +52,7 @@ func TestContractLockerLockBlocks(t *testing.T) {
 
 	select {
 	case <-acquired:
-	case <-time.After(time.Second):
+	case <-time.After(250 * time.Millisecond):
 		t.Fatal("second LockContract should have acquired after first unlock")
 	}
 

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -466,6 +466,10 @@ paths:
       tags:
         - auth
       summary: Request application connection to the indexer
+      description: >
+        Initiates a connection request. The request must be signed with an ephemeral ed25519 key
+        using the signed URL scheme. The server binds the connection flow to that ephemeral key —
+        subsequent calls to the status and register endpoints must be signed with the same key.
       operationId: requestAppConnection
       requestBody:
         required: true
@@ -536,7 +540,8 @@ paths:
 
             func main() {
               client := app.NewClient("http://localhost:9982")
-              connectResp, err := client.RequestAppConnection(context.Background(), app.RegisterAppRequest{
+              ephemeralKey := types.GeneratePrivateKey()
+              connectResp, err := client.RequestAppConnection(context.Background(), ephemeralKey, app.RegisterAppRequest{
                 AppID:       appID,
                 Name:        "Test App",
                 Description: "A test application",
@@ -636,6 +641,10 @@ paths:
       tags:
         - auth
       summary: Check the status of a connection request
+      description: >
+        Returns whether the user has approved or rejected the connection request. Must be signed
+        with the same ephemeral key used in the initial `POST /auth/connect` request. If approved,
+        the response includes the `userSecret` used to derive the application key.
       operationId: authConnectStatus
       parameters:
         - name: requestID
@@ -650,6 +659,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AuthConnectStatusResponse"
+        "401":
+          description: Signed with a different ephemeral key than the one used to initiate the request
         "404":
           description: Request invalid or expired
 
@@ -659,8 +670,11 @@ paths:
         - auth
       summary: Finalize application registration after approval
       description: >
-        Registers the application's public key using a signed request derived from the user secret returned by the status endpoint.
-        This endpoint must be called after the user has approved the request.
+        Registers the application key. The request URL must be signed with the ephemeral key from
+        the initial connect request. The body contains the application public key and a
+        proof-of-possession signature: `appKey.Sign(hash("registerAppKey" + ephemeralPubKey + requestID))`.
+        This proves the caller both controls the ephemeral key and knows the private key of the app
+        key being registered.
       operationId: authRegister
       parameters:
         - name: requestID
@@ -668,11 +682,31 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - appKey
+                - signature
+              properties:
+                appKey:
+                  allOf:
+                    - $ref: "#/components/schemas/PublicKey"
+                    - description: The application public key to register
+                signature:
+                  type: string
+                  format: byte
+                  description: >
+                    ed25519 signature by `appKey` over `hash("registerAppKey" + ephemeralPubKey + requestID)`,
+                    proving ownership of the application key
       responses:
-        "200":
+        "204":
           description: Application registered successfully
         "401":
-          description: Invalid signature or connect key
+          description: Signed with a different ephemeral key than the one used to initiate the request, or invalid proof-of-possession signature
         "403":
           description: Connect key exhausted or request not approved
         "404":

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"go.sia.tech/core/types"
@@ -46,12 +47,32 @@ type Builder struct {
 	request      app.RegisterAppRequest
 	registerResp *app.RegisterAppResponse
 	sharedSecret types.Hash256
+
+	consumed *atomic.Bool
+}
+
+// consume marks the builder as consumed, preventing further use. It panics if the builder has already been consumed.
+func (b *Builder) consume() {
+	if !b.consumed.CompareAndSwap(false, true) {
+		panic("Builder can only be used once")
+	}
+}
+
+// checkConsumed panics if the builder has already been consumed.
+func (b *Builder) checkConsumed() {
+	if b.consumed.Load() {
+		panic("Builder can only be used once")
+	}
 }
 
 // WaitForApproval waits for the user to approve the app connection request.
 // The user must visit the response URL returned by [Builder.Connect] to approve
 // the request. It will block until the request is either approved or denied.
+//
+// Panics if the builder has already created an SDK instance.
 func (b *Builder) WaitForApproval(ctx context.Context) (bool, error) {
+	b.checkConsumed()
+
 	if b.registerResp == nil {
 		return false, fmt.Errorf("no connection request to wait for approval")
 	} else if time.Until(b.registerResp.Expiration) <= 0 {
@@ -84,7 +105,11 @@ func (b *Builder) WaitForApproval(ctx context.Context) (bool, error) {
 // This key should be stored securely by the application and never
 // shared with anyone else. It can be regenerated using the same app
 // ID, user account, and seed phrase.
+//
+// // Panics if the builder has already created an SDK instance.
 func (b *Builder) Register(ctx context.Context, mnemonic string) (*SDK, error) {
+	b.checkConsumed()
+
 	if b.sharedSecret == (types.Hash256{}) {
 		return nil, fmt.Errorf("app not connected")
 	}
@@ -106,7 +131,10 @@ func (b *Builder) Register(ctx context.Context, mnemonic string) (*SDK, error) {
 //
 // It returns a response URL that the user must visit to approve the request.
 // The app should display the response URL to the user.
+//
+// // Panics if the builder has already created an SDK instance.
 func (b *Builder) RequestConnection(ctx context.Context) (string, error) {
+	b.checkConsumed()
 	resp, err := b.client.RequestAppConnection(ctx, b.ephemeralKey, b.request)
 	if err != nil {
 		return "", fmt.Errorf("failed to request app connection: %w", err)
@@ -117,7 +145,11 @@ func (b *Builder) RequestConnection(ctx context.Context) (string, error) {
 
 // SDK creates a new SDK instance using the given application key. If the
 // key is not authorized, an error is returned.
+//
+// Panics if the builder has already created an SDK instance.
 func (b *Builder) SDK(appKey types.PrivateKey, opts ...Option) (*SDK, error) {
+	b.checkConsumed()
+
 	if ok, err := b.client.CheckAppAuth(context.Background(), appKey); err != nil {
 		return nil, fmt.Errorf("failed to check app auth: %w", err)
 	} else if !ok {
@@ -127,6 +159,7 @@ func (b *Builder) SDK(appKey types.PrivateKey, opts ...Option) (*SDK, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create host store: %w", err)
 	}
+	b.consume()
 	return initSDK(appKey, b.client, client.New(client.NewProvider(hostStore)), opts...), nil
 }
 
@@ -143,6 +176,9 @@ func deriveAppKey(mnemonic string, appID types.Hash256, sharedSecret types.Hash2
 }
 
 // NewBuilder creates a new Builder for connecting applications to the indexer.
+//
+// A builder can only be used to create a single SDK instance. Attempting to
+// reuse a builder will result in a panic.
 func NewBuilder(indexerURL string, metadata AppMetadata) *Builder {
 	return &Builder{
 		ephemeralKey: types.GeneratePrivateKey(),
@@ -154,7 +190,8 @@ func NewBuilder(indexerURL string, metadata AppMetadata) *Builder {
 			ServiceURL:  metadata.ServiceURL,
 			CallbackURL: metadata.CallbackURL,
 		},
-		client: app.NewClient(indexerURL),
+		client:   app.NewClient(indexerURL),
+		consumed: &atomic.Bool{},
 	}
 }
 

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -40,7 +40,8 @@ type (
 // A Builder helps connect an application to an indexer
 // and initialize an SDK instance.
 type Builder struct {
-	client *app.Client
+	ephemeralKey types.PrivateKey
+	client       *app.Client
 
 	request      app.RegisterAppRequest
 	registerResp *app.RegisterAppResponse
@@ -65,7 +66,7 @@ func (b *Builder) WaitForApproval(ctx context.Context) (bool, error) {
 		case <-ctx.Done():
 			return false, ctx.Err()
 		case <-time.After(time.Second):
-			if status, err := b.client.RequestStatus(ctx, b.registerResp.StatusURL); errors.Is(err, app.ErrUserRejected) {
+			if status, err := b.client.RequestStatus(ctx, b.ephemeralKey, b.registerResp.StatusURL); errors.Is(err, app.ErrUserRejected) {
 				return false, nil
 			} else if err != nil {
 				return false, fmt.Errorf("failed to check request status: %w", err)
@@ -91,7 +92,7 @@ func (b *Builder) Register(ctx context.Context, mnemonic string) (*SDK, error) {
 	appKey, err := deriveAppKey(mnemonic, b.request.AppID, b.sharedSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive app key: %w", err)
-	} else if err := b.client.RegisterApp(ctx, b.registerResp.RegisterURL, appKey); err != nil {
+	} else if err := b.client.RegisterApp(ctx, b.registerResp.RegisterURL, b.ephemeralKey, appKey); err != nil {
 		return nil, fmt.Errorf("failed to register app key: %w", err)
 	}
 
@@ -106,7 +107,7 @@ func (b *Builder) Register(ctx context.Context, mnemonic string) (*SDK, error) {
 // It returns a response URL that the user must visit to approve the request.
 // The app should display the response URL to the user.
 func (b *Builder) RequestConnection(ctx context.Context) (string, error) {
-	resp, err := b.client.RequestAppConnection(ctx, b.request)
+	resp, err := b.client.RequestAppConnection(ctx, b.ephemeralKey, b.request)
 	if err != nil {
 		return "", fmt.Errorf("failed to request app connection: %w", err)
 	}
@@ -144,6 +145,7 @@ func deriveAppKey(mnemonic string, appID types.Hash256, sharedSecret types.Hash2
 // NewBuilder creates a new Builder for connecting applications to the indexer.
 func NewBuilder(indexerURL string, metadata AppMetadata) *Builder {
 	return &Builder{
+		ephemeralKey: types.GeneratePrivateKey(),
 		request: app.RegisterAppRequest{
 			AppID:       metadata.ID,
 			Name:        metadata.Name,

--- a/sdk/connect.go
+++ b/sdk/connect.go
@@ -106,7 +106,7 @@ func (b *Builder) WaitForApproval(ctx context.Context) (bool, error) {
 // shared with anyone else. It can be regenerated using the same app
 // ID, user account, and seed phrase.
 //
-// // Panics if the builder has already created an SDK instance.
+// Panics if the builder has already created an SDK instance.
 func (b *Builder) Register(ctx context.Context, mnemonic string) (*SDK, error) {
 	b.checkConsumed()
 


### PR DESCRIPTION
`GET /auth/connect/:requestID/status` and `POST /auth/connect/:requestID/register` previously accepted requests from any caller who knew the `requestID`. This meant observers could steal the `userSecret` or register an arbitrary key. It's unlikely to guess the random request ID, but it's also an easily avoidable vulnerability. This adds an ephemeral key pair to authenticate the request. The initial connect request is signed with it then all subsequent steps in the flow verify the signature in the same way app requests are verified.

Sia Storage and the Rust SDK will need to be updated similarly.
