### PR TITLE
slabs: update object_events once per migrated slab

### DIFF
--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -357,6 +357,9 @@ CREATE TABLE object_events (
 -- fast sorting by update time and key
 CREATE INDEX object_events_updated_at_object_key_idx ON object_events(updated_at ASC, object_key ASC);
 
+-- probe by object_key alone since the PK leads with account_id
+CREATE INDEX object_events_object_key_idx ON object_events(object_key);
+
 CREATE TABLE account_slabs (
     account_id INTEGER REFERENCES accounts(id) NOT NULL, -- account that owns slab
     slab_id BIGSERIAL REFERENCES slabs(id) NOT NULL,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -86,4 +86,8 @@ UPDATE hosts SET has_quic = EXISTS (
 		_, err := tx.Exec(ctx, `ALTER TABLE hosts DROP COLUMN has_bad_quic_port`)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		_, err := tx.Exec(ctx, `CREATE INDEX object_events_object_key_idx ON object_events(object_key);`)
+		return err
+	},
 }

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -934,8 +934,8 @@ func (s *Store) RecordSlabMigrated(slabID slabs.SlabID) error {
 		_, err := tx.Exec(ctx, `
 			UPDATE object_events
 			SET updated_at = date_trunc('second', NOW())
-			WHERE (account_id, object_key) IN (
-				SELECT DISTINCT o.account_id, o.object_key
+			WHERE object_key IN (
+				SELECT DISTINCT o.object_key
 				FROM object_slabs os
 				INNER JOIN objects o ON os.object_id = o.id
 				WHERE os.slab_digest = $1

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -926,22 +926,45 @@ func (s *Store) UnhealthySlabs(limit int) (unhealthy []slabs.SlabID, err error) 
 	return
 }
 
+// RecordSlabMigrated updates the database to reflect that a slab was migrated.
+// This should be called after a slab was migrated and one or more of its
+// sectors were updated.
+func (s *Store) RecordSlabMigrated(slabID slabs.SlabID) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE object_events
+			SET updated_at = date_trunc('second', NOW())
+			WHERE (account_id, object_key) IN (
+				SELECT DISTINCT o.account_id, o.object_key
+				FROM object_slabs os
+				INNER JOIN objects o ON os.object_id = o.id
+				WHERE os.slab_digest = $1
+			)
+		`, sqlHash256(slabID))
+		if err != nil {
+			return fmt.Errorf("failed to update affected object events: %w", err)
+		}
+		return nil
+	})
+}
+
 // MigrateSector updates a sector that was just migrated in the database to be
 // linked to the new host identified by 'hostKey'. This will reset the contract
 // ID since a freshly migrated sector isn't pinned yet. To pin a sector
 // 'PinSectors' is used. If the host is not found, e.g. due to being deleted in
