### PR TITLE
Add network read and write throughput estimates

### DIFF
--- a/.changeset/add_network_throughput_estimates.md
+++ b/.changeset/add_network_throughput_estimates.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Add network read and write throughput estimates to the client.
+
+The client now exposes `ReadEstimate` and `WriteEstimate`, returning the expected duration to transfer a given number of bytes from the network-wide observed throughput. Both fall back to a default rate before any bulk transfers have been sampled.

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -334,6 +334,20 @@ func (c *Client) Prioritize(hosts []types.PublicKey) []types.PublicKey {
 	return c.hosts.Prioritize(hosts)
 }
 
+// ReadEstimate returns the expected time to read the given number of bytes
+// based on the network-wide observed read throughput. See
+// [Provider.ReadEstimate].
+func (c *Client) ReadEstimate(bytes uint64) time.Duration {
+	return c.hosts.ReadEstimate(bytes)
+}
+
+// WriteEstimate returns the expected time to write the given number of bytes
+// based on the network-wide observed write throughput. See
+// [Provider.WriteEstimate].
+func (c *Client) WriteEstimate(bytes uint64) time.Duration {
+	return c.hosts.WriteEstimate(bytes)
+}
+
 // PickWrite atomically selects the highest-scoring write candidate and
 // reserves an inflight slot. See [Provider.PickWrite].
 func (c *Client) PickWrite(candidates []types.PublicKey) (host types.PublicKey, release func(), remaining []types.PublicKey, ok bool) {

--- a/client/v2/hostqueue.go
+++ b/client/v2/hostqueue.go
@@ -17,6 +17,15 @@ import (
 const (
 	emaAlpha            = 0.2
 	settingsPayloadSize = 270 // size of host settings in bytes
+
+	// defaultReadThroughput is the assumed read rate before bulk reads are sampled
+	defaultReadThroughput = 1 << 20 // 1 MiB/s
+
+	// defaultWriteThroughput is the assumed write rate before bulk writes are sampled
+	defaultWriteThroughput = (1 << 22) / 5 // 4 MiB sector / 5s
+
+	// minThroughputSampleBytes is the smallest transfer that feeds the network-wide throughput estimate
+	minThroughputSampleBytes = 1 << 16 // 64 KiB
 )
 
 type rpcAverage struct {
@@ -189,6 +198,12 @@ type Provider struct {
 
 	mu      sync.Mutex // protects the fields below
 	metrics map[types.PublicKey]*hostMetric
+
+	// globalReadThroughput and globalWriteThroughput are network-wide EMAs of
+	// bulk transfer throughput in bytes/second, used by Read/WriteEstimate to
+	// size adaptive racing.
+	globalReadThroughput  rpcAverage
+	globalWriteThroughput rpcAverage
 }
 
 func (p *Provider) sortHosts(hosts []types.PublicKey) {
@@ -258,9 +273,27 @@ func (p *Provider) AddReadSample(hostKey types.PublicKey, bytes uint64, elapsed 
 	defer p.mu.Unlock()
 	metric := p.metric(hostKey)
 	if elapsed > 0 {
-		metric.rpcReadAverage.AddSample(float64(bytes) / elapsed.Seconds())
+		throughput := float64(bytes) / elapsed.Seconds()
+		metric.rpcReadAverage.AddSample(throughput)
+		// only bulk reads are taken into account for the global estimate
+		if bytes >= minThroughputSampleBytes {
+			p.globalReadThroughput.AddSample(throughput)
+		}
 	}
 	metric.rpcFailRate.AddSample(true)
+}
+
+// ReadEstimate returns the expected time to read the given number of bytes
+// based on the network-wide observed read throughput, falling back to
+// defaultReadThroughput before any bulk reads have been sampled.
+func (p *Provider) ReadEstimate(bytes uint64) time.Duration {
+	p.mu.Lock()
+	rate, ok := p.globalReadThroughput.Value()
+	p.mu.Unlock()
+	if !ok || rate <= 0 {
+		rate = defaultReadThroughput
+	}
+	return time.Duration(float64(bytes) / rate * float64(time.Second))
 }
 
 // AddWriteSample records a successful write RPC attempt to the specified host.
@@ -271,9 +304,27 @@ func (p *Provider) AddWriteSample(hostKey types.PublicKey, bytes uint64, elapsed
 	defer p.mu.Unlock()
 	metric := p.metric(hostKey)
 	if elapsed > 0 {
-		metric.rpcWriteAverage.AddSample(float64(bytes) / elapsed.Seconds())
+		throughput := float64(bytes) / elapsed.Seconds()
+		metric.rpcWriteAverage.AddSample(throughput)
+		// only bulk writes are taken into account for the global estimate
+		if bytes >= minThroughputSampleBytes {
+			p.globalWriteThroughput.AddSample(throughput)
+		}
 	}
 	metric.rpcFailRate.AddSample(true)
+}
+
+// WriteEstimate returns the expected time to write the given number of bytes
+// based on the network-wide observed write throughput, falling back to
+// defaultWriteThroughput before any bulk writes have been sampled.
+func (p *Provider) WriteEstimate(bytes uint64) time.Duration {
+	p.mu.Lock()
+	rate, ok := p.globalWriteThroughput.Value()
+	p.mu.Unlock()
+	if !ok || rate <= 0 {
+		rate = defaultWriteThroughput
+	}
+	return time.Duration(float64(bytes) / rate * float64(time.Second))
 }
 
 // AddSettingsSample records a successful settings RPC to the specified host.

--- a/client/v2/hostqueue_test.go
+++ b/client/v2/hostqueue_test.go
@@ -603,6 +603,74 @@ func TestProviderInflightWeighting(t *testing.T) {
 	}
 }
 
+func TestProviderReadEstimate(t *testing.T) {
+	s := newTestStore(t)
+	store := hosts.NewHostStore(s.Store)
+
+	hostA := s.addUsableHost(t)
+
+	provider := client.NewProvider(store)
+
+	// before any samples, a 1 MiB read uses the 1 MiB/s default and takes ~1s
+	if got := provider.ReadEstimate(1 << 20); got < 900*time.Millisecond || got > 1100*time.Millisecond {
+		t.Fatalf("expected ~1s default estimate, got %v", got)
+	}
+
+	// a tiny latency-bound read must not skew the network-wide estimate
+	provider.AddReadSample(hostA, 270, 100*time.Millisecond)
+	if got := provider.ReadEstimate(1 << 20); got < 900*time.Millisecond || got > 1100*time.Millisecond {
+		t.Fatalf("sub-threshold read should not change the estimate, got %v", got)
+	}
+
+	// a bulk read at 4 MiB / 100ms = ~41.9 MiB/s should drop the estimate for
+	// a 4 MiB read to ~100ms
+	provider.AddReadSample(hostA, 4<<20, 100*time.Millisecond)
+	if got := provider.ReadEstimate(4 << 20); got < 80*time.Millisecond || got > 130*time.Millisecond {
+		t.Fatalf("expected ~100ms estimate after bulk sample, got %v", got)
+	}
+
+	// the estimate scales linearly with the requested size
+	full := provider.ReadEstimate(4 << 20)
+	half := provider.ReadEstimate(2 << 20)
+	if half < full/2-10*time.Millisecond || half > full/2+10*time.Millisecond {
+		t.Fatalf("expected half-size estimate (~%v) to be half of full (%v)", half, full)
+	}
+}
+
+func TestProviderWriteEstimate(t *testing.T) {
+	s := newTestStore(t)
+	store := hosts.NewHostStore(s.Store)
+
+	hostA := s.addUsableHost(t)
+
+	provider := client.NewProvider(store)
+
+	// before any samples, a 4 MiB write uses the 4 MiB / 5s default and takes ~5s
+	if got := provider.WriteEstimate(4 << 20); got < 4500*time.Millisecond || got > 5500*time.Millisecond {
+		t.Fatalf("expected ~5s default estimate, got %v", got)
+	}
+
+	// a tiny latency-bound write must not skew the network-wide estimate
+	provider.AddWriteSample(hostA, 270, 100*time.Millisecond)
+	if got := provider.WriteEstimate(4 << 20); got < 4500*time.Millisecond || got > 5500*time.Millisecond {
+		t.Fatalf("sub-threshold write should not change the estimate, got %v", got)
+	}
+
+	// a bulk write at 4 MiB / 100ms = ~41.9 MiB/s should drop the estimate for
+	// a 4 MiB write to ~100ms
+	provider.AddWriteSample(hostA, 4<<20, 100*time.Millisecond)
+	if got := provider.WriteEstimate(4 << 20); got < 80*time.Millisecond || got > 130*time.Millisecond {
+		t.Fatalf("expected ~100ms estimate after bulk sample, got %v", got)
+	}
+
+	// the estimate scales linearly with the requested size
+	full := provider.WriteEstimate(4 << 20)
+	half := provider.WriteEstimate(2 << 20)
+	if half < full/2-10*time.Millisecond || half > full/2+10*time.Millisecond {
+		t.Fatalf("expected half-size estimate (~%v) to be half of full (%v)", half, full)
+	}
+}
+
 func TestDuplicateHostQueue(t *testing.T) {
 	hosts := []types.PublicKey{
 		types.GeneratePrivateKey().PublicKey(),


### PR DESCRIPTION
This PR exposes a global read/write estimate on the client. Required for https://github.com/SiaFoundation/sia-storage-go/issues/27 also going to be introduced in https://github.com/SiaFoundation/indexd/pull/1013 so figured I'd extract it into a separate PR. 