### PR TITLE
Update default slab prune cutoff to 72 hours instead of 1 hour

### DIFF
--- a/.changeset/update_default_cutoff_when_pruning_slabs_to_72_hours.md
+++ b/.changeset/update_default_cutoff_when_pruning_slabs_to_72_hours.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Update default cutoff when pruning slabs to 72 hours

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -387,7 +387,7 @@ func (a *admin) handleDELETESlab(jc jape.Context) {
 }
 
 func (a *admin) handlePOSTPruneAccounts(jc jape.Context) {
-	cutoff := time.Now().Add(-time.Hour)
+	cutoff := time.Now().Add(-api.DefaultSlabPruneCutoff)
 	if jc.Request.FormValue("before") != "" {
 		if jc.DecodeForm("before", &cutoff) != nil {
 			return
@@ -742,7 +742,7 @@ func (a *admin) handlePOSTAccountPrune(jc jape.Context) {
 	if jc.DecodeParam("accountkey", &ak) != nil {
 		return
 	}
-	cutoff := time.Now().Add(-time.Hour)
+	cutoff := time.Now().Add(-api.DefaultSlabPruneCutoff)
 	if jc.Request.FormValue("before") != "" {
 		if jc.DecodeForm("before", &cutoff) != nil {
 			return

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -395,7 +395,7 @@ func (a *app) handlePOSTSlabs(jc jape.Context, pk types.PublicKey) {
 }
 
 func (a *app) handlePOSTSlabsPrune(jc jape.Context, pk types.PublicKey) {
-	cutoff := time.Now().Add(-time.Hour)
+	cutoff := time.Now().Add(-api.DefaultSlabPruneCutoff)
 	if jc.Request.FormValue("before") != "" {
 		if jc.DecodeForm("before", &cutoff) != nil {
 			return

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -204,7 +204,7 @@ func (c *Client) Slab(ctx context.Context, appKey types.PrivateKey, slabID slabs
 }
 
 // PruneSlabs prunes all pinned slabs of a user not currently connected to an
-// object. Use api.WithBefore to override the default cutoff (1 hour ago).
+// object. Use api.WithBefore to override the default cutoff (24 hours ago).
 func (c *Client) PruneSlabs(ctx context.Context, appKey types.PrivateKey, opts ...api.URLQueryParameterOption) error {
 	values := url.Values{}
 	for _, opt := range opts {

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -204,7 +204,7 @@ func (c *Client) Slab(ctx context.Context, appKey types.PrivateKey, slabID slabs
 }
 
 // PruneSlabs prunes all pinned slabs of a user not currently connected to an
-// object. Use api.WithBefore to override the default cutoff (24 hours ago).
+// object. Use api.WithBefore to override the default cutoff (72 hours ago).
 func (c *Client) PruneSlabs(ctx context.Context, appKey types.PrivateKey, opts ...api.URLQueryParameterOption) error {
 	values := url.Values{}
 	for _, opt := range opts {

--- a/api/options.go
+++ b/api/options.go
@@ -18,6 +18,10 @@ const (
 	// MaxLimit is the maximum value of the 'limit' query parameter accepted by
 	// paginated endpoints.
 	MaxLimit = 500
+
+	// DefaultSlabPruneCutoff is the default age a slab must exceed to be
+	// eligible for pruning when no explicit 'before' cutoff is provided.
+	DefaultSlabPruneCutoff = 72 * time.Hour
 )
 
 var (

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -651,7 +651,7 @@ paths:
             type: string
         - name: before
           in: query
-          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to one hour ago.
+          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to 72 hours ago.
           schema:
             type: string
             format: date-time
@@ -1016,7 +1016,7 @@ paths:
       parameters:
         - name: before
           in: query
-          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to one hour ago.
+          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to 72 hours ago.
           schema:
             type: string
             format: date-time

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -446,7 +446,7 @@ paths:
       parameters:
         - name: before
           in: query
-          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to one hour ago.
+          description: Only slabs pinned before this timestamp are eligible for pruning. Defaults to 72 hours ago.
           schema:
             type: string
             format: date-time


### PR DESCRIPTION
To align with the amount of time the indexer has to pin a slab to a contract. 