### PR TITLE
contracts: drop redundant index and skip contract_sector_map delete

### DIFF
--- a/.changeset/speed_up_deletecontract.md
+++ b/.changeset/speed_up_deletecontract.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# speed up DeleteContract

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -748,11 +748,8 @@ func (s *Store) DeleteContract(contractID types.FileContractID) error {
 			return fmt.Errorf("failed to unpin sectors: %w", err)
 		}
 
-		// delete the entry in contract_sectors_map_id
-		_, err = tx.Exec(ctx, `DELETE FROM contract_sectors_map WHERE id = $1`, contractMapID)
-		if err != nil {
-			return fmt.Errorf("failed to delete from contract sectors map: %w", err)
-		}
+		// NOTE: we leave the contract_sectors_map row itself because PruneContractSectorsMap
+		// will take care of it for us and we can save some time on contracts with a lot of sectors
 
 		// update stats
 		if pinned := res.RowsAffected(); pinned > 0 {

--- a/persist/postgres/contracts.go
+++ b/persist/postgres/contracts.go
@@ -748,8 +748,11 @@ func (s *Store) DeleteContract(contractID types.FileContractID) error {
 			return fmt.Errorf("failed to unpin sectors: %w", err)
 		}
 
-		// NOTE: we leave the contract_sectors_map row itself because PruneContractSectorsMap
-		// will take care of it for us and we can save some time on contracts with a lot of sectors
+		// delete the entry in contract_sectors_map_id
+		_, err = tx.Exec(ctx, `DELETE FROM contract_sectors_map WHERE id = $1`, contractMapID)
+		if err != nil {
+			return fmt.Errorf("failed to delete from contract sectors map: %w", err)
+		}
 
 		// update stats
 		if pinned := res.RowsAffected(); pinned > 0 {

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -2292,6 +2292,56 @@ func BenchmarkMarkContractBad(b *testing.B) {
 	}
 }
 
+func BenchmarkDeleteContract(b *testing.B) {
+	store := initPostgres(b, zap.NewNop())
+
+	// one account, many hosts so each contract is on its own host
+	account := proto.Account{1}
+	store.addTestAccount(b, types.PublicKey(account))
+
+	const (
+		sectorsPerContract = 5000
+		numContracts       = 50
+	)
+
+	fcids := make([]types.FileContractID, 0, numContracts)
+	for range numContracts {
+		hk := store.addTestHost(b)
+		fcid := store.addTestContract(b, hk)
+		fcids = append(fcids, fcid)
+
+		sectors := make([]slabs.PinnedSector, sectorsPerContract)
+		for j := range sectors {
+			sectors[j] = slabs.PinnedSector{Root: frand.Entropy256(), HostKey: hk}
+		}
+		if _, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+			MinShards: 1, EncryptionKey: frand.Entropy256(), Sectors: sectors,
+		}); err != nil {
+			b.Fatal(err)
+		}
+		unpinned, err := store.UnpinnedSectors(hk, sectorsPerContract)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := store.PinSectors(fcid, unpinned); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	idx := 0
+	for b.Loop() {
+		if idx >= len(fcids) {
+			b.StopTimer()
+			b.Fatalf("ran out of contracts after %d iterations", idx)
+		}
+		if err := store.DeleteContract(fcids[idx]); err != nil {
+			b.Fatal(err)
+		}
+		idx++
+	}
+}
+
 func (s *Store) addTestContract(t testing.TB, hk types.PublicKey, fcids ...types.FileContractID) types.FileContractID {
 	t.Helper()
 

--- a/persist/postgres/contracts_test.go
+++ b/persist/postgres/contracts_test.go
@@ -2353,20 +2353,18 @@ func BenchmarkDeleteContract(b *testing.B) {
 	store := initPostgres(b, zap.NewNop())
 
 	// one account, many hosts so each contract is on its own host
-	account := proto.Account{1}
+	account := proto.Account(frand.Entropy256())
 	store.addTestAccount(b, types.PublicKey(account))
 
 	const (
 		sectorsPerContract = 5000
-		numContracts       = 50
+		batchSize          = 50
 	)
 
-	fcids := make([]types.FileContractID, 0, numContracts)
-	for range numContracts {
+	addContract := func() types.FileContractID {
+		b.Helper()
 		hk := store.addTestHost(b)
 		fcid := store.addTestContract(b, hk)
-		fcids = append(fcids, fcid)
-
 		sectors := make([]slabs.PinnedSector, sectorsPerContract)
 		for j := range sectors {
 			sectors[j] = slabs.PinnedSector{Root: frand.Entropy256(), HostKey: hk}
@@ -2383,6 +2381,12 @@ func BenchmarkDeleteContract(b *testing.B) {
 		if err := store.PinSectors(fcid, unpinned); err != nil {
 			b.Fatal(err)
 		}
+		return fcid
+	}
+
+	fcids := make([]types.FileContractID, 0, batchSize)
+	for range batchSize {
+		fcids = append(fcids, addContract())
 	}
 
 	b.ResetTimer()
@@ -2390,7 +2394,10 @@ func BenchmarkDeleteContract(b *testing.B) {
 	for b.Loop() {
 		if idx >= len(fcids) {
 			b.StopTimer()
-			b.Fatalf("ran out of contracts after %d iterations", idx)
+			for range batchSize {
+				fcids = append(fcids, addContract())
+			}
+			b.StartTimer()
 		}
 		if err := store.DeleteContract(fcids[idx]); err != nil {
 			b.Fatal(err)

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -401,18 +401,14 @@ CREATE INDEX stats_deltas_stat_name_idx ON stats_deltas(stat_name);
 -- quick lookup of sectors that failed the integrity checks too many times
 CREATE INDEX sectors_consecutive_failed_checks_idx ON sectors(host_id, consecutive_failed_checks) WHERE consecutive_failed_checks > 0;
 
--- quick lookup of sectors to pin prioritized by upload time
-CREATE INDEX sectors_contract_sectors_map_id_uploaded_at_idx ON sectors(contract_sectors_map_id, uploaded_at ASC);
-
 -- speed up lookup of unpinned sectors
 CREATE INDEX sectors_host_id_uploaded_at_idx ON sectors(host_id, uploaded_at ASC) WHERE contract_sectors_map_id IS NULL;
 
--- speed up prunable roots check
+-- speed up prunable roots check and any csm_id equality lookup
 CREATE INDEX sectors_contract_sectors_map_id_sector_root_idx ON sectors(contract_sectors_map_id, sector_root);
 
 -- foreign key constraint keys
 CREATE INDEX sectors_host_id_idx ON sectors(host_id);
--- CREATE INDEX sectors_contract_sectors_map_id_idx ON sectors(contract_sectors_map_id); -- covered by sectors_contract_sectors_map_id_uploaded_at_idx
 
 -- speed up integrity check query
 CREATE INDEX sectors_host_id_next_integrity_check_idx ON sectors(host_id, next_integrity_check ASC);

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -90,4 +90,8 @@ UPDATE hosts SET has_quic = EXISTS (
 		_, err := tx.Exec(ctx, `DROP INDEX IF EXISTS sectors_next_integrity_check_idx`)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		_, err := tx.Exec(ctx, `DROP INDEX IF EXISTS sectors_contract_sectors_map_id_uploaded_at_idx`)
+		return err
+	},
 }

--- a/persist/postgres/migrations_test.go
+++ b/persist/postgres/migrations_test.go
@@ -406,18 +406,14 @@ CREATE TABLE stats (
 -- quick lookup of sectors that failed the integrity checks too many times
 CREATE INDEX sectors_consecutive_failed_checks_idx ON sectors(host_id, consecutive_failed_checks) WHERE consecutive_failed_checks > 0;
 
--- quick lookup of sectors to pin prioritized by upload time
-CREATE INDEX sectors_contract_sectors_map_id_uploaded_at_idx ON sectors(contract_sectors_map_id, uploaded_at ASC);
-
 -- speed up lookup of unpinned sectors
 CREATE INDEX sectors_host_id_uploaded_at_idx ON sectors(host_id, uploaded_at ASC) WHERE contract_sectors_map_id IS NULL;
 
--- speed up prunable roots check
+-- speed up prunable roots check and any csm_id equality lookup
 CREATE INDEX sectors_contract_sectors_map_id_sector_root_idx ON sectors(contract_sectors_map_id, sector_root);
 
 -- foreign key constraint keys
 CREATE INDEX sectors_host_id_idx ON sectors(host_id);
--- CREATE INDEX sectors_contract_sectors_map_id_idx ON sectors(contract_sectors_map_id); -- covered by sectors_contract_sectors_map_id_uploaded_at_idx
 
 -- speed up integrity check query
 CREATE INDEX sectors_host_id_next_integrity_check_idx ON sectors(host_id, next_integrity_check ASC);


### PR DESCRIPTION
Debugging another query on Zeus I noticed that we have a redundant index, it took 858 buffer reads to retrieve only 532 rows, so very bloated index. It's being selected over other indices because the `uploaded_at` is only 8 bytes vs the 32 byte sector root. We're maintaining this index without any upside, all other queries that need to sort on `uploaded_at` use the partial indexes `sectors_host_id_uploaded_at_idx` or `sectors_uploaded_at_unpinned_idx`. Removing this will also lower maintenance on update. 

```
EXPLAIN (ANALYZE, BUFFERS, VERBOSE, TIMING ON)
UPDATE sectors
SET contract_sectors_map_id = NULL, uploaded_at = NOW()
WHERE contract_sectors_map_id = 1156;
                                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Update on public.sectors  (cost=4580.45..283964.29 rows=0 width=0) (actual time=1748.407..1748.408 rows=0.00 loops=1)
   Buffers: shared hit=19991 read=4282 dirtied=2698
   ->  Bitmap Heap Scan on public.sectors  (cost=4580.45..283964.29 rows=264785 width=18) (actual time=345.675..405.019 rows=532.00 loops=1)
         Output: NULL::integer, now(), ctid
         Recheck Cond: (sectors.contract_sectors_map_id = 1156)
         Heap Blocks: exact=499
         Buffers: shared hit=95 read=1264
         ->  Bitmap Index Scan on sectors_contract_sectors_map_id_uploaded_at_idx  (cost=0.00..4514.26 rows=264785 width=0) (actual time=251.866..251.866 rows=532.00 loops=1)
               Index Cond: (sectors.contract_sectors_map_id = 1156)
               Index Searches: 1
               Buffers: shared hit=2 read=858
 Planning:
   Buffers: shared hit=3
 Planning Time: 0.178 ms
 JIT:
   Functions: 4
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 14.175 ms (Deform 0.221 ms), Inlining 0.000 ms, Optimization 29.882 ms, Emission 65.124 ms, Total 109.181 ms
 Execution Time: 1765.463 ms
(19 rows)
```

In DeleteContract we also perform a delete on the `contract_sector_map`, I decided to remove that because it saves us time on large contracts and the row will get handled by `PruneContractSectorsMap` anyway. I was on the fence on whether to add this yes or no, I was not going to push it initially but figured we might as well.

References #879 