### PR TITLE
Make UnhealthySlabs safe to be called from multiple goroutines

### DIFF
--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -907,23 +907,28 @@ func (s *Store) UnhealthySlabs(cursor int64, limit int) (unhealthy []slabs.SlabI
 				SELECT id FROM (SELECT id FROM lost UNION ALL SELECT id FROM bad) u
 				ORDER BY id LIMIT $2
 			), unhealthy AS (
-				SELECT DISTINCT s.id, s.digest
+				SELECT DISTINCT ss.slab_id AS id
 				FROM slab_sectors ss
-				JOIN slabs s ON s.id = ss.slab_id
 				WHERE ss.sector_id IN (SELECT id FROM batch)
-					AND s.next_repair_attempt < NOW()
+			), claimed AS (
+				UPDATE slabs SET next_repair_attempt = $3
+				WHERE id IN (
+					SELECT id FROM slabs
+					WHERE id IN (SELECT id FROM unhealthy) AND next_repair_attempt < NOW()
+					FOR UPDATE SKIP LOCKED
+				)
+				RETURNING id, digest
 			)
-			SELECT cur.next_cursor, u.id, u.digest
+			SELECT cur.next_cursor, c.id, c.digest
 			FROM (SELECT max(id) AS next_cursor FROM batch) cur
-			LEFT JOIN unhealthy u ON true;`
+			LEFT JOIN claimed c ON true;`
 
-		rows, err := tx.Query(ctx, query, cursor, limit)
+		rows, err := tx.Query(ctx, query, cursor, limit, time.Now().Add(minRepairBackoff))
 		if err != nil {
 			return fmt.Errorf("failed to query unhealthy slabs: %w", err)
 		}
 		defer rows.Close()
 
-		var slabIDs []int64
 		for rows.Next() {
 			var nc, slabID sql.NullInt64
 			var digest sql.Null[sqlHash256]
@@ -933,23 +938,9 @@ func (s *Store) UnhealthySlabs(cursor int64, limit int) (unhealthy []slabs.SlabI
 			nextCursor = nc.Int64
 			if slabID.Valid {
 				unhealthy = append(unhealthy, slabs.SlabID(digest.V))
-				slabIDs = append(slabIDs, slabID.Int64)
 			}
 		}
-		rows.Close()
-		if err := rows.Err(); err != nil {
-			return fmt.Errorf("failed to get unhealthy slabs: %w", err)
-		} else if len(slabIDs) == 0 {
-			return nil
-		}
-
-		// update next repair attempt time
-		_, err = tx.Exec(ctx, `UPDATE slabs SET next_repair_attempt = $1 WHERE id = ANY($2)`, time.Now().Add(minRepairBackoff), slabIDs)
-		if err != nil {
-			return fmt.Errorf("failed to update next repair attempt: %w", err)
-		}
-
-		return nil
+		return rows.Err()
 	})
 	if err == nil {
 		s.log.Debug("unhealthy slabs", zap.Int64("cursor", cursor), zap.Int64("nextCursor", nextCursor), zap.Int("slabs", len(unhealthy)), zap.Duration("elapsed", time.Since(start)))

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -2024,6 +2025,76 @@ func TestUnhealthySlabs(t *testing.T) {
 	unhealthy = assertUnhealthySlabs(1)
 	if unhealthy[0] != want {
 		t.Fatalf("expected slab ID %v, got %v", want, unhealthy[0])
+	}
+}
+
+// TestUnhealthySlabsConcurrent verifies that multiple processes walking
+// UnhealthySlabs against the same database claim disjoint sets of slabs.
+func TestUnhealthySlabsConcurrent(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	const numSlabs = 2000
+	want := make(map[slabs.SlabID]struct{}, numSlabs)
+	for i := range numSlabs {
+		// mix 1-of-2 and 2-of-2 slabs
+		want[store.pinTestSlab(t, account, uint(1+i%2), []types.PublicKey{hk, hk})] = struct{}{}
+	}
+	// pin every sector to the contract, mark it bad, and make all slabs
+	// immediately eligible so the whole set is unhealthy at once.
+	if _, err := store.pool.Exec(t.Context(), "UPDATE sectors SET contract_sectors_map_id = 1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.pool.Exec(t.Context(), "UPDATE contracts SET good = FALSE"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.pool.Exec(t.Context(), "UPDATE slabs SET next_repair_attempt = NOW() - INTERVAL '1 hour'"); err != nil {
+		t.Fatal(err)
+	}
+
+	// run several concurrent walkers, each advancing its own cursor.
+	const workers = 8
+	var mu sync.Mutex
+	claimed := make(map[slabs.SlabID]int)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			var cursor int64
+			for {
+				batch, next, err := store.UnhealthySlabs(cursor, 10)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				mu.Lock()
+				for _, id := range batch {
+					claimed[id]++
+				}
+				mu.Unlock()
+				if next == 0 {
+					return
+				}
+				cursor = next
+			}
+		})
+	}
+	wg.Wait()
+
+	// every unhealthy slab claimed exactly once, by exactly one walker
+	for id, n := range claimed {
+		if n != 1 {
+			t.Fatalf("slab %v claimed %d times, want exactly 1", id, n)
+		}
+		if _, ok := want[id]; !ok {
+			t.Fatalf("claimed unexpected slab %v", id)
+		}
+	}
+	if len(claimed) != numSlabs {
+		t.Fatalf("claimed %d distinct slabs, want %d", len(claimed), numSlabs)
 	}
 }
 


### PR DESCRIPTION
This makes the `UnhealthySlabs` method usable from multiple threads which will be relevant later when we add the repair mode to indexd.

