### PR TITLE
Don't log failed slab download on shutdown

### DIFF
--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -62,7 +62,9 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 	downloadStart := time.Now()
 	shards, err := m.downloadShards(ctx, slab, log.Named("recover"))
 	if err != nil {
-		log.Error("failed to download slab", zap.Error(err))
+		if ctx.Err() == nil {
+			log.Error("failed to download slab", zap.Error(err))
+		}
 		return
 	}
 	log = log.With(zap.Duration("downloadElapsed", time.Since(downloadStart)))


### PR DESCRIPTION
Making sure we don't log inaccessible slabs on shutdown or interruptions.