### PR TITLE
sectors: record integrity checks in batches

### DIFF
--- a/.changeset/chunk_recordintegritycheck_updates_to_bound_tail_latency.md
+++ b/.changeset/chunk_recordintegritycheck_updates_to_bound_tail_latency.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Chunk RecordIntegrityCheck UPDATEs to bound per-statement latency and shorten row-lock windows.

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -79,44 +79,56 @@ func (s *Store) MarkSectorsLost(hostKey types.PublicKey, roots []types.Hash256) 
 	return err
 }
 
+const integrityCheckChunkSize = 100
+
 // RecordIntegrityCheck records the result of integrity checks for the given
 // sectors stored on the given host.
 func (s *Store) RecordIntegrityCheck(success bool, nextCheck time.Time, hostKey types.PublicKey, roots []types.Hash256) error {
-	return s.transaction(func(ctx context.Context, tx *txn) error {
-		sqlRoots := make([]sqlHash256, len(roots))
-		for i, root := range roots {
-			sqlRoots[i] = sqlHash256(root)
+	for start := 0; start < len(roots); start += integrityCheckChunkSize {
+		end := min(start+integrityCheckChunkSize, len(roots))
+		if err := s.transaction(func(ctx context.Context, tx *txn) error {
+			return recordIntegrityCheck(ctx, tx, success, nextCheck, hostKey, roots[start:end])
+		}); err != nil {
+			return err
 		}
-		var err error
-		if success {
-			_, err = tx.Exec(ctx, `
-				UPDATE sectors
-				SET next_integrity_check = $1, consecutive_failed_checks = 0
-				WHERE host_id = (SELECT id FROM hosts WHERE public_key = $2) AND
-					sector_root = ANY($3)
-			`, nextCheck, sqlPublicKey(hostKey), sqlRoots)
-		} else {
-			_, err = tx.Exec(ctx, `
-				UPDATE sectors
-				SET next_integrity_check = $1, consecutive_failed_checks = consecutive_failed_checks + 1
-				WHERE host_id = (SELECT id FROM hosts WHERE public_key = $2) AND
-					sector_root = ANY($3)
-			`, nextCheck, sqlPublicKey(hostKey), sqlRoots)
-		}
-		if err != nil {
-			return fmt.Errorf("failed to record integrity check: %w", err)
-		}
+	}
+	return nil
+}
 
-		if err := incrementNumSectorsChecked(ctx, tx, uint64(len(roots))); err != nil {
-			return fmt.Errorf("failed to increment sectors checked stat: %w", err)
+func recordIntegrityCheck(ctx context.Context, tx *txn, success bool, nextCheck time.Time, hostKey types.PublicKey, roots []types.Hash256) error {
+	sqlRoots := make([]sqlHash256, len(roots))
+	for i, root := range roots {
+		sqlRoots[i] = sqlHash256(root)
+	}
+	var err error
+	if success {
+		_, err = tx.Exec(ctx, `
+			UPDATE sectors
+			SET next_integrity_check = $1, consecutive_failed_checks = 0
+			WHERE host_id = (SELECT id FROM hosts WHERE public_key = $2) AND
+				sector_root = ANY($3)
+		`, nextCheck, sqlPublicKey(hostKey), sqlRoots)
+	} else {
+		_, err = tx.Exec(ctx, `
+			UPDATE sectors
+			SET next_integrity_check = $1, consecutive_failed_checks = consecutive_failed_checks + 1
+			WHERE host_id = (SELECT id FROM hosts WHERE public_key = $2) AND
+				sector_root = ANY($3)
+		`, nextCheck, sqlPublicKey(hostKey), sqlRoots)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to record integrity check: %w", err)
+	}
+
+	if err := incrementNumSectorsChecked(ctx, tx, uint64(len(roots))); err != nil {
+		return fmt.Errorf("failed to increment sectors checked stat: %w", err)
+	}
+	if !success {
+		if err := incrementNumSectorsFailed(ctx, tx, uint64(len(roots))); err != nil {
+			return fmt.Errorf("failed to increment sectors failed stat: %w", err)
 		}
-		if !success {
-			if err := incrementNumSectorsFailed(ctx, tx, uint64(len(roots))); err != nil {
-				return fmt.Errorf("failed to increment sectors failed stat: %w", err)
-			}
-		}
-		return nil
-	})
+	}
+	return nil
 }
 
 // SectorsForIntegrityCheck returns up to `limit` sectors that are due for an

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -89,7 +89,7 @@ func (s *Store) RecordIntegrityCheck(success bool, nextCheck time.Time, hostKey 
 		if err := s.transaction(func(ctx context.Context, tx *txn) error {
 			return recordIntegrityCheck(ctx, tx, success, nextCheck, hostKey, roots[start:end])
 		}); err != nil {
-			return err
+			return fmt.Errorf("chunk [%d:%d] of %d: %w", start, end, len(roots), err)
 		}
 	}
 	return nil

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -372,6 +372,27 @@ func TestRecordIntegrityCheck(t *testing.T) {
 
 	// host should have lost sector
 	assertLostSectors(1)
+
+	// record more than one chunk worth of sectors at once
+	manyRoots := make([]types.Hash256, integrityCheckChunkSize+1)
+	manySectors := make([]slabs.PinnedSector, len(manyRoots))
+	for i := range manyRoots {
+		manyRoots[i] = frand.Entropy256()
+		manySectors[i] = slabs.PinnedSector{Root: manyRoots[i], HostKey: hk}
+	}
+	if _, err := store.PinSlabs(account, pinTime, slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(), MinShards: 1, Sectors: manySectors,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now = time.Now().Add(time.Hour).Round(time.Microsecond)
+	record(true, now, manyRoots)
+	var updated int
+	if err := store.pool.QueryRow(t.Context(), "SELECT COUNT(*) FROM sectors WHERE next_integrity_check = $1", now).Scan(&updated); err != nil {
+		t.Fatal(err)
+	} else if updated != len(manyRoots) {
+		t.Fatalf("expected %d updated rows, got %d", len(manyRoots), updated)
+	}
 }
 
 func TestSectorsForIntegrityCheck(t *testing.T) {


### PR DESCRIPTION
This PR batches the recording of integrity check. On zeus this is the highest-volume slow query, sometimes hitting 2-3s even. This avoids row locks and gets rid of contention so other concurrent paths like `MigrateSector` and `MarkSectorsLost` don't have to wait for the single bulk update.

No regression in benchmarks:
```
Before:

    BenchmarkRecordIntegrityChecks/10-10        20    2384000 ns/op
    BenchmarkRecordIntegrityChecks/100-10       20    9695444 ns/op
    BenchmarkRecordIntegrityChecks/1000-10      20   41744594 ns/op

After:

    BenchmarkRecordIntegrityChecks/10-10        20    3841354 ns/op
    BenchmarkRecordIntegrityChecks/100-10       20    5197381 ns/op
    BenchmarkRecordIntegrityChecks/1000-10      20   43671067 ns/op
```

A bigger refactor would be to move fields like `next_integrity_check` and `consecutive_failed_checks` to a separate table. This should already get us pretty far though I think. I have not tested it on zeus but I'm interested to see the numbers.

References #879 