### PR TITLE
Prevent pinning of slabs with duplicate hosts

### DIFF
--- a/.changeset/prevent_pinning_of_slabs_that_contain_multiple_shards_stored_on_the_same_host.md
+++ b/.changeset/prevent_pinning_of_slabs_that_contain_multiple_shards_stored_on_the_same_host.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Prevent pinning of slabs that contain multiple shards stored on the same host.

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -366,7 +366,7 @@ func (a *app) handlePOSTSlabs(jc jape.Context, pk types.PublicKey) {
 	}
 
 	slabIDs, err := a.slabs.PinSlabs(jc.Request.Context(), proto.Account(pk), time.Now().Add(6*time.Hour), params...)
-	if errors.Is(err, slabs.ErrBadHosts) || errors.Is(err, slabs.ErrMinShards) {
+	if errors.Is(err, slabs.ErrBadHosts) || errors.Is(err, slabs.ErrMinShards) || errors.Is(err, slabs.ErrDuplicateHost) {
 		jc.Error(err, http.StatusBadRequest)
 		return
 	} else if jc.Check("failed to pin slab", err) != nil {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -1515,19 +1515,18 @@ func TestDeleteContract(t *testing.T) {
 	account := proto.Account{1}
 	store.addTestAccount(t, types.PublicKey(account))
 
-	// add a slab with sectors
-	params := slabs.SlabPinParams{
-		EncryptionKey: frand.Entropy256(),
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{Root: frand.Entropy256(), HostKey: hk},
-			{Root: frand.Entropy256(), HostKey: hk},
-			{Root: frand.Entropy256(), HostKey: hk},
-		},
-	}
-	_, err = store.PinSlabs(account, time.Now().Add(time.Hour), params)
-	if err != nil {
-		t.Fatal(err)
+	// add three single-sector slabs on the same host (slabs can't have
+	// duplicate hosts, so we need one slab per sector)
+	sectorRoots := []types.Hash256{frand.Entropy256(), frand.Entropy256(), frand.Entropy256()}
+	for _, root := range sectorRoots {
+		params := slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+		}
+		if _, err := store.PinSlabs(account, time.Now().Add(time.Hour), params); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// get unpinned sectors and pin them to the contract
@@ -1562,9 +1561,9 @@ func TestDeleteContract(t *testing.T) {
 	}
 
 	// get uploaded_at before deleting
-	sqlRoots := make([]sqlHash256, len(params.Sectors))
-	for i, s := range params.Sectors {
-		sqlRoots[i] = sqlHash256(s.Root)
+	sqlRoots := make([]sqlHash256, len(sectorRoots))
+	for i, root := range sectorRoots {
+		sqlRoots[i] = sqlHash256(root)
 	}
 	var uploadedAtBefore time.Time
 	err = store.pool.QueryRow(t.Context(), `SELECT MAX(uploaded_at) FROM sectors WHERE sector_root = ANY($1)`, sqlRoots).Scan(&uploadedAtBefore)

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -1054,35 +1054,24 @@ func TestHostsWithLostSectors(t *testing.T) {
 	db.addTestContract(t, hk1)
 	db.addTestContract(t, hk2)
 
-	// pin a slab that adds 2 sectors to each host
+	// pin two slabs, each with one sector per host (slabs can't have duplicate
+	// hosts), so each host ends up with 2 sectors
 	root1 := frand.Entropy256()
 	root2 := frand.Entropy256()
 	root3 := frand.Entropy256()
 	root4 := frand.Entropy256()
-	_, err := db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk1,
+	for _, pair := range [][2]types.Hash256{{root1, root3}, {root2, root4}} {
+		_, err := db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors: []slabs.PinnedSector{
+				{Root: pair[0], HostKey: hk1},
+				{Root: pair[1], HostKey: hk2},
 			},
-			{
-				Root:    root2,
-				HostKey: hk1,
-			},
-			{
-				Root:    root3,
-				HostKey: hk2,
-			},
-			{
-				Root:    root4,
-				HostKey: hk2,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	assertHosts := func(hks []types.PublicKey) {
@@ -1262,7 +1251,8 @@ func TestHostUnpinnedSectors(t *testing.T) {
 	assertHostUnpinned(hk1, 0)
 	assertHostUnpinned(hk2, 0)
 
-	// pin a slab, h1 gets 2 sectors
+	// pin slabs so h1 gets 2 sectors and h2 gets 1 (slabs can't have duplicate
+	// hosts, so split across two slabs)
 	root1 := frand.Entropy256()
 	root2 := frand.Entropy256()
 	root3 := frand.Entropy256()
@@ -1271,9 +1261,16 @@ func TestHostUnpinnedSectors(t *testing.T) {
 		MinShards:     1,
 		Sectors: []slabs.PinnedSector{
 			{Root: root1, HostKey: hk1},
-			{Root: root2, HostKey: hk1},
 			{Root: root3, HostKey: hk2},
 		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: root2, HostKey: hk1}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1398,19 +1395,27 @@ func TestHostUnpinnedSectors(t *testing.T) {
 	}
 	assertHostUnpinned(hk4, 0)
 
-	// unpinning a slab should delete its unpinned sectors and decrement
-	// per-host unpinned sector counts accordingly
+	// unpinning slabs should delete their unpinned sectors and decrement
+	// per-host unpinned sector counts accordingly (slabs can't have duplicate
+	// hosts, so split hk1's two sectors across two slabs)
 	root6 := frand.Entropy256()
 	root7 := frand.Entropy256()
 	root8 := frand.Entropy256()
-	slabIDs, err := db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+	slabIDs1, err := db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
 		MinShards:     1,
 		Sectors: []slabs.PinnedSector{
 			{Root: root6, HostKey: hk1},
-			{Root: root7, HostKey: hk1},
 			{Root: root8, HostKey: hk2},
 		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	slabIDs2, err := db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: root7, HostKey: hk1}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1418,7 +1423,10 @@ func TestHostUnpinnedSectors(t *testing.T) {
 	assertHostUnpinned(hk1, 2)
 	assertHostUnpinned(hk2, 1)
 
-	if err := db.UnpinSlab(account, slabIDs[0]); err != nil {
+	if err := db.UnpinSlab(account, slabIDs1[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UnpinSlab(account, slabIDs2[0]); err != nil {
 		t.Fatal(err)
 	}
 	assertHostUnpinned(hk1, 0)
@@ -1583,35 +1591,28 @@ func TestHostsWithUnpinnableSectors(t *testing.T) {
 	hk4 := db.addTestHost(t)
 	hk4FCID := db.addTestContract(t, hk4)
 
+	// PinSlabs rejects slabs where more than 20% of parity shards are on bad
+	// hosts. Add filler hosts (with good contracts) so the slab containing
+	// hk3 (no contract → bad) has enough good parity shards.
+	fillerHosts := make([]types.PublicKey, 4)
+	for i := range fillerHosts {
+		fillerHosts[i] = db.addTestHost(t)
+		db.addTestContract(t, fillerHosts[i])
+	}
+
+	// single slab: hk3 (1 bad) + hk4 + 4 filler hosts (5 good). parityShards=5,
+	// badHosts=1 → not rejected
+	sectors := []slabs.PinnedSector{
+		{Root: types.Hash256(hk3), HostKey: hk3},
+		{Root: types.Hash256(hk4), HostKey: hk4},
+	}
+	for _, hk := range fillerHosts {
+		sectors = append(sectors, slabs.PinnedSector{Root: frand.Entropy256(), HostKey: hk})
+	}
 	_, err := db.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
+		EncryptionKey: frand.Entropy256(),
 		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    types.Hash256(hk3),
-				HostKey: hk3,
-			},
-			{
-				Root:    types.Hash256(hk4),
-				HostKey: hk4,
-			},
-			{
-				Root:    frand.Entropy256(),
-				HostKey: hk4,
-			},
-			{
-				Root:    frand.Entropy256(),
-				HostKey: hk4,
-			},
-			{
-				Root:    frand.Entropy256(),
-				HostKey: hk4,
-			},
-			{
-				Root:    frand.Entropy256(),
-				HostKey: hk4,
-			},
-		},
+		Sectors:       sectors,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -36,8 +36,12 @@ func TestObject(t *testing.T) {
 	store := initPostgres(t, zap.NewNop())
 	acc := proto.Account{1}
 	store.addTestAccount(t, types.PublicKey(acc))
-	hk := store.addTestHost(t)
-	fcid := store.addTestContract(t, hk)
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	hk3 := store.addTestHost(t)
+	fcid := store.addTestContract(t, hk1)
+	store.addTestContract(t, hk2)
+	store.addTestContract(t, hk3)
 
 	params := slabs.SlabPinParams{
 		EncryptionKey: frand.Entropy256(),
@@ -45,15 +49,15 @@ func TestObject(t *testing.T) {
 		Sectors: []slabs.PinnedSector{
 			{
 				Root:    frand.Entropy256(),
-				HostKey: hk,
+				HostKey: hk1,
 			},
 			{
 				Root:    frand.Entropy256(),
-				HostKey: hk,
+				HostKey: hk2,
 			},
 			{
 				Root:    frand.Entropy256(),
-				HostKey: hk,
+				HostKey: hk3,
 			},
 		},
 	}
@@ -66,7 +70,7 @@ func TestObject(t *testing.T) {
 	// pin sector 1, keep sector 2 the way it is and mark sector 3 as lost
 	if err := store.PinSectors(fcid, []types.Hash256{params.Sectors[0].Root}); err != nil {
 		t.Fatal(err)
-	} else if err := store.MarkSectorsLost(hk, []types.Hash256{params.Sectors[2].Root}); err != nil {
+	} else if err := store.MarkSectorsLost(hk3, []types.Hash256{params.Sectors[2].Root}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -121,12 +125,19 @@ func TestObjects(t *testing.T) {
 		store.addTestAccount(t, types.PublicKey(acc))
 	}
 
-	hk := store.addTestHost(t)
-	store.addTestContract(t, hk)
+	// slabs can't have duplicate hosts; create enough hosts to fill the
+	// 10-sector slabs used below
+	hks := make([]types.PublicKey, 10)
+	for i := range hks {
+		hks[i] = store.addTestHost(t)
+		store.addTestContract(t, hks[i])
+	}
+	hk := hks[0]
 
 	// pin slab for both accounts
 	slab := slabs.SlabPinParams{
-		MinShards: 1,
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
 		Sectors: []slabs.PinnedSector{{
 			Root:    frand.Entropy256(),
 			HostKey: hk,
@@ -176,10 +187,10 @@ func TestObjects(t *testing.T) {
 				EncryptionKey: frand.Entropy256(),
 				MinShards:     1,
 			}
-			for range 10 {
+			for j := range hks {
 				s[i].Sectors = append(s[i].Sectors, slabs.PinnedSector{
 					Root:    types.Hash256(frand.Entropy256()),
-					HostKey: hk,
+					HostKey: hks[j],
 				})
 			}
 		}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -326,7 +326,8 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 			for i, sector := range slab.Sectors {
 				if _, ok := goodHosts[sector.HostKey]; !ok {
 					badHosts++
-				} else if _, used := usedHosts[sector.HostKey]; used {
+				}
+				if _, used := usedHosts[sector.HostKey]; used {
 					br.Close()
 					return fmt.Errorf("%w: %q", slabs.ErrDuplicateHost, sector.HostKey)
 				}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -322,10 +322,15 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 			var unpinnedDeltas []unpinnedDelta
 			br := tx.SendBatch(ctx, batch)
 			sectorIDs := make([]int64, len(slab.Sectors))
+			usedHosts := make(map[types.PublicKey]struct{})
 			for i, sector := range slab.Sectors {
 				if _, ok := goodHosts[sector.HostKey]; !ok {
 					badHosts++
+				} else if _, used := usedHosts[sector.HostKey]; used {
+					br.Close()
+					return fmt.Errorf("%w: %q", slabs.ErrDuplicateHost, sector.HostKey)
 				}
+				usedHosts[sector.HostKey] = struct{}{}
 
 				var inserted bool
 				var hostID int64

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -34,46 +34,43 @@ func TestMigrateSector(t *testing.T) {
 	// add contract for first host
 	fcid1 := store.addTestContract(t, hk1)
 
-	// pin a slab to add 2 sectors which are both stored on the first host
+	// pin two single-sector slabs on hk1 (slabs can't have duplicate hosts)
 	pinTime := time.Now().Round(time.Microsecond)
 	root1 := types.Hash256{1}
 	root2 := types.Hash256{2}
-	_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk1,
-			},
-			{
-				Root:    root2,
-				HostKey: hk1,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	encKey1 := frand.Entropy256()
+	encKey2 := frand.Entropy256()
+	for _, sp := range []struct {
+		key  slabs.EncryptionKey
+		root types.Hash256
+	}{
+		{encKey1, root1},
+		{encKey2, root2},
+	} {
+		_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
+			EncryptionKey: sp.key,
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{Root: sp.root, HostKey: hk1}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	// create an object using the pinned slab
+	// create an object referencing the two pinned slabs
 	so := slabs.SealedObject{
 		EncryptedDataKey:     frand.Bytes(72),
 		EncryptedMetadataKey: frand.Bytes(72),
 		Slabs: []slabs.SlabSlice{
 			{
-				EncryptionKey: [32]byte{},
+				EncryptionKey: encKey1,
 				MinShards:     1,
-				Sectors: []slabs.PinnedSector{
-					{
-						Root:    root1,
-						HostKey: hk1,
-					},
-					{
-						Root:    root2,
-						HostKey: hk2,
-					},
-				},
+				Sectors:       []slabs.PinnedSector{{Root: root1, HostKey: hk1}},
+			},
+			{
+				EncryptionKey: encKey2,
+				MinShards:     1,
+				Sectors:       []slabs.PinnedSector{{Root: root2, HostKey: hk2}},
 			},
 		},
 	}
@@ -100,8 +97,7 @@ func TestMigrateSector(t *testing.T) {
 		}
 	}
 
-	err = store.PinObject(account, so.PinRequest())
-	if err != nil {
+	if err := store.PinObject(account, so.PinRequest()); err != nil {
 		t.Fatal(err)
 	}
 	assertUpdated(true) // creation
@@ -164,7 +160,7 @@ func TestMigrateSector(t *testing.T) {
 		t.Helper()
 
 		var got int64
-		err = store.pool.QueryRow(t.Context(), sqlStatSelect(statMigratedSectors)).Scan(&got)
+		err := store.pool.QueryRow(t.Context(), sqlStatSelect(statMigratedSectors)).Scan(&got)
 		if err != nil {
 			t.Fatal(err)
 		} else if got != expected {
@@ -229,26 +225,19 @@ func TestRecordIntegrityCheck(t *testing.T) {
 	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
-	// pin a slab to add 2 sectors
+	// pin two single-sector slabs on hk (slabs can't have duplicate hosts)
 	pinTime := time.Now().Round(time.Microsecond)
 	root1 := types.Hash256{1}
 	root2 := types.Hash256{2}
-	_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk,
-			},
-			{
-				Root:    root2,
-				HostKey: hk,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	for _, root := range []types.Hash256{root1, root2} {
+		_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// helper to assert sector state
@@ -385,35 +374,20 @@ func TestSectorsForIntegrityCheck(t *testing.T) {
 	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
-	// pin a slab to add a few sectors to the database
+	// pin four single-sector slabs on hk (slabs can't have duplicate hosts)
 	root1 := frand.Entropy256()
 	root2 := frand.Entropy256()
 	root3 := frand.Entropy256()
 	root4 := frand.Entropy256()
-	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk,
-			},
-			{
-				Root:    root2,
-				HostKey: hk,
-			},
-			{
-				Root:    root3,
-				HostKey: hk,
-			},
-			{
-				Root:    root4,
-				HostKey: hk,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	for _, root := range []types.Hash256{root1, root2, root3, root4} {
+		_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// update next integrity check time for roots and assert the ordering works
@@ -1222,20 +1196,22 @@ func TestUnpinSlab(t *testing.T) {
 		}
 	}
 
-	// add host
-	hk := store.addTestHost(t)
-	store.addTestContract(t, hk)
+	// add two hosts (slabs can't have duplicate hosts)
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	store.addTestContract(t, hk1)
+	store.addTestContract(t, hk2)
 
-	// precreate 3 slabs, 2 sectors each
+	// precreate 3 slabs, 2 sectors each (one per host)
 	var params []slabs.SlabPinParams
 	slabSize := uint64(2 * proto.SectorSize) // 2 sectors per slab
 	for range 3 {
 		params = append(params, slabs.SlabPinParams{
-			EncryptionKey: [32]byte{},
+			EncryptionKey: frand.Entropy256(),
 			MinShards:     2,
 			Sectors: []slabs.PinnedSector{
-				{Root: frand.Entropy256(), HostKey: hk},
-				{Root: frand.Entropy256(), HostKey: hk},
+				{Root: frand.Entropy256(), HostKey: hk1},
+				{Root: frand.Entropy256(), HostKey: hk2},
 			},
 		})
 	}
@@ -1270,7 +1246,8 @@ func TestUnpinSlab(t *testing.T) {
 	assertPinnedData(acc1, 2*slabSize, 2*slabSize)
 	assertPinnedData(acc2, 2*slabSize, 2*slabSize)
 	assertSectorStats(0, 6, 0)
-	assertHostUnpinned(hk, 6)
+	assertHostUnpinned(hk1, 3)
+	assertHostUnpinned(hk2, 3)
 
 	// unpinning a slab that's not pinned to an account should return [slabs.ErrNotFound]
 	err := store.UnpinSlab(acc2, slab1)
@@ -1293,7 +1270,8 @@ func TestUnpinSlab(t *testing.T) {
 	assertPinnedData(acc1, slabSize, slabSize)
 	assertPinnedData(acc2, 2*slabSize, 2*slabSize)
 	assertSectorStats(0, 4, 0)
-	assertHostUnpinned(hk, 4)
+	assertHostUnpinned(hk1, 2)
+	assertHostUnpinned(hk2, 2)
 
 	// unpin second slab
 	err = store.UnpinSlab(acc1, slab2)
@@ -1310,7 +1288,8 @@ func TestUnpinSlab(t *testing.T) {
 	assertPinnedData(acc1, 0, 0)
 	assertPinnedData(acc2, 2*slabSize, 2*slabSize)
 	assertSectorStats(0, 4, 0)
-	assertHostUnpinned(hk, 4)
+	assertHostUnpinned(hk1, 2)
+	assertHostUnpinned(hk2, 2)
 
 	// unpin second slab on second account
 	err = store.UnpinSlab(acc2, slab2)
@@ -1327,7 +1306,8 @@ func TestUnpinSlab(t *testing.T) {
 	assertPinnedData(acc1, 0, 0)
 	assertPinnedData(acc2, slabSize, slabSize)
 	assertSectorStats(0, 2, 0)
-	assertHostUnpinned(hk, 2)
+	assertHostUnpinned(hk1, 1)
+	assertHostUnpinned(hk2, 1)
 
 	// unpin third slab on second account
 	err = store.UnpinSlab(acc2, slab3)
@@ -1344,7 +1324,8 @@ func TestUnpinSlab(t *testing.T) {
 	assertPinnedData(acc1, 0, 0)
 	assertPinnedData(acc2, 0, 0)
 	assertSectorStats(0, 0, 0)
-	assertHostUnpinned(hk, 0)
+	assertHostUnpinned(hk1, 0)
+	assertHostUnpinned(hk2, 0)
 }
 
 func TestPinSectors(t *testing.T) {
@@ -1359,31 +1340,16 @@ func TestPinSectors(t *testing.T) {
 	contractID1 := store.addTestContract(t, hk, types.FileContractID{1})
 	contractID2 := store.addTestContract(t, hk, types.FileContractID{2})
 
-	// create 4 sectors
-	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: frand.Entropy256(),
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				HostKey: hk,
-				Root:    types.Hash256{1},
-			},
-			{
-				HostKey: hk,
-				Root:    types.Hash256{2},
-			},
-			{
-				HostKey: hk,
-				Root:    types.Hash256{3},
-			},
-			{
-				HostKey: hk,
-				Root:    types.Hash256{4},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	// create 4 sectors as 4 single-sector slabs (slabs can't have duplicate hosts)
+	for _, root := range []types.Hash256{{1}, {2}, {3}, {4}} {
+		_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{HostKey: hk, Root: root}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// set the sectors' host IDs to NULL to make sure PinSectors also sets
@@ -1491,9 +1457,9 @@ func TestUnhealthySlabs(t *testing.T) {
 	hk := store.addTestHost(t)
 	contractID := store.addTestContract(t, hk)
 
-	// add two slabs
-	slabID1 := store.pinTestSlab(t, account, 1, []types.PublicKey{hk, hk})
-	slabID2 := store.pinTestSlab(t, account, 1, []types.PublicKey{hk, hk})
+	// add two single-sector slabs on hk (slabs can't have duplicate hosts)
+	slabID1 := store.pinTestSlab(t, account, 1, []types.PublicKey{hk})
+	slabID2 := store.pinTestSlab(t, account, 1, []types.PublicKey{hk})
 	resetNextRepairAttemptTime()
 
 	// pin all sectors to the contract
@@ -1634,30 +1600,19 @@ func TestMarkSectorsUnpinnable(t *testing.T) {
 	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
-	// pin a slab to add a few sectors to the database
+	// pin three single-sector slabs on hk (slabs can't have duplicate hosts)
 	root1 := frand.Entropy256()
 	root2 := frand.Entropy256()
 	root3 := frand.Entropy256()
-	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk,
-			},
-			{
-				Root:    root2,
-				HostKey: hk,
-			},
-			{
-				Root:    root3,
-				HostKey: hk,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	for _, root := range []types.Hash256{root1, root2, root3} {
+		_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// assert initial count
@@ -1728,31 +1683,16 @@ func TestUnpinnedSectors(t *testing.T) {
 	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
-	// create 4 sectors
-	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: frand.Entropy256(),
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				HostKey: hk,
-				Root:    types.Hash256{1},
-			},
-			{
-				HostKey: hk,
-				Root:    types.Hash256{2},
-			},
-			{
-				HostKey: hk,
-				Root:    types.Hash256{3},
-			},
-			{
-				HostKey: hk,
-				Root:    types.Hash256{4},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	// create 4 sectors as 4 single-sector slabs (slabs can't have duplicate hosts)
+	for _, root := range []types.Hash256{{1}, {2}, {3}, {4}} {
+		_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{HostKey: hk, Root: root}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// helper to update sector's pinned state
@@ -2619,35 +2559,24 @@ func TestMarkSectorsLost(t *testing.T) {
 	fcid1 := store.addTestContract(t, hk1)
 	_ = store.addTestContract(t, hk2)
 
-	// pin a slab that adds 2 sectors to each host
+	// pin two slabs, each with one sector per host (slabs can't have duplicate
+	// hosts), so each host ends up with 2 sectors
 	root1 := frand.Entropy256()
 	root2 := frand.Entropy256()
 	root3 := frand.Entropy256()
 	root4 := frand.Entropy256()
-	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk1,
+	for _, pair := range [][2]types.Hash256{{root1, root3}, {root2, root4}} {
+		_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors: []slabs.PinnedSector{
+				{Root: pair[0], HostKey: hk1},
+				{Root: pair[1], HostKey: hk2},
 			},
-			{
-				Root:    root2,
-				HostKey: hk1,
-			},
-			{
-				Root:    root3,
-				HostKey: hk2,
-			},
-			{
-				Root:    root4,
-				HostKey: hk2,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	assertSectorStats := func(expectedPinned, expectedUnpinned, expectedUnpinnable int64) {

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1035,6 +1035,23 @@ func TestPinSlabsBadHost(t *testing.T) {
 	if _, err := store.PinSlabs(proto.Account{1}, nextCheck, slab2); err == nil || !errors.Is(err, slabs.ErrBadHosts) {
 		t.Fatalf("expected error %v, got %v", slabs.ErrBadHosts, err)
 	}
+
+	// a slab with the same good host appearing on multiple shards should
+	// fail with ErrDuplicateHost
+	_, slab3 := newSlab(2, hk1, hk1)
+	if _, err := store.PinSlabs(proto.Account{1}, nextCheck, slab3); err == nil || !errors.Is(err, slabs.ErrDuplicateHost) {
+		t.Fatalf("expected error %v, got %v", slabs.ErrDuplicateHost, err)
+	}
+
+	// a slab with all unique good hosts should still succeed
+	hk3 := store.addTestHost(t)
+	store.addTestContract(t, hk3)
+	slab4ID, slab4 := newSlab(3, hk1, hk3)
+	if slabIDs, err := store.PinSlabs(proto.Account{1}, nextCheck, slab4); err != nil {
+		t.Fatal(err)
+	} else if slabIDs[0] != slab4ID {
+		t.Fatalf("expected slab ID %v, got %v", slab4ID, slabIDs[0])
+	}
 }
 
 func TestPinSlabsConflict(t *testing.T) {

--- a/persist/postgres/stats_test.go
+++ b/persist/postgres/stats_test.go
@@ -24,11 +24,13 @@ import (
 func TestSectorStatsNumSlabs(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 
-	// add account and host
+	// add account and two hosts (slabs can't have duplicate hosts)
 	account := proto.Account{1}
 	store.addTestAccount(t, types.PublicKey(account))
-	hk := store.addTestHost(t)
-	store.addTestContract(t, hk)
+	hk1 := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
+	store.addTestContract(t, hk1)
+	store.addTestContract(t, hk2)
 
 	// helper to create slabs
 	newSlab := func(i byte) slabs.SlabPinParams {
@@ -38,11 +40,11 @@ func TestSectorStatsNumSlabs(t *testing.T) {
 			Sectors: []slabs.PinnedSector{
 				{
 					Root:    frand.Entropy256(),
-					HostKey: hk,
+					HostKey: hk1,
 				},
 				{
 					Root:    frand.Entropy256(),
-					HostKey: hk,
+					HostKey: hk2,
 				},
 			},
 		}
@@ -377,26 +379,19 @@ func TestIntegrityCheckStats(t *testing.T) {
 	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
 
-	// pin a slab to add 2 sectors
+	// pin two single-sector slabs on hk (slabs can't have duplicate hosts)
 	pinTime := time.Now().Round(time.Microsecond)
 	root1 := types.Hash256{1}
 	root2 := types.Hash256{2}
-	_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
-		EncryptionKey: [32]byte{},
-		MinShards:     1,
-		Sectors: []slabs.PinnedSector{
-			{
-				Root:    root1,
-				HostKey: hk,
-			},
-			{
-				Root:    root2,
-				HostKey: hk,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
+	for _, root := range []types.Hash256{root1, root2} {
+		_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	assertSectorStats := func(expectedLost, expectedChecked, expectedCheckFailed int64) {

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -32,6 +32,10 @@ var (
 	// sectors on bad hosts.
 	ErrBadHosts = errors.New("slab has too many sectors on bad hosts")
 
+	// ErrDuplicateHost is returned when attempting to pin a slab with duplicate
+	// host keys.
+	ErrDuplicateHost = errors.New("slab has duplicate host keys")
+
 	// ErrMinShards is returned when attempting to pin a slab with an invalid
 	// number of minimum shards, for example if `MinShards` exceeds the number
 	// of sectors.


### PR DESCRIPTION
Related to https://github.com/SiaFoundation/indexd/issues/971

This doesn't fix the issue but it hardens the backend against clients that might attempt to pin slabs like that. 