-// the meantime, this operation is a no-op.
+// the meantime, this operation is a no-op. The caller is responsible for
+// invoking RecordSlabMigrated once per slab after the batch completes to bump
+// the corresponding object_events rows.
 func (s *Store) MigrateSector(root types.Hash256, hostKey types.PublicKey) (migrated bool, err error) {
 	err = s.transaction(func(ctx context.Context, tx *txn) error {
 		var oldHostID sql.NullInt64
 		var contractMapID sql.NullInt64
-		var sectorID int64
 		err := tx.QueryRow(ctx, `
-			SELECT id, host_id, contract_sectors_map_id
+			SELECT host_id, contract_sectors_map_id
 			FROM sectors
 			WHERE sector_root = $1
 			FOR UPDATE
-		`, sqlHash256(root)).Scan(&sectorID, &oldHostID, &contractMapID)
+		`, sqlHash256(root)).Scan(&oldHostID, &contractMapID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // not migrated
 		} else if err != nil {
@@ -960,23 +983,6 @@ func (s *Store) MigrateSector(root types.Hash256, hostKey types.PublicKey) (migr
 			return nil
 		} else if err != nil {
 			return err
-		}
-
-		// update affected objects
-		_, err = tx.Exec(ctx, `
-			UPDATE object_events
-			SET updated_at = date_trunc('second', NOW())
-			WHERE (account_id, object_key) IN (
-				SELECT DISTINCT o.account_id, o.object_key
-				FROM slab_sectors
-				INNER JOIN slabs ON slab_sectors.slab_id = slabs.id
-				INNER JOIN object_slabs ON object_slabs.slab_digest = slabs.digest
-				INNER JOIN objects o ON object_slabs.object_id = o.id
-				WHERE slab_sectors.sector_id = $1
-			)
-		`, sectorID)
-		if err != nil {
-			return fmt.Errorf("failed to update affected object events: %w", err)
 		}
 
 		migrated = true

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -256,23 +256,41 @@ func TestRecordSlabMigrated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	updatedAt := func() time.Time {
-		t.Helper()
-		var ts time.Time
-		if err := store.pool.QueryRow(t.Context(), `SELECT updated_at FROM object_events WHERE account_id = (SELECT id FROM accounts WHERE public_key = $1) AND object_key = $2`, sqlPublicKey(types.PublicKey(account)), sqlHash256(so.ID())).Scan(&ts); err != nil {
-			t.Fatal(err)
-		}
-		return ts
+	// assert object events count
+	var count int
+	err = store.pool.QueryRow(t.Context(), `SELECT COUNT(*) FROM object_events`).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("expected 1 object events, got %d", count)
 	}
 
-	// updated_at has second precision, so wait past the next second boundary
-	before := updatedAt()
-	time.Sleep(time.Second)
+	// set updated_at in the past
+	ts := time.Now().Add(-time.Hour).Round(time.Second)
+	if _, err := store.pool.Exec(t.Context(), `UPDATE object_events SET updated_at = $1`, ts); err != nil {
+		t.Fatal(err)
+	}
 
+	// record slab migration
 	if err := store.RecordSlabMigrated(slabIDs[0]); err != nil {
 		t.Fatal(err)
-	} else if after := updatedAt(); !after.After(before) {
-		t.Fatalf("expected updated_at to advance, before=%s after=%s", before, after)
+	}
+
+	// assert count has not changed
+	err = store.pool.QueryRow(t.Context(), `SELECT COUNT(*) FROM object_events`).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	} else if count != 1 {
+		t.Fatalf("expected 1 object events, got %d", count)
+	}
+
+	// assert updated_at has been updated
+	var updatedAt time.Time
+	err = store.pool.QueryRow(t.Context(), `SELECT updated_at FROM object_events LIMIT 1`).Scan(&updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	} else if !updatedAt.After(ts) {
+		t.Fatalf("expected updated_at to be updated, got %v", updatedAt)
 	}
 
 	// unknown slab is a no-op

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
@@ -3121,6 +3122,86 @@ func BenchmarkMigrateSector(b *testing.B) {
 		hostKey := hks[frand.Intn(len(hks))]
 		_, err := store.MigrateSector(root, hostKey)
 		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkRecordSlabMigrated benchmarks RecordSlabMigrated.
+func BenchmarkRecordSlabMigrated(b *testing.B) {
+	const (
+		numAccounts       = 1000
+		objectsPerAccount = 1000
+		flushEvery        = 50
+	)
+
+	store := initPostgres(b, zap.NewNop())
+
+	connectKey, err := store.AddAppConnectKey(accounts.AppConnectKeyRequest{
+		Key:         "benchmark-connect-key",
+		Description: "benchmark connect key",
+		Quota:       "default",
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	var connectKeyID int64
+	if err := store.pool.QueryRow(b.Context(), `SELECT id FROM app_connect_keys WHERE app_key = $1`, connectKey.Key).Scan(&connectKeyID); err != nil {
+		b.Fatal(err)
+	}
+
+	sampleSlabDigests := make([]slabs.SlabID, 0, numAccounts*objectsPerAccount)
+
+	flush := func(batch *pgx.Batch) {
+		b.Helper()
+		if err := store.pool.SendBatch(b.Context(), batch).Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	batch := &pgx.Batch{}
+	accountID, objectID, slabID := 0, 0, 0
+	for range numAccounts {
+		ak := types.GeneratePrivateKey().PublicKey()
+		batch.Queue(`INSERT INTO accounts(public_key, connect_key_id, max_pinned_data) VALUES ($1, $2, 1000000000000)`, sqlPublicKey(ak), connectKeyID)
+		accountID++
+
+		for range objectsPerAccount {
+			objectKey := frand.Entropy256()
+			slabDigest := slabs.SlabID(frand.Entropy256())
+
+			batch.Queue(`INSERT INTO objects(object_key, account_id, encrypted_data_key, encrypted_meta_key, data_signature, meta_signature) VALUES ($1, $2, $3, $4, $5, $6)`,
+				sqlHash256(objectKey), accountID, frand.Bytes(72), frand.Bytes(72), frand.Bytes(64), frand.Bytes(64))
+			objectID++
+
+			batch.Queue(`INSERT INTO object_events(object_key, account_id, was_deleted) VALUES ($1, $2, FALSE)`, sqlHash256(objectKey), accountID)
+
+			batch.Queue(`INSERT INTO slabs(digest, encryption_key, min_shards) VALUES ($1, $2, 1)`, sqlHash256(slabDigest), sqlHash256(frand.Entropy256()))
+			slabID++
+
+			batch.Queue(`INSERT INTO account_slabs(account_id, slab_id) VALUES ($1, $2)`, accountID, slabID)
+			batch.Queue(`INSERT INTO object_slabs(object_id, slab_digest, slab_index, slab_offset, slab_length) VALUES ($1, $2, 0, 0, 0)`, objectID, sqlHash256(slabDigest))
+
+			sampleSlabDigests = append(sampleSlabDigests, slabDigest)
+		}
+
+		if accountID%flushEvery == 0 {
+			flush(batch)
+			batch = &pgx.Batch{}
+		}
+	}
+	if batch.Len() > 0 {
+		flush(batch)
+	}
+
+	if _, err := store.pool.Exec(b.Context(), `VACUUM FULL ANALYZE;`); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		digest := sampleSlabDigests[frand.Intn(len(sampleSlabDigests))]
+		if err := store.RecordSlabMigrated(digest); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -38,7 +38,7 @@ func TestMigrateSector(t *testing.T) {
 	pinTime := time.Now().Round(time.Microsecond)
 	root1 := types.Hash256{1}
 	root2 := types.Hash256{2}
-	_, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
+	slabIDs, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
 		EncryptionKey: [32]byte{},
 		MinShards:     1,
 		Sectors: []slabs.PinnedSector{
@@ -55,6 +55,7 @@ func TestMigrateSector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	slabID := slabIDs[0]
 
 	// create an object using the pinned slab
 	so := slabs.SealedObject{
@@ -180,7 +181,13 @@ func TestMigrateSector(t *testing.T) {
 			t.Fatal(err)
 		} else if migrated != expectedMigrated {
 			t.Fatalf("expected migrated %v, got %v", expectedMigrated, migrated)
+		} else if migrated {
+			// record the slab being migrated, as we do in production
+			if err := store.RecordSlabMigrated(slabID); err != nil {
+				t.Fatal(err)
+			}
 		}
+
 		afterUploadedAt := sectorUploadedAt(root)
 
 		if expectedMigrated && afterUploadedAt.Compare(beforeUploadedAt) != 1 {

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -225,6 +225,62 @@ func TestMigrateSector(t *testing.T) {
 	assertUpdated(true)
 }
 
+func TestRecordSlabMigrated(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+	hk := store.addTestHost(t)
+	fcid := store.addTestContract(t, hk)
+
+	// pin a slab and an object that references it
+	root := frand.Entropy256()
+	encKey := frand.Entropy256()
+	slabIDs, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+		EncryptionKey: encKey,
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: root, HostKey: hk}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if err := store.PinSectors(fcid, []types.Hash256{root}); err != nil {
+		t.Fatal(err)
+	}
+
+	so := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: frand.Bytes(72),
+		Slabs:                []slabs.SlabSlice{{EncryptionKey: encKey, MinShards: 1, Sectors: []slabs.PinnedSector{{Root: root, HostKey: hk}}}},
+	}
+	if err := store.PinObject(account, so.PinRequest()); err != nil {
+		t.Fatal(err)
+	}
+
+	updatedAt := func() time.Time {
+		t.Helper()
+		var ts time.Time
+		if err := store.pool.QueryRow(t.Context(), `SELECT updated_at FROM object_events WHERE account_id = (SELECT id FROM accounts WHERE public_key = $1) AND object_key = $2`, sqlPublicKey(types.PublicKey(account)), sqlHash256(so.ID())).Scan(&ts); err != nil {
+			t.Fatal(err)
+		}
+		return ts
+	}
+
+	// updated_at has second precision, so wait past the next second boundary
+	before := updatedAt()
+	time.Sleep(time.Second)
+
+	if err := store.RecordSlabMigrated(slabIDs[0]); err != nil {
+		t.Fatal(err)
+	} else if after := updatedAt(); !after.After(before) {
+		t.Fatalf("expected updated_at to advance, before=%s after=%s", before, after)
+	}
+
+	// unknown slab is a no-op
+	if err := store.RecordSlabMigrated(slabs.SlabID(frand.Entropy256())); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRecordIntegrityCheck(t *testing.T) {
 	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
 

--- a/slabs/manager.go
+++ b/slabs/manager.go
@@ -102,6 +102,7 @@ type (
 		MarkSectorsLost(hostKey types.PublicKey, roots []types.Hash256) error
 		MarkSlabRepaired(slabID SlabID, success bool) error
 		MigrateSector(root types.Hash256, hostKey types.PublicKey) (bool, error)
+		RecordSlabMigrated(slabID SlabID) error
 		PinSlabs(account proto.Account, nextIntegrityCheck time.Time, toPin ...SlabPinParams) ([]SlabID, error)
 		UnpinSlab(proto.Account, SlabID) error
 		RecordIntegrityCheck(success bool, nextCheck time.Time, hostKey types.PublicKey, roots []types.Hash256) error

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -124,7 +124,7 @@ top:
 
 	// record the slab got migrated so object events gets updated
 	if err := m.store.RecordSlabMigrated(slab.ID); err != nil {
-		log.Error("failed to record slab migration", zap.Error(err))
+		log.Debug("failed to record slab migration", zap.Error(err))
 	}
 	return int(migrated), nil
 }

--- a/slabs/uploads.go
+++ b/slabs/uploads.go
@@ -121,6 +121,11 @@ top:
 	if migrated == 0 {
 		return 0, fmt.Errorf("no shards were uploaded during migration")
 	}
+
+	// record the slab got migrated so object events gets updated
+	if err := m.store.RecordSlabMigrated(slab.ID); err != nil {
+		log.Error("failed to record slab migration", zap.Error(err))
+	}
 	return int(migrated), nil
 }
 


### PR DESCRIPTION
This PR moves updating `object_events` out of `MigrateSector` because we were doing that for every single sector. I also found out we can cleanup the query a little bit by getting of a redundant JOIN. 

Benchmarks:

```
Before:

    BenchmarkMigrateSector-10    	     823	   1228398 ns/op	3414.45 MB/s	    2883 B/op	      65 allocs/op
    BenchmarkMigrateSector-10    	     933	   1110778 ns/op	3776.00 MB/s	    2882 B/op	      65 allocs/op
    BenchmarkMigrateSector-10    	     985	   1127339 ns/op	3720.53 MB/s	    2882 B/op	      65 allocs/op
    BenchmarkMigrateSector-10    	     782	   1285995 ns/op	3261.52 MB/s	    2884 B/op	      65 allocs/op
    BenchmarkMigrateSector-10    	    1005	   1027657 ns/op	4081.42 MB/s	    2881 B/op	      65 allocs/op

After:

    BenchmarkMigrateSector-10    	    1077	   1094869 ns/op	3830.87 MB/s	    2714 B/op	      60 allocs/op
    BenchmarkMigrateSector-10    	    1022	   1038303 ns/op	4039.58 MB/s	    2715 B/op	      60 allocs/op
    BenchmarkMigrateSector-10    	    1044	   1136143 ns/op	3691.70 MB/s	    2714 B/op	      60 allocs/op
    BenchmarkMigrateSector-10    	    1086	   1017254 ns/op	4123.16 MB/s	    2713 B/op	      60 allocs/op
    BenchmarkMigrateSector-10    	    1086	   1000083 ns/op	4193.96 MB/s	    2714 B/op	      60 allocs/op
```

The big win here of course is that we call this once per slab instead of once per migrated sector.

References #879
