### PR TITLE
Check tip height of host against local tip height when appending sectors

### DIFF
--- a/.changeset/check_tip_height_of_host_against_local_height_in_appendsectors.md
+++ b/.changeset/check_tip_height_of_host_against_local_height_in_appendsectors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Check tip height of host against local height in AppendSectors.

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -149,9 +149,10 @@ top:
 
 // A Client is used to interact with Sia hosts over RHP4.
 type Client struct {
-	log   *zap.Logger
-	tg    *threadgroup.ThreadGroup
-	hosts *Provider
+	log             *zap.Logger
+	tg              *threadgroup.ThreadGroup
+	hosts           *Provider
+	heightTolerance uint64
 
 	mu             sync.Mutex // protects the fields below
 	cachedSettings map[types.PublicKey]proto.HostSettings
@@ -447,10 +448,40 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// ErrPricesHeightDrift is returned when the tip height a host claims in its
+// signed prices is too far behind the local tip height.
+var ErrPricesHeightDrift = errors.New("host prices tip height too far behind local tip height")
+
+// checkPricesHeight verifies that the tip height a host claims in its signed
+// prices is no more than the client's height tolerance behind the local tip
+// height.
+func (c *Client) checkPricesHeight(prices proto.HostPrices, localHeight uint64) error {
+	if prices.TipHeight+c.heightTolerance < localHeight {
+		return fmt.Errorf("%w: host height %d, local height %d, tolerance %d", ErrPricesHeightDrift, prices.TipHeight, localHeight, c.heightTolerance)
+	}
+	return nil
+}
+
+// refreshSettings fetches the host settings from the host, bypassing the
+// cache. Valid settings are cached for future use.
+func (c *Client) refreshSettings(ctx context.Context, hostKey types.PublicKey, transport rhp.TransportClient) (proto.HostSettings, error) {
+	settings, err := rhp.RPCSettings(ctx, transport)
+	if err != nil {
+		return proto.HostSettings{}, err
+	}
+
+	if settings.Prices.Validate(hostKey) == nil {
+		c.mu.Lock()
+		c.cachedSettings[hostKey] = settings
+		c.mu.Unlock()
+	}
+	return settings, nil
+}
+
 // settings fetches the host settings using an existing transport connection.
 //
 // If the settings are cached and valid, the cached settings are returned with a
-// boolean flag set to 'true'.
+// boolean flag set to 'true'. Otherwise, they are refreshed from the host.
 func (c *Client) settings(ctx context.Context, hostKey types.PublicKey, transport rhp.TransportClient) (proto.HostSettings, bool, error) {
 	c.mu.Lock()
 	settings := c.cachedSettings[hostKey]
@@ -460,15 +491,9 @@ func (c *Client) settings(ctx context.Context, hostKey types.PublicKey, transpor
 	}
 	c.mu.Unlock()
 
-	settings, err := rhp.RPCSettings(ctx, transport)
+	settings, err := c.refreshSettings(ctx, hostKey, transport)
 	if err != nil {
 		return proto.HostSettings{}, false, err
-	}
-
-	if settings.Prices.Validate(hostKey) == nil {
-		c.mu.Lock()
-		c.cachedSettings[hostKey] = settings
-		c.mu.Unlock()
 	}
 	return settings, false, nil
 }
@@ -494,10 +519,11 @@ func shouldResetTransport(err error) bool {
 // New creates a new Client.
 func New(hosts *Provider, log *zap.Logger) *Client {
 	return &Client{
-		log:            log,
-		tg:             threadgroup.New(),
-		hosts:          hosts,
-		cachedSettings: make(map[types.PublicKey]proto.HostSettings),
-		transports:     make(map[types.PublicKey]*transport),
+		heightTolerance: 36, // ~6 hours of blocks
+		log:             log,
+		tg:              threadgroup.New(),
+		hosts:           hosts,
+		cachedSettings:  make(map[types.PublicKey]proto.HostSettings),
+		transports:      make(map[types.PublicKey]*transport),
 	}
 }

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -468,13 +468,13 @@ func (c *Client) refreshSettings(ctx context.Context, hostKey types.PublicKey, t
 	settings, err := rhp.RPCSettings(ctx, transport)
 	if err != nil {
 		return proto.HostSettings{}, err
+	} else if err := settings.Prices.Validate(hostKey); err != nil {
+		return proto.HostSettings{}, fmt.Errorf("host returned invalid prices: %w", err)
 	}
 
-	if settings.Prices.Validate(hostKey) == nil {
-		c.mu.Lock()
-		c.cachedSettings[hostKey] = settings
-		c.mu.Unlock()
-	}
+	c.mu.Lock()
+	c.cachedSettings[hostKey] = settings
+	c.mu.Unlock()
 	return settings, nil
 }
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -456,7 +456,7 @@ var ErrPricesHeightDrift = errors.New("host prices tip height too far behind loc
 // prices is no more than the client's height tolerance behind the local tip
 // height.
 func (c *Client) checkPricesHeight(prices proto.HostPrices, localHeight uint64) error {
-	if prices.TipHeight+c.heightTolerance < localHeight {
+	if prices.TipHeight < localHeight && localHeight-prices.TipHeight > c.heightTolerance {
 		return fmt.Errorf("%w: host height %d, local height %d, tolerance %d", ErrPricesHeightDrift, prices.TipHeight, localHeight, c.heightTolerance)
 	}
 	return nil

--- a/client/v2/contracts.go
+++ b/client/v2/contracts.go
@@ -186,16 +186,17 @@ func (c *Client) AppendSectors(ctx context.Context, signer rhp.ContractSigner, c
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
 		}
-		if c.checkPricesHeight(settings.Prices, chain.TipState().Index.Height) != nil {
+		tipState := chain.TipState()
+		if c.checkPricesHeight(settings.Prices, tipState.Index.Height) != nil {
 			settings, err = c.refreshSettings(ctx, hostKey, transport)
 			if err != nil {
 				return fmt.Errorf("failed to refresh host prices: %w", err)
 			}
 		}
-		if err := c.checkPricesHeight(settings.Prices, chain.TipState().Index.Height); err != nil {
+		if err := c.checkPricesHeight(settings.Prices, tipState.Index.Height); err != nil {
 			return err
 		}
-		res, err = rhp.RPCAppendSectors(ctx, transport, signer, chain.TipState(), settings.Prices, revision, sectors)
+		res, err = rhp.RPCAppendSectors(ctx, transport, signer, tipState, settings.Prices, revision, sectors)
 		return err
 	})
 	return

--- a/client/v2/contracts.go
+++ b/client/v2/contracts.go
@@ -181,9 +181,19 @@ func (c *Client) AppendSectors(ctx context.Context, signer rhp.ContractSigner, c
 	defer done()
 
 	err = c.rpcFn(ctx, revision.Revision.HostPublicKey, func(ctx context.Context, transport rhp.TransportClient) error {
-		settings, _, err := c.settings(ctx, revision.Revision.HostPublicKey, transport)
+		hostKey := revision.Revision.HostPublicKey
+		settings, _, err := c.settings(ctx, hostKey, transport)
 		if err != nil {
 			return fmt.Errorf("failed to get host prices: %w", err)
+		}
+		if c.checkPricesHeight(settings.Prices, chain.TipState().Index.Height) != nil {
+			settings, err = c.refreshSettings(ctx, hostKey, transport)
+			if err != nil {
+				return fmt.Errorf("failed to refresh host prices: %w", err)
+			}
+		}
+		if err := c.checkPricesHeight(settings.Prices, chain.TipState().Index.Height); err != nil {
+			return err
 		}
 		res, err = rhp.RPCAppendSectors(ctx, transport, signer, chain.TipState(), settings.Prices, revision, sectors)
 		return err

--- a/client/v2/settings_test.go
+++ b/client/v2/settings_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -64,6 +65,7 @@ func TestCheckPricesHeight(t *testing.T) {
 		{"host far ahead is fine", 1000, 100, false},
 		{"local at tolerance from genesis", 0, 10, false},
 		{"local beyond tolerance from genesis", 0, 11, true},
+		{"host height near max does not overflow", math.MaxUint64 - 5, 100, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/v2/settings_test.go
+++ b/client/v2/settings_test.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+)
+
+// fakeSettingsTransport is a TransportClient that serves RPCSettings with a
+// fixed set of settings and counts how often they were fetched.
+type fakeSettingsTransport struct {
+	hostKey  types.PrivateKey
+	settings proto.HostSettings
+
+	fetches int
+}
+
+func (t *fakeSettingsTransport) DialStream(context.Context) (net.Conn, error) {
+	t.fetches++
+	client, server := net.Pipe()
+	go func() {
+		defer server.Close()
+		if id, err := proto.ReadID(server); err != nil || id != proto.RPCSettingsID {
+			return
+		}
+		_ = proto.WriteResponse(server, &proto.RPCSettingsResponse{Settings: t.settings})
+	}()
+	return client, nil
+}
+
+func (t *fakeSettingsTransport) FrameSize() int           { return 1440 }
+func (t *fakeSettingsTransport) PeerKey() types.PublicKey { return t.hostKey.PublicKey() }
+func (t *fakeSettingsTransport) Close() error             { return nil }
+
+// testSettings returns host settings with prices claiming the given tip
+// height, signed by the given host key.
+func testSettings(hostKey types.PrivateKey, tipHeight uint64, validUntil time.Time) proto.HostSettings {
+	prices := proto.HostPrices{
+		TipHeight:  tipHeight,
+		ValidUntil: validUntil,
+	}
+	prices.Signature = hostKey.SignHash(prices.SigHash())
+	return proto.HostSettings{Prices: prices}
+}
+
+func TestCheckPricesHeight(t *testing.T) {
+	c := &Client{heightTolerance: 10}
+
+	tests := []struct {
+		name        string
+		tipHeight   uint64
+		localHeight uint64
+		wantErr     bool
+	}{
+		{"equal heights", 100, 100, false},
+		{"host behind within tolerance", 95, 100, false},
+		{"host behind at tolerance", 90, 100, false},
+		{"host behind beyond tolerance", 89, 100, true},
+		{"host far ahead is fine", 1000, 100, false},
+		{"local at tolerance from genesis", 0, 10, false},
+		{"local beyond tolerance from genesis", 0, 11, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.checkPricesHeight(proto.HostPrices{TipHeight: tt.tipHeight}, tt.localHeight)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("host height %d, local height %d: expected error %t, got %v", tt.tipHeight, tt.localHeight, tt.wantErr, err)
+			} else if err != nil && !errors.Is(err, ErrPricesHeightDrift) {
+				t.Fatalf("expected ErrPricesHeightDrift, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSettingsRefresh(t *testing.T) {
+	hostKey := types.GeneratePrivateKey()
+	hk := hostKey.PublicKey()
+	validUntil := time.Now().Add(10 * time.Minute)
+
+	const localHeight = 200
+	staleSettings := testSettings(hostKey, 100, validUntil) // beyond tolerance behind localHeight
+	freshSettings := testSettings(hostKey, 199, validUntil)
+
+	transport := &fakeSettingsTransport{hostKey: hostKey, settings: freshSettings}
+	c := &Client{
+		heightTolerance: 36,
+		cachedSettings:  map[types.PublicKey]proto.HostSettings{hk: staleSettings},
+	}
+
+	// settings returns the stale cached settings without fetching
+	settings, cached, err := c.settings(context.Background(), hk, transport)
+	if err != nil {
+		t.Fatal(err)
+	} else if !cached || transport.fetches != 0 {
+		t.Fatalf("expected cached settings without a fetch, got cached=%t, fetches=%d", cached, transport.fetches)
+	} else if settings.Prices.TipHeight != 100 {
+		t.Fatalf("expected tip height 100, got %d", settings.Prices.TipHeight)
+	}
+
+	// the stale prices fail the height check
+	if err := c.checkPricesHeight(settings.Prices, localHeight); !errors.Is(err, ErrPricesHeightDrift) {
+		t.Fatalf("expected ErrPricesHeightDrift, got %v", err)
+	}
+
+	// refreshSettings bypasses the cache and fetches fresh settings that pass
+	// the height check
+	settings, err = c.refreshSettings(context.Background(), hk, transport)
+	if err != nil {
+		t.Fatal(err)
+	} else if transport.fetches != 1 {
+		t.Fatalf("expected 1 fetch, got %d", transport.fetches)
+	} else if settings.Prices.TipHeight != 199 {
+		t.Fatalf("expected tip height 199, got %d", settings.Prices.TipHeight)
+	} else if err := c.checkPricesHeight(settings.Prices, localHeight); err != nil {
+		t.Fatal(err)
+	}
+
+	// the fresh settings replaced the stale ones in the cache
+	settings, cached, err = c.settings(context.Background(), hk, transport)
+	if err != nil {
+		t.Fatal(err)
+	} else if !cached || transport.fetches != 1 {
+		t.Fatalf("expected cached settings without a fetch, got cached=%t, fetches=%d", cached, transport.fetches)
+	} else if settings.Prices.TipHeight != 199 {
+		t.Fatalf("expected tip height 199, got %d", settings.Prices.TipHeight)
+	}
+}

--- a/client/v2/settings_test.go
+++ b/client/v2/settings_test.go
@@ -132,3 +132,25 @@ func TestSettingsRefresh(t *testing.T) {
 		t.Fatalf("expected tip height 199, got %d", settings.Prices.TipHeight)
 	}
 }
+
+func TestRefreshSettingsInvalidPrices(t *testing.T) {
+	hostKey := types.GeneratePrivateKey()
+	hk := hostKey.PublicKey()
+
+	// prices signed by a different key than the host's
+	transport := &fakeSettingsTransport{
+		hostKey:  hostKey,
+		settings: testSettings(types.GeneratePrivateKey(), 100, time.Now().Add(10*time.Minute)),
+	}
+	c := &Client{
+		heightTolerance: 36,
+		cachedSettings:  make(map[types.PublicKey]proto.HostSettings),
+	}
+
+	if _, err := c.refreshSettings(context.Background(), hk, transport); err == nil {
+		t.Fatal("expected error for invalidly signed prices")
+	}
+	if len(c.cachedSettings) != 0 {
+		t.Fatal("invalid settings should not be cached")
+	}
+}

--- a/contracts/e2e_test.go
+++ b/contracts/e2e_test.go
@@ -245,20 +245,31 @@ func TestSectorPinning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// assert the slab is pinned
-	time.Sleep(time.Second)
-	res, err := indexer.Store().Slabs(acc.AccountKey, slabIDs)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(res) != 1 {
-		t.Fatalf("expected 1 slab, got %d", len(res))
-	}
-
-	// assert the sectors were pinned
-	for _, sector := range res[0].Sectors {
-		if sector.HostKey == nil || sector.ContractID == nil {
-			t.Fatal("sector is not pinned")
+	// assert the slab and all its sectors are pinned; pinning happens
+	// asynchronously so poll until it's done
+	var pinned bool
+	for range 100 {
+		res, err := indexer.Store().Slabs(acc.AccountKey, slabIDs)
+		if err != nil {
+			t.Fatal(err)
+		} else if len(res) != 1 {
+			t.Fatalf("expected 1 slab, got %d", len(res))
 		}
+
+		pinned = true
+		for _, sector := range res[0].Sectors {
+			if sector.HostKey == nil || sector.ContractID == nil {
+				pinned = false
+				break
+			}
+		}
+		if pinned {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !pinned {
+		t.Fatal("sector is not pinned")
 	}
 
 	// unpin the slab


### PR DESCRIPTION
This PR adds a sanity check before appending sectors to make sure a host's height isn't more than 6 hours in the past relative to our synced height. 