### PR TITLE
add reconnecting field

### DIFF
--- a/.changeset/added_reconnecting_field_to_auth_connect_status_so_apps_can_tell_if_a_user_is_returning_or_connecting_for_the_first_time.md
+++ b/.changeset/added_reconnecting_field_to_auth_connect_status_so_apps_can_tell_if_a_user_is_returning_or_connecting_for_the_first_time.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Added `reconnecting` field to auth connect status so apps can tell if a user is returning or connecting for the first time.

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -165,6 +165,12 @@ func (m *AccountManager) Quotas(ctx context.Context, offset, limit int) ([]Quota
 	return m.store.Quotas(offset, limit)
 }
 
+// HasAppAccount reports whether an account already exists for the given
+// connect key and app ID.
+func (m *AccountManager) HasAppAccount(connectKey string, appID types.Hash256) (bool, error) {
+	return m.store.HasAppAccount(connectKey, appID)
+}
+
 // AppSecret derives a unique application secret using a stored user secret
 // associated with the given connect key and the provided app ID.
 func (m *AccountManager) AppSecret(connectKey string, appID types.Hash256) (types.Hash256, error) {

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -48,6 +48,7 @@ type (
 
 		ValidAppConnectKey(string) error
 		AppConnectKeyUserSecret(string) (secret types.Hash256, err error)
+		HasAppAccount(connectKey string, appID types.Hash256) (bool, error)
 		RegisterAppKey(string, types.PublicKey, AppMeta) error
 		AddAppConnectKey(AppConnectKeyRequest) (ConnectKey, error)
 		UpdateAppConnectKey(AppConnectKeyRequest) (ConnectKey, error)

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -58,6 +58,7 @@ type (
 		ValidAppConnectKey(context.Context, string) error
 		RegisterAppKey(string, types.PublicKey, accounts.AppMeta) error
 		AppSecret(connectKey string, appID types.Hash256) (types.Hash256, error)
+		HasAppAccount(connectKey string, appID types.Hash256) (bool, error)
 
 		HasAccount(context.Context, types.PublicKey) (bool, error)
 		Account(context.Context, types.PublicKey) (accounts.Account, error)
@@ -80,9 +81,10 @@ type (
 		Expiration   time.Time
 
 		// set when the user approves the request
-		Approved   bool
-		UserSecret types.Hash256
-		ConnectKey string // ties the request to the app connect key used
+		Approved     bool
+		Reconnecting bool
+		UserSecret   types.Hash256
+		ConnectKey   string // ties the request to the app connect key used
 	}
 
 	// A RegisterAppRequest is the request body for registering a new application.
@@ -98,8 +100,11 @@ type (
 	// AuthConnectStatusResponse is the response body for checking the status of an
 	// application connection request.
 	AuthConnectStatusResponse struct {
-		Approved   bool          `json:"approved"`
-		UserSecret types.Hash256 `json:"userSecret,omitempty"`
+		Approved bool `json:"approved"`
+		// Reconnecting is true if the user has previously connected the app.
+		// It is only set if the user approved the request.
+		Reconnecting bool          `json:"reconnecting"`
+		UserSecret   types.Hash256 `json:"userSecret,omitempty"`
 	}
 
 	// RegisterAppResponse is the response body for registering a new application.
@@ -601,9 +606,17 @@ func (a *app) handlePOSTAuthConnect(jc jape.Context) {
 		return
 	}
 
+	// check whether the user has previously connected the app
+	reconnecting, err := a.accounts.HasAppAccount(connectKey, authReq.Request.AppID)
+	if err != nil {
+		jc.Error(fmt.Errorf("failed to check for existing app account: %w", err), http.StatusInternalServerError)
+		return
+	}
+
 	// update the auth request with the shared secret and approval status
 	authReq.UserSecret = sharedSecret
 	authReq.Approved = approveReq.Approve
+	authReq.Reconnecting = reconnecting
 	authReq.ConnectKey = connectKey
 	a.authRequests[requestID] = authReq
 	jc.Encode(nil)
@@ -628,8 +641,9 @@ func (a *app) handleGETAuthConnectStatus(jc jape.Context) {
 		return
 	}
 	jc.Encode(AuthConnectStatusResponse{
-		Approved:   authReq.Approved,
-		UserSecret: authReq.UserSecret,
+		Approved:     authReq.Approved,
+		Reconnecting: authReq.Reconnecting,
+		UserSecret:   authReq.UserSecret,
 	})
 }
 

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -594,6 +594,8 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("expected request to be approved")
 	} else if status.UserSecret == (types.Hash256{}) {
 		t.Fatal("expected non-empty user secret")
+	} else if status.Reconnecting {
+		t.Fatal("expected first connection to not be reconnecting")
 	}
 
 	if err := appClient.RegisterApp(ctx, resp.RegisterURL, ephemeralSK, sk); err != nil {
@@ -663,6 +665,8 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("expected request to be approved")
 	} else if status.UserSecret != secondStatus.UserSecret {
 		t.Fatal("expected same user secret")
+	} else if !secondStatus.Reconnecting {
+		t.Fatal("expected reconnecting")
 	}
 
 	// verify re-auth succeeds even when the connect key is exhausted

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -82,6 +82,10 @@ func (s *mockAccounts) AppSecret(connectKey string, appID types.Hash256) (types.
 	return frand.Entropy256(), nil
 }
 
+func (s *mockAccounts) HasAppAccount(connectKey string, appID types.Hash256) (bool, error) {
+	return false, nil
+}
+
 func TestAuthConnectFieldLimits(t *testing.T) {
 	s := &mockAccounts{tokens: make(map[types.PublicKey]struct{})}
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -911,6 +911,9 @@ components:
         approved:
           type: boolean
           description: The status of an application connection request.
+        reconnecting:
+          type: boolean
+          description: Whether the user has previously connected the app. Only set when the request is approved.
         userSecret:
           allOf:
             - $ref: "#/components/schemas/Hash256"

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -205,6 +205,21 @@ func (s *Store) AppConnectKeyUserSecret(connectKey string) (secret types.Hash256
 	return
 }
 
+// HasAppAccount reports whether an account already exists for the given
+// connect key and app ID.
+func (s *Store) HasAppAccount(connectKey string, appID types.Hash256) (exists bool, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM accounts a
+				INNER JOIN app_connect_keys ack ON ack.id = a.connect_key_id
+				WHERE ack.app_key = $1 AND a.app_id = $2 AND a.deleted_at IS NULL
+			)
+		`, connectKey, sqlHash256(appID)).Scan(&exists)
+	})
+	return
+}
+
 // RegisterAppKey uses a connect key to register a new app account.
 // This secret must never be exposed to the user.
 func (s *Store) RegisterAppKey(connectKey string, appKey types.PublicKey, meta accounts.AppMeta) error {


### PR DESCRIPTION
Adds a `reconnecting` field to auth connect status so apps can tell if a user is returning or connecting for the first time.
