### PR TITLE
Lower scan frequency

### DIFF
--- a/hosts/manager.go
+++ b/hosts/manager.go
@@ -237,7 +237,7 @@ func NewManager(syncer Syncer, locator Locator, client HostClient, store Store, 
 
 	m := &HostManager{
 		announcementMaxAge: time.Hour * 24 * 365,
-		scanFrequency:      time.Hour,
+		scanFrequency:      5 * time.Minute,
 		scanInterval:       time.Hour * 24,
 
 		onlineChecker: &onlineChecker{addresses: fallbackSites, syncer: syncer},


### PR DESCRIPTION
We want to check for hosts to be scanned more often than once every hour. When you set up an indexer for the first time it looks as if hosts aren't getting scanned.