### PR TITLE
Add cutoff to PruneSlabs

### DIFF
--- a/.changeset/add_cutoff_argument_to_pruneslabs_to_only_prune_slabs_that_have_been_pinned_for_some_amount_of_time.md
+++ b/.changeset/add_cutoff_argument_to_pruneslabs_to_only_prune_slabs_that_have_been_pinned_for_some_amount_of_time.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add cutoff argument to PruneSlabs to only prune slabs that have been pinned for some amount of time.

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -132,7 +132,7 @@ type (
 	SlabManager interface {
 		DeleteObject(ctx context.Context, account proto.Account, objectKey types.Hash256) error
 		ObjectsForSlab(slabID slabs.SlabID) ([]slabs.SlabObject, error)
-		PruneSlabs(ctx context.Context, account proto.Account) error
+		PruneSlabs(ctx context.Context, account proto.Account, cutoff time.Time) error
 		SectorStats() (slabs.SectorsStats, error)
 	}
 
@@ -367,6 +367,13 @@ func (a *admin) handleDELETESlab(jc jape.Context) {
 }
 
 func (a *admin) handlePOSTPruneAccounts(jc jape.Context) {
+	cutoff := time.Now().Add(-time.Hour)
+	if jc.Request.FormValue("before") != "" {
+		if jc.DecodeForm("before", &cutoff) != nil {
+			return
+		}
+	}
+
 	const batchSize = 100
 	for offset := 0; ; offset += batchSize {
 		accs, err := a.accounts.Accounts(jc.Request.Context(), offset, batchSize)
@@ -378,7 +385,7 @@ func (a *admin) handlePOSTPruneAccounts(jc jape.Context) {
 			if err := jc.Request.Context().Err(); err != nil {
 				return
 			}
-			if err := a.slabs.PruneSlabs(jc.Request.Context(), acc.AccountKey); err != nil {
+			if err := a.slabs.PruneSlabs(jc.Request.Context(), acc.AccountKey, cutoff); err != nil {
 				jc.Check("failed to prune slabs", err)
 				return
 			}
@@ -650,7 +657,13 @@ func (a *admin) handlePOSTAccountPrune(jc jape.Context) {
 	if jc.DecodeParam("accountkey", &ak) != nil {
 		return
 	}
-	if err := a.slabs.PruneSlabs(jc.Request.Context(), ak); errors.Is(err, accounts.ErrNotFound) {
+	cutoff := time.Now().Add(-time.Hour)
+	if jc.Request.FormValue("before") != "" {
+		if jc.DecodeForm("before", &cutoff) != nil {
+			return
+		}
+	}
+	if err := a.slabs.PruneSlabs(jc.Request.Context(), ak, cutoff); errors.Is(err, accounts.ErrNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if err != nil {

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -1517,8 +1517,8 @@ func TestPruneSlabs(t *testing.T) {
 		t.Fatalf("expected 2 slabs, got %d", len(slabIDs))
 	}
 
-	// prune slabs via admin API
-	if err := adminClient.PruneSlabs(context.Background(), account); err != nil {
+	// prune slabs via admin API (use a future cutoff to cover the just-pinned slabs)
+	if err := adminClient.PruneSlabs(context.Background(), account, api.WithBefore(time.Now().Add(time.Hour))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1530,6 +1530,56 @@ func TestPruneSlabs(t *testing.T) {
 		t.Fatalf("expected 1 slab after prune, got %d", len(slabIDs))
 	} else if slabIDs[0] != slab1.Digest() {
 		t.Fatal("expected slab1 to remain")
+	}
+
+	// now verify the cutoff: pin two more orphaned slabs, backdate one to look
+	// like it was pinned an hour ago, then prune with a cutoff of 30 min ago.
+	// Only the backdated slab should be pruned.
+	slabOld := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    frand.Entropy256(),
+			HostKey: hk,
+		}},
+	}
+	slabNew := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    frand.Entropy256(),
+			HostKey: hk,
+		}},
+	}
+	if _, err := store.PinSlabs(acc, time.Time{}, slabOld, slabNew); err != nil {
+		t.Fatal(err)
+	}
+
+	// backdate slabOld's pinned_at directly in the db (postgres NOW() isn't
+	// controlled by the Go test clock, so we can't actually sleep for an hour)
+	oldDigest := slabOld.Digest()
+	if _, err := store.Exec(t.Context(), `UPDATE slabs SET pinned_at = NOW() - INTERVAL '1 hour' WHERE digest = $1`, oldDigest[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	// prune with cutoff = 30 min ago: slabOld is eligible, slabNew is not
+	if err := adminClient.PruneSlabs(t.Context(), account, api.WithBefore(time.Now().Add(-30*time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+
+	slabIDs, err = store.SlabIDs(acc, 0, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(slabIDs) != 2 {
+		t.Fatalf("expected 2 slabs after cutoff prune, got %d", len(slabIDs))
+	}
+	remaining := map[slabs.SlabID]bool{slabIDs[0]: true, slabIDs[1]: true}
+	if !remaining[slab1.Digest()] {
+		t.Fatal("expected slab1 to remain")
+	} else if !remaining[slabNew.Digest()] {
+		t.Fatal("expected slabNew to remain (pinned after cutoff)")
+	} else if remaining[slabOld.Digest()] {
+		t.Fatal("expected slabOld to be pruned (pinned before cutoff)")
 	}
 }
 
@@ -1694,8 +1744,8 @@ func TestPruneAccounts(t *testing.T) {
 		t.Fatalf("expected 2 slabs for acc1, got %d", len(slabIDs))
 	}
 
-	// prune all accounts
-	if err := adminClient.PruneAccounts(t.Context()); err != nil {
+	// prune all accounts (use a future cutoff to cover the just-pinned slabs)
+	if err := adminClient.PruneAccounts(t.Context(), api.WithBefore(time.Now().Add(time.Hour))); err != nil {
 		t.Fatal(err)
 	}
 

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -148,9 +148,18 @@ func (c *Client) UpdateAccount(ctx context.Context, ak types.PublicKey, updates 
 }
 
 // PruneSlabs prunes all pinned slabs of the given account not currently
-// connected to an object.
-func (c *Client) PruneSlabs(ctx context.Context, ak types.PublicKey) error {
-	return c.c.POST(ctx, fmt.Sprintf("/account/%s/slabs/prune", ak), nil, nil)
+// connected to an object. Use api.WithBefore to override the default cutoff
+// (1 hour ago).
+func (c *Client) PruneSlabs(ctx context.Context, ak types.PublicKey, opts ...api.URLQueryParameterOption) error {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	path := fmt.Sprintf("/account/%s/slabs/prune", ak)
+	if q := values.Encode(); q != "" {
+		path += "?" + q
+	}
+	return c.c.POST(ctx, path, nil, nil)
 }
 
 // Accounts returns all accounts registered in the indexer.
@@ -370,9 +379,17 @@ func (c *Client) DeleteSlab(ctx context.Context, slabID slabs.SlabID) error {
 }
 
 // PruneAccounts prunes orphaned slabs for all accounts. Only available in
-// debug mode.
-func (c *Client) PruneAccounts(ctx context.Context) error {
-	return c.c.POST(ctx, "/debug/slabs/prune", nil, nil)
+// debug mode. Use api.WithBefore to override the default cutoff (1 hour ago).
+func (c *Client) PruneAccounts(ctx context.Context, opts ...api.URLQueryParameterOption) error {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	path := "/debug/slabs/prune"
+	if q := values.Encode(); q != "" {
+		path += "?" + q
+	}
+	return c.c.POST(ctx, path, nil, nil)
 }
 
 // StatsAccounts returns statistics about the accounts registered on the

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -36,7 +36,7 @@ type (
 	// Slabs defines the slab interface for the application API.
 	Slabs interface {
 		PinSlabs(ctx context.Context, account proto.Account, nextIntegrityCheck time.Time, toPin ...slabs.SlabPinParams) ([]slabs.SlabID, error)
-		PruneSlabs(ctx context.Context, account proto.Account) error
+		PruneSlabs(ctx context.Context, account proto.Account, cutoff time.Time) error
 		PinnedSlab(ctx context.Context, account proto.Account, slabID slabs.SlabID) (slabs.PinnedSlab, error)
 		SlabIDs(ctx context.Context, account proto.Account, offset, limit int) ([]slabs.SlabID, error)
 		UnpinSlab(ctx context.Context, account proto.Account, slabID slabs.SlabID) error
@@ -380,7 +380,13 @@ func (a *app) handlePOSTSlabs(jc jape.Context, pk types.PublicKey) {
 }
 
 func (a *app) handlePOSTSlabsPrune(jc jape.Context, pk types.PublicKey) {
-	err := a.slabs.PruneSlabs(jc.Request.Context(), proto.Account(pk))
+	cutoff := time.Now().Add(-time.Hour)
+	if jc.Request.FormValue("before") != "" {
+		if jc.DecodeForm("before", &cutoff) != nil {
+			return
+		}
+	}
+	err := a.slabs.PruneSlabs(jc.Request.Context(), proto.Account(pk), cutoff)
 	if jc.Check("failed to prune slabs", err) != nil {
 		return
 	}

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -166,9 +166,17 @@ func (c *Client) Slab(ctx context.Context, appKey types.PrivateKey, slabID slabs
 }
 
 // PruneSlabs prunes all pinned slabs of a user not currently connected to an
-// object.
-func (c *Client) PruneSlabs(ctx context.Context, appKey types.PrivateKey) error {
-	return c.signedRequestJSON(ctx, appKey, http.MethodPost, "/slabs/prune", nil, nil)
+// object. Use api.WithBefore to override the default cutoff (1 hour ago).
+func (c *Client) PruneSlabs(ctx context.Context, appKey types.PrivateKey, opts ...api.URLQueryParameterOption) error {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	path := "/slabs/prune"
+	if q := values.Encode(); q != "" {
+		path += "?" + q
+	}
+	return c.signedRequestJSON(ctx, appKey, http.MethodPost, path, nil, nil)
 }
 
 // SlabIDs fetches the digests of slabs associated with the account. It supports

--- a/api/options.go
+++ b/api/options.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/jape"
@@ -68,6 +69,13 @@ func WithProtocol(protocol chain.Protocol) URLQueryParameterOption {
 func WithCountry(countryCode string) URLQueryParameterOption {
 	return func(q url.Values) {
 		q.Set("country", countryCode)
+	}
+}
+
+// WithBefore sets the 'before' parameter.
+func WithBefore(t time.Time) URLQueryParameterOption {
+	return func(q url.Values) {
+		q.Set("before", t.Format(time.RFC3339Nano))
 	}
 }
 

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -550,6 +550,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: before
+          in: query
+          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to one hour ago.
+          schema:
+            type: string
+            format: date-time
       responses:
         "204":
           description: Slabs pruned successfully
@@ -908,6 +914,13 @@ paths:
         longer referenced by any object. This route is only available in
         debug mode.
       operationId: postDebugSlabsPrune
+      parameters:
+        - name: before
+          in: query
+          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to one hour ago.
+          schema:
+            type: string
+            format: date-time
       responses:
         "200":
           description: All accounts pruned successfully.

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -433,6 +433,13 @@ paths:
         - slabs
       summary: Unpin all slabs not used by an object currently pinned by the user
       operationId: pruneSlabs
+      parameters:
+        - name: before
+          in: query
+          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to one hour ago.
+          schema:
+            type: string
+            format: date-time
       responses:
         "200":
           description: Slabs pruned successfully

--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -147,8 +147,8 @@ ORDER BY ss.slab_index ASC`, dbID)
 }
 
 // PruneSlabs prunes all pinned slabs of a user not currently connected to an
-// object.
-func (s *Store) PruneSlabs(account proto.Account) error {
+// object. Only slabs pinned before cutoff are eligible for pruning.
+func (s *Store) PruneSlabs(account proto.Account, cutoff time.Time) error {
 	var id int64
 	err := s.transaction(func(ctx context.Context, tx *txn) error {
 		var err error
@@ -167,6 +167,7 @@ func (s *Store) PruneSlabs(account proto.Account) error {
 FROM slabs s
 JOIN account_slabs a ON s.id = a.slab_id
 WHERE a.account_id = $1
+	AND s.pinned_at < $2
 	AND NOT EXISTS (
 		SELECT 1
 		FROM objects o
@@ -174,8 +175,8 @@ WHERE a.account_id = $1
 		WHERE o.account_id = a.account_id
 		AND os.slab_digest = s.digest
 	)
-LIMIT $2
-`, id, limit)
+LIMIT $3
+`, id, cutoff, limit)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get unused slabs: %w", err)
 		}

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -366,7 +366,7 @@ func TestSlabPruning(t *testing.T) {
 	assertSlabs(acc2, slab1ID)
 
 	// prune slabs for acc1
-	if err := store.PruneSlabs(acc1); err != nil {
+	if err := store.PruneSlabs(acc1, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -382,7 +382,7 @@ func TestSlabPruning(t *testing.T) {
 	assertSlabs(acc2, slab1ID)
 
 	// prune slabs for acc2
-	if err := store.PruneSlabs(acc2); err != nil {
+	if err := store.PruneSlabs(acc2, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -458,7 +458,7 @@ func BenchmarkPruneSlabs(b *testing.B) {
 	for b.Loop() {
 		b.ReportMetric(float64(objectsPerAccount)*float64(slabsPerObject)/2.0, "slabs/op")
 
-		if err := store.PruneSlabs(accs[frand.Intn(len(accs))]); err != nil {
+		if err := store.PruneSlabs(accs[frand.Intn(len(accs))], time.Now()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -111,7 +111,7 @@ type (
 		Slabs(account proto.Account, slabIDs []SlabID) ([]Slab, error)
 		SlabIDs(account proto.Account, offset, limit int) ([]SlabID, error)
 		UnhealthySlabs(limit int) ([]SlabID, error)
-		PruneSlabs(account proto.Account) error
+		PruneSlabs(account proto.Account, cutoff time.Time) error
 
 		// Object methods
 		Object(account proto.Account, key types.Hash256) (SealedObject, error)

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -208,9 +208,9 @@ func (m *SlabManager) SlabIDs(ctx context.Context, account proto.Account, offset
 }
 
 // PruneSlabs prunes all pinned slabs of a user not currently connected to an
-// object.
-func (m *SlabManager) PruneSlabs(ctx context.Context, account proto.Account) error {
-	return m.store.PruneSlabs(account)
+// object. Only slabs pinned before cutoff are eligible for pruning.
+func (m *SlabManager) PruneSlabs(ctx context.Context, account proto.Account, cutoff time.Time) error {
+	return m.store.PruneSlabs(account, cutoff)
 }
 
 // ValidateECParams checks the erasure coding parameters are


### PR DESCRIPTION
The SDK doesn't atomically pin slabs and objects. So during uploads pruning the account of the app might lead to slabs being pruned that the app still wants to pin to an object.

To fix this the endpoints for pruning now take a timestamp as a cutoff. Only slabs that were pinned before that cutoff are eligible for pruning. The default of 1 hour should usually be sufficient but clients can pick custom values as well.