### PR TITLE
Contracts stable sort

### DIFF
--- a/.changeset/stable_default_order_for_contracts_query.md
+++ b/.changeset/stable_default_order_for_contracts_query.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Default to a stable order in the contracts query
+
+Paginated callers of `Store.Contracts` that didn't pass a sort option were issuing `LIMIT/OFFSET` without an `ORDER BY`, which is non-deterministic in PostgreSQL and could cause rows to be silently skipped or duplicated between batches. The contracts query now defaults to ordering by `c.contract_id ASC` when no sort is specified.

--- a/contracts/renew.go
+++ b/contracts/renew.go
@@ -18,23 +18,26 @@ func (cm *ContractManager) performContractRenewals(ctx context.Context, period, 
 	minProofHeight := bh + renewWindow
 	newProofHeight := bh + period
 
+	var eligible, attempted, successful int
 	batchSize := 50
 	for offset := 0; ; offset += batchSize {
 		contracts, err := cm.store.Contracts(offset, batchSize, WithGood(true), WithRevisable(true))
 		if err != nil {
 			return fmt.Errorf("failed to fetch contracts for renewal: %w", err)
 		}
-
+		eligible += len(contracts)
 		for _, contract := range contracts {
 			if contract.ProofHeight > minProofHeight {
 				continue // too early to renew
 			} else if !contract.Good {
 				continue // contract is bad
 			}
-
+			attempted++
 			log := log.With(zap.Stringer("contractID", contract.ID), zap.Stringer("host", contract.HostKey))
 			if err := cm.renewContract(ctx, contract, newProofHeight, log); err != nil {
 				log.Error("failed to renew contract", zap.Error(err))
+			} else {
+				successful++
 			}
 		}
 
@@ -42,7 +45,7 @@ func (cm *ContractManager) performContractRenewals(ctx context.Context, period, 
 			break
 		}
 	}
-
+	log.Debug("renewals finished", zap.Int("eligible", eligible), zap.Int("attempted", attempted), zap.Int("successful", successful))
 	return nil
 }
 

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -276,7 +276,8 @@ LIMIT $3 OFFSET $4`, orderClause), opts.Good, opts.Revisable, limit, offset, ids
 
 func buildContractOrderByClause(sorts []contracts.ContractSortOpt) (string, error) {
 	if len(sorts) == 0 {
-		return "", nil
+		// provide a stable order when no sort is specified
+		return "ORDER BY c.contract_id ASC", nil
 	}
 
 	sortMapping := map[string]string{


### PR DESCRIPTION
Paginated callers of `Store.Contracts` that didn't pass a sort option were issuing `LIMIT/OFFSET` without an `ORDER BY`, which is non-deterministic in PostgreSQL and could cause rows to be silently skipped or duplicated between batches. The contracts query now defaults to ordering by `c.id ASC` when no sort is specified.