### PR TITLE
Don't reset transport on invalid proof error

### DIFF
--- a/.changeset/dont_reset_transport_for_invalid_proof_errors.md
+++ b/.changeset/dont_reset_transport_for_invalid_proof_errors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Don't reset transport for invalid proof errors.

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -431,6 +431,11 @@ func shouldResetTransport(err error) bool {
 		// os.ErrDeadlineExceeded indicates that the stream hit a timeout which was set
 		// using SetDeadline. In this case, the mux is still healthy.
 		return false
+	case errors.Is(err, rhp.ErrInvalidProof):
+		// An invalid proof error indicates that the host sent us a response
+		// with an invalid proof. This error is raised on our side and therefore
+		// not transport related.
+		return false
 	default:
 		return proto.ErrorCode(err) == proto.ErrorCodeTransport
 	}


### PR DESCRIPTION
Noticed a lot of "resetting transport" logging due to one host on Zeus returning invalid proofs.