### PR TITLE
Support pre-authorized keys

### DIFF
--- a/.changeset/added_support_for_pre_authorized_keys.md
+++ b/.changeset/added_support_for_pre_authorized_keys.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Added support for pre-authorized keys
+
+Pre-authorized keys let developers connect apps without requiring users to complete an interactive approval flow first.

--- a/accounts/connect.go
+++ b/accounts/connect.go
@@ -28,6 +28,22 @@ var (
 	// associated to it.
 	ErrKeyInUse = errors.New("key in use")
 
+	// ErrPreAuthorizedKeyExpired is returned when a pre-authorized key has
+	// passed its expiration time.
+	ErrPreAuthorizedKeyExpired = errors.New("pre-authorized key expired")
+
+	// ErrPreAuthorizedKeyExhausted is returned when a pre-authorized key has no
+	// remaining uses.
+	ErrPreAuthorizedKeyExhausted = errors.New("pre-authorized key has no remaining uses")
+
+	// ErrPreAuthorizedKeyAppMismatch is returned when a pre-authorized key is
+	// restricted to a different application.
+	ErrPreAuthorizedKeyAppMismatch = errors.New("pre-authorized key is not valid for this app")
+
+	// ErrInvalidPreAuthorizedKey is returned when a pre-authorized key request
+	// has invalid fields or signature.
+	ErrInvalidPreAuthorizedKey = errors.New("invalid pre-authorized key")
+
 	// ErrQuotaNotFound is returned when a quota is not found.
 	ErrQuotaNotFound = errors.New("quota not found")
 
@@ -74,6 +90,39 @@ type (
 		Quota       string `json:"quota"`
 	}
 
+	// PreAuthorizedKey is a limited-use authorization that allows an application
+	// to skip the interactive approval step for a connect key.
+	PreAuthorizedKey struct {
+		PublicKey     types.PublicKey `json:"publicKey"`
+		ConnectKey    string          `json:"connectKey"`
+		Expiration    time.Time       `json:"expiration"`
+		TotalUses     int             `json:"totalUses"`
+		RemainingUses int             `json:"remainingUses"`
+		AllowedAppID  *types.Hash256  `json:"allowedAppID,omitempty"`
+		DateCreated   time.Time       `json:"dateCreated"`
+		LastUsed      time.Time       `json:"lastUsed"`
+	}
+
+	// PreAuthorizedKeyRequest is the request type for creating a
+	// pre-authorized key.
+	PreAuthorizedKeyRequest struct {
+		PublicKey types.PublicKey `json:"publicKey"`
+		Signature types.Signature `json:"signature"`
+
+		ConnectKey   string         `json:"connectKey"`
+		Expiration   time.Time      `json:"expiration"`
+		TotalUses    int            `json:"totalUses"`
+		AllowedAppID *types.Hash256 `json:"allowedAppID,omitempty"`
+	}
+
+	// AppAuthorization contains the information needed to complete an
+	// application connection.
+	AppAuthorization struct {
+		ConnectKey   string
+		UserSecret   types.Hash256
+		Reconnecting bool
+	}
+
 	// AppMeta contains additional metadata associated with an account.
 	AppMeta struct {
 		ID          types.Hash256 `json:"id"`
@@ -91,6 +140,29 @@ type (
 		FundTargetBytes *uint64 `json:"fundTargetBytes"`
 	}
 )
+
+// SigHash returns the domain-separated hash signed when creating a
+// pre-authorized key.
+func (req PreAuthorizedKeyRequest) SigHash() types.Hash256 {
+	h := types.NewHasher()
+	h.E.WriteString("indexd/preauthorized-key/create/v1")
+	req.PublicKey.EncodeTo(h.E)
+	h.E.WriteString(req.ConnectKey)
+	h.E.WriteTime(req.Expiration)
+	h.E.WriteUint64(uint64(req.TotalUses))
+	h.E.WriteBool(req.AllowedAppID != nil)
+	if req.AllowedAppID != nil {
+		h.E.Write(req.AllowedAppID[:])
+	}
+	return h.Sum()
+}
+
+// Sign proves control of privateKey and binds the complete pre-authorization
+// policy to its corresponding public key.
+func (req *PreAuthorizedKeyRequest) Sign(privateKey types.PrivateKey) {
+	req.PublicKey = privateKey.PublicKey()
+	req.Signature = privateKey.SignHash(req.SigHash())
+}
 
 // AddAppConnectKey adds a new app connect key. If the key field in the
 // request is empty, a random key will be generated.
@@ -129,6 +201,51 @@ func (m *AccountManager) AppConnectKeys(ctx context.Context, offset, limit int) 
 	return m.store.AppConnectKeys(offset, limit)
 }
 
