### PR TITLE
Fix migration upload bottleneck

### DIFF
--- a/client/v2/candidates.go
+++ b/client/v2/candidates.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/indexd/hosts"
@@ -215,8 +216,8 @@ func (p *Provider) AddWriteSample(hostKey types.PublicKey, latency time.Duration
 
 // AddFailedRPC records a failed RPC attempt to the specified host.
 func (p *Provider) AddFailedRPC(hostKey types.PublicKey, err error) {
-	if errors.Is(err, ErrAbortedRPC) {
-		return // do not record aborted RPCs as failures
+	if errors.Is(err, ErrAbortedRPC) || errors.Is(err, proto.ErrSectorNotFound) {
+		return // do not record aborted RPCs or missing sectors as failures
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -249,6 +249,7 @@ func (c *Client) HostSettings(ctx context.Context, hostKey types.PublicKey) (set
 		return err
 	})
 	if err != nil {
+		c.hosts.AddFailedRPC(hostKey, err)
 		return proto.HostSettings{}, err
 	}
 	if settings.Prices.Validate(hostKey) == nil {

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -287,11 +286,7 @@ func (c *Client) ReadSector(ctx context.Context, accountKey types.PrivateKey, ho
 		result, err = rhp.RPCReadSector(ctx, transport, prices, token, w, root, offset, length)
 		return err
 	})
-	if err != nil && strings.Contains(err.Error(), proto.ErrSectorNotFound.Error()) {
-		// a ErrSectorNotFound error is neither a failed RPC nor do we want to
-		// record its latency since no data was served
-		return
-	} else if err == nil {
+	if err == nil {
 		c.hosts.AddReadSample(hostKey, time.Since(start))
 	}
 	return

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -205,6 +205,11 @@ func (c *Client) rpcFn(ctx context.Context, hostKey types.PublicKey, fn func(ctx
 	if errors.Is(err, mux.ErrClosedStream) && context.Cause(ctx) != nil {
 		err = fmt.Errorf("%w: %w", err, context.Cause(ctx))
 	}
+
+	// increment the failed RPC count for the host if the RPC failed
+	if err != nil {
+		c.hosts.AddFailedRPC(hostKey, err)
+	}
 	return err
 }
 
@@ -220,43 +225,17 @@ func (c *Client) AccountBalance(ctx context.Context, hostKey types.PublicKey, ac
 // Prices fetches the host prices from the specified host.
 //
 // If the prices are cached and valid, the cached prices are returned.
-func (c *Client) Prices(ctx context.Context, hostKey types.PublicKey) (proto.HostPrices, error) {
-	c.mu.Lock()
-	prices := c.cachedPrices[hostKey]
-	if prices.Validate(hostKey) == nil && time.Until(prices.ValidUntil) > 30*time.Second {
-		c.mu.Unlock()
-		return prices, nil
-	}
-	c.mu.Unlock()
-
-	settings, err := c.HostSettings(ctx, hostKey)
-	if err != nil {
-		return proto.HostPrices{}, err
-	}
-	return settings.Prices, nil
-}
-
-// HostSettings fetches the host settings from the specified host.
-func (c *Client) HostSettings(ctx context.Context, hostKey types.PublicKey) (settings proto.HostSettings, err error) {
+func (c *Client) Prices(ctx context.Context, hostKey types.PublicKey) (prices proto.HostPrices, err error) {
 	done, err := c.tg.Add()
 	if err != nil {
-		return proto.HostSettings{}, err
+		return proto.HostPrices{}, err
 	}
 	defer done()
 
 	err = c.rpcFn(ctx, hostKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		settings, err = rhp.RPCSettings(ctx, transport)
+		prices, err = c.prices(ctx, hostKey, transport)
 		return err
 	})
-	if err != nil {
-		c.hosts.AddFailedRPC(hostKey, err)
-		return proto.HostSettings{}, err
-	}
-	if settings.Prices.Validate(hostKey) == nil {
-		c.mu.Lock()
-		c.cachedPrices[hostKey] = settings.Prices
-		c.mu.Unlock()
-	}
 	return
 }
 
@@ -272,7 +251,7 @@ func (c *Client) WriteSector(ctx context.Context, accountKey types.PrivateKey, h
 
 	start := time.Now()
 	err = c.rpcFn(ctx, hostKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, hostKey)
+		prices, err := c.prices(ctx, hostKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -280,9 +259,7 @@ func (c *Client) WriteSector(ctx context.Context, accountKey types.PrivateKey, h
 		result, err = rhp.RPCWriteSector(ctx, transport, prices, token, bytes.NewReader(data), uint64(len(data)))
 		return err
 	})
-	if err != nil {
-		c.hosts.AddFailedRPC(hostKey, err)
-	} else {
+	if err == nil {
 		c.hosts.AddWriteSample(hostKey, time.Since(start))
 	}
 	return
@@ -299,7 +276,7 @@ func (c *Client) ReadSector(ctx context.Context, accountKey types.PrivateKey, ho
 
 	start := time.Now()
 	err = c.rpcFn(ctx, hostKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, hostKey)
+		prices, err := c.prices(ctx, hostKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -311,9 +288,7 @@ func (c *Client) ReadSector(ctx context.Context, accountKey types.PrivateKey, ho
 		// a ErrSectorNotFound error is neither a failed RPC nor do we want to
 		// record its latency since no data was served
 		return
-	} else if err != nil {
-		c.hosts.AddFailedRPC(hostKey, err)
-	} else {
+	} else if err == nil {
 		c.hosts.AddReadSample(hostKey, time.Since(start))
 	}
 	return
@@ -347,6 +322,30 @@ func (c *Client) Close() error {
 		transport.close()
 	}
 	return nil
+}
+
+// prices fetches the host prices using an existing transport connection.
+//
+// If the prices are cached and valid, the cached prices are returned.
+func (c *Client) prices(ctx context.Context, hostKey types.PublicKey, transport rhp.TransportClient) (proto.HostPrices, error) {
+	c.mu.Lock()
+	prices := c.cachedPrices[hostKey]
+	if prices.Validate(hostKey) == nil && time.Until(prices.ValidUntil) > 30*time.Second {
+		c.mu.Unlock()
+		return prices, nil
+	}
+	c.mu.Unlock()
+
+	settings, err := rhp.RPCSettings(ctx, transport)
+	if err != nil {
+		return proto.HostPrices{}, err
+	}
+	if settings.Prices.Validate(hostKey) == nil {
+		c.mu.Lock()
+		c.cachedPrices[hostKey] = settings.Prices
+		c.mu.Unlock()
+	}
+	return settings.Prices, nil
 }
 
 func shouldResetTransport(err error) bool {

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -186,7 +186,14 @@ func (c *Client) hostTransport(ctx context.Context, hostKey types.PublicKey) (rh
 	return t.dial(ctx, hostKey, addresses)
 }
 
-func (c *Client) rpcFn(ctx context.Context, hostKey types.PublicKey, fn func(ctx context.Context, transport rhp.TransportClient) error) error {
+func (c *Client) rpcFn(ctx context.Context, hostKey types.PublicKey, fn func(ctx context.Context, transport rhp.TransportClient) error) (err error) {
+	defer func() {
+		// increment the failed RPC count for the host if the RPC failed
+		if err != nil {
+			c.hosts.AddFailedRPC(hostKey, err)
+		}
+	}()
+
 	transport, err := c.hostTransport(ctx, hostKey)
 	if err != nil {
 		return fmt.Errorf("failed to get transport: %w", err)
@@ -206,10 +213,6 @@ func (c *Client) rpcFn(ctx context.Context, hostKey types.PublicKey, fn func(ctx
 		err = fmt.Errorf("%w: %w", err, context.Cause(ctx))
 	}
 
-	// increment the failed RPC count for the host if the RPC failed
-	if err != nil {
-		c.hosts.AddFailedRPC(hostKey, err)
-	}
 	return err
 }
 

--- a/client/v2/contracts.go
+++ b/client/v2/contracts.go
@@ -55,7 +55,7 @@ func (c *Client) FormContract(ctx context.Context, chain ChainManager, signer rh
 	defer done()
 
 	err = c.rpcFn(ctx, params.HostKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, params.HostKey)
+		prices, err := c.prices(ctx, params.HostKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -81,7 +81,7 @@ func (c *Client) RefreshContract(ctx context.Context, chain ChainManager, signer
 	}
 
 	err = c.rpcFn(ctx, revision.HostPublicKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, revision.HostPublicKey)
+		prices, err := c.prices(ctx, revision.HostPublicKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -108,7 +108,7 @@ func (c *Client) RenewContract(ctx context.Context, chain ChainManager, signer r
 	}
 
 	err = c.rpcFn(ctx, revision.HostPublicKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, revision.HostPublicKey)
+		prices, err := c.prices(ctx, revision.HostPublicKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -142,7 +142,7 @@ func (c *Client) SectorRoots(ctx context.Context, signer rhp.ContractSigner, cha
 	defer done()
 
 	err = c.rpcFn(ctx, contract.Revision.HostPublicKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, contract.Revision.HostPublicKey)
+		prices, err := c.prices(ctx, contract.Revision.HostPublicKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -161,7 +161,7 @@ func (c *Client) FreeSectors(ctx context.Context, signer rhp.ContractSigner, cha
 	defer done()
 
 	err = c.rpcFn(ctx, contract.Revision.HostPublicKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, contract.Revision.HostPublicKey)
+		prices, err := c.prices(ctx, contract.Revision.HostPublicKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
@@ -180,7 +180,7 @@ func (c *Client) AppendSectors(ctx context.Context, signer rhp.ContractSigner, c
 	defer done()
 
 	err = c.rpcFn(ctx, revision.Revision.HostPublicKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		prices, err := c.Prices(ctx, revision.Revision.HostPublicKey)
+		prices, err := c.prices(ctx, revision.Revision.HostPublicKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -26,7 +27,7 @@ func (cm *ContractManager) performAccountFunding(ctx context.Context, force bool
 	for _, hk := range hostsToFund {
 		wg.Add(1)
 		go func(ctx context.Context, hostKey types.PublicKey, log *zap.Logger) {
-			ctx, cancel := context.WithTimeout(ctx, fundTimeout)
+			ctx, cancel := context.WithTimeoutCause(ctx, fundTimeout, client.ErrAbortedRPC)
 			defer func() {
 				wg.Done()
 				cancel()

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -12,6 +12,7 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -43,7 +44,7 @@ loop:
 
 		wg.Add(1)
 		go func(ctx context.Context, hostKey types.PublicKey, hostLog *zap.Logger) {
-			ctx, cancel := context.WithTimeout(ctx, pinTimeout)
+			ctx, cancel := context.WithTimeoutCause(ctx, pinTimeout, client.ErrAbortedRPC)
 			defer func() {
 				<-sema
 				wg.Done()

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -10,6 +10,7 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -42,7 +43,7 @@ loop:
 
 		wg.Add(1)
 		go func(ctx context.Context, hostKey types.PublicKey, hostLog *zap.Logger) {
-			ctx, cancel := context.WithTimeout(ctx, pruneTimeout)
+			ctx, cancel := context.WithTimeoutCause(ctx, pruneTimeout, client.ErrAbortedRPC)
 			defer func() {
 				<-sema
 				wg.Done()

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,7 +12,6 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/mux/v2"
 	"go.uber.org/zap"
@@ -64,6 +62,8 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Lo
 		defer func() {
 			<-sema
 		}()
+		ctx, timeoutCancel := context.WithTimeout(ctx, m.shardTimeout)
+		defer timeoutCancel()
 
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -84,7 +84,7 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Lo
 
 		start := time.Now()
 		buf := bytes.NewBuffer(make([]byte, 0, proto.SectorSize))
-		if _, err := m.downloadShard(ctx, hostKey, buf, sector.root); err != nil {
+		if _, err := m.hosts.ReadSector(ctx, m.migrationAccountKey, hostKey, sector.root, buf, 0, proto.SectorSize); err != nil {
 			if isErrLostSector(err) {
 				log.Debug("host reports sector lost", zap.Duration("elapsed", time.Since(start)))
 				if err := m.store.MarkSectorsLost(hostKey, []types.Hash256{sector.root}); err != nil {
@@ -172,13 +172,6 @@ raceLoop:
 		return nil, fmt.Errorf("downloaded %d sectors, minimum required: %d: %w", downloaded.Load(), slab.MinShards, errNotEnoughShards)
 	}
 	return shards, nil
-}
-
-func (m *SlabManager) downloadShard(ctx context.Context, hostKey types.PublicKey, w io.Writer, root types.Hash256) (rhp.RPCReadSectorResult, error) {
-	ctx, cancel := context.WithTimeout(ctx, m.shardTimeout)
-	defer cancel()
-
-	return m.hosts.ReadSector(ctx, m.migrationAccountKey, hostKey, root, w, 0, proto.SectorSize)
 }
 
 func isErrLostSector(err error) bool {

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -137,7 +137,7 @@ raceLoop:
 	for i := int(slab.MinShards); downloaded.Load() < uint32(slab.MinShards) && i < len(candidates); i++ {
 		hostKey := candidates[i]
 		select {
-		case <-ctx.Done():
+		case <-initialCtx.Done():
 			break raceLoop
 		case <-failedCh:
 			// a download has failed
@@ -161,7 +161,7 @@ raceLoop:
 					}
 				}
 			})
-		case <-ctx.Done():
+		case <-initialCtx.Done():
 			break raceLoop
 		}
 	}


### PR DESCRIPTION
I noticed that all migrations succeed after spending pretty much exactly 60s on uploads. Turns out a single host kept timing out on fetching settings for 60 seconds.

I was wondering why we kept using that host instead of a different one but the problem is that failing to fetch settings was not punished. Only writes and reads are. After fixing that I'm seeing some pretty decent migration times.

This PR also fixes a delay caused by waiting on the wrong context in the download code. 

```
indexd-1  | 2026-03-20T16:07:05Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "c3a32c4e43622e6b532218c34db6e5defa87186b6d0a00c45967127b27256298", "toMigrate": 16, "uploadCandidates": 118, "downloadElapsed": "2.796011685s", "uploadElapsed": "994.395446ms", "migrated": 16}
indexd-1  | 2026-03-20T16:07:05Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "d81bf1c1456cbb151e213dc58515a2e06e89c9a5ae9e7dddd5cc9e7b43c3c442", "toMigrate": 12, "uploadCandidates": 113, "downloadElapsed": "2.222683462s", "uploadElapsed": "874.729409ms", "migrated": 12}
indexd-1  | 2026-03-20T16:07:07Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "e4c96af19c31515c95d6530dcc90b3d4e6c6c4f6fe2a9c5bbe6ea8eda9735f9f", "toMigrate": 13, "uploadCandidates": 115, "downloadElapsed": "2.931924018s", "uploadElapsed": "790.600316ms", "migrated": 13}
indexd-1  | 2026-03-20T16:07:08Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "1e1a5ecf67d30ddd258fba87fdc67a1a17592a6f58c7155cd1d8aaeda67df62f", "toMigrate": 15, "uploadCandidates": 117, "downloadElapsed": "10.340617987s", "uploadElapsed": "1.425506648s", "migrated": 15}
indexd-1  | 2026-03-20T16:07:08Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "f988d903010d32d96c1f5e2b353904b5bcc734c0f16a74e21e1b01bf6174a36a", "toMigrate": 18, "uploadCandidates": 117, "downloadElapsed": "4.344597974s", "uploadElapsed": "1.322897443s", "migrated": 18}
indexd-1  | 2026-03-20T16:07:09Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "e31fd73f666e01ef38321480c3e482d65e6ae5172ee6a2adc3a289e9907c7846", "toMigrate": 17, "uploadCandidates": 117, "downloadElapsed": "6.582339872s", "uploadElapsed": "1.142146497s", "migrated": 17}
indexd-1  | 2026-03-20T16:07:10Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "101c75d47977b82f0dae80d9344f20ce6cfe1cad3b5e65716ac3c80436a6c0db", "toMigrate": 18, "uploadCandidates": 119, "downloadElapsed": "6.986556241s", "uploadElapsed": "1.118196583s", "migrated": 18}
indexd-1  | 2026-03-20T16:07:11Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "1c42ec361bf9b49bb1b1273ac4c78b493126a68b1156b2da7d86ad2e997c0466", "toMigrate": 19, "uploadCandidates": 119, "downloadElapsed": "5.827169538s", "uploadElapsed": "1.307459016s", "migrated": 19}
indexd-1  | 2026-03-20T16:07:12Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "393d74224b2b5cc7721cbf83b0f8ec4d66674321f446417b665f5309117990af", "toMigrate": 16, "uploadCandidates": 116, "downloadElapsed": "5.472074532s", "uploadElapsed": "1.117605114s", "migrated": 16}
indexd-1  | 2026-03-20T16:07:12Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "f180e4c69fb7faaf2e0edf89036de02ff009ed49fbc9b36d2fd1bb75bd61738f", "toMigrate": 14, "uploadCandidates": 115, "downloadElapsed": "3.081292856s", "uploadElapsed": "782.03781ms", "migrated": 14}
indexd-1  | 2026-03-20T16:07:13Z	DEBUG	slabs.migrations	slab successfully repaired	{"slab": "d48b9b82068a226362b718f4bdafd6b235802fddf0598d6cf6f89340e3a4f3a4", "toMigrate": 14, "uploadCandidates": 114, "downloadElapsed": "6.857210696s", "uploadElapsed": "780.031003ms", "migrated": 14}
```