### PR TITLE
Download GeoIP database on demand

### DIFF
--- a/.changeset/download_geoip_database_on_demand_rather_than_embedding_it.md
+++ b/.changeset/download_geoip_database_on_demand_rather_than_embedding_it.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Download geoip database on demand rather than embedding it.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-geoip/GeoLite2-City.mmdb filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -54,12 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: GeoLite2-City.mmdb
-          key: geolite2-city-mmdb
-      - name: Download GeoLite2 database
-        run: |
-          if [ ! -f GeoLite2-City.mmdb ]; then
-            curl -sSfL -o GeoLite2-City.mmdb https://sia.tech/api/media/file/GeoLite2-City.mmdb
-          fi
+          key: geolite2-city-mmdb-2026-04
       - name: Test
         uses: n8maninger/action-golang-test@v2
         with:

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,10 +12,6 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false # required on Windows
       - uses: actions/checkout@v5
-        with:
-          lfs: true
-      - name: Checkout LFS objects
-        run: git lfs checkout
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
@@ -51,13 +47,19 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v5
-        with:
-          lfs: true
-      - name: Checkout LFS objects
-        run: git lfs checkout
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"
+      - name: Cache GeoLite2 database
+        uses: actions/cache@v4
+        with:
+          path: GeoLite2-City.mmdb
+          key: geolite2-city-mmdb
+      - name: Download GeoLite2 database
+        run: |
+          if [ ! -f GeoLite2-City.mmdb ]; then
+            curl -sSfL -o GeoLite2-City.mmdb https://sia.tech/api/media/file/GeoLite2-City.mmdb
+          fi
       - name: Test
         uses: n8maninger/action-golang-test@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,10 +29,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v5
-        with:
-          lfs: true
-      - name: Checkout LFS objects
-        run: git lfs checkout
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 .worktrees
 indexd.yml
 CLAUDE.md
+GeoLite2-City.mmdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN go mod download
 # copy source
 COPY . .
 
