### PR TITLE
Add versioning to objects

### DIFF
--- a/.changeset/added_versioning_to_objects.md
+++ b/.changeset/added_versioning_to_objects.md
@@ -1,0 +1,7 @@
+---
+default: major
+---
+
+# Added versioning to objects
+
+Added a version field to `SealedObject` and `PinObjectRequest`. This enables us to change the behavior of objects without breaking compatibility with existing data.

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -373,6 +373,7 @@ func TestApplicationAPI(t *testing.T) {
 	}
 
 	obj := slabs.SealedObject{
+		Version:              1,
 		EncryptedDataKey:     frand.Bytes(72),
 		EncryptedMetadataKey: frand.Bytes(72),
 		Slabs: []slabs.SlabSlice{
@@ -389,6 +390,24 @@ func TestApplicationAPI(t *testing.T) {
 
 	// sign and save the object
 	obj.Sign(sk)
+
+	// objects with a version above the maximum are rejected
+	for _, v := range []uint32{2, 3} {
+		badVersion := obj
+		badVersion.Version = v
+		if err := client.PinObject(context.Background(), sk, badVersion); err == nil || !strings.Contains(err.Error(), slabs.ErrObjectUnsupportedVersion.Error()) {
+			t.Fatalf("version %d: expected %v, got %v", v, slabs.ErrObjectUnsupportedVersion, err)
+		}
+	}
+
+	// version 0 is accepted for backwards compatibility
+	v0 := obj
+	v0.Version = 0
+	v0.Sign(sk) // version is part of the signature, so re-sign at version 0
+	if err := client.PinObject(context.Background(), sk, v0); err != nil {
+		t.Fatalf("expected version 0 to be accepted, got %v", err)
+	}
+
 	if err := client.PinObject(context.Background(), sk, obj); err != nil {
 		t.Fatal(err)
 	}
@@ -451,6 +470,7 @@ func TestApplicationAPI(t *testing.T) {
 
 	// Try to save an object referencing that slab on first account
 	badObj := slabs.SealedObject{
+		Version:              1,
 		EncryptedDataKey:     frand.Bytes(72),
 		EncryptedMetadataKey: frand.Bytes(72),
 		Slabs:                []slabs.SlabSlice{p2.Slice(0, 256)},
@@ -791,6 +811,7 @@ func TestSharedObjects(t *testing.T) {
 
 	// add the object to the db
 	obj := slabs.SealedObject{
+		Version:              1,
 		EncryptedDataKey:     frand.Bytes(72),
 		EncryptedMetadataKey: frand.Bytes(72),
 		Slabs: []slabs.SlabSlice{

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -195,6 +195,10 @@ components:
           allOf:
             - $ref: "#/components/schemas/Hash256"
             - description: The object's unique ID
+        version:
+          type: integer
+          format: uint32
+          description: The object format version. 0 represents an object pinned before versioning was introduced; the highest currently supported version is 1.
         encryptedDataKey:
           type: string
           format: byte
@@ -289,6 +293,10 @@ components:
           allOf:
             - $ref: "#/components/schemas/Hash256"
             - description: The object's ID, computed as a hash of its slabs. The server validates this matches the computed value.
+        version:
+          type: integer
+          format: uint32
+          description: The object format version. Defaults to 0 when omitted, which represents an object pinned before versioning was introduced. The highest currently supported version is 1; higher values are rejected.
         encryptedDataKey:
           type: string
           format: byte
@@ -301,7 +309,7 @@ components:
         dataSignature:
           allOf:
             - $ref: "#/components/schemas/Signature"
-            - description: A signature of blake2b(object ID, encrypted_data_key) attesting that the object data has not been tampered with
+            - description: A signature of blake2b(object ID, encrypted_data_key) attesting that the object data has not been tampered with. When version is non-zero it is also covered by the signature.
         encryptedMetadataKey:
           type: string
           format: byte
@@ -313,7 +321,7 @@ components:
         metadataSignature:
           allOf:
             - $ref: "#/components/schemas/Signature"
-            - description: A signature of blake2b(object ID, metadata key, encrypted_metadata) attesting that the metadata has not been tampered with
+            - description: A signature of blake2b(object ID, metadata key, encrypted_metadata) attesting that the metadata has not been tampered with. When version is non-zero it is also covered by the signature.
 
     ObjectEvent:
       type: object

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -317,6 +317,7 @@ CREATE INDEX slabs_id_next_repair_attempt_idx ON slabs(next_repair_attempt ASC);
 CREATE TABLE objects (
     id BIGSERIAL PRIMARY KEY,
     object_key BYTEA NOT NULL CHECK(LENGTH(object_key) = 32),
+    version INTEGER NOT NULL DEFAULT 0, -- object format version (0 = pinned before versioning)
     encrypted_data_key BYTEA UNIQUE NOT NULL CHECK(LENGTH(encrypted_data_key) = 72), -- user provided, data encryption key (xchacha20 nonce + key + tag)
     encrypted_meta_key BYTEA UNIQUE CHECK(LENGTH(encrypted_meta_key) = 72), -- user provided, metadata encryption key (xchacha20 nonce + key + tag)
     account_id INTEGER REFERENCES accounts(id) NOT NULL, -- account that owns object

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -86,4 +86,9 @@ UPDATE hosts SET has_quic = EXISTS (
 		_, err := tx.Exec(ctx, `ALTER TABLE hosts DROP COLUMN has_bad_quic_port`)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		// existing objects predate versioning, so default them to 0
+		_, err := tx.Exec(ctx, `ALTER TABLE objects ADD COLUMN version INTEGER NOT NULL DEFAULT 0`)
+		return err
+	},
 }

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -94,8 +94,8 @@ func (s *Store) Object(account proto.Account, key types.Hash256) (obj slabs.Seal
 
 		var objID int64
 		var metaKey sql.Null[[]byte]
-		err = tx.QueryRow(ctx, `SELECT id, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, created_at, updated_at FROM objects WHERE account_id = $1 AND object_key = $2
-		`, accountID, sqlHash256(key)).Scan(&objID, &obj.EncryptedDataKey, &metaKey, &obj.EncryptedMetadata, (*sqlSignature)(&obj.DataSignature), (*sqlSignature)(&obj.MetadataSignature), &obj.CreatedAt, &obj.UpdatedAt)
+		err = tx.QueryRow(ctx, `SELECT id, version, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, created_at, updated_at FROM objects WHERE account_id = $1 AND object_key = $2
+		`, accountID, sqlHash256(key)).Scan(&objID, &obj.Version, &obj.EncryptedDataKey, &metaKey, &obj.EncryptedMetadata, (*sqlSignature)(&obj.DataSignature), (*sqlSignature)(&obj.MetadataSignature), &obj.CreatedAt, &obj.UpdatedAt)
 		if errors.Is(err, sql.ErrNoRows) {
 			return slabs.ErrObjectNotFound
 		} else if err != nil {
@@ -183,12 +183,12 @@ func (s *Store) ListObjects(account proto.Account, cursor slabs.Cursor, limit in
 			var obj slabs.SealedObject
 			var objID int64
 			var metaKey sql.Null[[]byte]
-			err := tx.QueryRow(ctx, `SELECT id, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, created_at, updated_at
+			err := tx.QueryRow(ctx, `SELECT id, version, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, created_at, updated_at
 				FROM objects
 				WHERE account_id = $1 AND object_key = $2`,
 				accountID,
 				sqlHash256(events[i].Key),
-			).Scan(&objID, &obj.EncryptedDataKey, &metaKey, &obj.EncryptedMetadata, (*sqlSignature)(&obj.DataSignature), (*sqlSignature)(&obj.MetadataSignature), &obj.CreatedAt, &obj.UpdatedAt)
+			).Scan(&objID, &obj.Version, &obj.EncryptedDataKey, &metaKey, &obj.EncryptedMetadata, (*sqlSignature)(&obj.DataSignature), (*sqlSignature)(&obj.MetadataSignature), &obj.CreatedAt, &obj.UpdatedAt)
 			if err != nil {
 				return fmt.Errorf("failed to query objects: %w", err)
 			}
@@ -332,10 +332,10 @@ func (s *Store) PinObject(account proto.Account, obj slabs.PinObjectRequest) err
 
 		var objectID int64
 		err = tx.QueryRow(ctx, `
-			INSERT INTO objects (object_key, account_id, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature) VALUES ($1, $2, $3, $4, $5, $6, $7)
-			ON CONFLICT (account_id, object_key) DO UPDATE SET (encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, updated_at) = (EXCLUDED.encrypted_data_key, EXCLUDED.encrypted_meta_key, EXCLUDED.encrypted_metadata, EXCLUDED.data_signature, EXCLUDED.meta_signature, NOW())
+			INSERT INTO objects (object_key, account_id, version, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			ON CONFLICT (account_id, object_key) DO UPDATE SET (version, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, updated_at) = (EXCLUDED.version, EXCLUDED.encrypted_data_key, EXCLUDED.encrypted_meta_key, EXCLUDED.encrypted_metadata, EXCLUDED.data_signature, EXCLUDED.meta_signature, NOW())
 			RETURNING id`,
-			sqlHash256(obj.ID), accountID, obj.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(obj.DataSignature), sqlSignature(obj.MetadataSignature)).Scan(&objectID)
+			sqlHash256(obj.ID), accountID, obj.Version, obj.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(obj.DataSignature), sqlSignature(obj.MetadataSignature)).Scan(&objectID)
 		if err != nil {
 			return fmt.Errorf("failed to insert object: %w", err)
 		}

--- a/slabs/encoding.go
+++ b/slabs/encoding.go
@@ -64,6 +64,7 @@ func (s *SlabSlice) DecodeFrom(d *types.Decoder) {
 
 // EncodeTo implements types.EncoderTo.
 func (so SealedObject) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(uint64(so.Version))
 	e.WriteBytes(so.EncryptedDataKey)
 	types.EncodeSlice(e, so.Slabs)
 	so.DataSignature.EncodeTo(e)
@@ -76,6 +77,7 @@ func (so SealedObject) EncodeTo(e *types.Encoder) {
 
 // DecodeFrom implements types.DecoderFrom.
 func (so *SealedObject) DecodeFrom(d *types.Decoder) {
+	so.Version = uint32(d.ReadUint64())
 	so.EncryptedDataKey = d.ReadBytes()
 	types.DecodeSlice(d, &so.Slabs)
 	so.DataSignature.DecodeFrom(d)

--- a/slabs/encoding_test.go
+++ b/slabs/encoding_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"reflect"
 	"testing"
+	"time"
 
 	"go.sia.tech/core/types"
 	"lukechampine.com/frand"
@@ -37,5 +38,47 @@ func TestEncodeSlabSlice(t *testing.T) {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(s, s2) {
 		t.Fatalf("decoded slab slice does not match original: got %+v, want %+v", s2, s)
+	}
+}
+
+func TestEncodeSealedObject(t *testing.T) {
+	so := SealedObject{
+		Version:          1,
+		EncryptedDataKey: frand.Bytes(72),
+		Slabs: []SlabSlice{{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors: []PinnedSector{{
+				Root:    frand.Entropy256(),
+				HostKey: frand.Entropy256(),
+			}},
+			Offset: 200,
+			Length: 300,
+		}},
+		DataSignature:        types.Signature(frand.Bytes(64)),
+		EncryptedMetadataKey: frand.Bytes(72),
+		EncryptedMetadata:    frand.Bytes(50),
+		MetadataSignature:    types.Signature(frand.Bytes(64)),
+		CreatedAt:            time.Unix(1700000000, 0).UTC(),
+		UpdatedAt:            time.Unix(1700000123, 0).UTC(),
+	}
+
+	b, err := so.MarshalSia()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var so2 SealedObject
+	if err := so2.UnmarshalSia(b); err != nil {
+		t.Fatal(err)
+	} else if !so2.CreatedAt.Equal(so.CreatedAt) || !so2.UpdatedAt.Equal(so.UpdatedAt) {
+		t.Fatalf("decoded timestamps do not match: got %v/%v, want %v/%v", so2.CreatedAt, so2.UpdatedAt, so.CreatedAt, so.UpdatedAt)
+	}
+
+	// ReadTime returns the instant in local time; compare the rest of the
+	// fields after normalizing the (already-checked) timestamps.
+	so2.CreatedAt, so2.UpdatedAt = so.CreatedAt, so.UpdatedAt
+	if !reflect.DeepEqual(so, so2) {
+		t.Fatalf("decoded object does not match original: got %+v, want %+v", so2, so)
 	}
 }

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -19,6 +19,7 @@ type (
 	// It can be safely serialized and shared, but cannot be used to access
 	// the underlying data until it has been unlocked with the app key.
 	SealedObject struct {
+		Version          uint32      `json:"version"`
 		EncryptedDataKey []byte      `json:"encryptedDataKey"`
 		Slabs            []SlabSlice `json:"slabs"`
 		// DataSignature is a signature of the blake2b(object ID, encrypted_data_key)
@@ -89,6 +90,7 @@ type (
 	// A PinObjectRequest is the minimal fields for pinning an object to the indexer. It should be created using [SealedObject.PinRequest].
 	PinObjectRequest struct {
 		ID               types.Hash256 `json:"id"`
+		Version          uint32        `json:"version"`
 		EncryptedDataKey []byte        `json:"encryptedDataKey"`
 		Slabs            []ObjectSlab  `json:"slabs"`
 		// DataSignature is a signature of the blake2b(object ID, encrypted_data_key)
@@ -107,10 +109,15 @@ type (
 )
 
 // DataSigHash returns the hash used for signing/verifying the data signature.
-// It covers the slabs through the object ID and the encrypted data key.
+// It covers the slabs through the object ID and the encrypted data key. The
+// version is only included when non-zero so that signatures produced before
+// versioning (version 0) remain valid.
 func (pr *PinObjectRequest) DataSigHash() types.Hash256 {
 	h := types.NewHasher()
 	pr.ID.EncodeTo(h.E)
+	if pr.Version > 0 {
+		h.E.WriteUint64(uint64(pr.Version))
+	}
 	h.E.Write(pr.EncryptedDataKey)
 	return h.Sum()
 }
@@ -121,6 +128,9 @@ func (pr *PinObjectRequest) DataSigHash() types.Hash256 {
 func (pr *PinObjectRequest) MetaSigHash() types.Hash256 {
 	h := types.NewHasher()
 	pr.ID.EncodeTo(h.E)
+	if pr.Version > 0 {
+		h.E.WriteUint64(uint64(pr.Version))
+	}
 	h.E.Write(pr.EncryptedMetadataKey)
 	h.E.Write(pr.EncryptedMetadata)
 	return h.Sum()
@@ -163,6 +173,11 @@ func (o *SharedObject) Size() uint64 {
 // store.
 const metadataLimit = 1024
 
+// maxSupportedObjectVersion is the highest object format version the indexer
+// will accept. Version 0 represents an object pinned before versioning was
+// introduced and is accepted for backwards compatibility.
+const maxSupportedObjectVersion = 1
+
 var (
 	// ErrInvalidObjectSignature is returned when an object's signature is invalid.
 	ErrInvalidObjectSignature = errors.New("invalid object signature")
@@ -175,6 +190,9 @@ var (
 	// ErrObjectUnpinnedSlab is returned when an user attempts to save an
 	// object containing a slab that is not pinned to their account.
 	ErrObjectUnpinnedSlab = errors.New("object contains unpinned slab")
+	// ErrObjectUnsupportedVersion is returned when an object's version is
+	// greater than the highest supported version.
+	ErrObjectUnsupportedVersion = fmt.Errorf("object version must be at most %d", maxSupportedObjectVersion)
 )
 
 // ID returns the object's ID, which is a hash of its slabs.
@@ -194,6 +212,7 @@ func (so *SealedObject) PinRequest() PinObjectRequest {
 	}
 	return PinObjectRequest{
 		ID:                   so.ID(),
+		Version:              so.Version,
 		EncryptedDataKey:     so.EncryptedDataKey,
 		Slabs:                os,
 		DataSignature:        so.DataSignature,
@@ -233,10 +252,15 @@ func pinnedObjectID(slabs []ObjectSlab) types.Hash256 {
 }
 
 // DataSigHash returns the hash used for signing/verifying the data signature.
-// It covers the slabs through the object ID and the encrypted data key.
+// It covers the slabs through the object ID and the encrypted data key. The
+// version is only included when non-zero so that signatures produced before
+// versioning (version 0) remain valid.
 func (so *SealedObject) DataSigHash() types.Hash256 {
 	h := types.NewHasher()
 	so.ID().EncodeTo(h.E)
+	if so.Version > 0 {
+		h.E.WriteUint64(uint64(so.Version))
+	}
 	h.E.Write(so.EncryptedDataKey)
 	return h.Sum()
 }
@@ -247,6 +271,9 @@ func (so *SealedObject) DataSigHash() types.Hash256 {
 func (so *SealedObject) MetaSigHash() types.Hash256 {
 	h := types.NewHasher()
 	so.ID().EncodeTo(h.E)
+	if so.Version > 0 {
+		h.E.WriteUint64(uint64(so.Version))
+	}
 	h.E.Write(so.EncryptedMetadataKey)
 	h.E.Write(so.EncryptedMetadata)
 	return h.Sum()
@@ -291,6 +318,8 @@ func (m *SlabManager) DeleteObject(ctx context.Context, account proto.Account, o
 func (m *SlabManager) PinObject(ctx context.Context, account proto.Account, obj PinObjectRequest) error {
 	if len(obj.Slabs) == 0 {
 		return ErrObjectMinimumSlabs
+	} else if obj.Version > maxSupportedObjectVersion {
+		return ErrObjectUnsupportedVersion
 	} else if len(obj.EncryptedMetadata) > metadataLimit {
 		return fmt.Errorf("%w: got %d bytes", ErrObjectMetadataLimitExceeded, len(obj.EncryptedMetadata))
 	} else if pinnedObjectID(obj.Slabs) != obj.ID {

--- a/slabs/objects_test.go
+++ b/slabs/objects_test.go
@@ -53,3 +53,39 @@ func TestObjectEquivalency(t *testing.T) {
 		t.Fatalf("unexpected error verifying signatures: %v", err)
 	}
 }
+
+func TestObjectVersionSignature(t *testing.T) {
+	sk := types.GeneratePrivateKey()
+	obj := SealedObject{
+		Version:          1,
+		EncryptedDataKey: frand.Bytes(72),
+		Slabs: []SlabSlice{{
+			EncryptionKey: frand.Entropy256(),
+			MinShards:     1,
+			Sectors:       []PinnedSector{{Root: frand.Entropy256(), HostKey: frand.Entropy256()}},
+		}},
+		EncryptedMetadataKey: frand.Bytes(72),
+		EncryptedMetadata:    frand.Bytes(50),
+	}
+
+	v0 := obj
+	v0.Version = 0
+	if obj.DataSigHash() == v0.DataSigHash() {
+		t.Fatal("version should be included in the data signature hash")
+	} else if obj.MetaSigHash() == v0.MetaSigHash() {
+		t.Fatal("version should be included in the metadata signature hash")
+	}
+
+	// tampering with the version after signing invalidates both signatures
+	obj.Sign(sk)
+	if err := obj.VerifySignatures(sk.PublicKey()); err != nil {
+		t.Fatalf("expected valid signatures, got %v", err)
+	}
+	tampered := obj
+	tampered.Version = 0
+	if err := tampered.VerifyDataSignature(sk.PublicKey()); err == nil {
+		t.Fatal("expected data signature verification to fail after tampering with version")
+	} else if err := tampered.VerifyMetadataSignature(sk.PublicKey()); err == nil {
+		t.Fatal("expected metadata signature verification to fail after tampering with version")
+	}
+}


### PR DESCRIPTION
Added a version field to `SealedObject` and `PinObjectRequest`. This enables us to change the behavior of objects without breaking compatibility with existing data. Everything but the Sia wire format should remain backwards compatible with existing pinned objects (I believe all existing usages are JSON so that's fine).

The reasoning will be clear in a follow-up in the Rust client SDK.