### PR TITLE
Remove ErrAbortedRPC

### DIFF
--- a/.changeset/remove_errabortedrpc.md
+++ b/.changeset/remove_errabortedrpc.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Remove ErrAbortedRPC.

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -186,16 +186,22 @@ func (c *Client) hostTransport(ctx context.Context, hostKey types.PublicKey) (rh
 	return t.dial(ctx, hostKey, addresses)
 }
 
+func isFailedRPC(ctx context.Context, err error) bool {
+	switch {
+	case ctx.Err() != nil:
+		return false // interrupted RPC
+	case errors.Is(err, proto.ErrSectorNotFound):
+		return false
+	default:
+		return true
+	}
+}
+
 func (c *Client) rpcFn(ctx context.Context, hostKey types.PublicKey, fn func(ctx context.Context, transport rhp.TransportClient) error) (err error) {
 	defer func() {
-		// increment the failed RPC count for the host if the RPC failed
-		if err != nil {
-			// decorate the error with the context error to indicate whether the failed
-			// rpc is a consequence of context cancellation or timeout
-			if context.Cause(ctx) != nil {
-				err = fmt.Errorf("%w: %w", err, context.Cause(ctx))
-			}
-			c.hosts.AddFailedRPC(hostKey, err)
+		// increment the failed RPC count if the RPC is considered failed
+		if isFailedRPC(ctx, err) {
+			c.hosts.AddFailedRPC(hostKey)
 		}
 	}()
 
@@ -215,10 +221,15 @@ func (c *Client) rpcFn(ctx context.Context, hostKey types.PublicKey, fn func(ctx
 	return err
 }
 
-// AddFailedRPC unconditionally records a failed RPC attempt to the
-// specified host, lowering its priority in future queues.
+// AddFailedRPC records a failed RPC attempt to the specified host, lowering its
+// priority in future queues.
+// NOTE: This should only be used after an RPC failed due to context
+// cancellation or a context deadline as those failures won't be recorded by the
+// client implicitly. The client can't know whether the caller intends to treat
+// those as failed RPCs or not and punishing a good host for a cancelled RPC
+// could severely degrade performance.
 func (c *Client) AddFailedRPC(hostKey types.PublicKey) {
-	c.hosts.recordFailure(hostKey)
+	c.hosts.AddFailedRPC(hostKey)
 }
 
 // AccountBalance fetches the account balance from the specified host.

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -193,7 +193,7 @@ func isFailedRPC(ctx context.Context, err error) bool {
 	case errors.Is(err, proto.ErrSectorNotFound):
 		return false
 	default:
-		return true
+		return err != nil
 	}
 }
 

--- a/client/v2/hostqueue.go
+++ b/client/v2/hostqueue.go
@@ -2,14 +2,12 @@ package client
 
 import (
 	"cmp"
-	"errors"
 	"iter"
 	"math"
 	"sort"
 	"sync"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/indexd/hosts"
@@ -20,11 +18,6 @@ const (
 	settingsPayloadSize = 270       // size of host settings in bytes
 	defaultThroughput   = 125000000 // 1 Gbps in bytes per second
 )
-
-// ErrAbortedRPC is a special error that can be used as the cancel for an RPC
-// context to indicate that the RPC was interrupted and that the corresponding
-// host should not have a failure recorded for that RPC.
-var ErrAbortedRPC = errors.New("aborted RPC")
 
 type rpcAverage struct {
 	value float64
@@ -241,17 +234,7 @@ func (p *Provider) AddSettingsSample(hostKey types.PublicKey, latency time.Durat
 }
 
 // AddFailedRPC records a failed RPC attempt to the specified host.
-// Aborted RPCs and missing sector errors are not counted as failures.
-func (p *Provider) AddFailedRPC(hostKey types.PublicKey, err error) {
-	if errors.Is(err, ErrAbortedRPC) || errors.Is(err, proto.ErrSectorNotFound) {
-		return
-	}
-	p.recordFailure(hostKey)
-}
-
-// recordFailure unconditionally records a failure for the specified host,
-// lowering its priority in future queues.
-func (p *Provider) recordFailure(hostKey types.PublicKey) {
+func (p *Provider) AddFailedRPC(hostKey types.PublicKey) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	metric, exists := p.metrics[hostKey]

--- a/client/v2/hostqueue_test.go
+++ b/client/v2/hostqueue_test.go
@@ -101,7 +101,7 @@ func TestProviderSettingsSample(t *testing.T) {
 	provider.AddSettingsSample(hostA, 100*time.Millisecond)
 
 	// add a failure to hostC
-	provider.AddFailedRPC(hostC, nil)
+	provider.AddFailedRPC(hostC)
 
 	// hostA should sort behind unknown hostB but ahead of failed hostC
 	sorted := provider.Prioritize(slices.Clone(usable))
@@ -132,7 +132,7 @@ func TestProviderSettingsSample(t *testing.T) {
 	}
 
 	// record a failed RPC to hostB; it should sort behind hostA
-	provider.AddFailedRPC(hostB, nil)
+	provider.AddFailedRPC(hostB)
 
 	sorted = provider.Prioritize(slices.Clone(usable))
 	if slices.Index(sorted, hostA) >= slices.Index(sorted, hostB) {
@@ -156,7 +156,7 @@ func TestProviderPriority(t *testing.T) {
 	}
 
 	// simulate a failed RPC
-	provider.AddFailedRPC(usable[0], nil)
+	provider.AddFailedRPC(usable[0])
 
 	// ensure the first host is now the worst candidate
 	sorted = provider.Prioritize(slices.Clone(usable))
@@ -167,8 +167,8 @@ func TestProviderPriority(t *testing.T) {
 	}
 
 	// simulate multiple failed RPCs to the second host
-	provider.AddFailedRPC(usable[1], nil)
-	provider.AddFailedRPC(usable[1], nil)
+	provider.AddFailedRPC(usable[1])
+	provider.AddFailedRPC(usable[1])
 
 	// ensure the second host is now the worst candidate
 	sorted = provider.Prioritize(slices.Clone(usable))

--- a/client/v2/rpc_test.go
+++ b/client/v2/rpc_test.go
@@ -4,64 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"testing"
 
 	proto "go.sia.tech/core/rhp/v4"
-	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/coreutils/threadgroup"
-	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/mux/v3"
-	"go.uber.org/zap"
 )
-
-type mockTransportClient struct{}
-
-func (mockTransportClient) DialStream(context.Context) (net.Conn, error) { return nil, nil }
-func (mockTransportClient) FrameSize() int                               { return 0 }
-func (mockTransportClient) PeerKey() types.PublicKey                     { return types.PublicKey{} }
-func (mockTransportClient) Close() error                                 { return nil }
-
-type mockStore struct{}
-
-func (mockStore) UsableHosts() ([]hosts.HostInfo, error) { return nil, nil }
-func (mockStore) Addresses(types.PublicKey) ([]chain.NetAddress, error) {
-	return []chain.NetAddress{{Protocol: "siamux", Address: "localhost:0"}}, nil
-}
-func (mockStore) Usable(types.PublicKey) (bool, error) { return true, nil }
-
-func TestRPCFnErrorDecoration(t *testing.T) {
-	hostKey := types.GeneratePrivateKey().PublicKey()
-	customErr := errors.New("custom context error")
-
-	c := &Client{
-		log:            zap.NewNop(),
-		tg:             threadgroup.New(),
-		hosts:          NewProvider(mockStore{}),
-		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
-		transports: map[types.PublicKey]*transport{
-			hostKey: {tc: mockTransportClient{}},
-		},
-	}
-	defer c.Close()
-
-	ctx, cancel := context.WithCancelCause(context.Background())
-	cancel(customErr)
-
-	err := c.rpcFn(ctx, hostKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		return mux.ErrClosedStream
-	})
-	if err == nil {
-		t.Fatal("expected error")
-	} else if !errors.Is(err, mux.ErrClosedStream) {
-		t.Fatalf("expected error to wrap ErrClosedStream, got: %v", err)
-	} else if !errors.Is(err, customErr) {
-		t.Fatalf("expected error to wrap custom context error, got: %v", err)
-	}
-}
 
 func TestShouldResetTransport(t *testing.T) {
 	tests := []struct {

--- a/client/v2/rpc_test.go
+++ b/client/v2/rpc_test.go
@@ -6,11 +6,46 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/mux/v3"
 )
+
+func TestIsFailedRPC(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadline, cancelDeadline := context.WithDeadline(context.Background(), time.Unix(0, 0))
+	defer cancelDeadline()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{"nil err", context.Background(), nil, false},
+		{"arbitrary err", context.Background(), errors.New("boom"), true},
+		{"wrapped arbitrary err", context.Background(), fmt.Errorf("wrapped: %w", errors.New("boom")), true},
+
+		{"sector not found", context.Background(), proto.ErrSectorNotFound, false},
+		{"wrapped sector not found", context.Background(), fmt.Errorf("wrapped: %w", proto.ErrSectorNotFound), false},
+
+		{"cancelled ctx, nil err", cancelled, nil, false},
+		{"cancelled ctx, arbitrary err", cancelled, errors.New("boom"), false},
+		{"cancelled ctx, sector not found", cancelled, proto.ErrSectorNotFound, false},
+		{"deadline ctx, arbitrary err", deadline, errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFailedRPC(tt.ctx, tt.err); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
 
 func TestShouldResetTransport(t *testing.T) {
 	tests := []struct {

--- a/contracts/maintenance.go
+++ b/contracts/maintenance.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -27,7 +26,7 @@ func (cm *ContractManager) performAccountFunding(ctx context.Context, force bool
 	for _, hk := range hostsToFund {
 		wg.Add(1)
 		go func(ctx context.Context, hostKey types.PublicKey, log *zap.Logger) {
-			ctx, cancel := context.WithTimeoutCause(ctx, fundTimeout, client.ErrAbortedRPC)
+			ctx, cancel := context.WithTimeout(ctx, fundTimeout)
 			defer func() {
 				wg.Done()
 				cancel()

--- a/contracts/pinning.go
+++ b/contracts/pinning.go
@@ -12,7 +12,6 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -44,7 +43,7 @@ loop:
 
 		wg.Add(1)
 		go func(ctx context.Context, hostKey types.PublicKey, hostLog *zap.Logger) {
-			ctx, cancel := context.WithTimeoutCause(ctx, pinTimeout, client.ErrAbortedRPC)
+			ctx, cancel := context.WithTimeout(ctx, pinTimeout)
 			defer func() {
 				<-sema
 				wg.Done()

--- a/contracts/pruning.go
+++ b/contracts/pruning.go
@@ -10,7 +10,6 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
-	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/indexd/hosts"
 	"go.uber.org/zap"
 )
@@ -43,7 +42,7 @@ loop:
 
 		wg.Add(1)
 		go func(ctx context.Context, hostKey types.PublicKey, hostLog *zap.Logger) {
-			ctx, cancel := context.WithTimeoutCause(ctx, pruneTimeout, client.ErrAbortedRPC)
+			ctx, cancel := context.WithTimeout(ctx, pruneTimeout)
 			defer func() {
 				<-sema
 				wg.Done()

--- a/slabs/dataintegrity.go
+++ b/slabs/dataintegrity.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/client/v2"
 	"go.uber.org/zap"
 )
 
@@ -17,7 +16,7 @@ func (m *SlabManager) performIntegrityChecksForHost(ctx context.Context, hostKey
 	// apply a timeout on a per-host basis, ensuring that we don't spend more than 5 minutes
 	// on integrity checks for a single host, if the host has a large number of sectors to check,
 	// or is slow to respond, the next integrity check will pick up where we left off
-	ctx, cancel := context.WithTimeoutCause(ctx, m.integrityCheckTimeout, client.ErrAbortedRPC)
+	ctx, cancel := context.WithTimeout(ctx, m.integrityCheckTimeout)
 	defer cancel()
 
 	const batchSize = 1000 // batch size for sector retrieval

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -12,7 +12,6 @@ import (
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
-	"go.sia.tech/indexd/client/v2"
 	"go.sia.tech/mux/v3"
 	"go.uber.org/zap"
 )
@@ -27,12 +26,7 @@ type slabDownload struct {
 // downloadShards downloads at least the minimum number of shards required to
 // recover the slab.
 func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Logger) ([][]byte, error) {
-	initialCtx, initialCancel := context.WithCancel(ctx)
-	overdriveCtx, overdriveCancel := context.WithCancelCause(ctx)
-	cancel := func() {
-		initialCancel()
-		overdriveCancel(client.ErrAbortedRPC)
-	}
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	shards := make([][]byte, len(slab.Sectors))
@@ -58,7 +52,7 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Lo
 	sema := make(chan struct{}, slab.MinShards)
 
 	// helper to download a shard from a host
-	downloadShard := func(ctx context.Context, hostKey types.PublicKey, sector slabDownload, log *zap.Logger) error {
+	downloadShard := func(hostKey types.PublicKey, sector slabDownload, log *zap.Logger) error {
 		defer func() {
 			<-sema
 		}()
@@ -120,12 +114,17 @@ initialLoop:
 		sector := slabHosts[hostKey]
 		log := log.With(zap.Stringer("hostKey", hostKey), zap.Stringer("sectorRoot", sector.root))
 		wg.Go(func() {
-			if err := downloadShard(initialCtx, hostKey, slabHosts[hostKey], log); err != nil {
+			if err := downloadShard(hostKey, slabHosts[hostKey], log); err != nil {
 				log.Debug("shard download failed", zap.Error(err))
 				// non-blocking send to indicate a failure
 				select {
 				case failedCh <- struct{}{}:
 				default:
+				}
+				// initial shard failures due to cancellation are considered
+				// failed RPCs to demote slow hosts
+				if ctx.Err() != nil {
+					m.hosts.AddFailedRPC(hostKey)
 				}
 			}
 		})
@@ -137,7 +136,7 @@ raceLoop:
 	for i := int(slab.MinShards); downloaded.Load() < uint32(slab.MinShards) && i < len(candidates); i++ {
 		hostKey := candidates[i]
 		select {
-		case <-initialCtx.Done():
+		case <-ctx.Done():
 			break raceLoop
 		case <-failedCh:
 			// a download has failed
@@ -152,7 +151,7 @@ raceLoop:
 			sector := slabHosts[hostKey]
 			log := log.With(zap.Stringer("hostKey", hostKey), zap.Stringer("sectorRoot", sector.root))
 			wg.Go(func() {
-				if err := downloadShard(overdriveCtx, hostKey, slabHosts[hostKey], log); err != nil {
+				if err := downloadShard(hostKey, slabHosts[hostKey], log); err != nil {
 					log.Debug("shard download failed", zap.Error(err))
 					// non-blocking send to indicate a failure
 					select {
@@ -161,7 +160,7 @@ raceLoop:
 					}
 				}
 			})
-		case <-initialCtx.Done():
+		case <-ctx.Done():
 			break raceLoop
 		}
 	}

--- a/slabs/downloads.go
+++ b/slabs/downloads.go
@@ -48,17 +48,12 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Lo
 	}
 	candidates = m.hosts.Prioritize(candidates)
 
-	var wg sync.WaitGroup
-	sema := make(chan struct{}, slab.MinShards)
-
 	// helper to download a shard from a host
-	downloadShard := func(hostKey types.PublicKey, sector slabDownload, log *zap.Logger) error {
+	sema := make(chan struct{}, slab.MinShards)
+	downloadShard := func(ctx context.Context, hostKey types.PublicKey, sector slabDownload, log *zap.Logger) error {
 		defer func() {
 			<-sema
 		}()
-		ctx, timeoutCancel := context.WithTimeout(ctx, m.shardTimeout)
-		defer timeoutCancel()
-
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -97,12 +92,35 @@ func (m *SlabManager) downloadShards(ctx context.Context, slab Slab, log *zap.Lo
 		return nil
 	}
 
+	var wg sync.WaitGroup
+	failedCh := make(chan struct{}, slab.MinShards)
+	spawnDownload := func(hostKey types.PublicKey, sector slabDownload, initial bool) {
+		log := log.With(zap.Stringer("hostKey", hostKey), zap.Stringer("sectorRoot", sector.root))
+		wg.Go(func() {
+			timeoutCtx, timeoutCancel := context.WithTimeout(ctx, m.shardTimeout)
+			defer timeoutCancel()
+			if err := downloadShard(timeoutCtx, hostKey, slabHosts[hostKey], log); err != nil {
+				log.Debug("shard download failed", zap.Error(err))
+				// non-blocking send to indicate a failure
+				select {
+				case failedCh <- struct{}{}:
+				default:
+				}
+				// a host gets demoted if either
+				// 1. it hit the shard timeout
+				// 2. it was part of the initial batch of hosts and was interrupted
+				if (timeoutCtx.Err() != nil && ctx.Err() == nil) || (initial && ctx.Err() != nil) {
+					m.hosts.AddFailedRPC(hostKey)
+				}
+			}
+		})
+	}
+
 	if len(candidates) < int(slab.MinShards) {
 		return nil, fmt.Errorf("only %d available sectors, minimum required: %d: %w", len(candidates), slab.MinShards, errNotEnoughShards)
 	}
 
 	// start initial shards
-	failedCh := make(chan struct{}, slab.MinShards)
 initialLoop:
 	for _, hostKey := range candidates[:int(slab.MinShards)] {
 		select {
@@ -110,24 +128,7 @@ initialLoop:
 			break initialLoop
 		case sema <- struct{}{}:
 		}
-
-		sector := slabHosts[hostKey]
-		log := log.With(zap.Stringer("hostKey", hostKey), zap.Stringer("sectorRoot", sector.root))
-		wg.Go(func() {
-			if err := downloadShard(hostKey, slabHosts[hostKey], log); err != nil {
-				log.Debug("shard download failed", zap.Error(err))
-				// non-blocking send to indicate a failure
-				select {
-				case failedCh <- struct{}{}:
-				default:
-				}
-				// initial shard failures due to cancellation are considered
-				// failed RPCs to demote slow hosts
-				if ctx.Err() != nil {
-					m.hosts.AddFailedRPC(hostKey)
-				}
-			}
-		})
+		spawnDownload(hostKey, slabHosts[hostKey], true)
 	}
 
 	t := time.NewTicker(m.shardTimeout / 4)
@@ -148,18 +149,7 @@ raceLoop:
 		// wait for an available slot
 		select {
 		case sema <- struct{}{}:
-			sector := slabHosts[hostKey]
-			log := log.With(zap.Stringer("hostKey", hostKey), zap.Stringer("sectorRoot", sector.root))
-			wg.Go(func() {
-				if err := downloadShard(hostKey, slabHosts[hostKey], log); err != nil {
-					log.Debug("shard download failed", zap.Error(err))
-					// non-blocking send to indicate a failure
-					select {
-					case failedCh <- struct{}{}:
-					default:
-					}
-				}
-			})
+			spawnDownload(hostKey, slabHosts[hostKey], false)
 		case <-ctx.Done():
 			break raceLoop
 		}

--- a/slabs/downloads_test.go
+++ b/slabs/downloads_test.go
@@ -155,3 +155,160 @@ func TestDownloadShards(t *testing.T) {
 		}
 	})
 }
+
+// TestDownloadShardsDemotion exercises the demote logic in downloadShards.
+// A host is demoted (AddFailedRPC) when:
+//  1. it hits its per-shard timeout while the overall download is still in
+//     progress, or
+//  2. it was part of the initial batch and was interrupted by the parent ctx
+//     being cancelled (because enough other shards completed).
+//
+// In particular, a hedge spawn that gets interrupted by parent-ctx cancellation
+// should NOT be demoted, and a host that returns an immediate non-timeout error
+// should NOT be demoted either.
+func TestDownloadShardsDemotion(t *testing.T) {
+	setup := func(t *testing.T, numHosts int, minShards uint) (*slabs.SlabManager, *mockHostClient, []hosts.Host, slabs.Slab) {
+		log := zaptest.NewLogger(t)
+		store := newMockStore(t)
+		chain := newMockChainManager()
+		am := newMockAccountManager()
+		hm := newMockHostManager()
+		client := newMockHostClient()
+
+		hs := make([]hosts.Host, numHosts)
+		slab := slabs.Slab{MinShards: minShards}
+		for i := range hs {
+			sk := types.GeneratePrivateKey()
+			h := client.addTestHost(sk)
+			hm.hosts[sk.PublicKey()] = h
+			hs[i] = h
+			store.AddTestHost(t, h)
+
+			result, err := client.WriteSector(t.Context(), types.GeneratePrivateKey(), h.PublicKey, []byte{byte(i + 1)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			slab.Sectors = append(slab.Sectors, slabs.Sector{
+				Root:    result.Root,
+				HostKey: &h.PublicKey,
+			})
+		}
+
+		account := types.GeneratePrivateKey()
+		sm := slabs.NewSlabManager(chain, am, nil, hm, store, client, alerts.NewManager(), account, types.GeneratePrivateKey(), slabs.WithLogger(log.Named("slabs")))
+		sm.SetShardTimeout(2 * time.Second)
+		return sm, client, hs, slab
+	}
+
+	wasDemoted := func(client *mockHostClient, hk types.PublicKey) bool {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return client.failedRPCs[hk] > 0
+	}
+
+	// MinShards equals total hosts, so there are no race-loop candidates. The
+	// slow initial host hits its per-shard timeout while the parent ctx is
+	// still alive (downloaded < MinShards), exercising the first demote
+	// clause.
+	t.Run("initial host shard timeout", func(t *testing.T) {
+		sm, client, hs, slab := setup(t, 3, 3)
+		client.slowHosts[hs[0].PublicKey] = 30 * time.Minute
+
+		synctest.Test(t, func(t *testing.T) {
+			_, err := sm.DownloadShards(context.Background(), slab, zap.NewNop())
+			if !errors.Is(err, slabs.ErrNotEnoughShards) {
+				t.Fatalf("expected ErrNotEnoughShards, got %v", err)
+			}
+		})
+
+		if !wasDemoted(client, hs[0].PublicKey) {
+			t.Fatalf("expected initial timed-out host to be demoted")
+		}
+		for i := 1; i < 3; i++ {
+			if wasDemoted(client, hs[i].PublicKey) {
+				t.Fatalf("expected hs[%d] not to be demoted", i)
+			}
+		}
+	})
+
+	// 3 hosts, MinShards=2. hs[0] is a very slow initial host. hs[1] is an
+	// instant initial host. hs[2] is an instant hedge spawned via the race
+	// ticker; once it succeeds the parent ctx cancels and hs[0] is
+	// interrupted before its per-shard timeout fires - the second demote
+	// clause should apply.
+	t.Run("initial host interrupted by parent cancel", func(t *testing.T) {
+		sm, client, hs, slab := setup(t, 3, 2)
+		client.slowHosts[hs[0].PublicKey] = 30 * time.Minute
+
+		synctest.Test(t, func(t *testing.T) {
+			if _, err := sm.DownloadShards(context.Background(), slab, zap.NewNop()); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		if !wasDemoted(client, hs[0].PublicKey) {
+			t.Fatalf("expected initial interrupted host to be demoted")
+		}
+		for i := 1; i < 3; i++ {
+			if wasDemoted(client, hs[i].PublicKey) {
+				t.Fatalf("expected hs[%d] not to be demoted", i)
+			}
+		}
+	})
+
+	// 4 hosts, MinShards=2.
+	//   hs[0] succeeds instantly (initial).
+	//   hs[1] returns an immediate non-timeout error (initial).
+	//   hs[2] is a very slow hedge spawned via failedCh; the parent ctx
+	//         cancels before its timeout, so it should NOT be demoted.
+	//   hs[3] succeeds instantly as a hedge spawned via the ticker.
+	// Result: none of the hosts should be demoted.
+	t.Run("hedge interrupt and quick error not demoted", func(t *testing.T) {
+		sm, client, hs, slab := setup(t, 4, 2)
+		client.failHosts[hs[1].PublicKey] = errors.New("simulated read failure")
+		client.slowHosts[hs[2].PublicKey] = 30 * time.Minute
+
+		synctest.Test(t, func(t *testing.T) {
+			if _, err := sm.DownloadShards(context.Background(), slab, zap.NewNop()); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		for i, h := range hs {
+			if wasDemoted(client, h.PublicKey) {
+				t.Fatalf("expected no host to be demoted, but hs[%d] was", i)
+			}
+		}
+	})
+
+	// 4 hosts, MinShards=2. Same shape as above, but hs[3] is also slow, so
+	// neither hedge completes and both hit their per-shard timeout while the
+	// overall download is still in progress - the first demote clause fires
+	// for hedges too.
+	t.Run("hedge host shard timeout", func(t *testing.T) {
+		sm, client, hs, slab := setup(t, 4, 2)
+		client.failHosts[hs[1].PublicKey] = errors.New("simulated read failure")
+		client.slowHosts[hs[2].PublicKey] = 30 * time.Minute
+		client.slowHosts[hs[3].PublicKey] = 30 * time.Minute
+
+		synctest.Test(t, func(t *testing.T) {
+			_, err := sm.DownloadShards(context.Background(), slab, zap.NewNop())
+			if !errors.Is(err, slabs.ErrNotEnoughShards) {
+				t.Fatalf("expected ErrNotEnoughShards, got %v", err)
+			}
+		})
+
+		if !wasDemoted(client, hs[2].PublicKey) {
+			t.Fatalf("expected hs[2] (timed-out hedge) to be demoted")
+		}
+		if !wasDemoted(client, hs[3].PublicKey) {
+			t.Fatalf("expected hs[3] (timed-out hedge) to be demoted")
+		}
+		if wasDemoted(client, hs[0].PublicKey) {
+			t.Fatalf("expected hs[0] not to be demoted")
+		}
+		if wasDemoted(client, hs[1].PublicKey) {
+			t.Fatalf("expected hs[1] not to be demoted")
+		}
+	})
+}

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -77,6 +77,7 @@ type (
 	// A HostClient defines the minimal interface for interacting with hosts that
 	// the SlabManager requires.
 	HostClient interface {
+		AddFailedRPC(hostKey types.PublicKey)
 		Prices(context.Context, types.PublicKey) (proto.HostPrices, error)
 		WriteSector(ctx context.Context, accountKey types.PrivateKey, hostKey types.PublicKey, data []byte) (rhp.RPCWriteSectorResult, error)
 		ReadSector(ctx context.Context, accountKey types.PrivateKey, hostKey types.PublicKey, root types.Hash256, w io.Writer, offset, length uint64) (rhp.RPCReadSectorResult, error)

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -410,7 +410,7 @@ func (m *mockHostClient) addTestHost(sk types.PrivateKey) hosts.Host {
 }
 
 // AddFailedRPC is a mock implementation that does nothing.
-func (c *mockHostClient) AddFailedRPC(hostKey types.PublicKey) {
+func (m *mockHostClient) AddFailedRPC(hostKey types.PublicKey) {
 }
 
 // Prices is a mock implementation that returns the preset host settings.

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -391,6 +391,7 @@ type mockHostClient struct {
 	hostKeys        map[types.PublicKey]types.PrivateKey
 	hostSettings    map[types.PublicKey]proto.HostSettings
 	unusable        map[types.PublicKey]struct{}
+	failedRPCs      map[types.PublicKey]int
 }
 
 func (m *mockHostClient) resetStorage() {
@@ -409,8 +410,11 @@ func (m *mockHostClient) addTestHost(sk types.PrivateKey) hosts.Host {
 	return h
 }
 
-// AddFailedRPC is a mock implementation that does nothing.
+// AddFailedRPC records demote calls for inspection by tests.
 func (m *mockHostClient) AddFailedRPC(hostKey types.PublicKey) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failedRPCs[hostKey]++
 }
 
 // Prices is a mock implementation that returns the preset host settings.
@@ -542,5 +546,6 @@ func newMockHostClient() *mockHostClient {
 		hostKeys:        make(map[types.PublicKey]types.PrivateKey),
 		hostSettings:    make(map[types.PublicKey]proto.HostSettings),
 		unusable:        make(map[types.PublicKey]struct{}),
+		failedRPCs:      make(map[types.PublicKey]int),
 	}
 }

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -409,6 +409,10 @@ func (m *mockHostClient) addTestHost(sk types.PrivateKey) hosts.Host {
 	return h
 }
 
+// AddFailedRPC is a mock implementation that does nothing.
+func (c *mockHostClient) AddFailedRPC(hostKey types.PublicKey) {
+}
+
 // Prices is a mock implementation that returns the preset host settings.
 func (m *mockHostClient) Prices(ctx context.Context, hostKey types.PublicKey) (proto.HostPrices, error) {
 	m.mu.Lock()

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -75,9 +75,17 @@ top:
 					log := log.With(zap.Stringer("hostKey", hostKey))
 					// upload the shard
 					start := time.Now()
-					result, err := m.uploadShard(ctx, hostKey, shard)
+					timeoutCtx, timeoutCancel := context.WithTimeout(ctx, m.shardTimeout)
+					result, err := m.uploadShard(timeoutCtx, hostKey, shard)
+					timedOut := timeoutCtx.Err() != nil
+					timeoutCancel()
 					if err != nil {
 						log.Debug("failed to upload shard", zap.Duration("elapsed", time.Since(start)), zap.Error(err))
+						// demote the host if it hit the per-shard timeout while
+						// the overall migration is still in progress
+						if timedOut && ctx.Err() == nil {
+							m.hosts.AddFailedRPC(hostKey)
+						}
 						continue
 					} else if result.Root != shardRoot {
 						// note: since the RHP verifies that the root returned by the host
@@ -116,9 +124,6 @@ top:
 }
 
 func (m *SlabManager) uploadShard(ctx context.Context, hostKey types.PublicKey, shard []byte) (rhp.RPCWriteSectorResult, error) {
-	ctx, cancel := context.WithTimeout(ctx, m.shardTimeout)
-	defer cancel()
-
 	usable, err := m.hm.Usable(ctx, hostKey)
 	if err != nil {
 		return rhp.RPCWriteSectorResult{}, fmt.Errorf("failed to check if host is usable: %w", err)

--- a/slabs/uploads_test.go
+++ b/slabs/uploads_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
@@ -166,6 +167,74 @@ func TestUploadShards(t *testing.T) {
 				t.Fatalf("corrupted sector was uploaded: %v", root)
 			}
 		}
+	}
+}
+
+// TestUploadShardsDemotion verifies that uploadShards demotes a host when
+// the per-shard timeout fires while the overall migration is still in
+// progress, and does NOT demote on quick errors (e.g. host became unusable)
+// or on successful uploads.
+func TestUploadShardsDemotion(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	store := newMockStore(t)
+	chain := newMockChainManager()
+	am := newMockAccountManager()
+	hm := newMockHostManager()
+	account := types.GeneratePrivateKey()
+	client := newMockHostClient()
+
+	// 3 hosts; the queue iterates through them in order.
+	hs := make([]hosts.Host, 3)
+	available := make([]types.PublicKey, 0, len(hs))
+	for i := range hs {
+		sk := types.GeneratePrivateKey()
+		hs[i] = client.addTestHost(sk)
+		available = append(available, sk.PublicKey())
+	}
+
+	// 1 shard - one goroutine will iterate the queue trying each host.
+	root, sector := newTestSector()
+	shards := [][]byte{sector[:]}
+	slab := slabs.Slab{Sectors: []slabs.Sector{{Root: root}}}
+
+	sm := slabs.NewSlabManager(chain, am, nil, hm, store, client, alerts.NewManager(), account, types.GeneratePrivateKey())
+	sm.SetShardTimeout(2 * time.Second)
+
+	for _, hk := range available {
+		if err := am.UpdateServiceAccountBalance(hk, sm.MigrationAccount(), types.Siacoins(1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// hs[0] will hit the per-shard timeout (slow WriteSector) -> demote.
+	client.slowHosts[hs[0].PublicKey] = 30 * time.Minute
+	// hs[1] fails the Usable check fast -> not a timeout, not demoted.
+	hm.unusable[hs[1].PublicKey] = struct{}{}
+	// hs[2] is healthy -> succeeds, not demoted.
+
+	synctest.Test(t, func(t *testing.T) {
+		uploaded, err := sm.UploadShards(context.Background(), slab, shards, available, log)
+		if err != nil {
+			t.Fatal(err)
+		} else if uploaded != 1 {
+			t.Fatalf("expected 1 uploaded shard, got %d", uploaded)
+		}
+	})
+
+	wasDemoted := func(hk types.PublicKey) bool {
+		client.mu.Lock()
+		defer client.mu.Unlock()
+		return client.failedRPCs[hk] > 0
+	}
+
+	if !wasDemoted(hs[0].PublicKey) {
+		t.Fatalf("expected timed-out host hs[0] to be demoted")
+	}
+	if wasDemoted(hs[1].PublicKey) {
+		t.Fatalf("expected unusable host hs[1] not to be demoted")
+	}
+	if wasDemoted(hs[2].PublicKey) {
+		t.Fatalf("expected successful host hs[2] not to be demoted")
 	}
 }
 


### PR DESCRIPTION
With `AddFailedRPC` being exposed now for the Go SDK to use it the pattern we used with `ErrAbortedRPC` becomes more confusing. 

To clean this up, this PR removes `ErrAbortedRPC` and updates the client to only count failed RPCs if they were not caused by contexts. If they were, the client leaves it up to the caller to know what their intentions were.