### PR TITLE
Make integrity checks safe to run in parallel 

### DIFF
--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -2789,6 +2790,86 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatal(err)
 	} else if len(hosts) != 0 {
 		t.Fatalf("expected 0 hosts, got %d", len(hosts))
+	}
+}
+
+// TestHostsForIntegrityChecksConcurrent verifies that when multiple nodes run
+// the integrity-check loop concurrently against the same database, each host is
+// claimed by exactly one node (no duplicate work, full coverage). This mirrors
+// TestUnhealthySlabsConcurrent for the migration loop.
+func TestHostsForIntegrityChecksConcurrent(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	db := initPostgres(t, log.Named("postgres"))
+
+	acc := proto4.Account{1}
+	db.addTestAccount(t, types.PublicKey(acc))
+
+	// create many hosts, each with a contract and a single sector that is due
+	// for an integrity check (next_integrity_check in the past).
+	const nHosts = 200
+	oneHAgo := time.Now().Add(-time.Hour)
+	want := make(map[types.PublicKey]struct{}, nHosts)
+	for i := 0; i < nHosts; i++ {
+		hk := db.addTestHost(t)
+		db.addTestContract(t, hk)
+		if _, err := db.PinSlabs(acc, oneHAgo, slabs.SlabPinParams{
+			MinShards:     1,
+			EncryptionKey: frand.Entropy256(),
+			Sectors:       []slabs.PinnedSector{{Root: frand.Entropy256(), HostKey: hk}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		want[hk] = struct{}{}
+	}
+
+	// all hosts require
+	if _, err := db.pool.Exec(context.Background(), `UPDATE hosts SET last_integrity_check = NOW() - INTERVAL '1 hour'`); err != nil {
+		t.Fatal(err)
+	}
+	maxLastCheck := time.Now().Add(-time.Minute)
+
+	const (
+		walkers   = 8
+		batchSize = 5
+	)
+	var mu sync.Mutex
+	claimedBy := make(map[types.PublicKey]int) // host -> number of walkers that claimed it
+
+	var wg sync.WaitGroup
+	for w := 0; w < walkers; w++ {
+		wg.Go(func() {
+			for {
+				batch, err := db.HostsForIntegrityChecks(maxLastCheck, batchSize)
+				if err != nil {
+					t.Errorf("walker failed: %v", err)
+					return
+				}
+				if len(batch) == 0 {
+					return
+				}
+				mu.Lock()
+				for _, hk := range batch {
+					claimedBy[hk]++
+				}
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+
+	// every host must be claimed exactly once: no duplicates, full coverage.
+	var duplicates, missing int
+	for hk := range want {
+		switch claimedBy[hk] {
+		case 0:
+			missing++
+		case 1:
+		default:
+			duplicates++
+		}
+	}
+	if duplicates != 0 || missing != 0 {
+		t.Fatalf("expected every host claimed exactly once: %d duplicated, %d missing (of %d)", duplicates, missing, nHosts)
 	}
 }
 

--- a/persist/postgres/hosts_test.go
+++ b/persist/postgres/hosts_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -2790,86 +2789,6 @@ func TestHostsForIntegrityChecks(t *testing.T) {
 		t.Fatal(err)
 	} else if len(hosts) != 0 {
 		t.Fatalf("expected 0 hosts, got %d", len(hosts))
-	}
-}
-
-// TestHostsForIntegrityChecksConcurrent verifies that when multiple nodes run
-// the integrity-check loop concurrently against the same database, each host is
-// claimed by exactly one node (no duplicate work, full coverage). This mirrors
-// TestUnhealthySlabsConcurrent for the migration loop.
-func TestHostsForIntegrityChecksConcurrent(t *testing.T) {
-	log := zaptest.NewLogger(t)
-	db := initPostgres(t, log.Named("postgres"))
-
-	acc := proto4.Account{1}
-	db.addTestAccount(t, types.PublicKey(acc))
-
-	// create many hosts, each with a contract and a single sector that is due
-	// for an integrity check (next_integrity_check in the past).
-	const nHosts = 200
-	oneHAgo := time.Now().Add(-time.Hour)
-	want := make(map[types.PublicKey]struct{}, nHosts)
-	for i := 0; i < nHosts; i++ {
-		hk := db.addTestHost(t)
-		db.addTestContract(t, hk)
-		if _, err := db.PinSlabs(acc, oneHAgo, slabs.SlabPinParams{
-			MinShards:     1,
-			EncryptionKey: frand.Entropy256(),
-			Sectors:       []slabs.PinnedSector{{Root: frand.Entropy256(), HostKey: hk}},
-		}); err != nil {
-			t.Fatal(err)
-		}
-		want[hk] = struct{}{}
-	}
-
-	// all hosts require
-	if _, err := db.pool.Exec(context.Background(), `UPDATE hosts SET last_integrity_check = NOW() - INTERVAL '1 hour'`); err != nil {
-		t.Fatal(err)
-	}
-	maxLastCheck := time.Now().Add(-time.Minute)
-
-	const (
-		walkers   = 8
-		batchSize = 5
-	)
-	var mu sync.Mutex
-	claimedBy := make(map[types.PublicKey]int) // host -> number of walkers that claimed it
-
-	var wg sync.WaitGroup
-	for w := 0; w < walkers; w++ {
-		wg.Go(func() {
-			for {
-				batch, err := db.HostsForIntegrityChecks(maxLastCheck, batchSize)
-				if err != nil {
-					t.Errorf("walker failed: %v", err)
-					return
-				}
-				if len(batch) == 0 {
-					return
-				}
-				mu.Lock()
-				for _, hk := range batch {
-					claimedBy[hk]++
-				}
-				mu.Unlock()
-			}
-		})
-	}
-	wg.Wait()
-
-	// every host must be claimed exactly once: no duplicates, full coverage.
-	var duplicates, missing int
-	for hk := range want {
-		switch claimedBy[hk] {
-		case 0:
-			missing++
-		case 1:
-		default:
-			duplicates++
-		}
-	}
-	if duplicates != 0 || missing != 0 {
-		t.Fatalf("expected every host claimed exactly once: %d duplicated, %d missing (of %d)", duplicates, missing, nHosts)
 	}
 }
 

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -22,6 +22,13 @@ const (
 	// maxBadParityShards is the maximum proportion of parity shards that can be
 	// on bad hosts when pinning a slab.
 	maxBadParityShards = 0.2
+	// integrityCheckClaimInterval is how far into the future
+	// SectorsForIntegrityCheck pushes the next_integrity_check of the sectors
+	// it hands out. It acts as a lease so that concurrent integrity-check
+	// workers never fetch the same sectors. If a check is interrupted before
+	// its result is recorded, the sectors are retried after this interval
+	// instead of immediately.
+	integrityCheckClaimInterval = 30 * time.Minute
 )
 
 // MarkSectorsLost marks the sectors as lost by setting both the contract ID and
@@ -133,7 +140,13 @@ func recordIntegrityCheck(ctx context.Context, tx *txn, success bool, nextCheck 
 }
 
 // SectorsForIntegrityCheck returns up to `limit` sectors that are due for an
-// integrity check.
+// integrity check, claiming them by pushing their next_integrity_check
+// integrityCheckClaimInterval into the future. The claim is atomic (FOR UPDATE
+// SKIP LOCKED) so that concurrent callers receive disjoint sets of sectors
+// rather than re-verifying the same ones. Once a sector is checked,
+// RecordIntegrityCheck overwrites next_integrity_check with the real
+// (success/failure) interval; if the check is interrupted before that, the
+// sector is retried after the claim interval.
 func (s *Store) SectorsForIntegrityCheck(hostKey types.PublicKey, limit int) ([]types.Hash256, error) {
 	var sectors []types.Hash256
 	err := s.transaction(func(ctx context.Context, tx *txn) error {
@@ -143,14 +156,20 @@ func (s *Store) SectorsForIntegrityCheck(hostKey types.PublicKey, limit int) ([]
 			WITH hid AS (
 				SELECT id FROM hosts WHERE public_key = $1
 			)
-			SELECT sector_root
-			FROM sectors
-			WHERE
-				host_id = (SELECT id FROM hid)
-				AND next_integrity_check <= NOW()
-			ORDER BY next_integrity_check ASC
-			LIMIT $2
-		`, sqlPublicKey(hostKey), limit)
+			UPDATE sectors
+			SET next_integrity_check = NOW() + make_interval(secs => $3)
+			WHERE id IN (
+				SELECT id
+				FROM sectors
+				WHERE
+					host_id = (SELECT id FROM hid)
+					AND next_integrity_check <= NOW()
+				ORDER BY next_integrity_check ASC
+				LIMIT $2
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING sector_root
+		`, sqlPublicKey(hostKey), limit, integrityCheckClaimInterval.Seconds())
 		if err != nil {
 			return err
 		}

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -534,30 +534,141 @@ func TestSectorsForIntegrityCheck(t *testing.T) {
 	updateNextCheck(root3, now.Add(-time.Millisecond)) // requires check
 	updateNextCheck(root1, now.Add(1*time.Hour))       // doesn't require check
 
-	// make sure limit is applied
-	assertSectors := func(limit int) {
+	assertSet := func(got []types.Hash256, want ...types.Hash256) {
 		t.Helper()
-		expected := []types.Hash256{root2, root4, root3}
-		sectors, err := store.SectorsForIntegrityCheck(hk, limit)
-		if err != nil {
-			t.Fatal(err)
-		} else if len(sectors) != min(limit, len(expected)) {
-			t.Fatalf("expected 3 sectors, got %d", len(sectors))
-		} else if !reflect.DeepEqual(sectors, expected[:min(limit, len(expected))]) {
-			t.Fatal("sectors don't match expected roots")
+		gotSet := make(map[types.Hash256]struct{}, len(got))
+		for _, r := range got {
+			gotSet[r] = struct{}{}
+		}
+		if len(gotSet) != len(got) {
+			t.Fatalf("returned duplicate sectors: %v", got)
+		} else if len(got) != len(want) {
+			t.Fatalf("expected %d sectors, got %d", len(want), len(got))
+		}
+		for _, r := range want {
+			if _, ok := gotSet[r]; !ok {
+				t.Fatalf("expected sector %v in result %v", r, got)
+			}
 		}
 	}
-	assertSectors(10)
-	assertSectors(3)
-	assertSectors(2)
-	assertSectors(1)
 
-	// no sectors for unknown host
-	sectors, err := store.SectorsForIntegrityCheck(types.PublicKey{2}, 10)
+	// the limit selects the most-overdue sectors first: with a limit of 2 the two
+	// oldest (root2, root4) are returned, not the barely-due root3.
+	got, err := store.SectorsForIntegrityCheck(hk, 2)
 	if err != nil {
 		t.Fatal(err)
-	} else if len(sectors) != 0 {
-		t.Fatalf("expected 0 sectors, got %d", len(sectors))
+	}
+	assertSet(got, root2, root4)
+
+	// fetching claims the sectors (pushes their next_integrity_check into the
+	// future), so the next call no longer returns them and hands out the
+	// remaining due sector instead.
+	got, err = store.SectorsForIntegrityCheck(hk, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSet(got, root3)
+
+	// all due sectors have now been claimed -> nothing left to check
+	got, err = store.SectorsForIntegrityCheck(hk, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSet(got)
+
+	// the claimed sectors were pushed ~integrityCheckClaimInterval into the
+	// future, while root1 (never due, never returned) is untouched.
+	var root2Next, root1Next time.Time
+	if err := store.pool.QueryRow(t.Context(), `SELECT next_integrity_check FROM sectors WHERE sector_root = $1`, sqlHash256(root2)).Scan(&root2Next); err != nil {
+		t.Fatal(err)
+	} else if d := time.Until(root2Next); d < integrityCheckClaimInterval/2 {
+		t.Fatalf("expected root2 to be claimed ~%s into the future, got %s", integrityCheckClaimInterval, d)
+	}
+	if err := store.pool.QueryRow(t.Context(), `SELECT next_integrity_check FROM sectors WHERE sector_root = $1`, sqlHash256(root1)).Scan(&root1Next); err != nil {
+		t.Fatal(err)
+	} else if !root1Next.Equal(now.Add(time.Hour)) {
+		t.Fatalf("expected root1 next_integrity_check unchanged at %s, got %s", now.Add(time.Hour), root1Next)
+	}
+
+	// no sectors for unknown host
+	got, err = store.SectorsForIntegrityCheck(types.PublicKey{2}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSet(got)
+}
+
+// TestSectorsForIntegrityCheckConcurrent verifies that when multiple integrity
+// check workers - e.g. on different nodes checking the same host - fetch sectors
+// concurrently, each due sector is handed out exactly once (no duplicate checks,
+// full coverage), because fetching atomically claims the sectors.
+func TestSectorsForIntegrityCheckConcurrent(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// pin many sectors, all due for an integrity check
+	const nSectors = 500
+	roots := make([]slabs.PinnedSector, nSectors)
+	want := make(map[types.Hash256]struct{}, nSectors)
+	for i := range roots {
+		root := frand.Entropy256()
+		roots[i] = slabs.PinnedSector{Root: root, HostKey: hk}
+		want[root] = struct{}{}
+	}
+	if _, err := store.PinSlabs(account, time.Now().Add(-time.Hour), slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors:       roots,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		workers   = 8
+		batchSize = 7
+	)
+	var mu sync.Mutex
+	claimedBy := make(map[types.Hash256]int)
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for {
+				batch, err := store.SectorsForIntegrityCheck(hk, batchSize)
+				if err != nil {
+					t.Errorf("worker failed: %v", err)
+					return
+				}
+				if len(batch) == 0 {
+					return
+				}
+				mu.Lock()
+				for _, r := range batch {
+					claimedBy[r]++
+				}
+				mu.Unlock()
+			}
+		})
+	}
+	wg.Wait()
+
+	// every sector must be claimed exactly once.
+	var duplicates, missing int
+	for r := range want {
+		switch claimedBy[r] {
+		case 0:
+			missing++
+		case 1:
+		default:
+			duplicates++
+		}
+	}
+	if duplicates != 0 || missing != 0 {
+		t.Fatalf("expected every sector claimed exactly once: %d duplicated, %d missing (of %d)", duplicates, missing, nSectors)
 	}
 }
 

--- a/slabs/dataintegrity_test.go
+++ b/slabs/dataintegrity_test.go
@@ -56,6 +56,17 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 		}
 	}
 
+	// prepare helper to force the host's sectors due for a check. Fetching a
+	// sector now claims it (pushes next_integrity_check into the future), so
+	// re-checking the same sector across calls requires making it due again
+	// rather than relying on the tiny re-check interval elapsing between calls.
+	makeDue := func() {
+		t.Helper()
+		if _, err := store.Exec(context.Background(), `UPDATE sectors SET next_integrity_check = NOW() - INTERVAL '1 minute' WHERE host_id = (SELECT id FROM hosts WHERE public_key = $1)`, host.PublicKey[:]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// prepare sectors
 	roots := make([]types.Hash256, 3)
 	for i := range roots {
@@ -113,6 +124,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 	// checks before a bad sector gets removed
 	for i := uint(1); i < sm.MaxFailedIntegrityChecks(); i++ {
 		resetBalance()
+		makeDue()
 		sm.PerformIntegrityChecksForHost(context.Background(), host.PublicKey, zap.NewNop())
 	}
 	assertLostAndFailed(nil, roots[1:3])
@@ -125,6 +137,7 @@ func TestPerformIntegrityChecksForHost(t *testing.T) {
 	if err := am.UpdateServiceAccountBalance(hostKey.PublicKey(), acc, types.ZeroCurrency); err != nil {
 		t.Fatal(err)
 	}
+	makeDue()
 	sm.PerformIntegrityChecksForHost(context.Background(), host.PublicKey, zap.NewNop())
 	if cm.triggeredRefills[acc] != 1 {
 		t.Fatalf("expected 1 triggered refill, got %d", cm.triggeredRefills[acc])


### PR DESCRIPTION
Similar to the PR related to migrations. With this both migrations and integrity checks should be able to run on multiple nodes in parallel. 