### PR TITLE
Check for hosts to scan every 5 minutes rather than every hour

### DIFF
--- a/.changeset/lower_host_scanning_interval_to_5_minutes.md
+++ b/.changeset/lower_host_scanning_interval_to_5_minutes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Lower host scanning interval to 5 minutes.

--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -237,7 +237,7 @@ func NewManager(syncer Syncer, locator Locator, client HostClient, store Store, 
 
 	m := &HostManager{
 		announcementMaxAge: time.Hour * 24 * 365,
-		scanFrequency:      time.Hour,
+		scanFrequency:      5 * time.Minute,
 		scanInterval:       time.Hour * 24,
 
 		onlineChecker: &onlineChecker{addresses: fallbackSites, syncer: syncer},


### PR DESCRIPTION
Instant syncing allows for syncing mainnet in 5 minutes. Then users need to wait for another 55 before hosts start getting scanned and appear as usable. 

This fixes this by significantly lowering the interval we use for checking if we have hosts to scan. 