### PR TITLE
return typed HTTPError from client

### DIFF
--- a/.changeset/client_http_error.md
+++ b/.changeset/client_http_error.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Return a typed HTTPError from the app client on non-2xx responses.
+
+The app client previously returned `errors.New("")` when an upstream proxy returned a non-2xx status code with an empty body, making failures impossible to diagnose. It now returns an `*HTTPError` carrying both the status code and body, formatted as `HTTP <code>: <message>`. Callers can `errors.As` on it to branch retry behavior on the status code.

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -108,6 +108,7 @@ func doRequest(ctx context.Context, method string, u *url.URL, body io.Reader, a
 		b, _ := io.ReadAll(r.Body)
 		return nil, &HTTPError{StatusCode: r.StatusCode, Body: strings.TrimSpace(string(b))}
 	} else if contentType := r.Header.Get("Content-Type"); r.StatusCode != http.StatusNoContent && accept != contentType {
+		r.Body.Close()
 		return nil, fmt.Errorf("expected content type %s, got %s", accept, contentType)
 	}
 

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -104,6 +104,7 @@ func doRequest(ctx context.Context, method string, u *url.URL, body io.Reader, a
 
 	if !(200 <= r.StatusCode && r.StatusCode < 300) {
 		defer r.Body.Close()
+		defer io.Copy(io.Discard, r.Body)
 		b, _ := io.ReadAll(r.Body)
 		return nil, &HTTPError{StatusCode: r.StatusCode, Body: strings.TrimSpace(string(b))}
 	} else if contentType := r.Header.Get("Content-Type"); r.StatusCode != http.StatusNoContent && accept != contentType {

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -105,10 +105,11 @@ func doRequest(ctx context.Context, method string, u *url.URL, body io.Reader, a
 	if !(200 <= r.StatusCode && r.StatusCode < 300) {
 		defer r.Body.Close()
 		defer io.Copy(io.Discard, r.Body)
-		b, _ := io.ReadAll(r.Body)
+		b, _ := io.ReadAll(io.LimitReader(r.Body, 1024))
 		return nil, &HTTPError{StatusCode: r.StatusCode, Body: strings.TrimSpace(string(b))}
 	} else if contentType := r.Header.Get("Content-Type"); r.StatusCode != http.StatusNoContent && accept != contentType {
-		r.Body.Close()
+		defer r.Body.Close()
+		defer io.Copy(io.Discard, r.Body)
 		return nil, fmt.Errorf("expected content type %s, got %s", accept, contentType)
 	}
 

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -31,6 +31,26 @@ type Client struct {
 	validity time.Duration
 }
 
+// HTTPError is returned by the client when the server responds with a non-2xx
+// status code. Callers can use errors.As to inspect StatusCode and decide
+// whether to retry.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error implements the error interface.
+func (e *HTTPError) Error() string {
+	msg := e.Body
+	if msg == "" {
+		msg = http.StatusText(e.StatusCode)
+	}
+	if msg == "" {
+		return fmt.Sprintf("HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, msg)
+}
+
 // sign signs the request with the appropriate headers and returns the signed URL
 // and request body.
 func sign(appKey types.PrivateKey, validUntil time.Time, method, endpointURL string, requestBuf []byte) (*url.URL, io.Reader, error) {
@@ -83,10 +103,9 @@ func doRequest(ctx context.Context, method string, u *url.URL, body io.Reader, a
 	}
 
 	if !(200 <= r.StatusCode && r.StatusCode < 300) {
-		defer io.Copy(io.Discard, r.Body)
 		defer r.Body.Close()
 		b, _ := io.ReadAll(r.Body)
-		return nil, errors.New(strings.TrimSpace(string(b)))
+		return nil, &HTTPError{StatusCode: r.StatusCode, Body: strings.TrimSpace(string(b))}
 	} else if contentType := r.Header.Get("Content-Type"); r.StatusCode != http.StatusNoContent && accept != contentType {
 		return nil, fmt.Errorf("expected content type %s, got %s", accept, contentType)
 	}

--- a/api/app/client_test.go
+++ b/api/app/client_test.go
@@ -1,0 +1,74 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestDoRequestHTTPError(t *testing.T) {
+	do := func(h http.HandlerFunc) error {
+		t.Helper()
+
+		srv := httptest.NewServer(h)
+		defer srv.Close()
+
+		u, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = doRequest(context.Background(), http.MethodGet, u, nil, applicationJSON)
+		return err
+	}
+
+	// empty body falls back to status text
+	err := do(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatal("expected HTTPError")
+	} else if httpErr.StatusCode != http.StatusBadGateway {
+		t.Fatal("unexpected", httpErr.StatusCode)
+	} else if httpErr.Body != "" {
+		t.Fatal("unexpected", httpErr.Body)
+	} else if httpErr.Error() != "HTTP 502: Bad Gateway" {
+		t.Fatal("unexpected", httpErr.Error())
+	}
+
+	// body is trimmed and used as the message
+	err = do(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("  database is down\n"))
+	})
+
+	if !errors.As(err, &httpErr) {
+		t.Fatal("expected HTTPError")
+	} else if httpErr.StatusCode != http.StatusInternalServerError {
+		t.Fatal("unexpected", httpErr.StatusCode)
+	} else if httpErr.Body != "database is down" {
+		t.Fatal("unexpected", httpErr.Body)
+	} else if httpErr.Error() != "HTTP 500: database is down" {
+		t.Fatal("unexpected", httpErr.Error())
+	}
+
+	// non-standard status with empty body omits the trailing colon
+	err = do(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(599)
+	})
+
+	if !errors.As(err, &httpErr) {
+		t.Fatal("expected HTTPError")
+	} else if httpErr.StatusCode != 599 {
+		t.Fatal("unexpected", httpErr.StatusCode)
+	} else if httpErr.Body != "" {
+		t.Fatal("unexpected", httpErr.Body)
+	} else if httpErr.Error() != "HTTP 599" {
+		t.Fatal("unexpected", httpErr.Error())
+	}
+}


### PR DESCRIPTION
This PR alters the app client to return a HTTPError instead of a regular error. Callers can use this to checkout the status code and have retry logic or more context. Often the response body is empty for errors like a gateway timeout for instance, resulting in client errors that say "failed to pin slabs: " without any context.