### PR TITLE
sectors: drop unused sectors_next_integrity_check_idx

### DIFF
--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -415,7 +415,6 @@ CREATE INDEX sectors_host_id_idx ON sectors(host_id);
 -- CREATE INDEX sectors_contract_sectors_map_id_idx ON sectors(contract_sectors_map_id); -- covered by sectors_contract_sectors_map_id_uploaded_at_idx
 
 -- speed up integrity check query
-CREATE INDEX sectors_next_integrity_check_idx ON sectors(next_integrity_check ASC);
 CREATE INDEX sectors_host_id_next_integrity_check_idx ON sectors(host_id, next_integrity_check ASC);
 
 -- speed up hosts for pinning query

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -86,4 +86,8 @@ UPDATE hosts SET has_quic = EXISTS (
 		_, err := tx.Exec(ctx, `ALTER TABLE hosts DROP COLUMN has_bad_quic_port`)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		_, err := tx.Exec(ctx, `DROP INDEX IF EXISTS sectors_next_integrity_check_idx`)
+		return err
+	},
 }

--- a/persist/postgres/migrations_test.go
+++ b/persist/postgres/migrations_test.go
@@ -420,7 +420,6 @@ CREATE INDEX sectors_host_id_idx ON sectors(host_id);
 -- CREATE INDEX sectors_contract_sectors_map_id_idx ON sectors(contract_sectors_map_id); -- covered by sectors_contract_sectors_map_id_uploaded_at_idx
 
 -- speed up integrity check query
-CREATE INDEX sectors_next_integrity_check_idx ON sectors(next_integrity_check ASC);
 CREATE INDEX sectors_host_id_next_integrity_check_idx ON sectors(host_id, next_integrity_check ASC);
 
 -- speed up hosts for pinning query


### PR DESCRIPTION
This PR drops an unused index, resulting in cost/time savings on update. 

Before:

    BenchmarkRecordIntegrityChecks/10-10      958    2428416 ns/op    17271.77 MB/s    3174 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      472    2721426 ns/op    15412.15 MB/s    3164 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      637    2732654 ns/op    15348.83 MB/s    3169 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      428    2517422 ns/op    16661.11 MB/s    3173 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      568    2554906 ns/op    16416.66 MB/s    3170 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     348    3907217 ns/op   107347.60 MB/s   30613 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     286    5654401 ns/op    74177.69 MB/s   30615 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     279    3993099 ns/op   105038.83 MB/s   30610 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     283    4014193 ns/op   104486.85 MB/s   30622 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     273    4174431 ns/op   100476.07 MB/s   30611 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     44   26696588 ns/op   157110.11 MB/s  318047 B/op   3047 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     52   27391028 ns/op   153126.93 MB/s  318064 B/op   3048 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     54   28292091 ns/op   148250.05 MB/s  318103 B/op   3047 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     43   28611933 ns/op   146592.82 MB/s  318056 B/op   3047 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     49   28282882 ns/op   148298.33 MB/s  318105 B/op   3047 allocs/op

After:

    BenchmarkRecordIntegrityChecks/10-10      849    2351503 ns/op    17836.70 MB/s    3176 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      409    2937316 ns/op    14279.38 MB/s    3167 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      475    2656627 ns/op    15788.08 MB/s    3175 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      391    2929837 ns/op    14315.83 MB/s    3168 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/10-10      426    2623626 ns/op    15986.67 MB/s    3169 B/op     61 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     380    3144755 ns/op   133374.60 MB/s   30613 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     392    3207357 ns/op   130771.33 MB/s   30610 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     364    3302220 ns/op   127014.68 MB/s   30611 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     342    3424639 ns/op   122474.32 MB/s   30609 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/100-10     313    3770626 ns/op   111236.27 MB/s   30599 B/op    338 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     49   23796725 ns/op   176255.51 MB/s  318113 B/op   3048 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     45   24215962 ns/op   173204.10 MB/s  318059 B/op   3047 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     54   23043191 ns/op   182019.24 MB/s  318065 B/op   3048 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     49   24126547 ns/op   173846.01 MB/s  318126 B/op   3048 allocs/op
    BenchmarkRecordIntegrityChecks/1000-10     50   24315337 ns/op   172496.23 MB/s  318072 B/op   3048 allocs/op


The effects are only visible at 100 and 1000 batch size,the throughput climbs from 150 GB/s to roughly 175 GB/s. I checked the query plan before and after and it remained unchanged (`Index Scan using sectors_host_id_sector_root_idx on public.sectors`)

References #879 