### PR TITLE
Reduce fund interval

### DIFF
--- a/.changeset/reduce_account_fund_interval_to_15_minutes.md
+++ b/.changeset/reduce_account_fund_interval_to_15_minutes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Reduce account fund interval to 15 minutes. This reduces the initial fund for new accounts and reduces the amount of time a high-usage account has to wait to be refilled.

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -23,7 +23,7 @@ const (
 	// required before an account is considered ready for use.
 	ReadyHostThreshold = 30
 	// AccountFundInterval is how often we will fund host accounts.
-	AccountFundInterval = time.Hour
+	AccountFundInterval = 15 * time.Minute
 	// AccountActivityThreshold is the threshold for determining whether an
 	// account has been active recently for the purposes of contract funding.
 	// An account is considered active if it has been used within the threshold

--- a/contracts/funding_test.go
+++ b/contracts/funding_test.go
@@ -188,7 +188,7 @@ func TestFunding(t *testing.T) {
 	}
 
 	// assert all accounts next fund was updated and consecutive failed funds was reset
-	expected = time.Now().Add(time.Hour)
+	expected = time.Now().Add(accounts.AccountFundInterval)
 	for _, ea := range s.hostAccounts(t) {
 		if !approxEqual(ea.NextFund, expected) {
 			t.Fatal("expected next fund to be updated to the next fund interval", ea.NextFund)

--- a/persist/postgres/accounts_test.go
+++ b/persist/postgres/accounts_test.go
@@ -1079,7 +1079,7 @@ func TestAccountFundingInfo(t *testing.T) {
 		}
 	}
 
-	const defaultFundTarget = uint64(16e9) // 16 GB, matches migration default
+	const defaultFundTarget = uint64(4e9) // 4 GB, matches init.sql default
 	if defaultInfo.ActiveAccounts != 2 {
 		t.Fatalf("expected 2 default active accounts, got %d", defaultInfo.ActiveAccounts)
 	} else if defaultInfo.FundTargetBytes != defaultFundTarget {

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -6,9 +6,9 @@ CREATE TABLE quotas (
     fund_target_bytes BIGINT NOT NULL CHECK (fund_target_bytes >= 0) -- funding target in bytes per host (0 means no funding)
 );
 
--- insert default quota: 1TB max data, 5 total uses, 16 GB fund target
+-- insert default quota: 1TB max data, 5 total uses, 4 GB fund target
 INSERT INTO quotas (name, description, max_pinned_data, total_uses, fund_target_bytes)
-VALUES ('default', 'Default quota', 1000000000000, 5, 16000000000);
+VALUES ('default', 'Default quota', 1000000000000, 5, 4000000000);
 
 CREATE TABLE app_connect_keys (
     id SERIAL PRIMARY KEY,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -46,4 +46,11 @@ WHERE EXISTS (
 		_, err := tx.Exec(ctx, query, networkProtocolQUIC)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		// AccountFundInterval dropped from 1h to 15m, so accounts refill 4x as
+		// often. Divide existing quota targets by 4 to preserve the bytes/hour
+		// rate they were sized for.
+		_, err := tx.Exec(ctx, `UPDATE quotas SET fund_target_bytes = fund_target_bytes / 4;`)
+		return err
+	},
 }


### PR DESCRIPTION
Reduce account fund interval to 15 minutes. This reduces the initial fund for new accounts and reduces the amount of time a high-usage account has to wait to be refilled.