### PR TITLE
Configure migration workers

### DIFF
--- a/.changeset/configurable_slab_migration_goroutines.md
+++ b/.changeset/configurable_slab_migration_goroutines.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Make slab migration concurrency configurable
+
+Added a new `slabs.migrationWorkers` config field that controls the number of slabs migrated in parallel by the slab manager.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ consensus:
 explorer:
     enabled: true
     url: https://api.siascan.com
+slabs:
+    migrationWorkers: 16 # number of slabs to migrate in parallel (0 defaults to runtime.NumCPU())
 log:
     stdout:
         enabled: true # enable logging to stdout

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -251,7 +251,11 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer contracts.Close()
 
-	slabs, err := slabs.NewManager(cm, am, contracts, hm, store, client, alerter, keys.DerivePrivateKey(walletKey, "migration"), keys.DerivePrivateKey(walletKey, "integrity"), slabs.WithLogger(log.Named("slabs")))
+	slabOpts := []slabs.Option{slabs.WithLogger(log.Named("slabs"))}
+	if cfg.Slabs.MigrationWorkers > 0 {
+		slabOpts = append(slabOpts, slabs.WithNumMigrationGoroutines(cfg.Slabs.MigrationWorkers))
+	}
+	slabs, err := slabs.NewManager(cm, am, contracts, hm, store, client, alerter, keys.DerivePrivateKey(walletKey, "migration"), keys.DerivePrivateKey(walletKey, "integrity"), slabOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create slabs manager: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,13 @@ type (
 		URL     string `yaml:"url"`
 	}
 
+	// Slabs contains the configuration for the slab manager.
+	Slabs struct {
+		// MigrationWorkers is the number of slabs to migrate in parallel. If
+		// zero, defaults to runtime.NumCPU().
+		MigrationWorkers int `yaml:"migrationWorkers"`
+	}
+
 	// FileLog configures the file output of the logger.
 	FileLog struct {
 		Enabled bool            `yaml:"enabled"`
@@ -88,6 +95,7 @@ type (
 		Syncer         Syncer                  `yaml:"syncer"`
 		Consensus      Consensus               `yaml:"consensus"`
 		Explorer       Explorer                `yaml:"explorer"`
+		Slabs          Slabs                   `yaml:"slabs"`
 		Log            Log                     `yaml:"log"`
 		Database       postgres.ConnectionInfo `yaml:"database"`
 	}


### PR DESCRIPTION
Added a new `slabs.migrationWorkers` config field that controls the number of slabs migrated in parallel by the slab manager.
