### PR TITLE
Update sectors to migrate

### DIFF
--- a/.changeset/fix_unnecessary_slab_migrations.md
+++ b/.changeset/fix_unnecessary_slab_migrations.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-# Slab migrations no longer move sectors whose contracts are healthy but in the renew window or at max size.
+# Slab migrations no longer move sectors whose contracts are healthy but excluded from appends, e.g. because they are in the renew window, at max size, or low on allowance/collateral.

--- a/.changeset/fix_unnecessary_slab_migrations.md
+++ b/.changeset/fix_unnecessary_slab_migrations.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Slab migrations no longer move sectors whose contracts are healthy but in the renew window or at max size.

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -400,8 +400,7 @@ func (cm *ContractManager) MaintenanceSettings(ctx context.Context) (Maintenance
 }
 
 // HealthyContracts returns all contracts that are revisable and good regardless
-// of renew window or size limits. Use ContractsForAppend for the narrower set
-// of contracts eligible for new sector uploads.
+// of renew window or size limits.
 func (cm *ContractManager) HealthyContracts() ([]Contract, error) {
 	var good []Contract
 	const batchSize = 50
@@ -415,47 +414,6 @@ func (cm *ContractManager) HealthyContracts() ([]Contract, error) {
 			return good, nil
 		}
 	}
-}
-
-// ContractsForAppend returns all contracts that are good for appending data.
-// These contracts are revisable, not in their renew window, good and have not
-// reached their maximum size.
-func (cm *ContractManager) ContractsForAppend() (good []Contract, err error) {
-	settings, err := cm.store.MaintenanceSettings()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch maintenance settings: %w", err)
-	}
-
-	hostsMap := make(map[types.PublicKey]proto.HostSettings)
-
-	const batchSize = 50
-	for offset := 0; ; offset += batchSize {
-		batch, err := cm.store.Contracts(offset, batchSize, WithRevisable(true), WithGood(true))
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch contracts: %w", err)
-		} else if len(batch) == 0 {
-			break
-		}
-
-		height := cm.chain.TipState().Index.Height
-
-		for _, c := range batch {
-			hostSettings, ok := hostsMap[c.HostKey]
-			if !ok {
-				host, err := cm.hosts.Host(context.Background(), c.HostKey)
-				if err != nil {
-					return nil, fmt.Errorf("failed to fetch host %s: %w", c.HostKey.String(), err)
-				}
-				hostSettings = host.Settings
-				hostsMap[c.HostKey] = hostSettings
-			}
-
-			if c.GoodForAppend(hostSettings, settings.RenewWindow, height, settings.Period) == nil {
-				good = append(good, c)
-			}
-		}
-	}
-	return
 }
 
 // TriggerAccountRefill triggers a refill for the given account by marking it

--- a/contracts/manager.go
+++ b/contracts/manager.go
@@ -399,6 +399,24 @@ func (cm *ContractManager) MaintenanceSettings(ctx context.Context) (Maintenance
 	return cm.store.MaintenanceSettings()
 }
 
