### PR TITLE
Use minimal object request for saving

### DIFF
--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1505,7 +1505,7 @@ func TestPruneSlabs(t *testing.T) {
 		DataSignature:     types.Signature(frand.Bytes(64)),
 		MetadataSignature: types.Signature(frand.Bytes(64)),
 	}
-	if err := store.SaveObject(acc, obj); err != nil {
+	if err := store.SaveObject(acc, obj.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1505,7 +1505,7 @@ func TestPruneSlabs(t *testing.T) {
 		DataSignature:     types.Signature(frand.Bytes(64)),
 		MetadataSignature: types.Signature(frand.Bytes(64)),
 	}
-	if err := store.SaveObject(acc, obj.PinRequest()); err != nil {
+	if err := store.PinObject(acc, obj.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -43,7 +43,7 @@ type (
 
 		Object(ctx context.Context, account proto.Account, key types.Hash256) (slabs.SealedObject, error)
 		DeleteObject(ctx context.Context, account proto.Account, objectKey types.Hash256) error
-		SaveObject(ctx context.Context, account proto.Account, obj slabs.SealedObject) error
+		SaveObject(ctx context.Context, account proto.Account, obj slabs.PinObjectRequest) error
 		ListObjects(ctx context.Context, account proto.Account, cursor slabs.Cursor, limit int) ([]slabs.ObjectEvent, error)
 		SharedObject(ctx context.Context, key types.Hash256) (slabs.SharedObject, error)
 	}
@@ -317,7 +317,7 @@ func (a *app) handleGETObjects(jc jape.Context, pk types.PublicKey) {
 }
 
 func (a *app) handlePOSTObjects(jc jape.Context, pk types.PublicKey) {
-	obj, ok := decodeRequest[slabs.SealedObject](jc)
+	obj, ok := decodeRequest[slabs.PinObjectRequest](jc)
 	if !ok {
 		return
 	}

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -323,7 +323,7 @@ func (a *app) handlePOSTObjects(jc jape.Context, pk types.PublicKey) {
 	}
 
 	err := a.slabs.SaveObject(jc.Request.Context(), proto.Account(pk), obj)
-	if errors.Is(err, slabs.ErrObjectMetadataLimitExceeded) || errors.Is(err, slabs.ErrObjectMinimumSlabs) || errors.Is(err, slabs.ErrObjectUnpinnedSlab) {
+	if errors.Is(err, slabs.ErrObjectMetadataLimitExceeded) || errors.Is(err, slabs.ErrObjectMinimumSlabs) || errors.Is(err, slabs.ErrObjectUnpinnedSlab) || errors.Is(err, slabs.ErrInvalidObjectSignature) {
 		jc.Error(err, http.StatusBadRequest)
 		return
 	} else if err != nil {

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -43,7 +43,7 @@ type (
 
 		Object(ctx context.Context, account proto.Account, key types.Hash256) (slabs.SealedObject, error)
 		DeleteObject(ctx context.Context, account proto.Account, objectKey types.Hash256) error
-		SaveObject(ctx context.Context, account proto.Account, obj slabs.PinObjectRequest) error
+		PinObject(ctx context.Context, account proto.Account, obj slabs.PinObjectRequest) error
 		ListObjects(ctx context.Context, account proto.Account, cursor slabs.Cursor, limit int) ([]slabs.ObjectEvent, error)
 		SharedObject(ctx context.Context, key types.Hash256) (slabs.SharedObject, error)
 	}
@@ -322,7 +322,7 @@ func (a *app) handlePOSTObjects(jc jape.Context, pk types.PublicKey) {
 		return
 	}
 
-	err := a.slabs.SaveObject(jc.Request.Context(), proto.Account(pk), obj)
+	err := a.slabs.PinObject(jc.Request.Context(), proto.Account(pk), obj)
 	if errors.Is(err, slabs.ErrObjectMetadataLimitExceeded) || errors.Is(err, slabs.ErrObjectMinimumSlabs) || errors.Is(err, slabs.ErrObjectUnpinnedSlab) || errors.Is(err, slabs.ErrInvalidObjectSignature) {
 		jc.Error(err, http.StatusBadRequest)
 		return

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -827,7 +827,7 @@ func TestMaxRequestSize(t *testing.T) {
 	indexer := cluster.Indexer
 
 	// create client
-	resp, err := http.Post(fmt.Sprintf("%s/objects", indexer.AppURL), "application/json", io.LimitReader(frand.Reader, (1<<20)+1))
+	resp, err := http.Post(fmt.Sprintf("%s/objects", indexer.AppURL), "application/json", io.LimitReader(frand.Reader, (10<<20)+1))
 	if err != nil {
 		t.Fatal("failed to send request:", err)
 	} else if resp.StatusCode != http.StatusRequestEntityTooLarge {

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -397,13 +397,13 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	// try to save the object with an invalid signature
-	if err := client.SaveObject(context.Background(), sk, obj); err == nil || !strings.Contains(err.Error(), slabs.ErrInvalidObjectSignature.Error()) {
+	if err := client.PinObject(context.Background(), sk, obj); err == nil || !strings.Contains(err.Error(), slabs.ErrInvalidObjectSignature.Error()) {
 		t.Fatalf("expected %v, got %v", slabs.ErrInvalidObjectSignature, err)
 	}
 
 	// sign and save the object
 	obj.Sign(sk)
-	if err := client.SaveObject(context.Background(), sk, obj); err != nil {
+	if err := client.PinObject(context.Background(), sk, obj); err != nil {
 		t.Fatal(err)
 	}
 
@@ -470,7 +470,7 @@ func TestApplicationAPI(t *testing.T) {
 		Slabs:                []slabs.SlabSlice{p2.Slice(0, 256)},
 	}
 	badObj.Sign(sk)
-	if err := client.SaveObject(context.Background(), sk, badObj); err == nil || !strings.Contains(err.Error(), slabs.ErrObjectUnpinnedSlab.Error()) {
+	if err := client.PinObject(context.Background(), sk, badObj); err == nil || !strings.Contains(err.Error(), slabs.ErrObjectUnpinnedSlab.Error()) {
 		t.Fatalf("expected %v, got %v", slabs.ErrObjectUnpinnedSlab, err)
 	}
 }
@@ -776,7 +776,7 @@ func TestSharedObjects(t *testing.T) {
 		},
 	}
 	obj.Sign(sk1)
-	if err := appClient.SaveObject(ctx, sk1, obj); err != nil {
+	if err := appClient.PinObject(ctx, sk1, obj); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -16,9 +16,8 @@ import (
 )
 
 // maxRequestSize determines the maximum size of an incoming
-// HTTP request body. 1MB is quite generous. A Slab with the
-// maximum 255 sectors is < 50KiB
-const maxRequestSize = 1 << 20 // 1 MB
+// HTTP request body.
+const maxRequestSize = 10 << 20 // 10 MB
 
 type authedHandler func(jape.Context, types.PublicKey)
 

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -204,7 +204,7 @@ func (c *Client) ListObjects(ctx context.Context, appKey types.PrivateKey, curso
 // SaveObject saves the given object for the given account. If an object with
 // the given key exists for an account, it is overwritten.
 func (c *Client) SaveObject(ctx context.Context, appKey types.PrivateKey, obj slabs.SealedObject) (err error) {
-	err = c.signedRequestJSON(ctx, appKey, http.MethodPost, "/objects", obj, nil)
+	err = c.signedRequestJSON(ctx, appKey, http.MethodPost, "/objects", obj.PinRequest(), nil)
 	return
 }
 

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -201,9 +201,9 @@ func (c *Client) ListObjects(ctx context.Context, appKey types.PrivateKey, curso
 	return
 }
 
-// SaveObject saves the given object for the given account. If an object with
+// PinObject pins the object to the given account. If an object with
 // the given key exists for an account, it is overwritten.
-func (c *Client) SaveObject(ctx context.Context, appKey types.PrivateKey, obj slabs.SealedObject) (err error) {
+func (c *Client) PinObject(ctx context.Context, appKey types.PrivateKey, obj slabs.SealedObject) (err error) {
 	err = c.signedRequestJSON(ctx, appKey, http.MethodPost, "/objects", obj.PinRequest(), nil)
 	return
 }

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -141,36 +141,12 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - key
-                - slabs
-                - meta
-              properties:
-                id:
-                  allOf:
-                    - $ref: "#/components/schemas/Hash256"
-                    - description: The object's unique ID
-                encryptedMasterKey:
-                  type: string
-                  format: byte
-                  minLength: 72
-                  maxLength: 72
-                  description: The encrypted master key used to encrypt the object's shards (base64-encoded in JSON)
-                slabs:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/SlabSlice"
-                  description: The list of slabs that make up the object
-                encryptedMetadata:
-                  type: string
-                  format: byte
-                  description: Optional metadata stored as a byte array (base64-encoded in JSON)
+              $ref: "#/components/schemas/PinObjectRequest"
       responses:
         "200":
           description: Object created or updated successfully
         "400":
-          description: Object has no slabs or metadata exceeds size limit
+          description: Object has no slabs, metadata exceeds size limit, or object contains unpinned slab
   /objects/{key}:
     get:
       tags:
@@ -740,5 +716,9 @@ components:
       $ref: "./components.yml#/components/schemas/SlabID"
     SlabSlice:
       $ref: "./components.yml#/components/schemas/SlabSlice"
+    PinObjectRequest:
+      $ref: "./components.yml#/components/schemas/PinObjectRequest"
+    ObjectSlab:
+      $ref: "./components.yml#/components/schemas/ObjectSlab"
     SharedObject:
       $ref: "./components.yml#/components/schemas/SharedObject"

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -254,6 +254,62 @@ components:
             - $ref: "#/components/schemas/PublicKey"
             - description: The public key of the host storing the sector
 
+    ObjectSlab:
+      type: object
+      description: A reference to a previously pinned slab that is part of an object
+      required:
+        - id
+        - offset
+        - length
+      properties:
+        id:
+          allOf:
+            - $ref: "#/components/schemas/SlabID"
+            - description: The ID of the pinned slab
+        offset:
+          type: integer
+          format: uint32
+          description: The offset within the slab where the slice starts
+        length:
+          type: integer
+          format: uint32
+          description: The length of the slice
+
+    PinObjectRequest:
+      type: object
+      description: The request body for creating or updating an object. Slabs must already be pinned to the indexer.
+      required:
+        - encryptedDataKey
+        - slabs
+        - dataSignature
+        - metadataSignature
+      properties:
+        encryptedDataKey:
+          type: string
+          format: byte
+          description: The encrypted data key used to encrypt and decrypt the object's data (base64-encoded in JSON)
+        slabs:
+          type: array
+          items:
+            $ref: "#/components/schemas/ObjectSlab"
+          description: The list of previously pinned slabs that make up the object
+        dataSignature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: A signature of blake2b(object ID, encrypted_data_key) attesting that the object data has not been tampered with
+        encryptedMetadataKey:
+          type: string
+          format: byte
+          description: The encrypted metadata key used to encrypt and decrypt the object's metadata (base64-encoded in JSON)
+        encryptedMetadata:
+          type: string
+          format: byte
+          description: Optional metadata stored as a byte array (base64-encoded in JSON, max 1024 bytes)
+        metadataSignature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: A signature of blake2b(object ID, metadata key, encrypted_metadata) attesting that the metadata has not been tampered with
+
     ObjectEvent:
       type: object
       properties:
@@ -264,7 +320,7 @@ components:
         deleted:
           type: boolean
           description: Whether the object was deleted or not
-        lastUpdated:
+        updatedAt:
           type: string
           format: date-time
           description: Last time the object was created, updated, or deleted.

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -279,11 +279,16 @@ components:
       type: object
       description: The request body for creating or updating an object. Slabs must already be pinned to the indexer.
       required:
+        - id
         - encryptedDataKey
         - slabs
         - dataSignature
         - metadataSignature
       properties:
+        id:
+          allOf:
+            - $ref: "#/components/schemas/Hash256"
+            - description: The object's ID, computed as a hash of its slabs. The server validates this matches the computed value.
         encryptedDataKey:
           type: string
           format: byte

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -720,7 +720,7 @@ func TestPruneAccount(t *testing.T) {
 	obj1Acc2.DataSignature = (types.Signature)(frand.Bytes(64))
 	obj1Acc2.EncryptedMetadataKey = frand.Bytes(72)
 	obj1Acc2.MetadataSignature = (types.Signature)(frand.Bytes(64))
-	if err := store.SaveObject(acc2, obj1Acc2); err != nil {
+	if err := store.SaveObject(acc2, obj1Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -734,7 +734,7 @@ func TestPruneAccount(t *testing.T) {
 	obj2Acc2.DataSignature = (types.Signature)(frand.Bytes(64))
 	obj2Acc2.EncryptedMetadataKey = frand.Bytes(72)
 	obj2Acc2.MetadataSignature = (types.Signature)(frand.Bytes(64))
-	if err := store.SaveObject(acc2, obj2Acc2); err != nil {
+	if err := store.SaveObject(acc2, obj2Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -720,7 +720,7 @@ func TestPruneAccount(t *testing.T) {
 	obj1Acc2.DataSignature = (types.Signature)(frand.Bytes(64))
 	obj1Acc2.EncryptedMetadataKey = frand.Bytes(72)
 	obj1Acc2.MetadataSignature = (types.Signature)(frand.Bytes(64))
-	if err := store.SaveObject(acc2, obj1Acc2.PinRequest()); err != nil {
+	if err := store.PinObject(acc2, obj1Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -734,7 +734,7 @@ func TestPruneAccount(t *testing.T) {
 	obj2Acc2.DataSignature = (types.Signature)(frand.Bytes(64))
 	obj2Acc2.EncryptedMetadataKey = frand.Bytes(72)
 	obj2Acc2.MetadataSignature = (types.Signature)(frand.Bytes(64))
-	if err := store.SaveObject(acc2, obj2Acc2.PinRequest()); err != nil {
+	if err := store.PinObject(acc2, obj2Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -282,7 +282,7 @@ func (s *Store) DeleteObject(account proto.Account, objectKey types.Hash256) err
 
 // SaveObject saves the given object for the given account. If an object with
 // the given key exists for an account, it is overwritten.
-func (s *Store) SaveObject(account proto.Account, obj slabs.SealedObject) error {
+func (s *Store) SaveObject(account proto.Account, obj slabs.PinObjectRequest) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
 		accountID, deleted, err := accountID(ctx, tx, account)
 		if err != nil {
@@ -321,7 +321,7 @@ func (s *Store) SaveObject(account proto.Account, obj slabs.SealedObject) error 
 
 		slabIDs := make([]slabs.SlabID, 0, len(obj.Slabs))
 		for _, slab := range obj.Slabs {
-			slabIDs = append(slabIDs, slab.Digest())
+			slabIDs = append(slabIDs, slab.ID)
 		}
 
 		// check that this account has pinned these slabs

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -280,9 +280,9 @@ func (s *Store) DeleteObject(account proto.Account, objectKey types.Hash256) err
 	})
 }
 
-// SaveObject saves the given object for the given account. If an object with
+// PinObject saves the given object for the given account. If an object with
 // the given key exists for an account, it is overwritten.
-func (s *Store) SaveObject(account proto.Account, obj slabs.PinObjectRequest) error {
+func (s *Store) PinObject(account proto.Account, obj slabs.PinObjectRequest) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
 		accountID, deleted, err := accountID(ctx, tx, account)
 		if err != nil {
@@ -306,7 +306,7 @@ func (s *Store) SaveObject(account proto.Account, obj slabs.PinObjectRequest) er
 			INSERT INTO objects (object_key, account_id, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature) VALUES ($1, $2, $3, $4, $5, $6, $7)
 			ON CONFLICT (account_id, object_key) DO UPDATE SET (encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, updated_at) = (EXCLUDED.encrypted_data_key, EXCLUDED.encrypted_meta_key, EXCLUDED.encrypted_metadata, EXCLUDED.data_signature, EXCLUDED.meta_signature, NOW())
 			RETURNING id`,
-			sqlHash256(obj.ID()), accountID, obj.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(obj.DataSignature), sqlSignature(obj.MetadataSignature)).Scan(&objectID)
+			sqlHash256(obj.ID), accountID, obj.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(obj.DataSignature), sqlSignature(obj.MetadataSignature)).Scan(&objectID)
 		if err != nil {
 			return fmt.Errorf("failed to insert object: %w", err)
 		}
@@ -314,7 +314,7 @@ func (s *Store) SaveObject(account proto.Account, obj slabs.PinObjectRequest) er
 		_, err = tx.Exec(ctx, `
 			INSERT INTO object_events (object_key, account_id, was_deleted) VALUES ($1, $2, FALSE)
 			ON CONFLICT (account_id, object_key) DO UPDATE SET (was_deleted, updated_at) = (FALSE, NOW())`,
-			sqlHash256(obj.ID()), accountID)
+			sqlHash256(obj.ID), accountID)
 		if err != nil {
 			return fmt.Errorf("failed to insert object event: %w", err)
 		}

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -26,7 +26,7 @@ func (s *Store) pinRandomObject(t testing.TB, acc proto.Account, ss []slabs.Slab
 		DataSignature:        (types.Signature)(frand.Bytes(64)),
 		MetadataSignature:    (types.Signature)(frand.Bytes(64)),
 	}
-	if err := s.SaveObject(acc, obj); err != nil {
+	if err := s.SaveObject(acc, obj.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 	return obj
@@ -70,26 +70,22 @@ func TestObject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	now := time.Now().UTC().Round(time.Second)
 	expected := slabs.SealedObject{
 		EncryptedDataKey:     frand.Bytes(72),
 		EncryptedMetadataKey: frand.Bytes(72),
 		EncryptedMetadata:    frand.Bytes(50),
 		DataSignature:        types.Signature(frand.Bytes(64)),
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
-		CreatedAt:            now,
-		UpdatedAt:            now,
+		// note: created at an updated at are set by the server
 		Slabs: []slabs.SlabSlice{
 			params.Slice(0, 100),
 		},
 	}
-	err = store.SaveObject(acc, expected)
+	err = store.SaveObject(acc, expected.PinRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected.CreatedAt = time.Time{}
-	expected.UpdatedAt = time.Time{}
 	expected.Slabs[0].Sectors[2].HostKey = types.PublicKey{}
 
 	got, err := store.Object(acc, expected.ID())
@@ -215,7 +211,7 @@ func TestObjects(t *testing.T) {
 	obj1Acc2.DataSignature = (types.Signature)(frand.Bytes(64))
 	obj1Acc2.EncryptedMetadataKey = frand.Bytes(72)
 	obj1Acc2.MetadataSignature = (types.Signature)(frand.Bytes(64))
-	if err := store.SaveObject(acc2, obj1Acc2); err != nil {
+	if err := store.SaveObject(acc2, obj1Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -269,7 +265,7 @@ func TestObjects(t *testing.T) {
 
 	// save object 1 again to update its timestamp
 	obj1Acc2.EncryptedMetadata = []byte("updated meta")
-	if err := store.SaveObject(acc2, obj1Acc2); err != nil {
+	if err := store.SaveObject(acc2, obj1Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -424,7 +420,7 @@ func TestSaveObject(t *testing.T) {
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
 	}
 
-	if err := store.SaveObject(acc, objWithMeta); err != nil {
+	if err := store.SaveObject(acc, objWithMeta.PinRequest()); err != nil {
 		t.Fatalf("failed to save object with metadata: %v", err)
 	}
 
@@ -450,7 +446,7 @@ func TestSaveObject(t *testing.T) {
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
 	}
 
-	if err := store.SaveObject(acc, objNoMeta); err != nil {
+	if err := store.SaveObject(acc, objNoMeta.PinRequest()); err != nil {
 		t.Fatalf("failed to save object without metadata: %v", err)
 	}
 
@@ -473,7 +469,7 @@ func TestSaveObject(t *testing.T) {
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
 	}
 
-	if err := store.SaveObject(acc, objEmptyMeta); err != nil {
+	if err := store.SaveObject(acc, objEmptyMeta.PinRequest()); err != nil {
 		t.Fatalf("failed to save object with empty metadata slice: %v", err)
 	}
 
@@ -536,7 +532,7 @@ func TestSharedObjects(t *testing.T) {
 		EncryptedMetadata:    []byte("hello world"),
 	}
 	obj.Slabs = slices.Clone(expectedSharedObj.Slabs)
-	if err := store.SaveObject(acc1, obj); err != nil {
+	if err := store.SaveObject(acc1, obj.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -616,15 +612,16 @@ func BenchmarkSaveObject(b *testing.B) {
 
 	for range 10000 {
 		obj := pinObject(b)
-		if err := store.SaveObject(acc1, obj); err != nil {
+		if err := store.SaveObject(acc1, obj.PinRequest()); err != nil {
 			b.Fatal(err)
 		}
 		objs = append(objs, obj)
 	}
 
 	obj := pinObject(b)
+	pinReq := obj.PinRequest()
 	for b.Loop() {
-		if err := store.SaveObject(acc1, obj); err != nil {
+		if err := store.SaveObject(acc1, pinReq); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -76,7 +76,7 @@ func TestObject(t *testing.T) {
 		EncryptedMetadata:    frand.Bytes(50),
 		DataSignature:        types.Signature(frand.Bytes(64)),
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
-		// note: created at an updated at are set by the server
+		// note: created at and updated at are set by the server
 		Slabs: []slabs.SlabSlice{
 			params.Slice(0, 100),
 		},

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -26,7 +26,7 @@ func (s *Store) pinRandomObject(t testing.TB, acc proto.Account, ss []slabs.Slab
 		DataSignature:        (types.Signature)(frand.Bytes(64)),
 		MetadataSignature:    (types.Signature)(frand.Bytes(64)),
 	}
-	if err := s.SaveObject(acc, obj.PinRequest()); err != nil {
+	if err := s.PinObject(acc, obj.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 	return obj
@@ -81,7 +81,7 @@ func TestObject(t *testing.T) {
 			params.Slice(0, 100),
 		},
 	}
-	err = store.SaveObject(acc, expected.PinRequest())
+	err = store.PinObject(acc, expected.PinRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestObjects(t *testing.T) {
 	obj1Acc2.DataSignature = (types.Signature)(frand.Bytes(64))
 	obj1Acc2.EncryptedMetadataKey = frand.Bytes(72)
 	obj1Acc2.MetadataSignature = (types.Signature)(frand.Bytes(64))
-	if err := store.SaveObject(acc2, obj1Acc2.PinRequest()); err != nil {
+	if err := store.PinObject(acc2, obj1Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -265,7 +265,7 @@ func TestObjects(t *testing.T) {
 
 	// save object 1 again to update its timestamp
 	obj1Acc2.EncryptedMetadata = []byte("updated meta")
-	if err := store.SaveObject(acc2, obj1Acc2.PinRequest()); err != nil {
+	if err := store.PinObject(acc2, obj1Acc2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -420,7 +420,7 @@ func TestSaveObject(t *testing.T) {
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
 	}
 
-	if err := store.SaveObject(acc, objWithMeta.PinRequest()); err != nil {
+	if err := store.PinObject(acc, objWithMeta.PinRequest()); err != nil {
 		t.Fatalf("failed to save object with metadata: %v", err)
 	}
 
@@ -446,7 +446,7 @@ func TestSaveObject(t *testing.T) {
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
 	}
 
-	if err := store.SaveObject(acc, objNoMeta.PinRequest()); err != nil {
+	if err := store.PinObject(acc, objNoMeta.PinRequest()); err != nil {
 		t.Fatalf("failed to save object without metadata: %v", err)
 	}
 
@@ -469,7 +469,7 @@ func TestSaveObject(t *testing.T) {
 		MetadataSignature:    types.Signature(frand.Bytes(64)),
 	}
 
-	if err := store.SaveObject(acc, objEmptyMeta.PinRequest()); err != nil {
+	if err := store.PinObject(acc, objEmptyMeta.PinRequest()); err != nil {
 		t.Fatalf("failed to save object with empty metadata slice: %v", err)
 	}
 
@@ -532,7 +532,7 @@ func TestSharedObjects(t *testing.T) {
 		EncryptedMetadata:    []byte("hello world"),
 	}
 	obj.Slabs = slices.Clone(expectedSharedObj.Slabs)
-	if err := store.SaveObject(acc1, obj.PinRequest()); err != nil {
+	if err := store.PinObject(acc1, obj.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -612,7 +612,7 @@ func BenchmarkSaveObject(b *testing.B) {
 
 	for range 10000 {
 		obj := pinObject(b)
-		if err := store.SaveObject(acc1, obj.PinRequest()); err != nil {
+		if err := store.PinObject(acc1, obj.PinRequest()); err != nil {
 			b.Fatal(err)
 		}
 		objs = append(objs, obj)
@@ -621,7 +621,7 @@ func BenchmarkSaveObject(b *testing.B) {
 	obj := pinObject(b)
 	pinReq := obj.PinRequest()
 	for b.Loop() {
-		if err := store.SaveObject(acc1, pinReq); err != nil {
+		if err := store.PinObject(acc1, pinReq); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -97,7 +97,7 @@ func TestMigrateSector(t *testing.T) {
 		}
 	}
 
-	err = store.SaveObject(account, so)
+	err = store.SaveObject(account, so.PinRequest())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -97,7 +97,7 @@ func TestMigrateSector(t *testing.T) {
 		}
 	}
 
-	err = store.SaveObject(account, so.PinRequest())
+	err = store.PinObject(account, so.PinRequest())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -321,7 +321,7 @@ func TestSlabPruning(t *testing.T) {
 		obj1.DataSignature = types.Signature(frand.Bytes(64))
 		obj1.EncryptedMetadataKey = frand.Bytes(72)
 		obj1.MetadataSignature = types.Signature(frand.Bytes(64))
-		if err := store.SaveObject(acc, obj1); err != nil {
+		if err := store.SaveObject(acc, obj1.PinRequest()); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -337,7 +337,7 @@ func TestSlabPruning(t *testing.T) {
 		},
 	}
 
-	if err := store.SaveObject(acc1, obj2); err != nil {
+	if err := store.SaveObject(acc1, obj2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -321,7 +321,7 @@ func TestSlabPruning(t *testing.T) {
 		obj1.DataSignature = types.Signature(frand.Bytes(64))
 		obj1.EncryptedMetadataKey = frand.Bytes(72)
 		obj1.MetadataSignature = types.Signature(frand.Bytes(64))
-		if err := store.SaveObject(acc, obj1.PinRequest()); err != nil {
+		if err := store.PinObject(acc, obj1.PinRequest()); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -337,7 +337,7 @@ func TestSlabPruning(t *testing.T) {
 		},
 	}
 
-	if err := store.SaveObject(acc1, obj2.PinRequest()); err != nil {
+	if err := store.PinObject(acc1, obj2.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -46,7 +46,7 @@ type (
 
 		ListObjects(ctx context.Context, appKey types.PrivateKey, cursor slabs.Cursor, limit int) ([]slabs.ObjectEvent, error)
 		Object(ctx context.Context, appKey types.PrivateKey, key types.Hash256) (slabs.SealedObject, error)
-		SaveObject(ctx context.Context, appKey types.PrivateKey, obj slabs.SealedObject) error
+		PinObject(ctx context.Context, appKey types.PrivateKey, obj slabs.SealedObject) error
 		DeleteObject(ctx context.Context, appKey types.PrivateKey, key types.Hash256) error
 
 		Slab(context.Context, types.PrivateKey, slabs.SlabID) (slabs.PinnedSlab, error)
@@ -411,7 +411,7 @@ func (s *SDK) PinObject(ctx context.Context, obj Object) error {
 		}
 	}
 
-	return s.client.SaveObject(ctx, s.appKey, obj.Seal(s.appKey).SealedObject)
+	return s.client.PinObject(ctx, s.appKey, obj.Seal(s.appKey).SealedObject)
 }
 
 func (s *SDK) downloadSlabs(ctx context.Context, w io.Writer, maxInflight int, hostTimeout time.Duration, ss []slabs.SlabSlice) error {

--- a/sdk/mock_test.go
+++ b/sdk/mock_test.go
@@ -272,8 +272,8 @@ func (mc *mockAppClient) SharedObject(ctx context.Context, sharedURL string) (sl
 	return slabs.SharedObject{Slabs: objSlabs}, encryptionKey, nil
 }
 
-// SaveObject implements the [appClient] interface.
-func (mc *mockAppClient) SaveObject(ctx context.Context, _ types.PrivateKey, obj slabs.SealedObject) (err error) {
+// PinObject implements the [appClient] interface.
+func (mc *mockAppClient) PinObject(ctx context.Context, _ types.PrivateKey, obj slabs.SealedObject) (err error) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.objects[obj.ID()] = obj

--- a/sdk/objects_test.go
+++ b/sdk/objects_test.go
@@ -1,6 +1,8 @@
 package sdk
 
 import (
+	"encoding/json"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -75,5 +77,53 @@ func TestSealedObjectRoundtrip(t *testing.T) {
 	obj2.updatedAt = obj.updatedAt
 	if !reflect.DeepEqual(obj, obj2) {
 		t.Fatalf("object mismatch: expected %+v, got %+v", obj, obj2)
+	}
+}
+
+func TestObjectEquivalency(t *testing.T) {
+	sk := types.GeneratePrivateKey()
+	obj := Object{
+		dataKey: frand.Bytes(32),
+		slabs: func() []slabs.SlabSlice {
+			ss := make([]slabs.SlabSlice, 30)
+			for i := range ss {
+				ss[i] = slabs.SlabSlice{
+					EncryptionKey: frand.Entropy256(),
+					MinShards:     10,
+					Sectors: func() []slabs.PinnedSector {
+						sectors := make([]slabs.PinnedSector, 30)
+						for j := range sectors {
+							sectors[j] = slabs.PinnedSector{
+								Root:    frand.Entropy256(),
+								HostKey: frand.Entropy256(),
+							}
+						}
+						return sectors
+					}(),
+					Offset: uint32(frand.Uint64n(math.MaxUint32)),
+					Length: uint32(frand.Uint64n(math.MaxUint32)),
+				}
+			}
+			return ss
+		}(),
+		metadata: json.RawMessage([]byte("{\"hello\": \"world\"}")),
+	}
+	objectID := obj.ID()
+	so := obj.Seal(sk)
+	if so.ID() != objectID {
+		t.Fatalf("unexpected ID: got %v, want %v", so.ID(), objectID)
+	} else if err := so.VerifySignatures(sk.PublicKey()); err != nil {
+		t.Fatalf("unexpected error verifying signatures: %v", err)
+	}
+
+	pr := so.PinRequest()
+	if pr.ID() != objectID {
+		t.Fatalf("unexpected ID: got %v, want %v", pr.ID(), objectID)
+	} else if pr.DataSigHash() != so.DataSigHash() {
+		t.Fatalf("unexpected data sig hash: got %v, want %v", pr.DataSigHash(), so.DataSigHash())
+	} else if pr.MetaSigHash() != so.MetaSigHash() {
+		t.Fatalf("unexpected metadata sig hash: got %v, want %v", pr.MetaSigHash(), so.MetaSigHash())
+	} else if err := pr.VerifySignatures(sk.PublicKey()); err != nil {
+		t.Fatalf("unexpected error verifying signatures: %v", err)
 	}
 }

--- a/sdk/objects_test.go
+++ b/sdk/objects_test.go
@@ -117,8 +117,8 @@ func TestObjectEquivalency(t *testing.T) {
 	}
 
 	pr := so.PinRequest()
-	if pr.ID() != objectID {
-		t.Fatalf("unexpected ID: got %v, want %v", pr.ID(), objectID)
+	if pr.ID != objectID {
+		t.Fatalf("unexpected ID: got %v, want %v", pr.ID, objectID)
 	} else if pr.DataSigHash() != so.DataSigHash() {
 		t.Fatalf("unexpected data sig hash: got %v, want %v", pr.DataSigHash(), so.DataSigHash())
 	} else if pr.MetaSigHash() != so.MetaSigHash() {

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -113,7 +113,7 @@ type (
 		// Object methods
 		Object(account proto.Account, key types.Hash256) (SealedObject, error)
 		DeleteObject(account proto.Account, objectKey types.Hash256) error
-		SaveObject(account proto.Account, obj SealedObject) error
+		SaveObject(account proto.Account, obj PinObjectRequest) error
 		ListObjects(account proto.Account, cursor Cursor, limit int) ([]ObjectEvent, error)
 		SharedObject(key types.Hash256) (SharedObject, error)
 	}

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -113,7 +113,7 @@ type (
 		// Object methods
 		Object(account proto.Account, key types.Hash256) (SealedObject, error)
 		DeleteObject(account proto.Account, objectKey types.Hash256) error
-		SaveObject(account proto.Account, obj PinObjectRequest) error
+		PinObject(account proto.Account, obj PinObjectRequest) error
 		ListObjects(account proto.Account, cursor Cursor, limit int) ([]ObjectEvent, error)
 		SharedObject(key types.Hash256) (SharedObject, error)
 	}

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -78,7 +78,88 @@ type (
 		After time.Time
 		Key   types.Hash256
 	}
+
+	// ObjectSlab represents a slab that should be associated with an object. It should already be pinned to the indexer.
+	ObjectSlab struct {
+		ID     SlabID `json:"id"`
+		Offset uint32 `json:"offset"`
+		Length uint32 `json:"length"`
+	}
+
+	// A PinObjectRequest is the minimal fields for pinning an object to the indexer. It should be created using [SealedObject.PinRequest].
+	PinObjectRequest struct {
+		EncryptedDataKey []byte       `json:"encryptedDataKey"`
+		Slabs            []ObjectSlab `json:"slabs"`
+		// DataSignature is a signature of the blake2b(object ID, encrypted_data_key)
+		// to attest that the object data has not been tampered with. This attestation
+		// is separate from the metadata attestation to allow for validating the
+		// encryption key when sharing the object which does not include the metadata.
+		DataSignature types.Signature `json:"dataSignature"`
+
+		EncryptedMetadataKey []byte `json:"encryptedMetadataKey,omitempty"`
+		EncryptedMetadata    []byte `json:"encryptedMetadata,omitempty"`
+		// MetadataSignature is a signature of the blake2b(object ID, metadata
+		// key, and encrypted_metadata) to attest that the object has not been
+		// tampered with.
+		MetadataSignature types.Signature `json:"metadataSignature"`
+	}
 )
+
+// ID returns the object's ID, which is a hash of its slabs. The
+// object ID is used to identify the object and retrieve it from
+// the indexer.
+func (pr *PinObjectRequest) ID() types.Hash256 {
+	h := types.NewHasher()
+	for _, slab := range pr.Slabs {
+		slab.ID.EncodeTo(h.E)
+		h.E.WriteUint64(uint64(slab.Offset)<<32 | uint64(slab.Length))
+	}
+	return h.Sum()
+}
+
+// DataSigHash returns the hash used for signing/verifying the data signature.
+// It covers the slabs through the object ID and the encrypted data key.
+func (pr *PinObjectRequest) DataSigHash() types.Hash256 {
+	h := types.NewHasher()
+	pr.ID().EncodeTo(h.E)
+	h.E.Write(pr.EncryptedDataKey)
+	return h.Sum()
+}
+
+// MetaSigHash returns the hash used for signing/verifying the metadata
+// signature. It covers the slabs through the object ID, the encrypted metadata
+// key, and the encrypted metadata.
+func (pr *PinObjectRequest) MetaSigHash() types.Hash256 {
+	h := types.NewHasher()
+	pr.ID().EncodeTo(h.E)
+	h.E.Write(pr.EncryptedMetadataKey)
+	h.E.Write(pr.EncryptedMetadata)
+	return h.Sum()
+}
+
+// VerifyDataSignature verifies the object's data signature using the given
+// public key.
+func (pr *PinObjectRequest) VerifyDataSignature(pk types.PublicKey) error {
+	if !pk.VerifyHash(pr.DataSigHash(), pr.DataSignature) {
+		return fmt.Errorf("%w: invalid data signature", ErrInvalidObjectSignature)
+	}
+	return nil
+}
+
+// VerifyMetadataSignature verifies the object's metadata signature using the
+// given public key.
+func (pr *PinObjectRequest) VerifyMetadataSignature(pk types.PublicKey) error {
+	if !pk.VerifyHash(pr.MetaSigHash(), pr.MetadataSignature) {
+		return fmt.Errorf("%w: invalid metadata signature", ErrInvalidObjectSignature)
+	}
+	return nil
+}
+
+// VerifySignatures verifies both the data and metadata signatures using the
+// given public key.
+func (pr *PinObjectRequest) VerifySignatures(pk types.PublicKey) error {
+	return errors.Join(pr.VerifyDataSignature(pk), pr.VerifyMetadataSignature(pk))
+}
 
 // Size returns the total size of the object in bytes.
 func (o *SharedObject) Size() uint64 {
@@ -110,6 +191,26 @@ var (
 // ID returns the object's ID, which is a hash of its slabs.
 func (so *SealedObject) ID() types.Hash256 {
 	return ObjectID(so.Slabs)
+}
+
+// PinRequest converts the SealedObject to a PinObjectRequest.
+func (so *SealedObject) PinRequest() PinObjectRequest {
+	os := make([]ObjectSlab, len(so.Slabs))
+	for i, slab := range so.Slabs {
+		os[i] = ObjectSlab{
+			ID:     slab.Digest(),
+			Offset: slab.Offset,
+			Length: slab.Length,
+		}
+	}
+	return PinObjectRequest{
+		EncryptedDataKey:     so.EncryptedDataKey,
+		Slabs:                os,
+		DataSignature:        so.DataSignature,
+		EncryptedMetadataKey: so.EncryptedMetadataKey,
+		EncryptedMetadata:    so.EncryptedMetadata,
+		MetadataSignature:    so.MetadataSignature,
+	}
 }
 
 // Sign signs the object's data and metadata signatures using the given private
@@ -186,7 +287,7 @@ func (m *SlabManager) DeleteObject(ctx context.Context, account proto.Account, o
 
 // SaveObject saves the given object for the given account. If an object with
 // the given key exists for an account, it is overwritten.
-func (m *SlabManager) SaveObject(ctx context.Context, account proto.Account, obj SealedObject) error {
+func (m *SlabManager) SaveObject(ctx context.Context, account proto.Account, obj PinObjectRequest) error {
 	if len(obj.Slabs) == 0 {
 		return ErrObjectMinimumSlabs
 	} else if len(obj.EncryptedMetadata) > metadataLimit {

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -286,7 +286,7 @@ func (m *SlabManager) DeleteObject(ctx context.Context, account proto.Account, o
 }
 
 // SaveObject saves the given object for the given account. If an object with
-// the given key exists for an account, it is overwritten.
+// the same ID already exists for the account, it is overwritten.
 func (m *SlabManager) SaveObject(ctx context.Context, account proto.Account, obj PinObjectRequest) error {
 	if len(obj.Slabs) == 0 {
 		return ErrObjectMinimumSlabs

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -88,8 +88,9 @@ type (
 
 	// A PinObjectRequest is the minimal fields for pinning an object to the indexer. It should be created using [SealedObject.PinRequest].
 	PinObjectRequest struct {
-		EncryptedDataKey []byte       `json:"encryptedDataKey"`
-		Slabs            []ObjectSlab `json:"slabs"`
+		ID               types.Hash256 `json:"id"`
+		EncryptedDataKey []byte        `json:"encryptedDataKey"`
+		Slabs            []ObjectSlab  `json:"slabs"`
 		// DataSignature is a signature of the blake2b(object ID, encrypted_data_key)
 		// to attest that the object data has not been tampered with. This attestation
 		// is separate from the metadata attestation to allow for validating the
@@ -105,23 +106,11 @@ type (
 	}
 )
 
-// ID returns the object's ID, which is a hash of its slabs. The
-// object ID is used to identify the object and retrieve it from
-// the indexer.
-func (pr *PinObjectRequest) ID() types.Hash256 {
-	h := types.NewHasher()
-	for _, slab := range pr.Slabs {
-		slab.ID.EncodeTo(h.E)
-		h.E.WriteUint64(uint64(slab.Offset)<<32 | uint64(slab.Length))
-	}
-	return h.Sum()
-}
-
 // DataSigHash returns the hash used for signing/verifying the data signature.
 // It covers the slabs through the object ID and the encrypted data key.
 func (pr *PinObjectRequest) DataSigHash() types.Hash256 {
 	h := types.NewHasher()
-	pr.ID().EncodeTo(h.E)
+	pr.ID.EncodeTo(h.E)
 	h.E.Write(pr.EncryptedDataKey)
 	return h.Sum()
 }
@@ -131,7 +120,7 @@ func (pr *PinObjectRequest) DataSigHash() types.Hash256 {
 // key, and the encrypted metadata.
 func (pr *PinObjectRequest) MetaSigHash() types.Hash256 {
 	h := types.NewHasher()
-	pr.ID().EncodeTo(h.E)
+	pr.ID.EncodeTo(h.E)
 	h.E.Write(pr.EncryptedMetadataKey)
 	h.E.Write(pr.EncryptedMetadata)
 	return h.Sum()
@@ -204,6 +193,7 @@ func (so *SealedObject) PinRequest() PinObjectRequest {
 		}
 	}
 	return PinObjectRequest{
+		ID:                   so.ID(),
 		EncryptedDataKey:     so.EncryptedDataKey,
 		Slabs:                os,
 		DataSignature:        so.DataSignature,
@@ -226,6 +216,17 @@ func ObjectID(slabs []SlabSlice) types.Hash256 {
 	for _, slab := range slabs {
 		slabID := slab.Digest()
 		h.E.Write(slabID[:])
+		h.E.WriteUint64(uint64(slab.Offset)<<32 | uint64(slab.Length))
+	}
+	return h.Sum()
+}
+
+// pinnedObjectID computes the object ID from its slabs. This can be compared
+// against the ID field to verify the client provided the correct ID.
+func pinnedObjectID(slabs []ObjectSlab) types.Hash256 {
+	h := types.NewHasher()
+	for _, slab := range slabs {
+		slab.ID.EncodeTo(h.E)
 		h.E.WriteUint64(uint64(slab.Offset)<<32 | uint64(slab.Length))
 	}
 	return h.Sum()
@@ -285,18 +286,19 @@ func (m *SlabManager) DeleteObject(ctx context.Context, account proto.Account, o
 	return m.store.DeleteObject(account, objectKey)
 }
 
-// SaveObject saves the given object for the given account. If an object with
+// PinObject pin the given object for the given account. If an object with
 // the same ID already exists for the account, it is overwritten.
-func (m *SlabManager) SaveObject(ctx context.Context, account proto.Account, obj PinObjectRequest) error {
+func (m *SlabManager) PinObject(ctx context.Context, account proto.Account, obj PinObjectRequest) error {
 	if len(obj.Slabs) == 0 {
 		return ErrObjectMinimumSlabs
 	} else if len(obj.EncryptedMetadata) > metadataLimit {
 		return fmt.Errorf("%w: got %d bytes", ErrObjectMetadataLimitExceeded, len(obj.EncryptedMetadata))
+	} else if pinnedObjectID(obj.Slabs) != obj.ID {
+		return fmt.Errorf("%w: object ID does not match slabs", ErrInvalidObjectSignature)
 	} else if err := obj.VerifySignatures(types.PublicKey(account)); err != nil {
 		return err
 	}
-
-	return m.store.SaveObject(account, obj)
+	return m.store.PinObject(account, obj)
 }
 
 // ListObjects lists objects for the given account that were updated after the

--- a/slabs/objects_test.go
+++ b/slabs/objects_test.go
@@ -1,0 +1,55 @@
+package slabs
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+func TestObjectEquivalency(t *testing.T) {
+	sk := types.GeneratePrivateKey()
+	so := SealedObject{
+		EncryptedDataKey: frand.Bytes(32 + 16),
+		Slabs: func() []SlabSlice {
+			slabs := make([]SlabSlice, 30)
+			for i := range slabs {
+				slabs[i] = SlabSlice{
+					EncryptionKey: frand.Entropy256(),
+					MinShards:     10,
+					Sectors: func() []PinnedSector {
+						sectors := make([]PinnedSector, 30)
+						for j := range sectors {
+							sectors[j] = PinnedSector{
+								Root:    frand.Entropy256(),
+								HostKey: frand.Entropy256(),
+							}
+						}
+						return sectors
+					}(),
+					Offset: uint32(frand.Uint64n(math.MaxUint32)),
+					Length: uint32(frand.Uint64n(math.MaxUint32)),
+				}
+			}
+			return slabs
+		}(),
+		EncryptedMetadataKey: frand.Bytes(32 + 16),
+		EncryptedMetadata:    frand.Bytes(32),
+		CreatedAt:            time.Now(),
+		UpdatedAt:            time.Now(),
+	}
+	so.Sign(sk)
+
+	pr := so.PinRequest()
+	if pr.ID() != so.ID() {
+		t.Fatalf("unexpected ID: got %v, want %v", pr.ID(), so.ID())
+	} else if pr.DataSigHash() != so.DataSigHash() {
+		t.Fatalf("unexpected data sig hash: got %v, want %v", pr.DataSigHash(), so.DataSigHash())
+	} else if pr.MetaSigHash() != so.MetaSigHash() {
+		t.Fatalf("unexpected metadata sig hash: got %v, want %v", pr.MetaSigHash(), so.MetaSigHash())
+	} else if err := pr.VerifySignatures(sk.PublicKey()); err != nil {
+		t.Fatalf("unexpected error verifying signatures: %v", err)
+	}
+}

--- a/slabs/objects_test.go
+++ b/slabs/objects_test.go
@@ -43,8 +43,8 @@ func TestObjectEquivalency(t *testing.T) {
 	so.Sign(sk)
 
 	pr := so.PinRequest()
-	if pr.ID() != so.ID() {
-		t.Fatalf("unexpected ID: got %v, want %v", pr.ID(), so.ID())
+	if pr.ID != so.ID() {
+		t.Fatalf("unexpected ID: got %v, want %v", pr.ID, so.ID())
 	} else if pr.DataSigHash() != so.DataSigHash() {
 		t.Fatalf("unexpected data sig hash: got %v, want %v", pr.DataSigHash(), so.DataSigHash())
 	} else if pr.MetaSigHash() != so.MetaSigHash() {


### PR DESCRIPTION
When sending a full object, the maximum object size given `maxRequestSize = 1MiB` is less than 10GiB at 10-of-30. This PR raises the limit to 10MiB and introduces a minimal `PinObjectRequest` upping the per request object size limit to over a TiB.

Just raising the limit to `maxRequestSize = 10MiB` is less than 100GiB per object. Just introducing the type is less than 500GiB per object. Both changes put us just under 4TiB. AWS S3 has an object size of 50TiB. I don't think we necessarily need to aim for that, but it's good context for expectations.