### PR TITLE
Make app ID required

### DIFF
--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -431,6 +431,9 @@ func (a *admin) handlePOSTAppsRegister(jc jape.Context) {
 	} else if req.AppKey == (types.PublicKey{}) {
 		jc.Error(errors.New("app key is required"), http.StatusBadRequest)
 		return
+	} else if req.Meta.ID == (types.Hash256{}) {
+		jc.Error(errors.New("app ID is required"), http.StatusBadRequest)
+		return
 	}
 
 	err := a.accounts.RegisterAppKey(req.ConnectKey, req.AppKey, req.Meta)

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -313,16 +313,19 @@ func TestRegisterAppKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// build app metadata
+	meta := accounts.AppMeta{
+		ID:          frand.Entropy256(),
+		Description: "test app",
+		ServiceURL:  "http://test-app.com",
+	}
+
 	// register an app key
 	appKey := types.GeneratePrivateKey().PublicKey()
 	err = adminClient.RegisterAppKey(context.Background(), admin.RegisterAppKeyRequest{
 		ConnectKey: connectKey.Key,
 		AppKey:     appKey,
-		Meta: accounts.AppMeta{
-			ID:          frand.Entropy256(),
-			Description: "test app",
-			ServiceURL:  "http://test-app.com",
-		},
+		Meta:       meta,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -340,6 +343,7 @@ func TestRegisterAppKey(t *testing.T) {
 	err = adminClient.RegisterAppKey(context.Background(), admin.RegisterAppKeyRequest{
 		ConnectKey: connectKey.Key,
 		AppKey:     appKey,
+		Meta:       meta,
 	})
 	if err != nil {
 		t.Fatal("expected duplicate registration to succeed, got", err)
@@ -366,6 +370,7 @@ func TestRegisterAppKey(t *testing.T) {
 	if err := adminClient.RegisterAppKey(context.Background(), admin.RegisterAppKeyRequest{
 		ConnectKey: oneUseKey.Key,
 		AppKey:     exhaustedAppKey,
+		Meta:       meta,
 	}); err != nil {
 		t.Fatal("expected first registration on 1-use key to succeed, got", err)
 	}
@@ -373,6 +378,7 @@ func TestRegisterAppKey(t *testing.T) {
 	if err := adminClient.RegisterAppKey(context.Background(), admin.RegisterAppKeyRequest{
 		ConnectKey: oneUseKey.Key,
 		AppKey:     exhaustedAppKey,
+		Meta:       meta,
 	}); err != nil {
 		t.Fatal("expected re-auth on exhausted key to succeed, got", err)
 	}
@@ -381,6 +387,7 @@ func TestRegisterAppKey(t *testing.T) {
 	err = adminClient.RegisterAppKey(context.Background(), admin.RegisterAppKeyRequest{
 		ConnectKey: "nonexistent",
 		AppKey:     types.GeneratePrivateKey().PublicKey(),
+		Meta:       meta,
 	})
 	if err == nil || !strings.Contains(err.Error(), accounts.ErrKeyNotFound.Error()) {
 		t.Fatal("expected ErrKeyNotFound, got", err)

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -290,7 +290,7 @@ paths:
         "200":
           description: App key registered successfully (or already exists)
         "400":
-          description: Connect key or app key is missing
+          description: Connect key, app key or app ID is missing
         "401":
           description: Connect key not found
         "403":

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -2041,9 +2041,12 @@ components:
             - $ref: "#/components/schemas/PublicKey"
             - description: The app's public key
         meta:
+          description: Metadata about the app
           allOf:
             - $ref: "#/components/schemas/AppMeta"
-            - description: Metadata about the app
+            - type: object
+              required:
+                - id
     AppMeta:
       $ref: "./components.yml#/components/schemas/AppMeta"
 


### PR DESCRIPTION
When we fetch account stats, we group on the app ID. We can't make it unique, but perhaps we should make it required when registering an app. Maybe we should generate a random value ourselves if the user doesn't want to pass an ID...