### PR TITLE
Rebind slabs

### DIFF
--- a/.changeset/allow_slabs_to_rebind_lost_host_sectors.md
+++ b/.changeset/allow_slabs_to_rebind_lost_host_sectors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Repinning a slab now rebinds host sectors that have been lost.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ go generate ./...
 go build -tags='netgo timetzdata' -trimpath -a -ldflags '-s -w' ./cmd/indexd
 ```
 
-## Getting Started
+## Running a node
+
+### Prerequisites
+- Postgresql 18
+
+### Config
 
 Running `indexd` requires a PostgreSQL database. By default, `indexd` looks for
 a PostgreSQL server running on `localhost:5432` with a database named `indexd`

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -261,7 +261,7 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 			}
 
 			digest := slab.Digest()
-			digests = append(digests, slab.Digest())
+			digests = append(digests, digest)
 
 			// insert slab
 			var slabID int64
@@ -292,17 +292,15 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 				newPinnedSize += slab.Size()
 			}
 
-			// if the slab already existed, we don't need to insert the sectors
-			if existingSlab {
-				continue
+			if !existingSlab {
+				if err := incrementNumSlabs(ctx, tx, 1); err != nil {
+					return fmt.Errorf("failed to increment number of slabs: %w", err)
+				}
 			}
 
-			// update slab stats
-			if err := incrementNumSlabs(ctx, tx, 1); err != nil {
-				return fmt.Errorf("failed to increment number of slabs: %w", err)
-			}
-
-			// insert slab's sectors in a single batch
+			// insert the slab's sectors. For a slab that already
+			// exists this may rebind any sectors that were marked
+			// lost since it was pinned.
 			batch := &pgx.Batch{}
 			for _, sector := range slab.Sectors {
 				batch.Queue(`
@@ -310,15 +308,17 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 				SELECT $1, h.id, $3
 				FROM hosts h
 				WHERE h.public_key = $2
-				ON CONFLICT (sector_root) DO UPDATE SET uploaded_at=NOW()
-				RETURNING id, host_id, (xmax = 0) AS inserted`,
+				ON CONFLICT (sector_root) DO UPDATE SET
+					uploaded_at = NOW(),
+					host_id = COALESCE(sectors.host_id, EXCLUDED.host_id)
+				RETURNING id, host_id, (OLD.id IS NULL) AS inserted, (OLD.id IS NOT NULL AND OLD.host_id IS NULL) AS rebound`,
 					sqlHash256(sector.Root),
 					sqlPublicKey(sector.HostKey),
 					nextIntegrityCheck)
 			}
 
 			var badHosts int
-			var unpinned int64
+			var unpinned, rebound int64
 			var unpinnedDeltas []unpinnedDelta
 			br := tx.SendBatch(ctx, batch)
 			sectorIDs := make([]int64, len(slab.Sectors))
@@ -327,17 +327,21 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 					badHosts++
 				}
 
-				var inserted bool
+				var inserted, isRebound bool
 				var hostID int64
-				if err := br.QueryRow().Scan(&sectorIDs[i], &hostID, &inserted); err != nil {
+				if err := br.QueryRow().Scan(&sectorIDs[i], &hostID, &inserted, &isRebound); err != nil {
 					br.Close()
 					if errors.Is(err, sql.ErrNoRows) {
 						return fmt.Errorf("unknown host %q for sector", sector.HostKey)
 					}
 					return fmt.Errorf("failed to insert sector %q: %w", sector.Root, err)
-				} else if inserted {
+				}
+				if inserted || isRebound {
 					unpinned++
 					unpinnedDeltas = append(unpinnedDeltas, unpinnedDelta{hostID: hostID, delta: 1})
+				}
+				if isRebound {
+					rebound++
 				}
 			}
 			br.Close()
@@ -354,6 +358,13 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 					return fmt.Errorf("failed to increment number of unpinned sectors: %w", err)
 				} else if err := incrementHostsUnpinnedSectors(ctx, tx, unpinnedDeltas); err != nil {
 					return fmt.Errorf("failed to update hosts unpinned sectors: %w", err)
+				}
+			}
+
+			// a hostless sector is counted as unpinnable; rebinding clears that.
+			if rebound > 0 {
+				if err := incrementNumUnpinnableSectors(ctx, tx, -rebound); err != nil {
+					return fmt.Errorf("failed to decrement number of unpinnable sectors: %w", err)
 				}
 			}
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1145,6 +1145,92 @@ func TestPinSlabsDuplicate(t *testing.T) {
 	assertNumSlabs(1)
 }
 