+// AddPreAuthorizedKey creates a limited-use authorization for bypassing the
+// interactive application approval flow.
+func (m *AccountManager) AddPreAuthorizedKey(ctx context.Context, req PreAuthorizedKeyRequest) (PreAuthorizedKey, error) {
+	if req.PublicKey == (types.PublicKey{}) || req.ConnectKey == "" || req.TotalUses <= 0 || !req.Expiration.After(time.Now()) || !req.PublicKey.VerifyHash(req.SigHash(), req.Signature) {
+		return PreAuthorizedKey{}, ErrInvalidPreAuthorizedKey
+	}
+	return m.store.AddPreAuthorizedKey(req)
+}
+
+// DeletePreAuthorizedKey deletes a pre-authorized key.
+func (m *AccountManager) DeletePreAuthorizedKey(ctx context.Context, publicKey types.PublicKey) error {
+	return m.store.DeletePreAuthorizedKey(publicKey)
+}
+
+// PreAuthorizedKey returns the pre-authorized key with the given public key.
+func (m *AccountManager) PreAuthorizedKey(ctx context.Context, publicKey types.PublicKey) (PreAuthorizedKey, error) {
+	return m.store.PreAuthorizedKey(publicKey)
+}
+
+// PreAuthorizedKeys returns a paginated list of pre-authorized keys.
+func (m *AccountManager) PreAuthorizedKeys(ctx context.Context, offset, limit int) ([]PreAuthorizedKey, error) {
+	return m.store.PreAuthorizedKeys(offset, limit)
+}
+
+// AuthorizePreAuthorizedKey consumes one use of a pre-authorized key and
+// returns the information needed to complete an application connection.
+func (m *AccountManager) AuthorizePreAuthorizedKey(publicKey types.PublicKey, appID types.Hash256) (AppAuthorization, error) {
+	connectKey, userSecret, reconnecting, err := m.store.ConsumePreAuthorizedKey(publicKey, appID)
+	if err != nil {
+		return AppAuthorization{}, err
+	}
+	return authorizeApp(connectKey, &userSecret, appID, reconnecting), nil
+}
+
+// AuthorizeAppConnectKey authorizes an application connection using a regular
+// connect key. It returns the app-specific secret and whether the application
+// was previously connected.
+func (m *AccountManager) AuthorizeAppConnectKey(connectKey string, appID types.Hash256) (AppAuthorization, error) {
+	userSecret, reconnecting, err := m.store.AppAuthorization(connectKey, appID)
+	if err != nil {
+		return AppAuthorization{}, err
+	}
+	return authorizeApp(connectKey, &userSecret, appID, reconnecting), nil
+}
+
 // RegisterAppKey uses an existing app connect key to add an account. If the key is exhausted, it
 // returns [ErrKeyExhausted]. If the key is not found, it returns [ErrKeyNotFound].
 func (m *AccountManager) RegisterAppKey(key string, pk types.PublicKey, meta AppMeta) error {
@@ -165,20 +282,13 @@ func (m *AccountManager) Quotas(ctx context.Context, offset, limit int) ([]Quota
 	return m.store.Quotas(offset, limit)
 }
 
-// HasAppAccount reports whether an account already exists for the given
-// connect key and app ID.
-func (m *AccountManager) HasAppAccount(connectKey string, appID types.Hash256) (bool, error) {
-	return m.store.HasAppAccount(connectKey, appID)
-}
-
-// AppSecret derives a unique application secret using a stored user secret
-// associated with the given connect key and the provided app ID.
-func (m *AccountManager) AppSecret(connectKey string, appID types.Hash256) (types.Hash256, error) {
-	secret, err := m.store.AppConnectKeyUserSecret(connectKey)
-	if err != nil {
-		return types.Hash256{}, err
+func authorizeApp(connectKey string, userSecret *types.Hash256, appID types.Hash256, reconnecting bool) AppAuthorization {
+	defer clear(userSecret[:])
+	return AppAuthorization{
+		ConnectKey:   connectKey,
+		UserSecret:   types.Hash256(keys.Derive(userSecret[:], appID[:], []byte("server app secret"), 32)),
+		Reconnecting: reconnecting,
 	}
-	return types.Hash256(keys.Derive(secret[:], appID[:], []byte("server app secret"), 32)), nil
 }
 
 // DeriveSharingAccountKey deterministically derives a connect key's sharing

--- a/accounts/manager.go
+++ b/accounts/manager.go
@@ -49,14 +49,19 @@ type (
 		UpdateHostPools(pools []HostPool) error
 
 		ValidAppConnectKey(string) error
-		AppConnectKeyUserSecret(string) (secret types.Hash256, err error)
-		HasAppAccount(connectKey string, appID types.Hash256) (bool, error)
+		AppAuthorization(connectKey string, appID types.Hash256) (userSecret types.Hash256, reconnecting bool, err error)
 		RegisterAppKey(string, types.PublicKey, AppMeta) error
 		AddAppConnectKey(AppConnectKeyRequest) (ConnectKey, error)
 		UpdateAppConnectKey(AppConnectKeyRequest) (ConnectKey, error)
 		DeleteAppConnectKey(string) error
 		AppConnectKey(key string) (ConnectKey, error)
 		AppConnectKeys(offset, limit int) ([]ConnectKey, error)
+		AddPreAuthorizedKey(PreAuthorizedKeyRequest) (PreAuthorizedKey, error)
+		DeletePreAuthorizedKey(types.PublicKey) error
+		PreAuthorizedKey(types.PublicKey) (PreAuthorizedKey, error)
+		PreAuthorizedKeys(offset, limit int) ([]PreAuthorizedKey, error)
+		ConsumePreAuthorizedKey(types.PublicKey, types.Hash256) (connectKey string, userSecret types.Hash256, reconnecting bool, err error)
+		PruneExpiredPreAuthorizedKeys(time.Time) error
 
 		PutQuota(key string, req PutQuotaRequest) error
 		DeleteQuota(key string) error
@@ -100,7 +105,8 @@ func WithLogger(l *zap.Logger) Option {
 	}
 }
 
-// WithPruneAccountsInterval sets the interval for pruning accounts.
+// WithPruneAccountsInterval sets the interval for pruning accounts and expired
+// pre-authorized keys.
 func WithPruneAccountsInterval(interval time.Duration) Option {
 	return func(m *AccountManager) {
 		m.pruneAccountsInterval = interval
@@ -294,20 +300,22 @@ func NewManager(store Store, opts ...Option) (*AccountManager, error) {
 	return m, nil
 }
 
-// maintenanceLoop performs any background tasks that the accounts manager
-// needs to perform on accounts
+// maintenanceLoop performs background account-management tasks.
 func (m *AccountManager) maintenanceLoop(ctx context.Context) {
-	healthTicker := time.NewTicker(m.pruneAccountsInterval)
-	defer healthTicker.Stop()
+	maintenanceTicker := time.NewTicker(m.pruneAccountsInterval)
+	defer maintenanceTicker.Stop()
 
 	for {
 		select {
-		case <-healthTicker.C:
+		case <-maintenanceTicker.C:
 		case <-ctx.Done():
 			return
 		}
 		if err := m.performPruneAccounts(); err != nil && !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 			m.log.Error("maintenance failed", zap.String("task", "prune accounts"), zap.Error(err))
+		}
+		if err := m.store.PruneExpiredPreAuthorizedKeys(time.Now()); err != nil && !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			m.log.Error("maintenance failed", zap.String("task", "prune expired pre-authorized keys"), zap.Error(err))
 		}
 	}
 }

--- a/accounts/manager_test.go
+++ b/accounts/manager_test.go
@@ -1,11 +1,14 @@
 package accounts_test
 
 import (
+	"errors"
 	"math"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/contracts"
 	"go.sia.tech/indexd/testutils"
@@ -195,6 +198,53 @@ func TestUpdateFundedPools(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPruneExpiredPreAuthorizedKeys(t *testing.T) {
+	store := newTestStore(t)
+	synctest.Test(t, func(t *testing.T) {
+		const maintenanceInterval = time.Hour
+		manager, err := accounts.NewManager(store, accounts.WithPruneAccountsInterval(maintenanceInterval))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer manager.Close()
+
+		fundTarget := uint64(1)
+		if err := manager.PutQuota(t.Context(), testutils.TestQuotaName, accounts.PutQuotaRequest{
+			MaxPinnedData:   1,
+			TotalUses:       1,
+			FundTargetBytes: &fundTarget,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		connectKey, err := manager.AddAppConnectKey(t.Context(), accounts.AppConnectKeyRequest{Key: "connect-key", Quota: testutils.TestQuotaName})
+		if err != nil {
+			t.Fatal(err)
+		}
+		preAuthorizedPrivateKey := types.GeneratePrivateKey()
+		preAuthorizedKeyRequest := accounts.PreAuthorizedKeyRequest{
+			ConnectKey: connectKey.Key,
+			Expiration: time.Now().Add(maintenanceInterval / 2),
+			TotalUses:  1,
+		}
+		preAuthorizedKeyRequest.Sign(preAuthorizedPrivateKey)
+		preAuthorizedKey, err := manager.AddPreAuthorizedKey(t.Context(), preAuthorizedKeyRequest)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		synctest.Wait()
+		if _, err := manager.PreAuthorizedKey(t.Context(), preAuthorizedKey.PublicKey); err != nil {
+			t.Fatalf("expected key before maintenance: %v", err)
+		}
+
+		time.Sleep(maintenanceInterval)
+		synctest.Wait()
+		if _, err := manager.PreAuthorizedKey(t.Context(), preAuthorizedKey.PublicKey); !errors.Is(err, accounts.ErrKeyNotFound) {
+			t.Fatalf("expected expired key to be pruned, got %v", err)
+		}
+	})
 }
 
 // approxEqual checks if two time.Time values are within a second of each

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -116,6 +116,10 @@ type (
 		DeleteAppConnectKey(context.Context, string) error
 		AppConnectKey(ctx context.Context, key string) (accounts.ConnectKey, error)
 		AppConnectKeys(ctx context.Context, offset, limit int) ([]accounts.ConnectKey, error)
+		AddPreAuthorizedKey(context.Context, accounts.PreAuthorizedKeyRequest) (accounts.PreAuthorizedKey, error)
+		DeletePreAuthorizedKey(context.Context, types.PublicKey) error
+		PreAuthorizedKey(context.Context, types.PublicKey) (accounts.PreAuthorizedKey, error)
+		PreAuthorizedKeys(context.Context, int, int) ([]accounts.PreAuthorizedKey, error)
 		RegisterAppKey(string, types.PublicKey, accounts.AppMeta) error
 
 		PutQuota(ctx context.Context, key string, req accounts.PutQuotaRequest) error
@@ -264,12 +268,16 @@ func NewAPI(chain ChainManager, accounts Accounts, contracts ContractManager, ho
 		"GET /txpool/recommendedfee": a.handleGETTxpoolRecommendedFee,
 
 		// connect endpoints
-		"GET    /apps/connect/keys":      a.handleGETAppConnectKeys,
-		"POST   /apps/connect/keys":      a.handlePOSTAppConnectKeys,
-		"PUT    /apps/connect/keys":      a.handlePUTAppConnectKeys,
-		"GET    /apps/connect/keys/:key": a.handleGETAppConnectKeysKey,
-		"DELETE /apps/connect/keys/:key": a.handleDELETEAppConnectKeys,
-		"POST   /apps/register":          a.handlePOSTAppsRegister,
+		"GET    /apps/connect/keys":                  a.handleGETAppConnectKeys,
+		"POST   /apps/connect/keys":                  a.handlePOSTAppConnectKeys,
+		"PUT    /apps/connect/keys":                  a.handlePUTAppConnectKeys,
+		"GET    /apps/connect/keys/:key":             a.handleGETAppConnectKeysKey,
+		"DELETE /apps/connect/keys/:key":             a.handleDELETEAppConnectKeys,
+		"GET    /apps/preauthorized/keys":            a.handleGETPreAuthorizedKeys,
+		"POST   /apps/preauthorized/keys":            a.handlePOSTPreAuthorizedKeys,
+		"GET    /apps/preauthorized/keys/:publicKey": a.handleGETPreAuthorizedKeysKey,
+		"DELETE /apps/preauthorized/keys/:publicKey": a.handleDELETEPreAuthorizedKeys,
+		"POST   /apps/register":                      a.handlePOSTAppsRegister,
 
 		// quota endpoints
 		"GET    /quotas":      a.handleGETQuotas,
@@ -483,6 +491,71 @@ func (a *admin) handleDELETEAppConnectKeys(jc jape.Context) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if jc.Check("failed to delete app connect key", err) != nil {
+		return
+	}
+	jc.Encode(nil)
+}
+
+func (a *admin) handleGETPreAuthorizedKeys(jc jape.Context) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	keys, err := a.accounts.PreAuthorizedKeys(jc.Request.Context(), offset, limit)
+	if jc.Check("failed to get pre-authorized keys", err) != nil {
+		return
+	}
+	jc.Encode(keys)
+}
+
+func (a *admin) handlePOSTPreAuthorizedKeys(jc jape.Context) {
+	var req accounts.PreAuthorizedKeyRequest
+	if jc.Decode(&req) != nil {
+		return
+	}
+
+	created, err := a.accounts.AddPreAuthorizedKey(jc.Request.Context(), req)
+	switch {
+	case errors.Is(err, accounts.ErrInvalidPreAuthorizedKey):
+		jc.Error(err, http.StatusBadRequest)
+	case errors.Is(err, accounts.ErrKeyNotFound):
+		jc.Error(err, http.StatusNotFound)
+	case errors.Is(err, accounts.ErrKeyAlreadyExists):
+		jc.Error(err, http.StatusConflict)
+	case jc.Check("failed to add pre-authorized key", err) != nil:
+	default:
+		jc.Encode(created)
+	}
+}
+
+func (a *admin) handleGETPreAuthorizedKeysKey(jc jape.Context) {
+	var publicKey types.PublicKey
+	if jc.DecodeParam("publicKey", &publicKey) != nil {
+		return
+	}
+
+	preAuthorizedKey, err := a.accounts.PreAuthorizedKey(jc.Request.Context(), publicKey)
+	if errors.Is(err, accounts.ErrKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to get pre-authorized key", err) != nil {
+		return
+	}
+	jc.Encode(preAuthorizedKey)
+}
+
+func (a *admin) handleDELETEPreAuthorizedKeys(jc jape.Context) {
+	var publicKey types.PublicKey
+	if jc.DecodeParam("publicKey", &publicKey) != nil {
+		return
+	}
+
+	err := a.accounts.DeletePreAuthorizedKey(jc.Request.Context(), publicKey)
+	if errors.Is(err, accounts.ErrKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if jc.Check("failed to delete pre-authorized key", err) != nil {
 		return
 	}
 	jc.Encode(nil)

--- a/api/admin/admin_test.go
+++ b/api/admin/admin_test.go
@@ -158,6 +158,74 @@ func TestAppConnectKeys(t *testing.T) {
 	}
 }
 
+func TestPreAuthorizedKeys(t *testing.T) {
+	c := testutils.NewConsensusNode(t, zap.NewNop())
+	indexer := testutils.NewIndexer(t, c, zap.NewNop())
+	adminClient := indexer.Admin
+	ctx := t.Context()
+
+	connectKey, err := adminClient.AddAppConnectKey(ctx, accounts.AppConnectKeyRequest{Quota: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	appID := types.Hash256(frand.Entropy256())
+	preAuthorizedPrivateKey := types.GeneratePrivateKey()
+	createRequest := accounts.PreAuthorizedKeyRequest{
+		ConnectKey:   connectKey.Key,
+		Expiration:   time.Now().Add(time.Hour),
+		TotalUses:    3,
+		AllowedAppID: &appID,
+	}
+	createRequest.Sign(preAuthorizedPrivateKey)
+	created, err := adminClient.AddPreAuthorizedKey(ctx, createRequest)
+	if err != nil {
+		t.Fatal(err)
+	} else if created.PublicKey != preAuthorizedPrivateKey.PublicKey() || created.ConnectKey != connectKey.Key {
+		t.Fatalf("unexpected pre-authorized key: %+v", created)
+	} else if created.TotalUses != 3 || created.RemainingUses != 3 {
+		t.Fatalf("unexpected use limits: %+v", created)
+	} else if created.AllowedAppID == nil || *created.AllowedAppID != appID {
+		t.Fatalf("unexpected app restriction: %+v", created)
+	}
+
+	keys, err := adminClient.PreAuthorizedKeys(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 1 {
+		t.Fatalf("unexpected key list: %+v", keys)
+	}
+	if !reflect.DeepEqual(keys[0], created) {
+		t.Fatalf("expected %+v, got %+v", created, keys[0])
+	}
+	got, err := adminClient.PreAuthorizedKey(ctx, created.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(got, created) {
+		t.Fatalf("expected %+v, got %+v", created, got)
+	}
+
+	expiredRequest := accounts.PreAuthorizedKeyRequest{
+		ConnectKey: connectKey.Key,
+		Expiration: time.Now().Add(-time.Minute),
+		TotalUses:  1,
+	}
+	expiredRequest.Sign(types.GeneratePrivateKey())
+	_, err = adminClient.AddPreAuthorizedKey(ctx, expiredRequest)
+	if err == nil {
+		t.Fatal("expected expired creation request to fail")
+	}
+
+	tamperedRequest := createRequest
+	tamperedRequest.TotalUses++
+	if _, err := adminClient.AddPreAuthorizedKey(ctx, tamperedRequest); err == nil {
+		t.Fatal("expected creation request with an invalid signature to fail")
+	} else if err := adminClient.DeletePreAuthorizedKey(ctx, created.PublicKey); err != nil {
+		t.Fatal(err)
+	} else if _, err := adminClient.PreAuthorizedKey(ctx, created.PublicKey); err == nil {
+		t.Fatal("expected deleted key to be missing")
+	}
+}
+
 func TestQuotasAPI(t *testing.T) {
 	c := testutils.NewConsensusNode(t, zap.NewNop())
 	indexer := testutils.NewIndexer(t, c, zap.NewNop())

--- a/api/admin/client.go
+++ b/api/admin/client.go
@@ -99,6 +99,32 @@ func (c *Client) UpdateAppConnectKey(ctx context.Context, req accounts.AppConnec
 	return c.c.PUT(ctx, "/apps/connect/keys", req)
 }
 
+// PreAuthorizedKeys retrieves a paginated list of pre-authorized keys.
+func (c *Client) PreAuthorizedKeys(ctx context.Context, offset, limit int) (keys []accounts.PreAuthorizedKey, err error) {
+	values := url.Values{}
+	values.Set("offset", fmt.Sprintf("%d", offset))
+	values.Set("limit", fmt.Sprintf("%d", limit))
+	err = c.c.GET(ctx, "/apps/preauthorized/keys?"+values.Encode(), &keys)
+	return
+}
+
+// PreAuthorizedKey retrieves a pre-authorized key by its public key.
+func (c *Client) PreAuthorizedKey(ctx context.Context, publicKey types.PublicKey) (preAuthorizedKey accounts.PreAuthorizedKey, err error) {
+	err = c.c.GET(ctx, fmt.Sprintf("/apps/preauthorized/keys/%s", publicKey), &preAuthorizedKey)
+	return
+}
+
+// AddPreAuthorizedKey registers a client-generated pre-authorized public key.
+func (c *Client) AddPreAuthorizedKey(ctx context.Context, req accounts.PreAuthorizedKeyRequest) (key accounts.PreAuthorizedKey, err error) {
+	err = c.c.POST(ctx, "/apps/preauthorized/keys", req, &key)
+	return
+}
+
+// DeletePreAuthorizedKey deletes a pre-authorized key by its public key.
+func (c *Client) DeletePreAuthorizedKey(ctx context.Context, publicKey types.PublicKey) error {
+	return c.c.DELETE(ctx, fmt.Sprintf("/apps/preauthorized/keys/%s", publicKey))
+}
+
 // RegisterAppKey registers an app key with the given connect key.
 func (c *Client) RegisterAppKey(ctx context.Context, req RegisterAppKeyRequest) error {
 	return c.c.POST(ctx, "/apps/register", req, nil)

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -57,8 +57,8 @@ type (
 	Accounts interface {
 		ValidAppConnectKey(context.Context, string) error
 		RegisterAppKey(string, types.PublicKey, accounts.AppMeta) error
-		AppSecret(connectKey string, appID types.Hash256) (types.Hash256, error)
-		HasAppAccount(connectKey string, appID types.Hash256) (bool, error)
+		AuthorizeAppConnectKey(connectKey string, appID types.Hash256) (accounts.AppAuthorization, error)
+		AuthorizePreAuthorizedKey(publicKey types.PublicKey, appID types.Hash256) (accounts.AppAuthorization, error)
 
 		HasAccount(context.Context, types.PublicKey) (bool, error)
 		Account(context.Context, types.PublicKey) (accounts.Account, error)
@@ -95,6 +95,11 @@ type (
 		LogoURL     string        `json:"logoURL"`
 		ServiceURL  string        `json:"serviceURL"`
 		CallbackURL string        `json:"callbackURL"`
+
+		// PreAuthorizedKey and PreAuthorizationSignature allow the request to
+		// bypass interactive approval when signed by a pre-authorized key.
+		PreAuthorizedKey          types.PublicKey `json:"preAuthorizedKey,omitzero"`
+		PreAuthorizationSignature types.Signature `json:"preAuthorizationSignature,omitzero"`
 	}
 
 	// AuthConnectStatusResponse is the response body for checking the status of an
@@ -104,7 +109,7 @@ type (
 		// Reconnecting is true if the user has previously connected the app.
 		// It is only set if the user approved the request.
 		Reconnecting bool          `json:"reconnecting"`
-		UserSecret   types.Hash256 `json:"userSecret,omitempty"`
+		UserSecret   types.Hash256 `json:"userSecret,omitzero"`
 	}
 
 	// RegisterAppResponse is the response body for registering a new application.
@@ -508,13 +513,47 @@ func (a *app) handleAuthRequest(jc jape.Context) {
 
 	requestID := hex.EncodeToString(frand.Bytes(16))
 	expiration := time.Now().Add(10 * time.Minute)
-
-	a.mu.Lock()
-	a.authRequests[requestID] = authReq{
+	authRequest := authReq{
 		Request:      req,
 		Expiration:   expiration,
 		EphemeralKey: ephemeralKey,
 	}
+
+	hasPreAuthorizedKey := req.PreAuthorizedKey != (types.PublicKey{})
+	hasPreAuthorizationSignature := req.PreAuthorizationSignature != (types.Signature{})
+	if hasPreAuthorizedKey != hasPreAuthorizationSignature {
+		jc.Error(errors.New("invalid pre-authorization"), http.StatusUnauthorized)
+		return
+	}
+	if hasPreAuthorizedKey {
+		proofHash := preAuthorizationHash(ephemeralKey, req)
+		if !req.PreAuthorizedKey.VerifyHash(proofHash, req.PreAuthorizationSignature) {
+			jc.Error(errors.New("invalid pre-authorization"), http.StatusUnauthorized)
+			return
+		}
+
+		authorization, err := a.accounts.AuthorizePreAuthorizedKey(req.PreAuthorizedKey, req.AppID)
+		switch {
+		case errors.Is(err, accounts.ErrKeyNotFound),
+			errors.Is(err, accounts.ErrPreAuthorizedKeyExpired),
+			errors.Is(err, accounts.ErrPreAuthorizedKeyExhausted),
+			errors.Is(err, accounts.ErrPreAuthorizedKeyAppMismatch):
+			jc.Error(errors.New("invalid pre-authorized key"), http.StatusUnauthorized)
+			return
+		case err != nil:
+			a.log.Debug("failed to authorize pre-authorized key", zap.Error(err))
+			jc.Error(ErrInternalError, http.StatusInternalServerError)
+			return
+		}
+
+		authRequest.Approved = true
+		authRequest.Reconnecting = authorization.Reconnecting
+		authRequest.UserSecret = authorization.UserSecret
+		authRequest.ConnectKey = authorization.ConnectKey
+	}
+
+	a.mu.Lock()
+	a.authRequests[requestID] = authRequest
 	a.mu.Unlock()
 	time.AfterFunc(time.Until(expiration), func() {
 		a.mu.Lock()
@@ -599,25 +638,17 @@ func (a *app) handlePOSTAuthConnect(jc jape.Context) {
 		return
 	}
 
-	// derive shared secret
-	sharedSecret, err := a.accounts.AppSecret(connectKey, authReq.Request.AppID)
+	authorization, err := a.accounts.AuthorizeAppConnectKey(connectKey, authReq.Request.AppID)
 	if err != nil {
-		jc.Error(fmt.Errorf("failed to derive app secret: %w", err), http.StatusInternalServerError)
-		return
-	}
-
-	// check whether the user has previously connected the app
-	reconnecting, err := a.accounts.HasAppAccount(connectKey, authReq.Request.AppID)
-	if err != nil {
-		jc.Error(fmt.Errorf("failed to check for existing app account: %w", err), http.StatusInternalServerError)
+		jc.Error(fmt.Errorf("failed to authorize app connect key: %w", err), http.StatusInternalServerError)
 		return
 	}
 
 	// update the auth request with the shared secret and approval status
-	authReq.UserSecret = sharedSecret
+	authReq.UserSecret = authorization.UserSecret
 	authReq.Approved = approveReq.Approve
-	authReq.Reconnecting = reconnecting
-	authReq.ConnectKey = connectKey
+	authReq.Reconnecting = authorization.Reconnecting
+	authReq.ConnectKey = authorization.ConnectKey
 	a.authRequests[requestID] = authReq
 	jc.Encode(nil)
 }

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -87,14 +87,19 @@ type (
 		ConnectKey   string // ties the request to the app connect key used
 	}
 
-	// A RegisterAppRequest is the request body for registering a new application.
-	RegisterAppRequest struct {
+	// Info describes an application requesting a connection.
+	Info struct {
 		AppID       types.Hash256 `json:"appID"`
 		Name        string        `json:"name"`
 		Description string        `json:"description"`
 		LogoURL     string        `json:"logoURL"`
 		ServiceURL  string        `json:"serviceURL"`
 		CallbackURL string        `json:"callbackURL"`
+	}
+
+	// A RegisterAppRequest is the request body for registering a new application.
+	RegisterAppRequest struct {
+		Info
 
 		// PreAuthorizedKey and PreAuthorizationSignature allow the request to
 		// bypass interactive approval when signed by a pre-authorized key.

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -512,6 +512,83 @@ func TestEphemeralKeyAuth(t *testing.T) {
 	}
 }
 
+func TestPreAuthorizedAppConnect(t *testing.T) {
+	ctx := t.Context()
+	cluster := testutils.NewCluster(t, testutils.WithHosts(0), testutils.WithLogger(zap.NewNop()))
+	indexer := cluster.Indexer
+
+	connectKey, err := indexer.Admin.AddAppConnectKey(ctx, accounts.AppConnectKeyRequest{
+		Quota: "default",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	appID := types.Hash256(frand.Entropy256())
+	preAuthorizedPrivateKey := types.GeneratePrivateKey()
+	preAuthorizedKeyRequest := accounts.PreAuthorizedKeyRequest{
+		ConnectKey:   connectKey.Key,
+		Expiration:   time.Now().Add(time.Hour),
+		TotalUses:    1,
+		AllowedAppID: &appID,
+	}
+	preAuthorizedKeyRequest.Sign(preAuthorizedPrivateKey)
+	preAuthorizedKey, err := indexer.Admin.AddPreAuthorizedKey(ctx, preAuthorizedKeyRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ephemeralKey := types.GeneratePrivateKey()
+	appKey := types.GeneratePrivateKey()
+	appMeta := app.RegisterAppRequest{
+		AppID:       appID,
+		Name:        "pre-authorized-app",
+		Description: "A pre-authorized application",
+		ServiceURL:  "https://example.com",
+	}
+	connectResp, err := indexer.App.RequestAppConnection(ctx, ephemeralKey, appMeta, app.WithPreAuthorizedKey(preAuthorizedPrivateKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := indexer.App.RequestStatus(ctx, ephemeralKey, connectResp.StatusURL)
+	if err != nil {
+		t.Fatal(err)
+	} else if !status.Approved {
+		t.Fatal("expected pre-authorized request to be approved")
+	} else if status.Reconnecting {
+		t.Fatal("expected first connection to not be reconnecting")
+	} else if status.UserSecret == (types.Hash256{}) {
+		t.Fatal("expected non-empty user secret")
+	}
+
+	preAuthorizedKey, err = indexer.Admin.PreAuthorizedKey(ctx, preAuthorizedKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	} else if preAuthorizedKey.RemainingUses != 0 {
+		t.Fatalf("expected pre-authorized key to be consumed, got %d remaining uses", preAuthorizedKey.RemainingUses)
+	} else if preAuthorizedKey.LastUsed.IsZero() {
+		t.Fatal("expected pre-authorized key last-used time to be set")
+	}
+
+	if err := indexer.App.RegisterApp(ctx, connectResp.RegisterURL, ephemeralKey, appKey); err != nil {
+		t.Fatal(err)
+	} else if authenticated, err := indexer.App.CheckAppAuth(ctx, appKey); err != nil {
+		t.Fatal(err)
+	} else if !authenticated {
+		t.Fatal("expected registered app to be authenticated")
+	}
+
+	account, err := indexer.Admin.Account(ctx, appKey.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	} else if account.ConnectKey != connectKey.Key {
+		t.Fatalf("expected connect key %q, got %q", connectKey.Key, account.ConnectKey)
+	} else if account.App.ID != appID || account.App.Name != appMeta.Name {
+		t.Fatalf("unexpected app metadata: %+v", account.App)
+	}
+}
+
 func TestAppConnect(t *testing.T) {
 	appID := frand.Entropy256()
 

--- a/api/app/app_test.go
+++ b/api/app/app_test.go
@@ -72,7 +72,7 @@ func newAccount(t *testing.T, cluster *testutils.Cluster) (types.PrivateKey, acc
 	}
 
 	ephemeralKey := types.GeneratePrivateKey()
-	connectResp, err := client.RequestAppConnection(ctx, ephemeralKey, app.RegisterAppRequest{
+	connectResp, err := client.RequestAppConnection(ctx, ephemeralKey, app.Info{
 		AppID:       frand.Entropy256(),
 		Name:        "Test App",
 		Description: "A test application",
@@ -478,7 +478,7 @@ func TestEphemeralKeyAuth(t *testing.T) {
 	appKey := types.GeneratePrivateKey()
 	appClient := indexer.App
 
-	connectResp, err := appClient.RequestAppConnection(ctx, ephemeralKey, app.RegisterAppRequest{
+	connectResp, err := appClient.RequestAppConnection(ctx, ephemeralKey, app.Info{
 		AppID:       frand.Entropy256(),
 		Name:        "test",
 		Description: "test",
@@ -540,7 +540,7 @@ func TestPreAuthorizedAppConnect(t *testing.T) {
 
 	ephemeralKey := types.GeneratePrivateKey()
 	appKey := types.GeneratePrivateKey()
-	appMeta := app.RegisterAppRequest{
+	appMeta := app.Info{
 		AppID:       appID,
 		Name:        "pre-authorized-app",
 		Description: "A pre-authorized application",
@@ -618,7 +618,7 @@ func TestAppConnect(t *testing.T) {
 		t.Fatal("expected app to not be authenticated yet")
 	}
 
-	resp, err := appClient.RequestAppConnection(ctx, ephemeralSK, app.RegisterAppRequest{
+	resp, err := appClient.RequestAppConnection(ctx, ephemeralSK, app.Info{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -652,7 +652,7 @@ func TestAppConnect(t *testing.T) {
 	}
 
 	// try again
-	resp, err = appClient.RequestAppConnection(ctx, ephemeralSK, app.RegisterAppRequest{
+	resp, err = appClient.RequestAppConnection(ctx, ephemeralSK, app.Info{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -725,7 +725,7 @@ func TestAppConnect(t *testing.T) {
 	}
 
 	// authenticate again to ensure the same user secret is returned
-	resp, err = appClient.RequestAppConnection(ctx, ephemeralSK, app.RegisterAppRequest{
+	resp, err = appClient.RequestAppConnection(ctx, ephemeralSK, app.Info{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -765,7 +765,7 @@ func TestAppConnect(t *testing.T) {
 
 	ephemeralKey := types.GeneratePrivateKey()
 	sk2 := types.GeneratePrivateKey()
-	appMeta := app.RegisterAppRequest{
+	appMeta := app.Info{
 		AppID:       frand.Entropy256(),
 		Name:        "test-app-2",
 		Description: "test-app-2",

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -167,6 +167,20 @@ func requestHash(method string, hostname, path string, validUntil time.Time, bod
 	return h.Sum()
 }
 
+func preAuthorizationHash(ephemeralKey types.PublicKey, request RegisterAppRequest) types.Hash256 {
+	h := types.NewHasher()
+	h.E.WriteString("indexd/preauthorize-app/v1")
+	ephemeralKey.EncodeTo(h.E)
+	request.AppID.EncodeTo(h.E)
+	h.E.WriteString(request.Name)
+	h.E.WriteString(request.Description)
+	h.E.WriteString(request.LogoURL)
+	h.E.WriteString(request.ServiceURL)
+	h.E.WriteString(request.CallbackURL)
+	request.PreAuthorizedKey.EncodeTo(h.E)
+	return h.Sum()
+}
+
 func registerAppKeyHash(ephemeralKey types.PublicKey, requestID string) types.Hash256 {
 	h := types.NewHasher()
 	h.E.Write([]byte("registerAppKey"))

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -55,7 +57,11 @@ func TestRemainingStorage(t *testing.T) {
 	}
 }
 
-type mockAccounts struct{ tokens map[types.PublicKey]struct{} }
+type mockAccounts struct {
+	tokens    map[types.PublicKey]struct{}
+	authorize func(types.PublicKey, types.Hash256) (accounts.AppAuthorization, error)
+	register  func(string, types.PublicKey, accounts.AppMeta) error
+}
 
 func (s *mockAccounts) HasAccount(_ context.Context, ak types.PublicKey) (bool, error) {
 	_, found := s.tokens[ak]
@@ -75,15 +81,152 @@ func (s *mockAccounts) ValidAppConnectKey(context.Context, string) error {
 }
 
 func (s *mockAccounts) RegisterAppKey(connectKey string, appKey types.PublicKey, meta accounts.AppMeta) error {
+	if s.register != nil {
+		return s.register(connectKey, appKey, meta)
+	}
 	return nil
 }
 
-func (s *mockAccounts) AppSecret(connectKey string, appID types.Hash256) (types.Hash256, error) {
-	return frand.Entropy256(), nil
+func (s *mockAccounts) AuthorizeAppConnectKey(connectKey string, appID types.Hash256) (accounts.AppAuthorization, error) {
+	return accounts.AppAuthorization{ConnectKey: connectKey, UserSecret: frand.Entropy256()}, nil
 }
 
-func (s *mockAccounts) HasAppAccount(connectKey string, appID types.Hash256) (bool, error) {
-	return false, nil
+func (s *mockAccounts) AuthorizePreAuthorizedKey(key types.PublicKey, appID types.Hash256) (accounts.AppAuthorization, error) {
+	if s.authorize != nil {
+		return s.authorize(key, appID)
+	}
+	return accounts.AppAuthorization{}, accounts.ErrKeyNotFound
+}
+
+type mockContracts struct{}
+
+func (*mockContracts) TriggerAccountFunding() error { return nil }
+
+func TestPreAuthorizedAuth(t *testing.T) {
+	appID := types.Hash256{1}
+	userSecret := types.Hash256{2}
+	appKey := types.GeneratePrivateKey()
+	preAuthorizedKey := types.GeneratePrivateKey()
+	var registered bool
+	s := &mockAccounts{
+		tokens: make(map[types.PublicKey]struct{}),
+		authorize: func(key types.PublicKey, gotAppID types.Hash256) (accounts.AppAuthorization, error) {
+			if key != preAuthorizedKey.PublicKey() || gotAppID != appID {
+				t.Fatalf("unexpected authorization: %v %v", key, gotAppID)
+			}
+			return accounts.AppAuthorization{
+				ConnectKey:   "connect-key",
+				UserSecret:   userSecret,
+				Reconnecting: true,
+			}, nil
+		},
+		register: func(connectKey string, gotAppKey types.PublicKey, meta accounts.AppMeta) error {
+			if connectKey != "connect-key" || gotAppKey != appKey.PublicKey() || meta.ID != appID {
+				t.Fatalf("unexpected registration: %q %v %+v", connectKey, gotAppKey, meta)
+			}
+			registered = true
+			return nil
+		},
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	appAPIAddr := fmt.Sprintf("http://%s", l.Addr())
+	handler, err := NewAPI(appAPIAddr, nil, s, &mockContracts{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: handler}
+	defer server.Close()
+	go server.Serve(l)
+
+	ephemeralKey := types.GeneratePrivateKey()
+	client := NewClient(appAPIAddr)
+	resp, err := client.RequestAppConnection(t.Context(), ephemeralKey, RegisterAppRequest{
+		AppID:       appID,
+		Name:        "test-app",
+		Description: "A test app",
+		ServiceURL:  "https://example.com",
+	}, WithPreAuthorizedKey(preAuthorizedKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := client.RequestStatus(t.Context(), ephemeralKey, resp.StatusURL)
+	if err != nil {
+		t.Fatal(err)
+	} else if !status.Approved || !status.Reconnecting || status.UserSecret != userSecret {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+	if err := client.RegisterApp(t.Context(), resp.RegisterURL, ephemeralKey, appKey); err != nil {
+		t.Fatal(err)
+	} else if !registered {
+		t.Fatal("expected app key to be registered")
+	}
+}
+
+func TestPreAuthorizationBoundToEphemeralKey(t *testing.T) {
+	preAuthorizedKey := types.GeneratePrivateKey()
+	var authorizeCalled bool
+	s := &mockAccounts{
+		tokens: make(map[types.PublicKey]struct{}),
+		authorize: func(types.PublicKey, types.Hash256) (accounts.AppAuthorization, error) {
+			authorizeCalled = true
+			return accounts.AppAuthorization{}, nil
+		},
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	appAPIAddr := fmt.Sprintf("http://%s", l.Addr())
+	handler, err := NewAPI(appAPIAddr, nil, s, &mockContracts{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &http.Server{Handler: handler}
+	defer server.Close()
+	go server.Serve(l)
+
+	request := RegisterAppRequest{
+		AppID:            types.Hash256{1},
+		Name:             "test-app",
+		Description:      "A test app",
+		ServiceURL:       "https://example.com",
+		PreAuthorizedKey: preAuthorizedKey.PublicKey(),
+	}
+	validUntil := time.Now().Add(time.Minute)
+	endpointURL := appAPIAddr + "/auth/connect"
+
+	// The pre-authorization proof was captured from a request using a different
+	// ephemeral key. Even though the attacker signs the outer request correctly,
+	// the proof in the request body must not authorize it.
+	originalEphemeralKey := types.GeneratePrivateKey()
+	proofHash := preAuthorizationHash(originalEphemeralKey.PublicKey(), request)
+	request.PreAuthorizationSignature = preAuthorizedKey.SignHash(proofHash)
+
+	requestBuf, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attackerEphemeralKey := types.GeneratePrivateKey()
+	u, body, err := sign(attackerEphemeralKey, validUntil, http.MethodPost, endpointURL, requestBuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = doRequest(t.Context(), http.MethodPost, u, body, applicationJSON)
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized response, got %v", err)
+	} else if authorizeCalled {
+		t.Fatal("invalid proof reached pre-authorized key consumption")
+	}
 }
 
 func TestAuthConnectFieldLimits(t *testing.T) {

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -145,7 +145,7 @@ func TestPreAuthorizedAuth(t *testing.T) {
 
 	ephemeralKey := types.GeneratePrivateKey()
 	client := NewClient(appAPIAddr)
-	resp, err := client.RequestAppConnection(t.Context(), ephemeralKey, RegisterAppRequest{
+	resp, err := client.RequestAppConnection(t.Context(), ephemeralKey, Info{
 		AppID:       appID,
 		Name:        "test-app",
 		Description: "A test app",
@@ -194,10 +194,12 @@ func TestPreAuthorizationBoundToEphemeralKey(t *testing.T) {
 	go server.Serve(l)
 
 	request := RegisterAppRequest{
-		AppID:            types.Hash256{1},
-		Name:             "test-app",
-		Description:      "A test app",
-		ServiceURL:       "https://example.com",
+		Info: Info{
+			AppID:       types.Hash256{1},
+			Name:        "test-app",
+			Description: "A test app",
+			ServiceURL:  "https://example.com",
+		},
 		PreAuthorizedKey: preAuthorizedKey.PublicKey(),
 	}
 	validUntil := time.Now().Add(time.Minute)
@@ -250,7 +252,7 @@ func TestAuthConnectFieldLimits(t *testing.T) {
 	client := NewClient(appAPIAddr)
 
 	// valid request should succeed
-	valid := RegisterAppRequest{
+	valid := Info{
 		AppID:       frand.Entropy256(),
 		Name:        "test-app",
 		Description: "A test app",
@@ -262,13 +264,13 @@ func TestAuthConnectFieldLimits(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		modify func(*RegisterAppRequest)
+		modify func(*Info)
 	}{
-		{"name too long", func(r *RegisterAppRequest) { r.Name = strings.Repeat("a", maxNameLen+1) }},
-		{"description too long", func(r *RegisterAppRequest) { r.Description = strings.Repeat("a", maxDescriptionLen+1) }},
-		{"logoURL too long", func(r *RegisterAppRequest) { r.LogoURL = strings.Repeat("a", maxURLLen+1) }},
-		{"serviceURL too long", func(r *RegisterAppRequest) { r.ServiceURL = strings.Repeat("a", maxURLLen+1) }},
-		{"callbackURL too long", func(r *RegisterAppRequest) { r.CallbackURL = strings.Repeat("a", maxURLLen+1) }},
+		{"name too long", func(r *Info) { r.Name = strings.Repeat("a", maxNameLen+1) }},
+		{"description too long", func(r *Info) { r.Description = strings.Repeat("a", maxDescriptionLen+1) }},
+		{"logoURL too long", func(r *Info) { r.LogoURL = strings.Repeat("a", maxURLLen+1) }},
+		{"serviceURL too long", func(r *Info) { r.ServiceURL = strings.Repeat("a", maxURLLen+1) }},
+		{"callbackURL too long", func(r *Info) { r.CallbackURL = strings.Repeat("a", maxURLLen+1) }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -303,7 +305,7 @@ func TestAuthConnectRateLimit(t *testing.T) {
 	ephemeralKey := types.GeneratePrivateKey()
 
 	client := NewClient(appAPIAddr)
-	req := RegisterAppRequest{
+	req := Info{
 		AppID:       frand.Entropy256(),
 		Name:        "test-app",
 		Description: "A test app",

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -315,7 +315,7 @@ func (c *Client) SharedObject(ctx context.Context, sharedURL string) (slabs.Shar
 }
 
 // RequestAppConnection requests an application connection to the indexer.
-func (c *Client) RequestAppConnection(ctx context.Context, ephemeralKey types.PrivateKey, request RegisterAppRequest, options ...RequestAppConnectionOption) (resp RegisterAppResponse, err error) {
+func (c *Client) RequestAppConnection(ctx context.Context, ephemeralKey types.PrivateKey, info Info, options ...RequestAppConnectionOption) (resp RegisterAppResponse, err error) {
 	var opts requestAppConnectionOptions
 	for _, option := range options {
 		option(&opts)
@@ -324,6 +324,7 @@ func (c *Client) RequestAppConnection(ctx context.Context, ephemeralKey types.Pr
 		return RegisterAppResponse{}, errors.New("invalid pre-authorized private key")
 	}
 
+	request := RegisterAppRequest{Info: info}
 	if opts.preAuthorizedKey != nil {
 		request.PreAuthorizedKey = opts.preAuthorizedKey.PublicKey()
 		proofHash := preAuthorizationHash(ephemeralKey.PublicKey(), request)

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,21 @@ type Client struct {
 	baseURL string
 
 	validity time.Duration
+}
+
+type requestAppConnectionOptions struct {
+	preAuthorizedKey types.PrivateKey
+}
+
+// RequestAppConnectionOption configures an application connection request.
+type RequestAppConnectionOption func(*requestAppConnectionOptions)
+
+// WithPreAuthorizedKey authorizes a connection request without interactive
+// approval. The key is used only to sign the request and is not transmitted.
+func WithPreAuthorizedKey(key types.PrivateKey) RequestAppConnectionOption {
+	return func(opts *requestAppConnectionOptions) {
+		opts.preAuthorizedKey = key
+	}
 }
 
 // HTTPError is returned by the client when the server responds with a non-2xx
@@ -299,7 +315,21 @@ func (c *Client) SharedObject(ctx context.Context, sharedURL string) (slabs.Shar
 }
 
 // RequestAppConnection requests an application connection to the indexer.
-func (c *Client) RequestAppConnection(ctx context.Context, ephemeralKey types.PrivateKey, request RegisterAppRequest) (resp RegisterAppResponse, err error) {
+func (c *Client) RequestAppConnection(ctx context.Context, ephemeralKey types.PrivateKey, request RegisterAppRequest, options ...RequestAppConnectionOption) (resp RegisterAppResponse, err error) {
+	var opts requestAppConnectionOptions
+	for _, option := range options {
+		option(&opts)
+	}
+	if opts.preAuthorizedKey != nil && len(opts.preAuthorizedKey) != ed25519.PrivateKeySize {
+		return RegisterAppResponse{}, errors.New("invalid pre-authorized private key")
+	}
+
+	if opts.preAuthorizedKey != nil {
+		request.PreAuthorizedKey = opts.preAuthorizedKey.PublicKey()
+		proofHash := preAuthorizationHash(ephemeralKey.PublicKey(), request)
+		request.PreAuthorizationSignature = opts.preAuthorizedKey.SignHash(proofHash)
+	}
+
 	requestBuf, err := json.Marshal(request)
 	if err != nil {
 		return RegisterAppResponse{}, fmt.Errorf("failed to marshal request data: %w", err)

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -273,6 +273,99 @@ paths:
         "404":
           description: Connect key not found
 
+  /apps/preauthorized/keys:
+    get:
+      tags:
+        - apps
+      summary: List pre-authorized application keys
+      operationId: getPreAuthorizedKeys
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: A list of pre-authorized keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PreAuthorizedKey"
+    post:
+      tags:
+        - apps
+      summary: Create a pre-authorized application key
+      description: Registers a client-generated Ed25519 public key as a limited-use authorization tied to a connect key. A signature proves control of the private key and binds the complete policy; the private key is never sent to the server.
+      operationId: createPreAuthorizedKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreAuthorizedKeyRequest"
+      responses:
+        "200":
+          description: Pre-authorized key created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreAuthorizedKey"
+        "400":
+          description: Public key, signature, expiration, or use count is invalid
+        "404":
+          description: Connect key not found
+        "409":
+          description: Pre-authorized key already exists
+
+  /apps/preauthorized/keys/{publicKey}:
+    get:
+      tags:
+        - apps
+      summary: Retrieve a pre-authorized application key
+      operationId: getPreAuthorizedKey
+      parameters:
+        - name: publicKey
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+      responses:
+        "200":
+          description: Pre-authorized key retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PreAuthorizedKey"
+        "404":
+          description: Pre-authorized key not found
+    delete:
+      tags:
+        - apps
+      summary: Delete a pre-authorized application key
+      operationId: deletePreAuthorizedKey
+      parameters:
+        - name: publicKey
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+      responses:
+        "204":
+          description: Pre-authorized key deleted successfully
+        "404":
+          description: Pre-authorized key not found
+
   /apps/register:
     post:
       tags:
@@ -2072,6 +2165,10 @@ components:
       $ref: "./components.yml#/components/schemas/UsabilitySettings"
     ConnectKey:
       $ref: "./components.yml#/components/schemas/ConnectKey"
+    PreAuthorizedKey:
+      $ref: "./components.yml#/components/schemas/PreAuthorizedKey"
+    PreAuthorizedKeyRequest:
+      $ref: "./components.yml#/components/schemas/PreAuthorizedKeyRequest"
     AccountStatsResponse:
       $ref: "./components.yml#/components/schemas/AccountStatsResponse"
     AppStatsResponse:

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -463,6 +463,8 @@ paths:
         Initiates a connection request. The request must be signed with an ephemeral ed25519 key
         using the signed URL scheme. The server binds the connection flow to that ephemeral key —
         subsequent calls to the status and register endpoints must be signed with the same key.
+        When a valid pre-authorization proof is supplied, the request is approved immediately. The
+        proof signs the exact request and ephemeral key; the private pre-authorized key is never sent.
       operationId: requestAppConnection
       requestBody:
         required: true
@@ -502,6 +504,14 @@ paths:
                   format: uri
                   maxLength: 2048
                   description: Optional URL the indexer can redirect to after approval
+                preAuthorizedKey:
+                  allOf:
+                    - $ref: "#/components/schemas/PublicKey"
+                    - description: Optional pre-authorized public key used to bypass interactive approval
+                preAuthorizationSignature:
+                  allOf:
+                    - $ref: "#/components/schemas/Signature"
+                    - description: Signature binding the pre-authorized key to this connection request and ephemeral key
       responses:
         "200":
           description: Application connection request accepted
@@ -511,6 +521,8 @@ paths:
                 $ref: "#/components/schemas/RegisterAppResponse"
         "400":
           description: Invalid request (missing required fields or field exceeds maximum length)
+        "401":
+          description: Invalid request signature or pre-authorization proof
         "409":
           description: Application already connected
         "429":
@@ -530,6 +542,7 @@ paths:
             )
 
             var appID = frand.Entropy256() // app ID should be constant for your application, not random
+            var preAuthorizedKey types.PrivateKey // generated and retained when its public key was pre-authorized
 
             func main() {
               client := app.NewClient("http://localhost:9982")
@@ -541,7 +554,7 @@ paths:
                 LogoURL:     "https://example.com/logo.png",
                 ServiceURL:  "https://example.com",
                 CallbackURL: "https://example.com/connected",
-              })
+              }, app.WithPreAuthorizedKey(preAuthorizedKey)) // optional
               ...
             }
 
@@ -727,6 +740,8 @@ components:
       $ref: "./components.yml#/components/schemas/ObjectEvent"
     PublicKey:
       $ref: "./components.yml#/components/schemas/PublicKey"
+    Signature:
+      $ref: "./components.yml#/components/schemas/Signature"
     RegisterAppResponse:
       $ref: "./components.yml#/components/schemas/RegisterAppResponse"
     SlabID:

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -1230,6 +1230,81 @@ components:
           format: uint64
           description: Sum of all the pinned data including redundancy of the accounts associated with this key
 
+    PreAuthorizedKey:
+      type: object
+      required:
+        - publicKey
+        - connectKey
+        - expiration
+        - totalUses
+        - remainingUses
+        - dateCreated
+      properties:
+        publicKey:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: Public key used to identify and manage the pre-authorization
+        connectKey:
+          type: string
+          description: Connect key this authorization uses
+        expiration:
+          type: string
+          format: date-time
+          description: Time after which this authorization cannot be used
+        totalUses:
+          type: integer
+          minimum: 1
+          description: Initial number of authorized uses
+        remainingUses:
+          type: integer
+          minimum: 0
+          description: Number of authorized uses remaining
+        allowedAppID:
+          allOf:
+            - $ref: "#/components/schemas/Hash256"
+            - description: Optional app ID restriction
+        dateCreated:
+          type: string
+          format: date-time
+          description: Time the authorization was created
+        lastUsed:
+          type: string
+          format: date-time
+          description: Time the authorization was last consumed
+
+    PreAuthorizedKeyRequest:
+      type: object
+      required:
+        - publicKey
+        - signature
+        - connectKey
+        - expiration
+        - totalUses
+      properties:
+        publicKey:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: Client-generated Ed25519 public key; the corresponding private key remains with the client
+        signature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: Proof of control of the private key, signing a domain-separated hash of the complete creation policy
+        connectKey:
+          type: string
+          description: Connect key this authorization should use
+        expiration:
+          type: string
+          format: date-time
+          description: Time after which this authorization cannot be used; must be in the future
+        totalUses:
+          type: integer
+          minimum: 1
+          description: Maximum number of times this authorization may be used
+        allowedAppID:
+          allOf:
+            - $ref: "#/components/schemas/Hash256"
+            - description: Optional app ID restriction
+
     AppConnectKeyRequest:
       type: object
       required:

--- a/persist/postgres/apps.go
+++ b/persist/postgres/apps.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -26,6 +27,29 @@ func scanConnectKey(s scanner) (key accounts.ConnectKey, err error) {
 		&key.Quota,
 		&key.RemainingUses,
 	)
+	if lastUsed.Valid {
+		key.LastUsed = lastUsed.Time
+	}
+	return
+}
+
+func scanPreAuthorizedKey(s scanner) (key accounts.PreAuthorizedKey, err error) {
+	var lastUsed sql.NullTime
+	var allowedAppID sql.Null[sqlHash256]
+	err = s.Scan(
+		(*sqlPublicKey)(&key.PublicKey),
+		&key.ConnectKey,
+		&key.Expiration,
+		&key.TotalUses,
+		&key.RemainingUses,
+		&allowedAppID,
+		&key.DateCreated,
+		&lastUsed,
+	)
+	if allowedAppID.Valid {
+		appID := types.Hash256(allowedAppID.V)
+		key.AllowedAppID = &appID
+	}
 	if lastUsed.Valid {
 		key.LastUsed = lastUsed.Time
 	}
@@ -167,6 +191,177 @@ func (s *Store) AppConnectKeys(offset, limit int) (keys []accounts.ConnectKey, e
 	return
 }
 
+// AddPreAuthorizedKey creates a limited-use application authorization key.
+func (s *Store) AddPreAuthorizedKey(req accounts.PreAuthorizedKeyRequest) (key accounts.PreAuthorizedKey, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		var connectKeyID int64
+		if err := tx.QueryRow(ctx, `SELECT id FROM app_connect_keys WHERE app_key = $1`, req.ConnectKey).Scan(&connectKeyID); errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get connect key ID: %w", err)
+		}
+
+		var allowedAppID any
+		if req.AllowedAppID != nil {
+			allowedAppID = sqlHash256(*req.AllowedAppID)
+		}
+		key, err = scanPreAuthorizedKey(tx.QueryRow(ctx, `
+			INSERT INTO preauthorized_keys (public_key, connect_key_id, expires_at, total_uses, remaining_uses, allowed_app_id)
+			VALUES ($1, $2, $3, $4, $4, $5)
+			ON CONFLICT (public_key) DO NOTHING
+			RETURNING public_key, $6::text, expires_at, total_uses, remaining_uses, allowed_app_id, created_at, last_used
+		`, sqlPublicKey(req.PublicKey), connectKeyID, req.Expiration, req.TotalUses, allowedAppID, req.ConnectKey))
+		if errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyAlreadyExists
+		}
+		return err
+	})
+	return
+}
+
+// PreAuthorizedKey returns a pre-authorized key by its public key.
+func (s *Store) PreAuthorizedKey(publicKey types.PublicKey) (preAuthorizedKey accounts.PreAuthorizedKey, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		preAuthorizedKey, err = scanPreAuthorizedKey(tx.QueryRow(ctx, `
+			SELECT pak.public_key, ack.app_key, pak.expires_at, pak.total_uses, pak.remaining_uses,
+				pak.allowed_app_id, pak.created_at, pak.last_used
+			FROM preauthorized_keys pak
+			INNER JOIN app_connect_keys ack ON ack.id = pak.connect_key_id
+			WHERE pak.public_key = $1
+		`, sqlPublicKey(publicKey)))
+		if errors.Is(err, sql.ErrNoRows) {
+			return accounts.ErrKeyNotFound
+		}
+		return err
+	})
+	return
+}
+
+// PreAuthorizedKeys returns a paginated list of pre-authorized keys.
+func (s *Store) PreAuthorizedKeys(offset, limit int) (keys []accounts.PreAuthorizedKey, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		keys = keys[:0]
+		rows, err := tx.Query(ctx, `
+			SELECT pak.public_key, ack.app_key, pak.expires_at, pak.total_uses, pak.remaining_uses,
+				pak.allowed_app_id, pak.created_at, pak.last_used
+			FROM preauthorized_keys pak
+			INNER JOIN app_connect_keys ack ON ack.id = pak.connect_key_id
+			ORDER BY pak.created_at DESC
+			LIMIT $1 OFFSET $2
+		`, limit, offset)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			key, err := scanPreAuthorizedKey(rows)
+			if err != nil {
+				return err
+			}
+			keys = append(keys, key)
+		}
+		return rows.Err()
+	})
+	return
+}
+
+// DeletePreAuthorizedKey deletes a pre-authorized key.
+func (s *Store) DeletePreAuthorizedKey(publicKey types.PublicKey) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		res, err := tx.Exec(ctx, `DELETE FROM preauthorized_keys WHERE public_key = $1`, sqlPublicKey(publicKey))
+		if err != nil {
+			return err
+		} else if res.RowsAffected() == 0 {
+			return accounts.ErrKeyNotFound
+		}
+		return nil
+	})
+}
+
+// PruneExpiredPreAuthorizedKeys deletes all pre-authorized keys that expired
+// on or before the cutoff.
+func (s *Store) PruneExpiredPreAuthorizedKeys(cutoff time.Time) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `DELETE FROM preauthorized_keys WHERE expires_at <= $1`, cutoff)
+		return err
+	})
+}
+
+// ConsumePreAuthorizedKey validates and consumes one use of a pre-authorized
+// key. The update and authorization lookup are atomic, preventing concurrent
+// callers from exceeding the key's use limit.
+func (s *Store) ConsumePreAuthorizedKey(publicKey types.PublicKey, appID types.Hash256) (connectKey string, userSecret types.Hash256, reconnecting bool, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		err := tx.QueryRow(ctx, `
+			UPDATE preauthorized_keys pak
+			SET remaining_uses = pak.remaining_uses - 1, last_used = NOW()
+			FROM app_connect_keys ack
+			WHERE pak.public_key = $1
+				AND ack.id = pak.connect_key_id
+				AND pak.expires_at > NOW()
+				AND pak.remaining_uses > 0
+				AND (pak.allowed_app_id IS NULL OR pak.allowed_app_id = $2)
+			RETURNING ack.app_key
+		`, sqlPublicKey(publicKey), sqlHash256(appID)).Scan(&connectKey)
+		if errors.Is(err, sql.ErrNoRows) {
+			var expired bool
+			var remainingUses int
+			var allowedAppID sql.Null[sqlHash256]
+			err = tx.QueryRow(ctx, `
+				SELECT expires_at <= NOW(), remaining_uses, allowed_app_id
+				FROM preauthorized_keys
+				WHERE public_key = $1
+			`, sqlPublicKey(publicKey)).Scan(&expired, &remainingUses, &allowedAppID)
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				return accounts.ErrKeyNotFound
+			case err != nil:
+				return err
+			case expired:
+				return accounts.ErrPreAuthorizedKeyExpired
+			case remainingUses <= 0:
+				return accounts.ErrPreAuthorizedKeyExhausted
+			case allowedAppID.Valid && types.Hash256(allowedAppID.V) != appID:
+				return accounts.ErrPreAuthorizedKeyAppMismatch
+			default:
+				return accounts.ErrKeyNotFound
+			}
+		} else if err != nil {
+			return err
+		}
+
+		userSecret, reconnecting, err = appAuthorization(ctx, tx, connectKey, appID)
+		return err
+	})
+	return
+}
+
+func appAuthorization(ctx context.Context, tx *txn, connectKey string, appID types.Hash256) (userSecret types.Hash256, reconnecting bool, err error) {
+	err = tx.QueryRow(ctx, `
+		SELECT ack.user_secret, EXISTS (
+			SELECT 1 FROM accounts a
+			WHERE a.connect_key_id = ack.id AND a.app_id = $2 AND a.deleted_at IS NULL
+		)
+		FROM app_connect_keys ack
+		WHERE ack.app_key = $1
+	`, connectKey, sqlHash256(appID)).Scan((*sqlHash256)(&userSecret), &reconnecting)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = accounts.ErrKeyNotFound
+	}
+	return
+}
+
+// AppAuthorization returns the raw authorization material for a connect key
+// and reports whether the application was previously connected.
+func (s *Store) AppAuthorization(connectKey string, appID types.Hash256) (userSecret types.Hash256, reconnecting bool, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		userSecret, reconnecting, err = appAuthorization(ctx, tx, connectKey, appID)
+		return err
+	})
+	return
+}
+
 // DeleteAppConnectKey deletes an application connection key from the database.
 func (s *Store) DeleteAppConnectKey(connectKey string) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
@@ -190,34 +385,6 @@ func (s *Store) DeleteAppConnectKey(connectKey string) error {
 		`, connectKey)
 		return err
 	})
-}
-
-// AppConnectKeyUserSecret retrieves the user secret associated with a connect key.
-func (s *Store) AppConnectKeyUserSecret(connectKey string) (secret types.Hash256, err error) {
-	err = s.transaction(func(ctx context.Context, tx *txn) error {
-		return tx.QueryRow(ctx, `
-			SELECT user_secret FROM app_connect_keys WHERE app_key = $1
-		`, connectKey).Scan((*sqlHash256)(&secret))
-	})
-	if errors.Is(err, sql.ErrNoRows) {
-		return types.Hash256{}, accounts.ErrKeyNotFound
-	}
-	return
-}
-
-// HasAppAccount reports whether an account already exists for the given
-// connect key and app ID.
-func (s *Store) HasAppAccount(connectKey string, appID types.Hash256) (exists bool, err error) {
-	err = s.transaction(func(ctx context.Context, tx *txn) error {
-		return tx.QueryRow(ctx, `
-			SELECT EXISTS (
-				SELECT 1 FROM accounts a
-				INNER JOIN app_connect_keys ack ON ack.id = a.connect_key_id
-				WHERE ack.app_key = $1 AND a.app_id = $2 AND a.deleted_at IS NULL
-			)
-		`, connectKey, sqlHash256(appID)).Scan(&exists)
-	})
-	return
 }
 
 // RegisterAppKey uses a connect key to register a new app account.

--- a/persist/postgres/apps_test.go
+++ b/persist/postgres/apps_test.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"math"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -284,5 +286,189 @@ func TestUpdateConnectKey(t *testing.T) {
 		Quota:       "updated-quota",
 	}); !errors.Is(err, accounts.ErrKeyNotFound) {
 		t.Fatalf("expected err %q, got %q", accounts.ErrKeyNotFound, err)
+	}
+}
+
+func TestPreAuthorizedKeys(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+	store.addTestQuota(t, "test-quota", 10, 3)
+
+	connectKey, err := store.AddAppConnectKey(accounts.AppConnectKeyRequest{
+		Key:   "connect-key",
+		Quota: "test-quota",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	appID := types.Hash256{1}
+	expiration := time.Now().Add(time.Hour).Truncate(time.Microsecond)
+	privateKey := types.GeneratePrivateKey()
+	created, err := store.AddPreAuthorizedKey(accounts.PreAuthorizedKeyRequest{
+		PublicKey:    privateKey.PublicKey(),
+		ConnectKey:   connectKey.Key,
+		Expiration:   expiration,
+		TotalUses:    2,
+		AllowedAppID: &appID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if created.PublicKey != privateKey.PublicKey() || created.ConnectKey != connectKey.Key {
+		t.Fatalf("unexpected pre-authorized key: %+v", created)
+	} else if !created.Expiration.Equal(expiration) || created.TotalUses != 2 || created.RemainingUses != 2 {
+		t.Fatalf("unexpected limits: %+v", created)
+	} else if created.AllowedAppID == nil || *created.AllowedAppID != appID {
+		t.Fatalf("unexpected allowed app ID: %+v", created.AllowedAppID)
+	} else if created.DateCreated.IsZero() || !created.LastUsed.IsZero() {
+		t.Fatalf("unexpected timestamps: %+v", created)
+	}
+	var storedPublicKey sqlPublicKey
+	if err := store.pool.QueryRow(t.Context(), `SELECT public_key FROM preauthorized_keys WHERE public_key = $1`, sqlPublicKey(created.PublicKey)).Scan(&storedPublicKey); err != nil {
+		t.Fatal(err)
+	} else if types.PublicKey(storedPublicKey) != created.PublicKey {
+		t.Fatalf("expected stored public key %v, got %v", created.PublicKey, storedPublicKey)
+	}
+
+	if _, err := store.AddPreAuthorizedKey(accounts.PreAuthorizedKeyRequest{
+		PublicKey:  created.PublicKey,
+		ConnectKey: connectKey.Key,
+		Expiration: expiration,
+		TotalUses:  1,
+	}); !errors.Is(err, accounts.ErrKeyAlreadyExists) {
+		t.Fatalf("expected duplicate key error, got %v", err)
+	}
+
+	if _, err := store.AddPreAuthorizedKey(accounts.PreAuthorizedKeyRequest{
+		PublicKey:  types.GeneratePrivateKey().PublicKey(),
+		ConnectKey: "missing",
+		Expiration: expiration,
+		TotalUses:  1,
+	}); !errors.Is(err, accounts.ErrKeyNotFound) {
+		t.Fatalf("expected connect key not found, got %v", err)
+	}
+
+	listed, err := store.PreAuthorizedKeys(0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(listed) != 1 {
+		t.Fatalf("unexpected pre-authorized keys: %+v", listed)
+	}
+	if !reflect.DeepEqual(listed[0], created) {
+		t.Fatalf("expected %+v, got %+v", created, listed[0])
+	}
+	got, err := store.PreAuthorizedKey(created.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(got, created) {
+		t.Fatalf("expected %+v, got %+v", created, got)
+	}
+
+	if _, _, _, err := store.ConsumePreAuthorizedKey(created.PublicKey, types.Hash256{2}); !errors.Is(err, accounts.ErrPreAuthorizedKeyAppMismatch) {
+		t.Fatalf("expected app mismatch, got %v", err)
+	}
+	got, err = store.PreAuthorizedKey(created.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	} else if got.RemainingUses != 2 {
+		t.Fatalf("app mismatch consumed a use: %+v", got)
+	}
+
+	consumedConnectKey, userSecret, reconnecting, err := store.ConsumePreAuthorizedKey(created.PublicKey, appID)
+	if err != nil {
+		t.Fatal(err)
+	} else if consumedConnectKey != connectKey.Key || userSecret == (types.Hash256{}) || reconnecting {
+		t.Fatalf("unexpected authorization result: %q %v %v", consumedConnectKey, userSecret, reconnecting)
+	}
+
+	if err := store.RegisterAppKey(connectKey.Key, types.GeneratePrivateKey().PublicKey(), accounts.AppMeta{ID: appID}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, reconnecting, err = store.ConsumePreAuthorizedKey(created.PublicKey, appID); err != nil {
+		t.Fatal(err)
+	} else if !reconnecting {
+		t.Fatal("expected reconnecting authorization")
+	} else if _, _, _, err := store.ConsumePreAuthorizedKey(created.PublicKey, appID); !errors.Is(err, accounts.ErrPreAuthorizedKeyExhausted) {
+		t.Fatalf("expected exhausted key, got %v", err)
+	}
+
+	expiredPrivateKey := types.GeneratePrivateKey()
+	expiredKey, err := store.AddPreAuthorizedKey(accounts.PreAuthorizedKeyRequest{
+		PublicKey:  expiredPrivateKey.PublicKey(),
+		ConnectKey: connectKey.Key,
+		Expiration: time.Now().Add(-time.Minute),
+		TotalUses:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if _, _, _, err := store.ConsumePreAuthorizedKey(expiredKey.PublicKey, appID); !errors.Is(err, accounts.ErrPreAuthorizedKeyExpired) {
+		t.Fatalf("expected expired key, got %v", err)
+	} else if err := store.PruneExpiredPreAuthorizedKeys(time.Now()); err != nil {
+		t.Fatal(err)
+	} else if _, err := store.PreAuthorizedKey(expiredKey.PublicKey); !errors.Is(err, accounts.ErrKeyNotFound) {
+		t.Fatalf("expected expired key to be pruned, got %v", err)
+	} else if _, err := store.PreAuthorizedKey(created.PublicKey); err != nil {
+		t.Fatalf("expected non-expired key to be retained, got %v", err)
+	}
+	unrestrictedPrivateKey := types.GeneratePrivateKey()
+	_, err = store.AddPreAuthorizedKey(accounts.PreAuthorizedKeyRequest{
+		PublicKey:  unrestrictedPrivateKey.PublicKey(),
+		ConnectKey: connectKey.Key,
+		Expiration: expiration,
+		TotalUses:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if _, _, _, err := store.ConsumePreAuthorizedKey(unrestrictedPrivateKey.PublicKey(), types.Hash256{9}); err != nil {
+		t.Fatalf("expected unrestricted key to allow any app ID, got %v", err)
+	}
+
+	concurrentPrivateKey := types.GeneratePrivateKey()
+	_, err = store.AddPreAuthorizedKey(accounts.PreAuthorizedKeyRequest{
+		PublicKey:  concurrentPrivateKey.PublicKey(),
+		ConnectKey: connectKey.Key,
+		Expiration: expiration,
+		TotalUses:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const consumers = 8
+	start := make(chan struct{})
+	errs := make(chan error, consumers)
+	var wg sync.WaitGroup
+	for range consumers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _, err := store.ConsumePreAuthorizedKey(concurrentPrivateKey.PublicKey(), types.Hash256{10})
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	var successes, exhausted int
+	for err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, accounts.ErrPreAuthorizedKeyExhausted):
+			exhausted++
+		default:
+			t.Fatalf("unexpected concurrent consumption error: %v", err)
+		}
+	}
+	if successes != 1 || exhausted != consumers-1 {
+		t.Fatalf("expected one successful consumption and %d exhausted, got %d and %d", consumers-1, successes, exhausted)
+	}
+
+	if err := store.DeletePreAuthorizedKey(created.PublicKey); err != nil {
+		t.Fatal(err)
+	} else if _, err := store.PreAuthorizedKey(created.PublicKey); !errors.Is(err, accounts.ErrKeyNotFound) {
+		t.Fatalf("expected deleted key to be missing, got %v", err)
+	} else if err := store.DeletePreAuthorizedKey(created.PublicKey); !errors.Is(err, accounts.ErrKeyNotFound) {
+		t.Fatalf("expected missing delete error, got %v", err)
 	}
 }

--- a/persist/postgres/funding_test.go
+++ b/persist/postgres/funding_test.go
@@ -582,7 +582,7 @@ func TestSharingPoolAttachments(t *testing.T) {
 
 	// the sharing account is derived from the connect key's user secret rather
 	// than stored, like the app secret
-	secret, err := store.AppConnectKeyUserSecret(apk)
+	secret, _, err := store.AppAuthorization(apk, types.Hash256{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -24,6 +24,19 @@ CREATE TABLE app_connect_keys (
 );
 CREATE INDEX app_connect_keys_quota_name_idx ON app_connect_keys(quota_name);
 
+CREATE TABLE preauthorized_keys (
+    public_key BYTEA PRIMARY KEY CHECK (LENGTH(public_key) = 32),
+    connect_key_id INTEGER NOT NULL REFERENCES app_connect_keys(id) ON DELETE CASCADE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    total_uses INTEGER NOT NULL CHECK (total_uses > 0),
+    remaining_uses INTEGER NOT NULL CHECK (remaining_uses >= 0 AND remaining_uses <= total_uses),
+    allowed_app_id BYTEA CHECK (allowed_app_id IS NULL OR LENGTH(allowed_app_id) = 32),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used TIMESTAMP WITH TIME ZONE
+);
+CREATE INDEX preauthorized_keys_connect_key_id_idx ON preauthorized_keys(connect_key_id);
+CREATE INDEX preauthorized_keys_expires_at_idx ON preauthorized_keys(expires_at);
+
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
     public_key BYTEA UNIQUE NOT NULL CHECK (LENGTH(public_key) = 32),

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -192,4 +192,21 @@ CREATE INDEX contracts_active_host_size_idx ON contracts(proof_height, host_id) 
 `)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		_, err := tx.Exec(ctx, `
+CREATE TABLE preauthorized_keys (
+    public_key BYTEA PRIMARY KEY CHECK (LENGTH(public_key) = 32),
+    connect_key_id INTEGER NOT NULL REFERENCES app_connect_keys(id) ON DELETE CASCADE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    total_uses INTEGER NOT NULL CHECK (total_uses > 0),
+    remaining_uses INTEGER NOT NULL CHECK (remaining_uses >= 0 AND remaining_uses <= total_uses),
+    allowed_app_id BYTEA CHECK (allowed_app_id IS NULL OR LENGTH(allowed_app_id) = 32),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    last_used TIMESTAMP WITH TIME ZONE
+);
+CREATE INDEX preauthorized_keys_connect_key_id_idx ON preauthorized_keys(connect_key_id);
+CREATE INDEX preauthorized_keys_expires_at_idx ON preauthorized_keys(expires_at);
+`)
+		return err
+	},
 }


### PR DESCRIPTION
Pre-authorized keys let developers connect apps without requiring users to complete an interactive approval flow first.
