### PR TITLE
Debug log level for 'no hosts for X'

### DIFF
--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -26,7 +26,7 @@ func (cm *ContractManager) performSectorPinning(ctx context.Context, log *zap.Lo
 	if err != nil {
 		return fmt.Errorf("failed to fetch hosts for pinning: %w", err)
 	} else if len(hfp) == 0 {
-		log.Warn("no hosts for pinning")
+		log.Debug("no hosts for pinning")
 		return nil
 	}
 

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -25,7 +25,7 @@ func (cm *ContractManager) performContractPruning(ctx context.Context, log *zap.
 	if err != nil {
 		return fmt.Errorf("failed to fetch hosts for pruning: %w", err)
 	} else if len(hfp) == 0 {
-		log.Warn("no hosts for pruning")
+		log.Debug("no hosts for pruning")
 		return nil
 	}
 


### PR DESCRIPTION
Noticed these on a fresh testnet host when testing instant syncing. There is really no reason for this to be a warning. Nothing the user should worry about.