-# install git lfs
-RUN apt-get -y update && apt-get install -y --no-install-recommends git-lfs && rm -rf /var/lib/apt/lists/*
-
 # mark as safe in git
 RUN git config --global --add safe.directory .
 

--- a/README.md
+++ b/README.md
@@ -20,27 +20,9 @@ Portal](https://devs.sia.storage).
 
 ## Building
 
-`indexd` embeds a
-[GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
-database for IP geolocation. This file is stored using [Git
-LFS](https://git-lfs.com), so you must have Git LFS installed before cloning the
-repository. Otherwise, indexd won't run because the embedded geolocation
-database will appear corrupted.
-
 ```sh
-# set up Git LFS (once per machine after installing Git LFS)
-git lfs install
-
-# clone the repository (LFS files are fetched automatically)
 git clone https://github.com/SiaFoundation/indexd.git
-
-# if you already cloned without LFS, pull the real files from within the repo
-git lfs pull
-```
-
-Once the LFS files are in place, build as usual:
-
-```sh
+cd indexd
 go generate ./...
 go build -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w' ./cmd/indexd
 ```
@@ -182,3 +164,8 @@ database:
     database: indexd # the name of the PostgreSQL database
     sslmode: verify-full # the SSL mode for the PostgreSQL connection (https://www.postgresql.org/docs/current/libpq-ssl.html)
 ```
+
+## Attributions
+
+Indexd uses GeoLite2 data created by MaxMind, available from
+[https://www.maxmind.com](https://www.maxmind.com).

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -214,7 +214,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer wm.Close()
 
-	locator, err := geoip.NewMaxMindLocator("")
+	locator, err := geoip.NewMaxMindLocator(cfg.Directory, log.Named("geoip"))
 	if err != nil {
 		return fmt.Errorf("failed to create MaxMind locator: %w", err)
 	}

--- a/geoip/GeoLite2-City.mmdb
+++ b/geoip/GeoLite2-City.mmdb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:18bf1695e85007dc1525e88bddd26d4f45b85550899bda8f8d1ebc1e804fc933
-size 62164308

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -1,18 +1,27 @@
 package geoip
 
 import (
-	_ "embed" // needed for geolocation database
+	"fmt"
+	"io"
 	"math"
 	"net"
+	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/oschwald/geoip2-golang"
+	"go.uber.org/zap"
 )
 
-//go:embed GeoLite2-City.mmdb
-var maxMindCityDB []byte
+const (
+	radiusKm = 6371.0088
 
-const radiusKm = 6371.0088
+	// maxMindCityDBURL is the URL to download the GeoLite2-City database from.
+	maxMindCityDBURL = "https://sia.tech/api/media/file/GeoLite2-City.mmdb"
+	// maxMindCityDBFilename is the filename of the GeoLite2-City database.
+	maxMindCityDBFilename = "GeoLite2-City.mmdb"
+)
 
 // A Location represents an ISO 3166-1 A-2 country codes and an approximate
 // latitude/longitude.
@@ -76,20 +85,55 @@ func (m *maxMindLocator) Close() error {
 	return m.db.Close()
 }
 
-// NewMaxMindLocator returns a Locator that uses an underlying MaxMind
-// database.  If no path is provided, a default embedded GeoLite2-City database
-// is used.
-func NewMaxMindLocator(path string) (Locator, error) {
-	var db *geoip2.Reader
-	var err error
-	if path == "" {
-		db, err = geoip2.FromBytes(maxMindCityDB)
-	} else {
-		db, err = geoip2.Open(path)
+// downloadMaxMindDB downloads the GeoLite2-City database to the given path.
+func downloadMaxMindDB(path string) error {
+	resp, err := http.Get(maxMindCityDBURL)
+	if err != nil {
+		return fmt.Errorf("failed to download MaxMind database: %w", err)
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download MaxMind database: unexpected status %d", resp.StatusCode)
+	}
+
+	f, err := os.CreateTemp(filepath.Dir(path), ".geolite2-*.mmdb.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer func() {
+		f.Close()
+		os.Remove(f.Name())
+	}()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("failed to write MaxMind database: %w", err)
+	} else if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	} else if err := os.Rename(f.Name(), path); err != nil {
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+	return nil
+}
+
+// NewMaxMindLocator returns a Locator that uses an underlying MaxMind
+// database. The dataDir is checked for a GeoLite2-City.mmdb file. If
+// one does not exist, it is downloaded from sia.tech.
+func NewMaxMindLocator(dataDir string, log *zap.Logger) (Locator, error) {
+	path := filepath.Join(dataDir, maxMindCityDBFilename)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Info("downloading GeoLite2 database", zap.String("url", maxMindCityDBURL), zap.String("path", path))
+		if err := downloadMaxMindDB(path); err != nil {
+			return nil, err
+		}
+		log.Info("GeoLite2 database downloaded successfully")
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to stat MaxMind database: %w", err)
+	}
+
+	db, err := geoip2.Open(path)
 	if err != nil {
 		return nil, err
 	}
-
 	return &maxMindLocator{db: db}, nil
 }

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -110,7 +110,7 @@ func downloadMaxMindDB(path string) error {
 		return fmt.Errorf("failed to write MaxMind database: %w", err)
 	} else if err := f.Close(); err != nil {
 		return fmt.Errorf("failed to close temp file: %w", err)
-	} else if err := os.Rename(f.Name(), path); err != nil {
+	} else if err := os.Rename(f.Name(), path); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 	return nil

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -160,7 +162,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	walletKey := types.GeneratePrivateKey()
 	wm := NewWallet(t, c, walletKey)
 
-	locator, err := geoip.NewMaxMindLocator("")
+	locator, err := geoip.NewMaxMindLocator(moduleRootDir(), log.Named("geoip"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,6 +367,27 @@ func (idx *Indexer) Tip() (types.ChainIndex, error) {
 // WalletAddr returns the address of the wallet.
 func (idx *Indexer) WalletAddr() types.Address {
 	return idx.wallet.Address()
+}
+
+// moduleRootDir walks up from the current working directory to find the
+// directory containing go.mod. Stops after 10 levels to avoid runaway
+// traversal.
+func moduleRootDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for range 10 {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+	return "."
 }
 
 // closeWithTimeout is a helper which closes a resource and panics if it takes


### PR DESCRIPTION
Closes https://github.com/SiaFoundation/indexd/issues/923

To reduce bandwidth usage during testing, this PR caches the database. Tests expect the database to exist in the root folder of the repo. This also makes local testing convenient since running any test for the first time will download the database without having to use additional env vars or flags to specify a location. 


Uncached CI run: https://github.com/SiaFoundation/indexd/actions/runs/24125398171/job/70388609461?pr=927
Cached CI run: https://github.com/SiaFoundation/indexd/actions/runs/24125398171/job/70390088401?pr=927