### PR TITLE
Add app name to AppMeta

### DIFF
--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -77,6 +77,7 @@ type (
 	// AppMeta contains additional metadata associated with an account.
 	AppMeta struct {
 		ID          types.Hash256 `json:"id"`
+		Name        string        `json:"name"`
 		Description string        `json:"description"`
 		LogoURL     string        `json:"logoURL"`
 		ServiceURL  string        `json:"serviceURL"`

--- a/api/admin/prometheus.go
+++ b/api/admin/prometheus.go
@@ -57,7 +57,8 @@ func (s AppStatsResponse) PrometheusMetric() []prometheus.Metric {
 // app's stats.
 func (s AppStats) PrometheusMetric() []prometheus.Metric {
 	labels := map[string]any{
-		"app_id": s.AppID.String(),
+		"app_id":   s.AppID.String(),
+		"app_name": s.Name,
 	}
 	return []prometheus.Metric{
 		{

--- a/api/admin/types.go
+++ b/api/admin/types.go
@@ -87,6 +87,7 @@ type (
 	// AppStats contains per-app statistics.
 	AppStats struct {
 		AppID      types.Hash256 `json:"appID"`
+		Name       string        `json:"name"`
 		Accounts   uint64        `json:"accounts"`
 		Active     uint64        `json:"active"`
 		PinnedData uint64        `json:"pinnedData"`

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -633,6 +633,7 @@ func (a *app) handleAuthRegister(jc jape.Context) {
 
 	err := a.accounts.RegisterAppKey(authReq.ConnectKey, appKey, accounts.AppMeta{
 		ID:          authReq.Request.AppID,
+		Name:        authReq.Request.Name,
 		Description: authReq.Request.Description,
 		LogoURL:     authReq.Request.LogoURL,
 		ServiceURL:  authReq.Request.ServiceURL,

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -441,6 +441,9 @@ components:
           allOf:
             - $ref: "#/components/schemas/Hash256"
             - description: The app's unique identifier
+        name:
+          type: string
+          description: Name of the app
         description:
           type: string
           description: Description of the app

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -863,6 +863,9 @@ components:
             allOf:
               - $ref: "#/components/schemas/Hash256"
               - description: The app's ID
+          name:
+            type: string
+            description: Name of the app
           accounts:
             type: integer
             format: uint64

--- a/persist/postgres/accounts.go
+++ b/persist/postgres/accounts.go
@@ -41,7 +41,7 @@ func (s *Store) Accounts(offset, limit int, opts ...accounts.QueryAccountsOpt) (
 		}
 
 		rows, err := tx.Query(ctx, `
-			SELECT a.public_key, ak.app_key, a.max_pinned_data, a.pinned_data, a.pinned_size, a.app_id, a.description, a.logo_url, a.service_url, a.last_used
+			SELECT a.public_key, ak.app_key, a.max_pinned_data, a.pinned_data, a.pinned_size, a.app_id, a.name, a.description, a.logo_url, a.service_url, a.last_used
 			FROM accounts a
 			INNER JOIN app_connect_keys ak ON ak.id = a.connect_key_id
 			WHERE a.deleted_at IS NULL AND
@@ -74,7 +74,7 @@ func (s *Store) Account(ak types.PublicKey) (accounts.Account, error) {
 	var account accounts.Account
 	account.AccountKey = proto.Account(ak) // no need to fetch key
 	err := s.transaction(func(ctx context.Context, tx *txn) (err error) {
-		account, err = scanAccount(tx.QueryRow(ctx, `SELECT a.public_key, ak.app_key, a.max_pinned_data, a.pinned_data, a.pinned_size, a.app_id, a.description, a.logo_url, a.service_url, a.last_used
+		account, err = scanAccount(tx.QueryRow(ctx, `SELECT a.public_key, ak.app_key, a.max_pinned_data, a.pinned_data, a.pinned_size, a.app_id, a.name, a.description, a.logo_url, a.service_url, a.last_used
 FROM accounts a
 INNER JOIN app_connect_keys ak ON ak.id = a.connect_key_id
 WHERE public_key = $1`, sqlPublicKey(ak)))
@@ -344,7 +344,7 @@ func addAccount(ctx context.Context, tx *txn, connectKey string, account types.P
 		return fmt.Errorf("failed to get app connect key ID: %w", err)
 	}
 
-	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key, connect_key_id, max_pinned_data, app_id, description, logo_url, service_url) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT DO NOTHING`, sqlPublicKey(account), connectKeyID, aao.MaxPinnedData, sqlHash256(meta.ID), meta.Description, meta.LogoURL, meta.ServiceURL)
+	res, err := tx.Exec(ctx, `INSERT INTO accounts (public_key, connect_key_id, max_pinned_data, app_id, name, description, logo_url, service_url) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT DO NOTHING`, sqlPublicKey(account), connectKeyID, aao.MaxPinnedData, sqlHash256(meta.ID), meta.Name, meta.Description, meta.LogoURL, meta.ServiceURL)
 	if err != nil {
 		return fmt.Errorf("failed to add account: %w", err)
 	} else if res.RowsAffected() == 0 {
@@ -450,6 +450,6 @@ LIMIT $3`, hostID, threshold, limit, quotaName)
 }
 
 func scanAccount(s scanner) (account accounts.Account, err error) {
-	err = s.Scan((*sqlPublicKey)(&account.AccountKey), &account.ConnectKey, &account.MaxPinnedData, &account.PinnedData, &account.PinnedSize, (*sqlHash256)(&account.App.ID), &account.App.Description, &account.App.LogoURL, &account.App.ServiceURL, &account.LastUsed)
+	err = s.Scan((*sqlPublicKey)(&account.AccountKey), &account.ConnectKey, &account.MaxPinnedData, &account.PinnedData, &account.PinnedSize, (*sqlHash256)(&account.App.ID), &account.App.Name, &account.App.Description, &account.App.LogoURL, &account.App.ServiceURL, &account.LastUsed)
 	return
 }

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -114,6 +114,7 @@ func TestAddAccount(t *testing.T) {
 		appID := frand.Entropy256()
 		err := addAccount(pk, accounts.AppMeta{
 			ID:          appID,
+			Name:        "name",
 			Description: "description",
 			LogoURL:     "logoURL",
 			ServiceURL:  "serviceURL",
@@ -138,6 +139,8 @@ func TestAddAccount(t *testing.T) {
 			t.Fatal(err)
 		} else if acc.App.ID != appID {
 			t.Fatalf("expected app ID %s, got %s", appID, acc.App.ID)
+		} else if acc.App.Name != "name" {
+			t.Fatalf("expected name %q, got %q", "name", acc.App.Name)
 		} else if acc.App.Description != "description" {
 			t.Fatalf("expected description %q, got %q", "description", acc.App.Description)
 		} else if acc.App.LogoURL != "logoURL" {

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -57,7 +57,7 @@ func TestAppConnectKeys(t *testing.T) {
 		t.Fatal("expected app connect key to have remaining uses")
 	}
 
-	assertAccount := func(acc types.PublicKey, pinned, maxPinned uint64, desc, logo, service string) {
+	assertAccount := func(acc types.PublicKey, pinned, maxPinned uint64, name, desc, logo, service string) {
 		t.Helper()
 		account, err := store.Account(types.PublicKey(acc))
 		if err != nil {
@@ -66,6 +66,8 @@ func TestAppConnectKeys(t *testing.T) {
 			t.Fatalf("expected %d pinned data for account %v, got %d", pinned, acc, account.PinnedData)
 		} else if account.MaxPinnedData != maxPinned {
 			t.Fatalf("expected max pinned data to be %d, got %d", maxPinned, account.MaxPinnedData)
+		} else if account.App.Name != name {
+			t.Fatalf("expected name to be %q, got %q", name, account.App.Name)
 		} else if account.App.Description != desc {
 			t.Fatalf("expected description to be %q, got %q", desc, account.App.Description)
 		} else if account.App.LogoURL != logo {
@@ -79,6 +81,7 @@ func TestAppConnectKeys(t *testing.T) {
 
 	acc := types.GeneratePrivateKey().PublicKey()
 	meta := accounts.AppMeta{
+		Name:        "myapp",
 		Description: "desc",
 		LogoURL:     "logo",
 		ServiceURL:  "service",
@@ -86,7 +89,7 @@ func TestAppConnectKeys(t *testing.T) {
 	if err := store.RegisterAppKey(connectKey, acc, meta); err != nil {
 		t.Fatal("failed to use app connect key:", err)
 	}
-	assertAccount(acc, 0, math.MaxInt64, "desc", "logo", "service")
+	assertAccount(acc, 0, math.MaxInt64, "myapp", "desc", "logo", "service")
 
 	// ensure the key's last used field was updated
 	keys, err := store.AppConnectKeys(0, 1)

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -33,6 +33,7 @@ CREATE TABLE accounts (
     pinned_size BIGINT NOT NULL DEFAULT 0 CHECK (pinned_size >= 0), -- total pinned data in bytes including redundancy
     max_pinned_data BIGINT NOT NULL CHECK (max_pinned_data >= 0), -- max pinned data in bytes
     app_id BYTEA NOT NULL DEFAULT '\x0000000000000000000000000000000000000000000000000000000000000000'::bytea CHECK (LENGTH(app_id) = 32), -- app identifier
+    name TEXT NOT NULL DEFAULT '',
     description TEXT NOT NULL DEFAULT '',
     logo_url TEXT NOT NULL DEFAULT '',
     service_url TEXT NOT NULL DEFAULT '',

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -831,4 +831,9 @@ WHERE ack.id = sub.connect_key_id;
 `)
 		return err
 	},
+	// add name column to accounts
+	func(ctx context.Context, tx *txn, _ *zap.Logger) error {
+		_, err := tx.Exec(ctx, `ALTER TABLE accounts ADD COLUMN name TEXT NOT NULL DEFAULT '';`)
+		return err
+	},
 }

--- a/persist/postgres/stats.go
+++ b/persist/postgres/stats.go
@@ -117,6 +117,7 @@ func (s *Store) AppStats(offset, limit int) ([]admin.AppStats, error) {
 		rows, err := tx.Query(ctx, `
 SELECT
 	app_id,
+	ANY_VALUE(name),
 	COUNT(*),
 	COUNT(*) FILTER (WHERE last_used >= $1),
 	COALESCE(SUM(pinned_data), 0),
@@ -135,7 +136,7 @@ OFFSET $2 LIMIT $3`,
 
 		for rows.Next() {
 			var as admin.AppStats
-			if err := rows.Scan((*sqlHash256)(&as.AppID), &as.Accounts, &as.Active, &as.PinnedData, &as.PinnedSize); err != nil {
+			if err := rows.Scan((*sqlHash256)(&as.AppID), &as.Name, &as.Accounts, &as.Active, &as.PinnedData, &as.PinnedSize); err != nil {
 				return err
 			}
 			stats = append(stats, as)

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -366,7 +366,7 @@ func TestAppStats(t *testing.T) {
 	appID1 := types.Hash256{1}
 	appID2 := types.Hash256{2}
 
-	addAccountWithApp := func(ak types.PublicKey, appID types.Hash256) {
+	addAccountWithApp := func(ak types.PublicKey, appID types.Hash256, name string) {
 		t.Helper()
 		connectKey := fmt.Sprintf("test-connect-key-%x", frand.Bytes(8))
 		_, err := store.AddAppConnectKey(accounts.AppConnectKeyRequest{
@@ -378,14 +378,14 @@ func TestAppStats(t *testing.T) {
 			t.Fatal(err)
 		}
 		err = store.transaction(func(ctx context.Context, tx *txn) error {
-			return addAccount(ctx, tx, connectKey, ak, accounts.AppMeta{ID: appID})
+			return addAccount(ctx, tx, connectKey, ak, accounts.AppMeta{ID: appID, Name: name})
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	assertStats := func(appID types.Hash256, expectedAccounts, expectedActive, expectedPinnedData uint64) {
+	assertStats := func(appID types.Hash256, expectedName string, expectedAccounts, expectedActive, expectedPinnedData uint64) {
 		t.Helper()
 		all, err := store.AppStats(0, 100)
 		if err != nil {
@@ -403,7 +403,9 @@ func TestAppStats(t *testing.T) {
 		if !found {
 			t.Fatalf("app %s not found in stats", appID)
 		}
-		if stats.Accounts != expectedAccounts {
+		if stats.Name != expectedName {
+			t.Fatalf("expected name %q, got %q", expectedName, stats.Name)
+		} else if stats.Accounts != expectedAccounts {
 			t.Fatalf("expected %d accounts, got %d", expectedAccounts, stats.Accounts)
 		} else if stats.Active != expectedActive {
 			t.Fatalf("expected %d active, got %d", expectedActive, stats.Active)
@@ -415,16 +417,16 @@ func TestAppStats(t *testing.T) {
 	// add accounts to app1
 	acc1 := types.GeneratePrivateKey().PublicKey()
 	acc2 := types.GeneratePrivateKey().PublicKey()
-	addAccountWithApp(acc1, appID1)
-	addAccountWithApp(acc2, appID1)
+	addAccountWithApp(acc1, appID1, "App One")
+	addAccountWithApp(acc2, appID1, "App One")
 
 	// add account to app2
 	acc3 := types.GeneratePrivateKey().PublicKey()
-	addAccountWithApp(acc3, appID2)
+	addAccountWithApp(acc3, appID2, "App Two")
 
 	// all accounts are active (recently created)
-	assertStats(appID1, 2, 2, 0)
-	assertStats(appID2, 1, 1, 0)
+	assertStats(appID1, "App One", 2, 2, 0)
+	assertStats(appID2, "App Two", 1, 1, 0)
 
 	// set pinned_data for some accounts
 	if _, err := store.pool.Exec(t.Context(), `UPDATE accounts SET pinned_data = 100 WHERE public_key = $1`, sqlPublicKey(acc1)); err != nil {
@@ -436,22 +438,22 @@ func TestAppStats(t *testing.T) {
 	if _, err := store.pool.Exec(t.Context(), `UPDATE accounts SET pinned_data = 500 WHERE public_key = $1`, sqlPublicKey(acc3)); err != nil {
 		t.Fatal(err)
 	}
-	assertStats(appID1, 2, 2, 300)
-	assertStats(appID2, 1, 1, 500)
+	assertStats(appID1, "App One", 2, 2, 300)
+	assertStats(appID2, "App Two", 1, 1, 500)
 
 	// make acc1 inactive by setting last_used sufficiently before the inactivity threshold
 	inactiveTime := time.Now().Add(-accounts.AccountActivityThreshold - time.Hour)
 	if _, err := store.pool.Exec(t.Context(), `UPDATE accounts SET last_used = $1 WHERE public_key = $2`, inactiveTime, sqlPublicKey(acc1)); err != nil {
 		t.Fatal(err)
 	}
-	assertStats(appID1, 2, 1, 300)
+	assertStats(appID1, "App One", 2, 1, 300)
 
 	// soft-delete acc2 — should be excluded entirely
 	if err := store.DeleteAccount(proto.Account(acc2)); err != nil {
 		t.Fatal(err)
 	}
-	assertStats(appID1, 1, 0, 100) // only acc1 remains (inactive)
-	assertStats(appID2, 1, 1, 500) // app2 unaffected
+	assertStats(appID1, "App One", 1, 0, 100) // only acc1 remains (inactive)
+	assertStats(appID2, "App Two", 1, 1, 500) // app2 unaffected
 }
 
 func TestHostStats(t *testing.T) {


### PR DESCRIPTION
Adds the name of the app to the accounts table. We already had that field in the request but somehow never passed it all the way down to the database.

Closes https://github.com/SiaStorage/siastorage/issues/58