+func TestPinSlabsRebindLostSector(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	assertStats := func(unpinned, unpinnable, lost int64) {
+		t.Helper()
+		stats, err := store.SectorStats()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stats.Unpinned != unpinned {
+			t.Fatalf("expected %d unpinned sectors, got %d", unpinned, stats.Unpinned)
+		} else if stats.Unpinnable != unpinnable {
+			t.Fatalf("expected %d unpinnable sectors, got %d", unpinnable, stats.Unpinnable)
+		} else if stats.Lost != lost {
+			t.Fatalf("expected %d lost sectors, got %d", lost, stats.Lost)
+		}
+	}
+
+	nextCheck := time.Now().Round(time.Microsecond).Add(time.Hour)
+	root := frand.Entropy256()
+
+	slab1 := slabs.SlabPinParams{
+		EncryptionKey: slabs.EncryptionKey{1},
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+	}
+	if _, err := store.PinSlabs(account, nextCheck, slab1); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(1, 0, 0)
+
+	if err := store.MarkSectorsLost(hk, []types.Hash256{root}); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(0, 1, 1)
+
+	slab2 := slabs.SlabPinParams{
+		EncryptionKey: slabs.EncryptionKey{2},
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+	}
+	slab2IDs, err := store.PinSlabs(account, nextCheck, slab2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertStats(1, 0, 1)
+
+	fetched, err := store.Slabs(account, slab2IDs)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(fetched) != 1 || len(fetched[0].Sectors) != 1 {
+		t.Fatalf("expected 1 slab with 1 sector, got %d slabs", len(fetched))
+	} else if fetched[0].Sectors[0].HostKey == nil {
+		t.Fatal("expected sector to be rebound to a host, got nil host key")
+	} else if *fetched[0].Sectors[0].HostKey != hk {
+		t.Fatalf("expected sector host %x, got %x", hk, *fetched[0].Sectors[0].HostKey)
+	}
+
+	if err := store.MarkSectorsLost(hk, []types.Hash256{root}); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(0, 1, 2)
+	if _, err := store.PinSlabs(account, nextCheck, slab2); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(1, 0, 2)
+
+	fetched, err = store.Slabs(account, slab2IDs)
+	if err != nil {
+		t.Fatal(err)
+	} else if fetched[0].Sectors[0].HostKey == nil || *fetched[0].Sectors[0].HostKey != hk {
+		t.Fatalf("expected sector rebound to host %x, got %v", hk, fetched[0].Sectors[0].HostKey)
+	}
+
+	if _, err := store.pool.Exec(t.Context(), "UPDATE contracts SET good = FALSE WHERE host_id = (SELECT id FROM hosts WHERE public_key = $1)", sqlPublicKey(hk)); err != nil {
+		t.Fatal(err)
+	} else if _, err := store.PinSlabs(account, nextCheck, slab2); !errors.Is(err, slabs.ErrBadHosts) {
+		t.Fatalf("expected ErrBadHosts re-pinning onto a bad host, got %v", err)
+	}
+}
+
 func TestUnpinSlab(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -1151,7 +1151,9 @@ func TestPinSlabsRebindLostSector(t *testing.T) {
 	account := proto.Account{1}
 	store.addTestAccount(t, types.PublicKey(account))
 	hk := store.addTestHost(t)
+	hk2 := store.addTestHost(t)
 	store.addTestContract(t, hk)
+	store.addTestContract(t, hk2)
 
 	assertStats := func(unpinned, unpinnable, lost int64) {
 		t.Helper()
@@ -1222,6 +1224,22 @@ func TestPinSlabsRebindLostSector(t *testing.T) {
 		t.Fatal(err)
 	} else if fetched[0].Sectors[0].HostKey == nil || *fetched[0].Sectors[0].HostKey != hk {
 		t.Fatalf("expected sector rebound to host %x, got %v", hk, fetched[0].Sectors[0].HostKey)
+	}
+
+	slabGood := slabs.SlabPinParams{
+		EncryptionKey: slabs.EncryptionKey{2},
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk2}},
+	}
+	if _, err := store.PinSlabs(account, nextCheck, slabGood); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(1, 0, 2)
+	fetched, err = store.Slabs(account, slab2IDs)
+	if err != nil {
+		t.Fatal(err)
+	} else if fetched[0].Sectors[0].HostKey == nil || *fetched[0].Sectors[0].HostKey != hk {
+		t.Fatalf("expected healthy sector host %x to be preserved, got %v", hk, fetched[0].Sectors[0].HostKey)
 	}
 
 	if _, err := store.pool.Exec(t.Context(), "UPDATE contracts SET good = FALSE WHERE host_id = (SELECT id FROM hosts WHERE public_key = $1)", sqlPublicKey(hk)); err != nil {

--- a/slabs/manager_test.go
+++ b/slabs/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,8 +15,10 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/indexd/alerts"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/testutils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -533,6 +536,45 @@ func (m *mockHostClient) setSlowHost(hostKey types.PublicKey, delay time.Duratio
 		delete(m.slowHosts, hostKey)
 	} else {
 		m.slowHosts[hostKey] = delay
+	}
+}
+
+func TestSlabManagerPinSlabsValidation(t *testing.T) {
+	store := newMockStore(t)
+	sm := slabs.NewSlabManager(newMockChainManager(), newMockAccountManager(), nil, newMockHostManager(), store, newMockHostClient(), alerts.NewManager(), types.GeneratePrivateKey(), types.GeneratePrivateKey())
+
+	accountPK := types.GeneratePrivateKey().PublicKey()
+	store.AddTestAccount(t, accountPK)
+	account := proto.Account(accountPK)
+	nextCheck := time.Now().Add(time.Hour)
+
+	hostKeys := make([]types.PublicKey, 30)
+	for i := range hostKeys {
+		hostKeys[i] = types.GeneratePrivateKey().PublicKey()
+		store.AddTestHost(t, hosts.Host{PublicKey: hostKeys[i], Settings: goodSettings, Usability: hosts.GoodUsability})
+		store.addTestContract(t, hostKeys[i])
+	}
+	newSlab := func(key byte, hostFor func(i int) types.PublicKey) slabs.SlabPinParams {
+		sectors := make([]slabs.PinnedSector, len(hostKeys))
+		for i := range sectors {
+			sectors[i] = slabs.PinnedSector{Root: frand.Entropy256(), HostKey: hostFor(i)}
+		}
+		return slabs.SlabPinParams{EncryptionKey: slabs.EncryptionKey{key}, MinShards: 10, Sectors: sectors}
+	}
+
+	dup := newSlab(1, func(i int) types.PublicKey {
+		if i == 1 {
+			return hostKeys[0]
+		}
+		return hostKeys[i]
+	})
+	if _, err := sm.PinSlabs(context.Background(), account, nextCheck, dup); err == nil || !strings.Contains(err.Error(), "duplicate host key") {
+		t.Fatalf("expected duplicate host key error, got %v", err)
+	}
+
+	valid := newSlab(2, func(i int) types.PublicKey { return hostKeys[i] })
+	if _, err := sm.PinSlabs(context.Background(), account, nextCheck, valid); err != nil {
+		t.Fatalf("expected valid slab to pin, got %v", err)
 	}
 }
 

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -173,6 +173,11 @@ func (s SlabPinParams) Validate() error {
 // PinSlabs adds slabs to the database for pinning. The slabs are associated
 // with the provided account.
 func (m *SlabManager) PinSlabs(ctx context.Context, account proto.Account, nextIntegrityCheck time.Time, toPin ...SlabPinParams) ([]SlabID, error) {
+	for i := range toPin {
+		if err := toPin[i].Validate(); err != nil {
+			return nil, fmt.Errorf("slab %d invalid: %w", i, err)
+		}
+	}
 	return m.store.PinSlabs(account, nextIntegrityCheck, toPin...)
 }
 


### PR DESCRIPTION
Repinning a slab now rebinds host sectors that have been lost. Also adds a check and test that makes sure we're calling `Validate` when pinning slabs. This change requires Postgres 18 for `old` in the `RETURNING` clause. 