+// HealthyContracts returns all contracts that are revisable and good regardless
+// of renew window or size limits. Use ContractsForAppend for the narrower set
+// of contracts eligible for new sector uploads.
+func (cm *ContractManager) HealthyContracts() ([]Contract, error) {
+	var good []Contract
+	const batchSize = 50
+	for offset := 0; ; offset += batchSize {
+		batch, err := cm.store.Contracts(offset, batchSize, WithRevisable(true), WithGood(true))
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch contracts: %w", err)
+		}
+		good = append(good, batch...)
+		if len(batch) < batchSize {
+			return good, nil
+		}
+	}
+}
+
 // ContractsForAppend returns all contracts that are good for appending data.
 // These contracts are revisable, not in their renew window, good and have not
 // reached their maximum size.

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -700,8 +700,8 @@ func (s *Store) PinSectors(contractID types.FileContractID, roots []types.Hash25
 		rows, err := tx.Query(ctx, `
 			SELECT id, host_id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = ANY($1) AND (host_id IS NULL OR host_id = $3) AND (contract_sectors_map_id IS NULL OR contract_sectors_map_id != $2)
-			FOR UPDATE`, sqlRoots, contractMapID, hostID)
+			WHERE sector_root = ANY($1) AND (host_id IS NULL OR host_id = $2) AND (contract_sectors_map_id IS NULL OR contract_sectors_map_id != $3)
+			FOR UPDATE`, sqlRoots, hostID, contractMapID)
 		if err != nil {
 			return fmt.Errorf("failed to query sectors: %w", err)
 		}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -670,10 +670,9 @@ ORDER BY ss.slab_index ASC`, slabID).Query(func(rows pgx.Rows) error {
 	return results, err
 }
 
-// PinSectors pins a batch of sector roots to a given contract. This also
-// updates the host the sector is associated with to the host that we have the
-// contract with. That way, we can avoid a race where the host changes in the
-// meantime and the contract then no longer matches the host.
+// PinSectors pins a batch of sector roots to a given contract. Only sectors
+// that are currently on the contract's host or have no host set are updated.
+// Sectors that were migrated to a different host in the meantime are skipped.
 func (s *Store) PinSectors(contractID types.FileContractID, roots []types.Hash256) error {
 	if len(roots) == 0 {
 		return nil
@@ -701,8 +700,8 @@ func (s *Store) PinSectors(contractID types.FileContractID, roots []types.Hash25
 		rows, err := tx.Query(ctx, `
 			SELECT id, host_id, contract_sectors_map_id
 			FROM sectors
-			WHERE sector_root = ANY($1) AND (contract_sectors_map_id IS NULL OR contract_sectors_map_id != $2)
-			FOR UPDATE`, sqlRoots, contractMapID)
+			WHERE sector_root = ANY($1) AND (host_id IS NULL OR host_id = $3) AND (contract_sectors_map_id IS NULL OR contract_sectors_map_id != $2)
+			FOR UPDATE`, sqlRoots, contractMapID, hostID)
 		if err != nil {
 			return fmt.Errorf("failed to query sectors: %w", err)
 		}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1436,6 +1436,36 @@ func TestPinSectors(t *testing.T) {
 	if !errors.Is(err, contracts.ErrNotFound) {
 		t.Fatal("expected ErrNotFound, got", err)
 	}
+
+	// add a second host and migrate sector 1 to it
+	hk2 := store.addTestHost(t)
+	migrated, err := store.MigrateSector(types.Hash256{1}, hk2)
+	if err != nil {
+		t.Fatal(err)
+	} else if !migrated {
+		t.Fatal("expected migration")
+	}
+
+	// PinSectors with contract 1 should skip the migrated sector since it is
+	// no longer on the contract's host
+	if err := store.PinSectors(contractID1, []types.Hash256{{1}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// verify the sector is still on host 2
+	var sectorHostID int64
+	err = store.pool.QueryRow(t.Context(),
+		`SELECT h.id FROM sectors s INNER JOIN hosts h ON s.host_id = h.id WHERE s.sector_root = $1`,
+		sqlHash256(types.Hash256{1})).Scan(&sectorHostID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hk2ID int64
+	if err := store.pool.QueryRow(t.Context(), `SELECT id FROM hosts WHERE public_key = $1`, sqlPublicKey(hk2)).Scan(&hk2ID); err != nil {
+		t.Fatal(err)
+	} else if sectorHostID != hk2ID {
+		t.Fatal("PinSectors should not overwrite a migrated sector's host")
+	}
 }
 
 func TestUnhealthySlabs(t *testing.T) {

--- a/slabs/export_test.go
+++ b/slabs/export_test.go
@@ -16,6 +16,8 @@ var (
 	ErrInsufficientServiceAccountBalance = errInsufficientServiceAccountBalance
 )
 
+type MigrationState = migrationState
+
 var (
 	SectorsToMigrate    = sectorsToMigrate
 	NewSlabManager      = newSlabManager

--- a/slabs/export_test.go
+++ b/slabs/export_test.go
@@ -31,12 +31,12 @@ func (m *SlabManager) DownloadShards(ctx context.Context, slab Slab, log *zap.Lo
 }
 
 func (m *SlabManager) MigrateSlabs(ctx context.Context, slabIDs []SlabID, log *zap.Logger) error {
-	allHosts, healthyContracts, migrationContracts, err := m.migrationCandidates()
+	state, err := m.fetchMigrationState()
 	if err != nil {
 		return err
 	}
 	for _, slabID := range slabIDs {
-		m.migrateSlab(ctx, slabID, allHosts, healthyContracts, migrationContracts, log.With(zap.Stringer("slab", slabID)))
+		m.migrateSlab(ctx, slabID, state, log.With(zap.Stringer("slab", slabID)))
 	}
 	return nil
 }

--- a/slabs/export_test.go
+++ b/slabs/export_test.go
@@ -31,12 +31,12 @@ func (m *SlabManager) DownloadShards(ctx context.Context, slab Slab, log *zap.Lo
 }
 
 func (m *SlabManager) MigrateSlabs(ctx context.Context, slabIDs []SlabID, log *zap.Logger) error {
-	allHosts, goodContracts, err := m.migrationCandidates()
+	allHosts, healthyContracts, migrationContracts, err := m.migrationCandidates()
 	if err != nil {
 		return err
 	}
 	for _, slabID := range slabIDs {
-		m.migrateSlab(ctx, slabID, allHosts, goodContracts, log.With(zap.Stringer("slab", slabID)))
+		m.migrateSlab(ctx, slabID, allHosts, healthyContracts, migrationContracts, log.With(zap.Stringer("slab", slabID)))
 	}
 	return nil
 }

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -72,7 +72,6 @@ type (
 	ContractManager interface {
 		TriggerAccountRefill(ctx context.Context, hostKey types.PublicKey, account proto.Account) error
 		HealthyContracts() ([]contracts.Contract, error)
-		ContractsForAppend() ([]contracts.Contract, error)
 	}
 
 	// A HostClient defines the minimal interface for interacting with hosts that
@@ -384,18 +383,16 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 	log.Debug("starting slab migrations")
 
 	// start a worker pool that pulls slabs from a channel
-	type slab struct {
-		id                 SlabID
-		allHosts           []hosts.Host
-		healthyContracts   []contracts.Contract
-		migrationContracts []contracts.Contract
+	type migrationJob struct {
+		id    SlabID
+		state MigrationState
 	}
-	slabCh := make(chan slab, m.numMigrationGoroutines)
+	slabCh := make(chan migrationJob, m.numMigrationGoroutines)
 	var wg sync.WaitGroup
 	for range m.numMigrationGoroutines {
 		wg.Go(func() {
-			for slab := range slabCh {
-				m.migrateSlab(ctx, slab.id, slab.allHosts, slab.healthyContracts, slab.migrationContracts, log.With(zap.Stringer("slab", slab.id)))
+			for job := range slabCh {
+				m.migrateSlab(ctx, job.id, job.state, log.With(zap.Stringer("slab", job.id)))
 			}
 		})
 	}
@@ -409,8 +406,8 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 			return err
 		}
 
-		// update the candidates for every batch
-		allHosts, healthyContracts, migrationContracts, err := m.migrationCandidates()
+		// update the state for every batch
+		state, err := m.fetchMigrationState()
 		if err != nil {
 			close(slabCh)
 			wg.Wait()
@@ -419,7 +416,7 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 
 		for _, id := range batch {
 			select {
-			case slabCh <- slab{id: id, allHosts: allHosts, healthyContracts: healthyContracts, migrationContracts: migrationContracts}:
+			case slabCh <- migrationJob{id: id, state: state}:
 			case <-ctx.Done():
 				close(slabCh)
 				wg.Wait()

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -71,6 +71,7 @@ type (
 	// manager.
 	ContractManager interface {
 		TriggerAccountRefill(ctx context.Context, hostKey types.PublicKey, account proto.Account) error
+		HealthyContracts() ([]contracts.Contract, error)
 		ContractsForAppend() ([]contracts.Contract, error)
 	}
 
@@ -384,16 +385,17 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 
 	// start a worker pool that pulls slabs from a channel
 	type slab struct {
-		id            SlabID
-		allHosts      []hosts.Host
-		goodContracts []contracts.Contract
+		id                 SlabID
+		allHosts           []hosts.Host
+		healthyContracts   []contracts.Contract
+		migrationContracts []contracts.Contract
 	}
 	slabCh := make(chan slab, m.numMigrationGoroutines)
 	var wg sync.WaitGroup
 	for range m.numMigrationGoroutines {
 		wg.Go(func() {
 			for slab := range slabCh {
-				m.migrateSlab(ctx, slab.id, slab.allHosts, slab.goodContracts, log.With(zap.Stringer("slab", slab.id)))
+				m.migrateSlab(ctx, slab.id, slab.allHosts, slab.healthyContracts, slab.migrationContracts, log.With(zap.Stringer("slab", slab.id)))
 			}
 		})
 	}
@@ -408,7 +410,7 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 		}
 
 		// update the candidates for every batch
-		allHosts, goodContracts, err := m.migrationCandidates()
+		allHosts, healthyContracts, migrationContracts, err := m.migrationCandidates()
 		if err != nil {
 			close(slabCh)
 			wg.Wait()
@@ -417,7 +419,7 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 
 		for _, id := range batch {
 			select {
-			case slabCh <- slab{id: id, allHosts: allHosts, goodContracts: goodContracts}:
+			case slabCh <- slab{id: id, allHosts: allHosts, healthyContracts: healthyContracts, migrationContracts: migrationContracts}:
 			case <-ctx.Done():
 				close(slabCh)
 				wg.Wait()

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -385,7 +385,7 @@ func (m *SlabManager) performSlabMigrations(ctx context.Context) error {
 	// start a worker pool that pulls slabs from a channel
 	type migrationJob struct {
 		id    SlabID
-		state MigrationState
+		state migrationState
 	}
 	slabCh := make(chan migrationJob, m.numMigrationGoroutines)
 	var wg sync.WaitGroup

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -342,12 +342,6 @@ func (m *mockContractManager) HealthyContracts() ([]contracts.Contract, error) {
 	return slices.Clone(m.contracts), nil
 }
 
-func (m *mockContractManager) ContractsForAppend() ([]contracts.Contract, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return slices.Clone(m.contracts), nil
-}
-
 type mockhostManager struct {
 	mu            sync.Mutex
 	hosts         map[types.PublicKey]hosts.Host

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -336,6 +336,12 @@ func (m *mockContractManager) TriggerAccountRefill(ctx context.Context, hostKey 
 	return nil
 }
 
+func (m *mockContractManager) HealthyContracts() ([]contracts.Contract, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return slices.Clone(m.contracts), nil
+}
+
 func (m *mockContractManager) ContractsForAppend() ([]contracts.Contract, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -13,44 +13,58 @@ import (
 	"golang.org/x/crypto/chacha20"
 )
 
-// migrationCandidates fetches all available hosts and contracts that can be
-// used for slab migrations. Two contract lists are returned, one with all
-// revisable healthy contracts for sector health checks and one with the subset
-// that is eligible for uploading migrated sectors.
-func (m *SlabManager) migrationCandidates() (allHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, err error) {
-	healthyContracts, err = m.cm.HealthyContracts()
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to fetch healthy contracts: %w", err)
-	}
-	migrationContracts, err = m.cm.ContractsForAppend()
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to fetch migration contracts: %w", err)
-	}
+// MigrationState holds the hosts, contracts, and chain state needed for
+// slab migrations.
+type MigrationState struct {
+	Height              uint64
+	HealthyContracts    []contracts.Contract
+	Hosts               []hosts.Host
+	MaintenanceSettings contracts.MaintenanceSettings
+}
 
+// MigrationState fetches all available hosts, contracts, maintenance settings,
+// and chain height needed for slab migrations.
+func (m *SlabManager) fetchMigrationState() (state MigrationState, err error) {
+	// fetch hosts
 	const batchSize = 500
 	for offset := 0; ; offset += batchSize {
-		var batch []hosts.Host
-		batch, err = m.store.Hosts(offset, batchSize,
+		batch, err := m.store.Hosts(offset, batchSize,
 			hosts.WithBlocked(false),
 			hosts.WithActiveContracts(true))
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to fetch hosts: %w", err)
+			return state, fmt.Errorf("failed to fetch hosts: %w", err)
 		}
 
-		allHosts = append(allHosts, batch...)
+		state.Hosts = append(state.Hosts, batch...)
 		if len(batch) < batchSize {
-			return
+			break
 		}
 	}
+
+	// fetch healthy contracts
+	state.HealthyContracts, err = m.cm.HealthyContracts()
+	if err != nil {
+		return state, fmt.Errorf("failed to fetch healthy contracts: %w", err)
+	}
+
+	// fetch maintenance settings
+	state.MaintenanceSettings, err = m.store.MaintenanceSettings()
+	if err != nil {
+		return state, fmt.Errorf("failed to fetch maintenance settings: %w", err)
+	}
+
+	// fetch chain height
+	state.Height = m.chain.Tip().Height
+	return state, nil
 }
 
-func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, log *zap.Logger) {
+func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, state MigrationState, log *zap.Logger) {
 	slab, err := m.store.Slab(slabID)
 	if err != nil {
 		log.Error("failed to fetch slab", zap.Error(err))
 		return
 	}
-	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, healthyContracts, migrationContracts, m.minHostDistanceKm)
+	indices, uploadCandidates := sectorsToMigrate(slab, state, m.minHostDistanceKm)
 	if len(indices) == 0 {
 		log.Debug("tried to migrate slab but no indices require migration")
 		return
@@ -143,31 +157,29 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 // sectors that require migration together with hosts that can be used to
 // migrate bad sectors to. These hosts are guaranteed to be at least
 // minHostDistance apart from each other and are returned in random order.
-// healthyContracts is the full set of revisable good contracts used to decide
-// whether a sector's contract is healthy. migrationContracts is the narrower
-// subset eligible for uploading migrated sectors, used to select candidate hosts.
-func sectorsToMigrate(slab Slab, allHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, minHostDistanceKm float64) ([]int, []types.PublicKey) {
+// The subset of healthy contracts eligible for uploading migrated sectors is
+// derived by filtering with GoodForAppend.
+func sectorsToMigrate(slab Slab, state MigrationState, minHostDistanceKm float64) ([]int, []types.PublicKey) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
-	for _, host := range allHosts {
+	for _, host := range state.Hosts {
 		if host.IsGood() {
 			hostsMap[host.PublicKey] = host
 		}
 	}
 
-	// prepare a map of healthy contracts for sector health checks
+	// prepare a map of healthy contracts for sector health checks and track
+	// which hosts have migration eligible contracts for candidate selection
 	healthyContractMap := make(map[types.FileContractID]contracts.Contract)
-	for _, contract := range healthyContracts {
-		if _, ok := hostsMap[contract.HostKey]; ok {
-			healthyContractMap[contract.ID] = contract
+	hasAppendContract := make(map[types.PublicKey]struct{})
+	for _, contract := range state.HealthyContracts {
+		host, ok := hostsMap[contract.HostKey]
+		if !ok {
+			continue
 		}
-	}
-
-	// track which hosts have migration eligible contracts for candidate selection
-	hasMigrationContract := make(map[types.PublicKey]struct{})
-	for _, contract := range migrationContracts {
-		if _, ok := hostsMap[contract.HostKey]; ok {
-			hasMigrationContract[contract.HostKey] = struct{}{}
+		healthyContractMap[contract.ID] = contract
+		if contract.GoodForAppend(host.Settings, state.MaintenanceSettings.RenewWindow, state.Height, state.MaintenanceSettings.Period) == nil {
+			hasAppendContract[contract.HostKey] = struct{}{}
 		}
 	}
 
@@ -214,8 +226,8 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, healthyContracts, migrat
 	}
 	var candidates []types.PublicKey
 	for _, host := range hostsMap {
-		if _, ok := hasMigrationContract[host.PublicKey]; !ok {
-			// must have a migration eligible contract
+		if _, ok := hasAppendContract[host.PublicKey]; !ok {
+			// must have an appendable contract
 			continue
 		} else if !host.StuckSince.IsZero() {
 			// can't migrate to stuck hosts

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -13,18 +13,18 @@ import (
 	"golang.org/x/crypto/chacha20"
 )
 
-// MigrationState holds the hosts, contracts, and chain state needed for
+// migrationState holds the hosts, contracts, and chain state needed for
 // slab migrations.
-type MigrationState struct {
+type migrationState struct {
 	Height              uint64
 	HealthyContracts    []contracts.Contract
 	Hosts               []hosts.Host
 	MaintenanceSettings contracts.MaintenanceSettings
 }
 
-// MigrationState fetches all available hosts, contracts, maintenance settings,
+// migrationState fetches all available hosts, contracts, maintenance settings,
 // and chain height needed for slab migrations.
-func (m *SlabManager) fetchMigrationState() (state MigrationState, err error) {
+func (m *SlabManager) fetchMigrationState() (state migrationState, err error) {
 	// fetch hosts
 	const batchSize = 500
 	for offset := 0; ; offset += batchSize {
@@ -58,7 +58,7 @@ func (m *SlabManager) fetchMigrationState() (state MigrationState, err error) {
 	return state, nil
 }
 
-func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, state MigrationState, log *zap.Logger) {
+func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, state migrationState, log *zap.Logger) {
 	slab, err := m.store.Slab(slabID)
 	if err != nil {
 		log.Error("failed to fetch slab", zap.Error(err))
@@ -159,7 +159,7 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, state Migr
 // minHostDistance apart from each other and are returned in random order.
 // The subset of healthy contracts eligible for uploading migrated sectors is
 // derived by filtering with GoodForAppend.
-func sectorsToMigrate(slab Slab, state MigrationState, minHostDistanceKm float64) ([]int, []types.PublicKey) {
+func sectorsToMigrate(slab Slab, state migrationState, minHostDistanceKm float64) ([]int, []types.PublicKey) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range state.Hosts {

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -14,39 +14,43 @@ import (
 )
 
 // migrationCandidates fetches all available hosts and contracts that can be
-// used for slab migrations.
-func (m *SlabManager) migrationCandidates() ([]hosts.Host, []contracts.Contract, error) {
-	goodContracts, err := m.cm.ContractsForAppend()
+// used for slab migrations. Two contract lists are returned, one with all
+// revisable healthy contracts for sector health checks and one with the subset
+// that is eligible for uploading migrated sectors.
+func (m *SlabManager) migrationCandidates() (allHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, err error) {
+	healthyContracts, err = m.cm.HealthyContracts()
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to fetch contracts: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to fetch healthy contracts: %w", err)
+	}
+	migrationContracts, err = m.cm.ContractsForAppend()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to fetch migration contracts: %w", err)
 	}
 
 	const batchSize = 500
-	var allHosts []hosts.Host
 	for offset := 0; ; offset += batchSize {
-		batch, err := m.store.Hosts(offset, batchSize,
+		var batch []hosts.Host
+		batch, err = m.store.Hosts(offset, batchSize,
 			hosts.WithBlocked(false),
 			hosts.WithActiveContracts(true))
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to fetch hosts: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed to fetch hosts: %w", err)
 		}
 
 		allHosts = append(allHosts, batch...)
 		if len(batch) < batchSize {
-			break
+			return
 		}
 	}
-
-	return allHosts, goodContracts, nil
 }
 
-func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts []hosts.Host, goodContracts []contracts.Contract, log *zap.Logger) {
+func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, log *zap.Logger) {
 	slab, err := m.store.Slab(slabID)
 	if err != nil {
 		log.Error("failed to fetch slab", zap.Error(err))
 		return
 	}
-	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, goodContracts, m.minHostDistanceKm)
+	indices, uploadCandidates := sectorsToMigrate(slab, allHosts, healthyContracts, migrationContracts, m.minHostDistanceKm)
 	if len(indices) == 0 {
 		log.Debug("tried to migrate slab but no indices require migration")
 		return
@@ -139,7 +143,10 @@ func (m *SlabManager) migrateSlab(ctx context.Context, slabID SlabID, allHosts [
 // sectors that require migration together with hosts that can be used to
 // migrate bad sectors to. These hosts are guaranteed to be at least
 // minHostDistance apart from each other and are returned in random order.
-func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contracts.Contract, minHostDistanceKm float64) ([]int, []types.PublicKey) {
+// healthyContracts is the full set of revisable good contracts used to decide
+// whether a sector's contract is healthy. migrationContracts is the narrower
+// subset eligible for uploading migrated sectors, used to select candidate hosts.
+func sectorsToMigrate(slab Slab, allHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, minHostDistanceKm float64) ([]int, []types.PublicKey) {
 	// prepare a map of good hosts
 	hostsMap := make(map[types.PublicKey]hosts.Host)
 	for _, host := range allHosts {
@@ -148,13 +155,19 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 		}
 	}
 
-	// prepare a map of good contracts
-	goodContractMap := make(map[types.FileContractID]contracts.Contract)
-	hasGoodContract := make(map[types.PublicKey]struct{})
-	for _, contract := range goodContracts {
+	// prepare a map of healthy contracts for sector health checks
+	healthyContractMap := make(map[types.FileContractID]contracts.Contract)
+	for _, contract := range healthyContracts {
 		if _, ok := hostsMap[contract.HostKey]; ok {
-			hasGoodContract[contract.HostKey] = struct{}{}
-			goodContractMap[contract.ID] = contract
+			healthyContractMap[contract.ID] = contract
+		}
+	}
+
+	// track which hosts have migration eligible contracts for candidate selection
+	hasMigrationContract := make(map[types.PublicKey]struct{})
+	for _, contract := range migrationContracts {
+		if _, ok := hostsMap[contract.HostKey]; ok {
+			hasMigrationContract[contract.HostKey] = struct{}{}
 		}
 	}
 
@@ -187,12 +200,12 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 		delete(hostsMap, *sector.HostKey)
 
 		if sector.ContractID != nil {
-			if _, ok := goodContractMap[*sector.ContractID]; !ok {
+			if _, ok := healthyContractMap[*sector.ContractID]; !ok {
 				// sector is on a bad contract
 				toMigrate = append(toMigrate, i)
 				continue
 			}
-			delete(goodContractMap, *sector.ContractID)
+			delete(healthyContractMap, *sector.ContractID)
 		}
 
 		// sector will not be migrated. Remove it from the hosts map
@@ -201,8 +214,8 @@ func sectorsToMigrate(slab Slab, allHosts []hosts.Host, goodContracts []contract
 	}
 	var candidates []types.PublicKey
 	for _, host := range hostsMap {
-		if _, ok := hasGoodContract[host.PublicKey]; !ok {
-			// must have a good contract
+		if _, ok := hasMigrationContract[host.PublicKey]; !ok {
+			// must have a migration eligible contract
 			continue
 		} else if !host.StuckSince.IsZero() {
 			// can't migrate to stuck hosts

--- a/slabs/migrations.go
+++ b/slabs/migrations.go
@@ -22,7 +22,7 @@ type migrationState struct {
 	MaintenanceSettings contracts.MaintenanceSettings
 }
 
-// migrationState fetches all available hosts, contracts, maintenance settings,
+// fetchMigrationState fetches all available hosts, contracts, maintenance settings,
 // and chain height needed for slab migrations.
 func (m *SlabManager) fetchMigrationState() (state migrationState, err error) {
 	// fetch hosts

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -274,9 +274,14 @@ func TestSectorsToMigrate(t *testing.T) {
 	}
 
 	// helper to assert result of sectorsToMigrate
-	assertResult := func(availableHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, expectedRoots []int, expectedHosts []hosts.Host) {
+	state := slabs.MigrationState{
+		MaintenanceSettings: contracts.MaintenanceSettings{Period: 100},
+	}
+	assertResult := func(availableHosts []hosts.Host, healthyContracts []contracts.Contract, expectedRoots []int, expectedHosts []hosts.Host) {
 		t.Helper()
-		toRepair, toUse := slabs.SectorsToMigrate(slab, availableHosts, healthyContracts, migrationContracts, 10)
+		state.Hosts = availableHosts
+		state.HealthyContracts = healthyContracts
+		toRepair, toUse := slabs.SectorsToMigrate(slab, state, 10)
 		if len(toRepair) != len(expectedRoots) {
 			t.Fatalf("expected %d roots to repair, got %d: %v", len(expectedRoots), len(toRepair), toRepair)
 		} else if len(toUse) != len(expectedHosts) {
@@ -300,13 +305,13 @@ func TestSectorsToMigrate(t *testing.T) {
 
 	// with no contracts or hosts, all sectors require migration but no
 	// contracts are available
-	assertResult(nil, nil, nil, []int{0, 1, 2, 3, 4}, nil)
+	assertResult(nil, nil, []int{0, 1, 2, 3, 4}, nil)
 
 	// with just the hosts and contracts the slab is stored on, only the
 	// missing sectors should require migration and no candidates are available
 	allHosts := []hosts.Host{goodHost, goodHostNoContract, sameLocationHost}
 	allContracts := []contracts.Contract{goodContract, badContract, sameLocationContract}
-	assertResult(allHosts, allContracts, allContracts, []int{1, 2}, nil)
+	assertResult(allHosts, allContracts, []int{1, 2}, nil)
 
 	// prepare a bunch of hosts and contracts which can't be used for repairs
 	badHost2 := newHost(false, false)
@@ -323,7 +328,7 @@ func TestSectorsToMigrate(t *testing.T) {
 	// add the bad hosts+contracts and try again, expect same result
 	allHosts = append(allHosts, badHost2, blockedHost, sameLocationHost2)
 	allContracts = append(allContracts, cBadHost2, cBlockedHost, cSameLocationHost2)
-	assertResult(allHosts, allContracts, allContracts, []int{1, 2}, nil)
+	assertResult(allHosts, allContracts, []int{1, 2}, nil)
 
 	// prepare 2 good hosts
 	goodHost2 := newHost(true, false)
@@ -335,12 +340,13 @@ func TestSectorsToMigrate(t *testing.T) {
 	// should use them
 	allHosts = append(allHosts, goodHost2, goodHost3)
 	allContracts = append(allContracts, cGoodHost2, cGoodHost3)
-	assertResult(allHosts, allContracts, allContracts, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
+	assertResult(allHosts, allContracts, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
 
 	// add a host with a healthy contract that is not eligible for migration
-	// uploads, e.g. because it is in the renew window or at max size
+	// uploads because it is in the renew window
 	healthyOnlyHost := newHost(true, false)
 	healthyOnlyContract := newContract(healthyOnlyHost.PublicKey, true)
+	healthyOnlyContract.ProofHeight = 40 // within renew window
 
 	slab.Sectors = append(slab.Sectors, slabs.Sector{
 		Root:       types.Hash256{6},
@@ -350,15 +356,15 @@ func TestSectorsToMigrate(t *testing.T) {
 
 	allHosts = append(allHosts, healthyOnlyHost)
 	healthyAll := append(slices.Clone(allContracts), healthyOnlyContract)
-	migrationOnly := slices.Clone(allContracts)
 
 	// sector 6 should not be migrated because its contract is healthy
 	// the host should not be a candidate because it has no migration contract
-	assertResult(allHosts, healthyAll, migrationOnly, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
+	state.MaintenanceSettings.RenewWindow = 50
+	assertResult(allHosts, healthyAll, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
 
 	// when the healthy only contract is missing from the healthy list too,
 	// the sector should be flagged for migration
-	assertResult(allHosts, migrationOnly, migrationOnly, []int{1, 2, 5}, []hosts.Host{goodHost2, goodHost3})
+	assertResult(allHosts, allContracts, []int{1, 2, 5}, []hosts.Host{goodHost2, goodHost3})
 }
 
 func newTestContract(hk types.PublicKey) contracts.Contract {

--- a/slabs/migrations_test.go
+++ b/slabs/migrations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -272,10 +273,10 @@ func TestSectorsToMigrate(t *testing.T) {
 		},
 	}
 
-	// helper to assert result of contractsForRepair
-	assertResult := func(availableHosts []hosts.Host, availableContracts []contracts.Contract, expectedRoots []int, expectedHosts []hosts.Host) {
+	// helper to assert result of sectorsToMigrate
+	assertResult := func(availableHosts []hosts.Host, healthyContracts, migrationContracts []contracts.Contract, expectedRoots []int, expectedHosts []hosts.Host) {
 		t.Helper()
-		toRepair, toUse := slabs.SectorsToMigrate(slab, availableHosts, availableContracts, 10)
+		toRepair, toUse := slabs.SectorsToMigrate(slab, availableHosts, healthyContracts, migrationContracts, 10)
 		if len(toRepair) != len(expectedRoots) {
 			t.Fatalf("expected %d roots to repair, got %d: %v", len(expectedRoots), len(toRepair), toRepair)
 		} else if len(toUse) != len(expectedHosts) {
@@ -299,13 +300,13 @@ func TestSectorsToMigrate(t *testing.T) {
 
 	// with no contracts or hosts, all sectors require migration but no
 	// contracts are available
-	assertResult(nil, nil, []int{0, 1, 2, 3, 4}, nil)
+	assertResult(nil, nil, nil, []int{0, 1, 2, 3, 4}, nil)
 
-	// calling contractsForRepair with just the hosts and contracts the slab is stored on should
-	// return the missing sectors and no contracts
+	// with just the hosts and contracts the slab is stored on, only the
+	// missing sectors should require migration and no candidates are available
 	allHosts := []hosts.Host{goodHost, goodHostNoContract, sameLocationHost}
 	allContracts := []contracts.Contract{goodContract, badContract, sameLocationContract}
-	assertResult(allHosts, allContracts, []int{1, 2}, nil)
+	assertResult(allHosts, allContracts, allContracts, []int{1, 2}, nil)
 
 	// prepare a bunch of hosts and contracts which can't be used for repairs
 	badHost2 := newHost(false, false)
@@ -319,10 +320,10 @@ func TestSectorsToMigrate(t *testing.T) {
 	sameLocationHost2.Longitude = goodHost.Longitude
 	cSameLocationHost2 := newContract(sameLocationHost2.PublicKey, true)
 
-	// add the bad hosts+contracts and try again - expect same result
+	// add the bad hosts+contracts and try again, expect same result
 	allHosts = append(allHosts, badHost2, blockedHost, sameLocationHost2)
 	allContracts = append(allContracts, cBadHost2, cBlockedHost, cSameLocationHost2)
-	assertResult(allHosts, allContracts, []int{1, 2}, nil)
+	assertResult(allHosts, allContracts, allContracts, []int{1, 2}, nil)
 
 	// prepare 2 good hosts
 	goodHost2 := newHost(true, false)
@@ -334,7 +335,30 @@ func TestSectorsToMigrate(t *testing.T) {
 	// should use them
 	allHosts = append(allHosts, goodHost2, goodHost3)
 	allContracts = append(allContracts, cGoodHost2, cGoodHost3)
-	assertResult(allHosts, allContracts, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
+	assertResult(allHosts, allContracts, allContracts, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
+
+	// add a host with a healthy contract that is not eligible for migration
+	// uploads, e.g. because it is in the renew window or at max size
+	healthyOnlyHost := newHost(true, false)
+	healthyOnlyContract := newContract(healthyOnlyHost.PublicKey, true)
+
+	slab.Sectors = append(slab.Sectors, slabs.Sector{
+		Root:       types.Hash256{6},
+		ContractID: &healthyOnlyContract.ID,
+		HostKey:    &healthyOnlyContract.HostKey,
+	})
+
+	allHosts = append(allHosts, healthyOnlyHost)
+	healthyAll := append(slices.Clone(allContracts), healthyOnlyContract)
+	migrationOnly := slices.Clone(allContracts)
+
+	// sector 6 should not be migrated because its contract is healthy
+	// the host should not be a candidate because it has no migration contract
+	assertResult(allHosts, healthyAll, migrationOnly, []int{1, 2}, []hosts.Host{goodHost2, goodHost3})
+
+	// when the healthy only contract is missing from the healthy list too,
+	// the sector should be flagged for migration
+	assertResult(allHosts, migrationOnly, migrationOnly, []int{1, 2, 5}, []hosts.Host{goodHost2, goodHost3})
 }
 
 func newTestContract(hk types.PublicKey) contracts.Contract {


### PR DESCRIPTION
In [this PR](https://github.com/SiaFoundation/indexd/pull/700) we added `ContractsForAppend` to determine whether a sector's contract is healthy. That method filters out contracts in the renew window, at max size, or low on funds. Sectors on those contracts are fine where they are but were getting flagged for migration anyway. This explains the inflated `toMigrate` counts we saw in production. This PR also tightens `PinSectors` to skip sectors that moved to a different host since they were queried.

Closes https://github.com/SiaFoundation/indexd/issues/971