### PR TITLE
Take into account whether contract reached proof height when marking sector lost

### DIFF
--- a/.changeset/dont_consider_sectors_lost_when_they_are_pinned_to_a_contract_beyond_its_proof_height.md
+++ b/.changeset/dont_consider_sectors_lost_when_they_are_pinned_to_a_contract_beyond_its_proof_height.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Don't consider sectors lost when they are pinned to a contract beyond its proof height.

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -35,6 +35,11 @@ const (
 // host ID to NULL. This is meant to be used in 2 cases:
 // - The host reports that the sector is lost (e.g. when pinning it, during the integrity check or when fetching it for migration)
 // - The host has failed the integrity check for that sector enough times
+//
+// A sector only counts against the host's lost_sectors counter if it is
+// unpinned or pinned to a contract that has not reached its proof height yet,
+// since past the proof height the host might have submitted a proof and
+// fulfilled its obligation to hold on to the data.
 func (s *Store) MarkSectorsLost(hostKey types.PublicKey, roots []types.Hash256) error {
 	if len(roots) == 0 {
 		return nil
@@ -53,30 +58,34 @@ func (s *Store) MarkSectorsLost(hostKey types.PublicKey, roots []types.Hash256) 
 		}
 
 		rows, err := tx.Query(ctx, `
-			SELECT id, host_id, contract_sectors_map_id
-			FROM sectors
-			WHERE host_id = $1 AND sector_root = ANY($2)
-			FOR UPDATE`, hostID, sqlRoots)
+			SELECT s.id, s.contract_sectors_map_id,
+				COALESCE(c.proof_height > g.scanned_height, TRUE) AS lost
+			FROM sectors s
+			LEFT JOIN contract_sectors_map csm ON s.contract_sectors_map_id = csm.id
+			LEFT JOIN contracts c ON csm.contract_id = c.contract_id
+			CROSS JOIN (SELECT scanned_height FROM global_settings) g
+			WHERE s.host_id = $1 AND s.sector_root = ANY($2)
+			FOR UPDATE OF s`, hostID, sqlRoots)
 		if err != nil {
 			return fmt.Errorf("failed to query sectors: %w", err)
 		}
 		defer rows.Close()
 
-		sectorIDs, pinned, unpinned, _, err := scanSectorIDs(rows)
+		sectorIDs, pinned, unpinned, lost, err := scanLostSectorIDs(rows)
 		if err != nil {
 			return fmt.Errorf("failed to scan sectors: %w", err)
 		} else if len(sectorIDs) == 0 {
 			return nil
 		}
 
-		totalLost := pinned + unpinned
+		detached := pinned + unpinned
 		if _, err := tx.Exec(ctx, `UPDATE sectors SET host_id = NULL, contract_sectors_map_id = NULL WHERE id = ANY($1)`, sectorIDs); err != nil {
 			return fmt.Errorf("failed to mark sectors as lost: %w", err)
 		}
-		if _, err := tx.Exec(ctx, `UPDATE hosts SET lost_sectors = lost_sectors + $1 WHERE id = $2`, totalLost, hostID); err != nil {
+		if _, err := tx.Exec(ctx, `UPDATE hosts SET lost_sectors = lost_sectors + $1 WHERE id = $2`, lost, hostID); err != nil {
 			return fmt.Errorf("failed to increment host's lost sectors: %w", err)
 		}
-		if err := updateSectorStats(ctx, tx, -pinned, -unpinned, totalLost); err != nil {
+		if err := updateSectorStats(ctx, tx, -pinned, -unpinned, detached); err != nil {
 			return fmt.Errorf("failed to update sector stats: %w", err)
 		} else if err := incrementHostUnpinnedSectors(ctx, tx, hostID, -unpinned); err != nil {
 			return fmt.Errorf("failed to update host %v unpinned sectors: %w", hostKey, err)
@@ -201,11 +210,12 @@ func (s *Store) MarkFailingSectorsLost(hostKey types.PublicKey, maxChecks uint) 
 	return nil
 }
 
-// markFailingSectorsLostBatch marks a batch of failing sectors as lost. We have
-// to batch it because we first need to select all sectors to update in order to
+// markFailingSectorsLostBatch marks a batch of failing sectors as lost and
+// returns the number of sectors that were detached from the host. We have to
+// batch it because we first need to select all sectors to update in order to
 // correctly updated the pinned sectors statistics.
 func (s *Store) markFailingSectorsLostBatch(hostKey types.PublicKey, maxChecks, batchSize uint) (int64, error) {
-	var totalLost int64
+	var detached int64
 	if err := s.transaction(func(ctx context.Context, tx *txn) error {
 		var hostID int64
 		err := tx.QueryRow(ctx, "SELECT id FROM hosts WHERE public_key = $1", sqlPublicKey(hostKey)).Scan(&hostID)
@@ -214,32 +224,36 @@ func (s *Store) markFailingSectorsLostBatch(hostKey types.PublicKey, maxChecks, 
 		}
 
 		rows, err := tx.Query(ctx, `
-			SELECT id, host_id, contract_sectors_map_id
-			FROM sectors
-			WHERE host_id = $1 AND consecutive_failed_checks >= $2
+			SELECT s.id, s.contract_sectors_map_id,
+				COALESCE(c.proof_height > g.scanned_height, TRUE) AS lost
+			FROM sectors s
+			LEFT JOIN contract_sectors_map csm ON s.contract_sectors_map_id = csm.id
+			LEFT JOIN contracts c ON csm.contract_id = c.contract_id
+			CROSS JOIN (SELECT scanned_height FROM global_settings) g
+			WHERE s.host_id = $1 AND s.consecutive_failed_checks >= $2
 			LIMIT $3
-			FOR UPDATE
+			FOR UPDATE OF s
 		`, hostID, maxChecks, batchSize)
 		if err != nil {
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
 		}
 		defer rows.Close()
 
-		sectorIDs, pinned, unpinned, _, err := scanSectorIDs(rows)
+		sectorIDs, pinned, unpinned, lost, err := scanLostSectorIDs(rows)
 		if err != nil {
 			return fmt.Errorf("failed to scan sectors: %w", err)
 		} else if len(sectorIDs) == 0 {
 			return nil
 		}
 
-		totalLost = pinned + unpinned
+		detached = pinned + unpinned
 		if _, err := tx.Exec(ctx, `UPDATE sectors SET host_id = NULL, contract_sectors_map_id = NULL WHERE id = ANY($1)`, sectorIDs); err != nil {
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
 		}
-		if _, err := tx.Exec(ctx, `UPDATE hosts SET lost_sectors = lost_sectors + $1 WHERE id = $2`, totalLost, hostID); err != nil {
+		if _, err := tx.Exec(ctx, `UPDATE hosts SET lost_sectors = lost_sectors + $1 WHERE id = $2`, lost, hostID); err != nil {
 			return fmt.Errorf("failed to mark failing sectors as lost: %w", err)
 		}
-		if err := updateSectorStats(ctx, tx, -pinned, -unpinned, totalLost); err != nil {
+		if err := updateSectorStats(ctx, tx, -pinned, -unpinned, detached); err != nil {
 			return fmt.Errorf("failed to update sector stats: %w", err)
 		} else if err := incrementHostUnpinnedSectors(ctx, tx, hostID, -unpinned); err != nil {
 			return fmt.Errorf("failed to update host %v unpinned sectors: %w", hostKey, err)
@@ -249,7 +263,7 @@ func (s *Store) markFailingSectorsLostBatch(hostKey types.PublicKey, maxChecks, 
 		return 0, err
 	}
 
-	return totalLost, nil
+	return detached, nil
 }
 
 // PinSlabs adds slabs to the database for pinning. The slabs are associated
@@ -1127,6 +1141,37 @@ func scanSectorIDs(rows *rows) (sectorIDs []int64, pinned, unpinned, unpinnable 
 			unpinned++
 		} else {
 			unpinnable++
+		}
+		sectorIDs = append(sectorIDs, sectorID)
+	}
+	err = rows.Err()
+	return
+}
+
+// scanLostSectorIDs scans sector IDs from the given rows. It also counts how
+// many of the sectors are currently pinned and unpinned as well as how many
+// count as lost for the host, i.e. are unpinned or pinned to a contract that
+// has not reached its proof height yet.
+//
+// Unpinned sectors always count as lost because [Store.MarkSectorsUnpinnable]
+// detaches sectors from their host once they have been unpinned for longer
+// than the retention window, so any unpinned sector that still has a host is
+// implicitly within the window the host is expected to retain it for.
+func scanLostSectorIDs(rows *rows) (sectorIDs []int64, pinned, unpinned, lost int64, err error) {
+	for rows.Next() {
+		var sectorID int64
+		var contractMapID sql.NullInt64
+		var isLost bool
+		if err := rows.Scan(&sectorID, &contractMapID, &isLost); err != nil {
+			return nil, 0, 0, 0, fmt.Errorf("failed to scan sector row: %w", err)
+		}
+		if contractMapID.Valid {
+			pinned++
+		} else {
+			unpinned++
+		}
+		if isLost {
+			lost++
 		}
 		sectorIDs = append(sectorIDs, sectorID)
 	}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -217,6 +217,7 @@ func (s *Store) MarkFailingSectorsLost(hostKey types.PublicKey, maxChecks uint) 
 func (s *Store) markFailingSectorsLostBatch(hostKey types.PublicKey, maxChecks, batchSize uint) (int64, error) {
 	var detached int64
 	if err := s.transaction(func(ctx context.Context, tx *txn) error {
+		detached = 0
 		var hostID int64
 		err := tx.QueryRow(ctx, "SELECT id FROM hosts WHERE public_key = $1", sqlPublicKey(hostKey)).Scan(&hostID)
 		if err != nil {

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -3413,6 +3413,209 @@ func TestMarkSectorsLost(t *testing.T) {
 	assertSectorLost(root4, true)
 }
 
+func TestMarkSectorsLostProofHeightCutoff(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// add account
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+
+	// add a host with a contract, the test revision has a proof height of 600
+	hk := store.addTestHost(t)
+	fcid := store.addTestContract(t, hk)
+
+	// pin a slab that adds 3 sectors to the host
+	rootPinned1 := frand.Entropy256()
+	rootPinned2 := frand.Entropy256()
+	rootUnpinned := frand.Entropy256()
+	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{
+			{
+				Root:    rootPinned1,
+				HostKey: hk,
+			},
+			{
+				Root:    rootPinned2,
+				HostKey: hk,
+			},
+			{
+				Root:    rootUnpinned,
+				HostKey: hk,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// pin the first two sectors to the contract, the third remains unpinned
+	if err := store.PinSectors(fcid, []types.Hash256{rootPinned1, rootPinned2}); err != nil {
+		t.Fatal(err)
+	}
+
+	assertSectorLost := func(root types.Hash256, lost bool) {
+		t.Helper()
+		var isLost bool
+		err := store.pool.QueryRow(t.Context(), `SELECT host_id IS NULL AND contract_sectors_map_id IS NULL FROM sectors WHERE sector_root = $1`, sqlHash256(root)).Scan(&isLost)
+		if err != nil {
+			t.Fatal(err)
+		} else if isLost != lost {
+			t.Fatalf("expected sector %x to be lost: %v, got %v", root, lost, isLost)
+		}
+	}
+
+	assertLostSectors := func(numLost int) {
+		t.Helper()
+		var count int
+		err := store.pool.QueryRow(t.Context(), `SELECT lost_sectors FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)).Scan(&count)
+		if err != nil {
+			t.Fatal(err)
+		} else if count != numLost {
+			t.Fatalf("expected %d lost sectors for host %x, got %d", numLost, hk, count)
+		}
+	}
+
+	setScannedHeight := func(height uint64) {
+		t.Helper()
+		if _, err := store.pool.Exec(t.Context(), `UPDATE global_settings SET scanned_height = $1`, height); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// a sector pinned to a contract that has not reached its proof height
+	// counts against the host when the host reports it lost
+	setScannedHeight(599)
+	if err := store.MarkSectorsLost(hk, []types.Hash256{rootPinned1}); err != nil {
+		t.Fatal(err)
+	}
+	assertSectorLost(rootPinned1, true)
+	assertLostSectors(1)
+
+	// once the contract reached its proof height the host might have submitted
+	// a proof and legitimately deleted the data, so the sector is unlinked but
+	// doesn't count against the host
+	setScannedHeight(600)
+	if err := store.MarkSectorsLost(hk, []types.Hash256{rootPinned2}); err != nil {
+		t.Fatal(err)
+	}
+	assertSectorLost(rootPinned2, true)
+	assertLostSectors(1)
+
+	// an unpinned sector counts against the host since the host is expected to
+	// retain it until it is either pinned or given up on and detached by
+	// MarkSectorsUnpinnable
+	if err := store.MarkSectorsLost(hk, []types.Hash256{rootUnpinned}); err != nil {
+		t.Fatal(err)
+	}
+	assertSectorLost(rootUnpinned, true)
+	assertLostSectors(2)
+}
+
+func TestMarkFailingSectorsLostProofHeightCutoff(t *testing.T) {
+	store := initPostgres(t, zaptest.NewLogger(t).Named("postgres"))
+
+	// add account
+	account := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(account))
+
+	// add a host with a contract, the test revision has a proof height of 600
+	hk := store.addTestHost(t)
+	fcid := store.addTestContract(t, hk)
+
+	// pin a slab that adds 3 sectors to the host
+	rootPinned1 := frand.Entropy256()
+	rootPinned2 := frand.Entropy256()
+	rootUnpinned := frand.Entropy256()
+	_, err := store.PinSlabs(account, time.Time{}, slabs.SlabPinParams{
+		EncryptionKey: [32]byte{},
+		MinShards:     1,
+		Sectors: []slabs.PinnedSector{
+			{
+				Root:    rootPinned1,
+				HostKey: hk,
+			},
+			{
+				Root:    rootPinned2,
+				HostKey: hk,
+			},
+			{
+				Root:    rootUnpinned,
+				HostKey: hk,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// pin the first two sectors to the contract, the third remains unpinned
+	if err := store.PinSectors(fcid, []types.Hash256{rootPinned1, rootPinned2}); err != nil {
+		t.Fatal(err)
+	}
+
+	assertSectorLost := func(root types.Hash256, lost bool) {
+		t.Helper()
+		var isLost bool
+		err := store.pool.QueryRow(t.Context(), `SELECT host_id IS NULL AND contract_sectors_map_id IS NULL FROM sectors WHERE sector_root = $1`, sqlHash256(root)).Scan(&isLost)
+		if err != nil {
+			t.Fatal(err)
+		} else if isLost != lost {
+			t.Fatalf("expected sector %x to be lost: %v, got %v", root, lost, isLost)
+		}
+	}
+
+	assertLostSectors := func(numLost int) {
+		t.Helper()
+		var count int
+		err := store.pool.QueryRow(t.Context(), `SELECT lost_sectors FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)).Scan(&count)
+		if err != nil {
+			t.Fatal(err)
+		} else if count != numLost {
+			t.Fatalf("expected %d lost sectors for host %x, got %d", numLost, hk, count)
+		}
+	}
+
+	setScannedHeight := func(height uint64) {
+		t.Helper()
+		if _, err := store.pool.Exec(t.Context(), `UPDATE global_settings SET scanned_height = $1`, height); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	record := func(roots ...types.Hash256) {
+		t.Helper()
+		if err := store.RecordIntegrityCheck(false, time.Now(), hk, roots); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// fail the integrity check twice for a pinned and an unpinned sector; the
+	// sector pinned to a contract that has not reached its proof height counts
+	// against the host, as does the unpinned sector
+	setScannedHeight(599)
+	record(rootPinned1, rootUnpinned)
+	record(rootPinned1, rootUnpinned)
+	if err := store.MarkFailingSectorsLost(hk, 2); err != nil {
+		t.Fatal(err)
+	}
+	assertSectorLost(rootPinned1, true)
+	assertSectorLost(rootUnpinned, true)
+	assertLostSectors(2)
+
+	// once the contract reached its proof height, a failing sector is unlinked
+	// but doesn't count against the host
+	setScannedHeight(600)
+	record(rootPinned2)
+	record(rootPinned2)
+	if err := store.MarkFailingSectorsLost(hk, 2); err != nil {
+		t.Fatal(err)
+	}
+	assertSectorLost(rootPinned2, true)
+	assertLostSectors(2)
+}
+
 // BenchmarkMarkSectorsLost benchmarks MarkSectorsLost in various batch sizes.
 func BenchmarkMarkSectorsLost(b *testing.B) {
 	store := initPostgres(b, zap.NewNop())

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -3461,7 +3461,7 @@ func TestMarkSectorsLostProofHeightCutoff(t *testing.T) {
 	if err := store.MarkSectorsLost(hk, []types.Hash256{rootPinned1}); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(t, store, rootPinned1, true)
+	assertSectorLost(t, store, rootPinned1)
 	assertHostLostSectors(t, store, hk, 1)
 
 	// once the contract reached its proof height the host might have submitted
@@ -3471,7 +3471,7 @@ func TestMarkSectorsLostProofHeightCutoff(t *testing.T) {
 	if err := store.MarkSectorsLost(hk, []types.Hash256{rootPinned2}); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(t, store, rootPinned2, true)
+	assertSectorLost(t, store, rootPinned2)
 	assertHostLostSectors(t, store, hk, 1)
 
 	// an unpinned sector counts against the host since the host is expected to
@@ -3480,7 +3480,7 @@ func TestMarkSectorsLostProofHeightCutoff(t *testing.T) {
 	if err := store.MarkSectorsLost(hk, []types.Hash256{rootUnpinned}); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(t, store, rootUnpinned, true)
+	assertSectorLost(t, store, rootUnpinned)
 	assertHostLostSectors(t, store, hk, 2)
 }
 
@@ -3542,8 +3542,8 @@ func TestMarkFailingSectorsLostProofHeightCutoff(t *testing.T) {
 	if err := store.MarkFailingSectorsLost(hk, 2); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(t, store, rootPinned1, true)
-	assertSectorLost(t, store, rootUnpinned, true)
+	assertSectorLost(t, store, rootPinned1)
+	assertSectorLost(t, store, rootUnpinned)
 	assertHostLostSectors(t, store, hk, 2)
 
 	// once the contract reached its proof height, a failing sector is unlinked
@@ -3554,7 +3554,7 @@ func TestMarkFailingSectorsLostProofHeightCutoff(t *testing.T) {
 	if err := store.MarkFailingSectorsLost(hk, 2); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(t, store, rootPinned2, true)
+	assertSectorLost(t, store, rootPinned2)
 	assertHostLostSectors(t, store, hk, 2)
 }
 
@@ -3854,16 +3854,16 @@ func (s *Store) pinTestSlab(t testing.TB, account proto.Account, minShards uint,
 	return slabIDs[0]
 }
 
-// assertSectorLost asserts whether the sector with the given root is lost,
-// i.e. detached from both its host and contract.
-func assertSectorLost(t *testing.T, store *Store, root types.Hash256, lost bool) {
+// assertSectorLost asserts that the sector with the given root is lost, i.e.
+// detached from both its host and contract.
+func assertSectorLost(t *testing.T, store *Store, root types.Hash256) {
 	t.Helper()
 	var isLost bool
 	err := store.pool.QueryRow(t.Context(), `SELECT host_id IS NULL AND contract_sectors_map_id IS NULL FROM sectors WHERE sector_root = $1`, sqlHash256(root)).Scan(&isLost)
 	if err != nil {
 		t.Fatal(err)
-	} else if isLost != lost {
-		t.Fatalf("expected sector %x to be lost: %v, got %v", root, lost, isLost)
+	} else if !isLost {
+		t.Fatalf("expected sector %x to be lost", root)
 	}
 }
 

--- a/persist/postgres/sectors_test.go
+++ b/persist/postgres/sectors_test.go
@@ -3455,53 +3455,24 @@ func TestMarkSectorsLostProofHeightCutoff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertSectorLost := func(root types.Hash256, lost bool) {
-		t.Helper()
-		var isLost bool
-		err := store.pool.QueryRow(t.Context(), `SELECT host_id IS NULL AND contract_sectors_map_id IS NULL FROM sectors WHERE sector_root = $1`, sqlHash256(root)).Scan(&isLost)
-		if err != nil {
-			t.Fatal(err)
-		} else if isLost != lost {
-			t.Fatalf("expected sector %x to be lost: %v, got %v", root, lost, isLost)
-		}
-	}
-
-	assertLostSectors := func(numLost int) {
-		t.Helper()
-		var count int
-		err := store.pool.QueryRow(t.Context(), `SELECT lost_sectors FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)).Scan(&count)
-		if err != nil {
-			t.Fatal(err)
-		} else if count != numLost {
-			t.Fatalf("expected %d lost sectors for host %x, got %d", numLost, hk, count)
-		}
-	}
-
-	setScannedHeight := func(height uint64) {
-		t.Helper()
-		if _, err := store.pool.Exec(t.Context(), `UPDATE global_settings SET scanned_height = $1`, height); err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	// a sector pinned to a contract that has not reached its proof height
 	// counts against the host when the host reports it lost
-	setScannedHeight(599)
+	setScannedHeight(t, store, 599)
 	if err := store.MarkSectorsLost(hk, []types.Hash256{rootPinned1}); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(rootPinned1, true)
-	assertLostSectors(1)
+	assertSectorLost(t, store, rootPinned1, true)
+	assertHostLostSectors(t, store, hk, 1)
 
 	// once the contract reached its proof height the host might have submitted
 	// a proof and legitimately deleted the data, so the sector is unlinked but
 	// doesn't count against the host
-	setScannedHeight(600)
+	setScannedHeight(t, store, 600)
 	if err := store.MarkSectorsLost(hk, []types.Hash256{rootPinned2}); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(rootPinned2, true)
-	assertLostSectors(1)
+	assertSectorLost(t, store, rootPinned2, true)
+	assertHostLostSectors(t, store, hk, 1)
 
 	// an unpinned sector counts against the host since the host is expected to
 	// retain it until it is either pinned or given up on and detached by
@@ -3509,8 +3480,8 @@ func TestMarkSectorsLostProofHeightCutoff(t *testing.T) {
 	if err := store.MarkSectorsLost(hk, []types.Hash256{rootUnpinned}); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(rootUnpinned, true)
-	assertLostSectors(2)
+	assertSectorLost(t, store, rootUnpinned, true)
+	assertHostLostSectors(t, store, hk, 2)
 }
 
 func TestMarkFailingSectorsLostProofHeightCutoff(t *testing.T) {
@@ -3555,35 +3526,6 @@ func TestMarkFailingSectorsLostProofHeightCutoff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertSectorLost := func(root types.Hash256, lost bool) {
-		t.Helper()
-		var isLost bool
-		err := store.pool.QueryRow(t.Context(), `SELECT host_id IS NULL AND contract_sectors_map_id IS NULL FROM sectors WHERE sector_root = $1`, sqlHash256(root)).Scan(&isLost)
-		if err != nil {
-			t.Fatal(err)
-		} else if isLost != lost {
-			t.Fatalf("expected sector %x to be lost: %v, got %v", root, lost, isLost)
-		}
-	}
-
-	assertLostSectors := func(numLost int) {
-		t.Helper()
-		var count int
-		err := store.pool.QueryRow(t.Context(), `SELECT lost_sectors FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)).Scan(&count)
-		if err != nil {
-			t.Fatal(err)
-		} else if count != numLost {
-			t.Fatalf("expected %d lost sectors for host %x, got %d", numLost, hk, count)
-		}
-	}
-
-	setScannedHeight := func(height uint64) {
-		t.Helper()
-		if _, err := store.pool.Exec(t.Context(), `UPDATE global_settings SET scanned_height = $1`, height); err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	record := func(roots ...types.Hash256) {
 		t.Helper()
 		if err := store.RecordIntegrityCheck(false, time.Now(), hk, roots); err != nil {
@@ -3594,26 +3536,26 @@ func TestMarkFailingSectorsLostProofHeightCutoff(t *testing.T) {
 	// fail the integrity check twice for a pinned and an unpinned sector; the
 	// sector pinned to a contract that has not reached its proof height counts
 	// against the host, as does the unpinned sector
-	setScannedHeight(599)
+	setScannedHeight(t, store, 599)
 	record(rootPinned1, rootUnpinned)
 	record(rootPinned1, rootUnpinned)
 	if err := store.MarkFailingSectorsLost(hk, 2); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(rootPinned1, true)
-	assertSectorLost(rootUnpinned, true)
-	assertLostSectors(2)
+	assertSectorLost(t, store, rootPinned1, true)
+	assertSectorLost(t, store, rootUnpinned, true)
+	assertHostLostSectors(t, store, hk, 2)
 
 	// once the contract reached its proof height, a failing sector is unlinked
 	// but doesn't count against the host
-	setScannedHeight(600)
+	setScannedHeight(t, store, 600)
 	record(rootPinned2)
 	record(rootPinned2)
 	if err := store.MarkFailingSectorsLost(hk, 2); err != nil {
 		t.Fatal(err)
 	}
-	assertSectorLost(rootPinned2, true)
-	assertLostSectors(2)
+	assertSectorLost(t, store, rootPinned2, true)
+	assertHostLostSectors(t, store, hk, 2)
 }
 
 // BenchmarkMarkSectorsLost benchmarks MarkSectorsLost in various batch sizes.
@@ -3910,4 +3852,37 @@ func (s *Store) pinTestSlab(t testing.TB, account proto.Account, minShards uint,
 		t.Fatal(err)
 	}
 	return slabIDs[0]
+}
+
+// assertSectorLost asserts whether the sector with the given root is lost,
+// i.e. detached from both its host and contract.
+func assertSectorLost(t *testing.T, store *Store, root types.Hash256, lost bool) {
+	t.Helper()
+	var isLost bool
+	err := store.pool.QueryRow(t.Context(), `SELECT host_id IS NULL AND contract_sectors_map_id IS NULL FROM sectors WHERE sector_root = $1`, sqlHash256(root)).Scan(&isLost)
+	if err != nil {
+		t.Fatal(err)
+	} else if isLost != lost {
+		t.Fatalf("expected sector %x to be lost: %v, got %v", root, lost, isLost)
+	}
+}
+
+// assertHostLostSectors asserts the lost_sectors counter of the given host.
+func assertHostLostSectors(t *testing.T, store *Store, hk types.PublicKey, numLost int) {
+	t.Helper()
+	var count int
+	err := store.pool.QueryRow(t.Context(), `SELECT lost_sectors FROM hosts WHERE public_key = $1`, sqlPublicKey(hk)).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	} else if count != numLost {
+		t.Fatalf("expected %d lost sectors for host %x, got %d", numLost, hk, count)
+	}
+}
+
+// setScannedHeight updates the global scanned height.
+func setScannedHeight(t *testing.T, store *Store, height uint64) {
+	t.Helper()
+	if _, err := store.pool.Exec(t.Context(), `UPDATE global_settings SET scanned_height = $1`, height); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Once a contract reaches its proof height a host can submit a storage proof and therefore fulfill their data storage obligation. When the host then drops the sectors of that contract while we also repair slabs that contain those sectors we will attempt to use that host for retrieving the sectors. The host will report that they don't have the sectors anymore and the indexer will mark the sectors as lost.

This is fixed by this PR by further restricting `MarkSectorsLost` to only mark a sector as lost if it doesn't belong to a contract that hasn't reached its proof height yet. Once it does, we have to expect that a host might drop the sectors at any moment. 

Closes https://github.com/SiaFoundation/indexd/issues/1030