### PR TITLE
Fetch all usable hosts in SDK

### DIFF
--- a/.changeset/fetch_all_hosts_in_updatehosts_rather_than_the_first_100.md
+++ b/.changeset/fetch_all_hosts_in_updatehosts_rather_than_the_first_100.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fetch all hosts in updateHosts rather than the first 100.

--- a/persist/postgres/hosts.go
+++ b/persist/postgres/hosts.go
@@ -668,8 +668,10 @@ WHERE` + sqlUsabilityFilter + ` AND
 		args := []any{limit, offset, queryOpts.CountryCode, (*sqlNetworkProtocol)(queryOpts.Protocol)}
 
 		if queryOpts.Location != nil {
-			baseQuery += `ORDER BY location <-> point($5, $6) `
+			baseQuery += `ORDER BY location <-> point($5, $6), hosts.id `
 			args = append(args, queryOpts.Location[0], queryOpts.Location[1])
+		} else {
+			baseQuery += `ORDER BY hosts.id `
 		}
 		baseQuery += `LIMIT $1 OFFSET $2;`
 

--- a/sdk/hosts.go
+++ b/sdk/hosts.go
@@ -9,6 +9,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/threadgroup"
+	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/api/app"
 	"go.sia.tech/indexd/hosts"
 )
@@ -74,13 +75,19 @@ func (chs *cachedHostStore) Usable(hostKey types.PublicKey) (bool, error) {
 }
 
 func (chs *cachedHostStore) updateHosts(ctx context.Context) error {
-	hostInfos, err := chs.client.Hosts(ctx, chs.appKey)
-	if err != nil {
-		return err
-	}
+	const pageSize = 100
 	hosts := make(map[types.PublicKey]hosts.HostInfo)
-	for _, host := range hostInfos {
-		hosts[host.PublicKey] = host
+	for offset := 0; ; offset += pageSize {
+		hostInfos, err := chs.client.Hosts(ctx, chs.appKey, api.WithOffset(offset), api.WithLimit(pageSize))
+		if err != nil {
+			return err
+		}
+		for _, host := range hostInfos {
+			hosts[host.PublicKey] = host
+		}
+		if len(hostInfos) < pageSize {
+			break
+		}
 	}
 
 	chs.mu.Lock()


### PR DESCRIPTION
We used the default limit which is 100 up until now unlike the Rust SDK which paginates using a page size of 100 until it has fetch all hosts.