### PR TITLE
Prune slabs after deleting an object 

### DIFF
--- a/.changeset/delete_slabs_of_an_object_after_deleting_the_object_if_the_slabs_become_unreferenced.md
+++ b/.changeset/delete_slabs_of_an_object_after_deleting_the_object_if_the_slabs_become_unreferenced.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Delete slabs of an object after deleting the object if the slabs become unreferenced

--- a/.changeset/unpinning_a_slab_that_is_still_referenced_by_an_object_returns_an_error.md
+++ b/.changeset/unpinning_a_slab_that_is_still_referenced_by_an_object_returns_an_error.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Unpinning a slab that is still referenced by an object returns an error
+
+`DELETE /slabs/:slabid` now fails with `409 Conflict` if one of the account's
+objects still references the slab. Previously the slab was unpinned anyway,
+freeing up the account's quota while the object kept the slab alive.

--- a/api/admin/admin.go
+++ b/api/admin/admin.go
@@ -377,7 +377,10 @@ func (a *admin) handleDELETESlab(jc jape.Context) {
 
 	// delete each object
 	for _, obj := range objects {
-		if err := a.slabs.DeleteObject(jc.Request.Context(), obj.Account, obj.ObjectID); err != nil {
+		err := a.slabs.DeleteObject(jc.Request.Context(), obj.Account, obj.ObjectID)
+		if errors.Is(err, slabs.ErrObjectNotFound) {
+			continue
+		} else if err != nil {
 			jc.Check("failed to delete object", err)
 			return
 		}

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -465,6 +465,9 @@ func (a *app) handleDELETESlab(jc jape.Context, pk types.PublicKey) {
 	if errors.Is(err, slabs.ErrSlabNotFound) {
 		jc.Error(fmt.Errorf("slab %s not found", slabID), http.StatusNotFound)
 		return
+	} else if errors.Is(err, slabs.ErrSlabInUse) {
+		jc.Error(fmt.Errorf("slab %s: %w", slabID, slabs.ErrSlabInUse), http.StatusConflict)
+		return
 	} else if jc.Check("failed to unpin slab", err) != nil {
 		return
 	}

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -192,7 +192,8 @@ func (c *Client) PinSlabs(ctx context.Context, appKey types.PrivateKey, params .
 	return
 }
 
-// UnpinSlab unpins a slab from the indexer.
+// UnpinSlab unpins a slab from the indexer. A slab that is still referenced by
+// one of the account's objects can not be unpinned.
 func (c *Client) UnpinSlab(ctx context.Context, appKey types.PrivateKey, slabID slabs.SlabID) error {
 	return c.signedRequestJSON(ctx, appKey, http.MethodDelete, fmt.Sprintf("/slabs/%s", slabID), nil, nil)
 }
@@ -255,6 +256,8 @@ func (c *Client) PinObject(ctx context.Context, appKey types.PrivateKey, obj sla
 }
 
 // DeleteObject deletes the object with the given key for the given account.
+// Slabs that were referenced by the object and are no longer referenced by any
+// of the account's objects are unpinned and queued for deletion.
 func (c *Client) DeleteObject(ctx context.Context, appKey types.PrivateKey, key types.Hash256) (err error) {
 	err = c.signedRequestJSON(ctx, appKey, http.MethodDelete, fmt.Sprintf("/objects/%s", key), nil, nil)
 	return

--- a/openapi/admin.yml
+++ b/openapi/admin.yml
@@ -983,8 +983,9 @@ paths:
       description: >
         Deletes all objects across all accounts that reference the given slab.
         This is useful for cleaning up old slabs that can no longer be
-        repaired. Use /debug/slabs/prune afterwards to prune orphaned
-        slabs. This route is only available in debug mode.
+        repaired. Slabs that are no longer referenced by any of an account's
+        objects are unpinned along the way and queued for deletion by a
+        background process. This route is only available in debug mode.
       operationId: deleteDebugSlab
       parameters:
         - name: slabid

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -171,6 +171,10 @@ paths:
       tags:
         - objects
       summary: Delete an object
+      description: >
+        Deletes the object. Slabs that were referenced by the object and are no
+        longer referenced by any of the account's objects are unpinned and
+        queued for deletion by a background process.
       parameters:
         - name: key
           in: path
@@ -415,6 +419,10 @@ paths:
       responses:
         "204":
           description: Slab unpinned successfully
+        "404":
+          description: Slab not found
+        "409":
+          description: Slab is still referenced by one of the account's objects
 
       x-codeSamples:
         - lang: Go

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -370,7 +370,7 @@ CREATE UNIQUE INDEX objects_account_id_object_key_idx ON objects(account_id, obj
 
 CREATE TABLE object_slabs (
     object_id BIGINT REFERENCES objects(id) ON DELETE CASCADE,
-    slab_digest BYTEA REFERENCES slabs(digest) ON DELETE CASCADE,
+    slab_digest BYTEA REFERENCES slabs(digest) ON DELETE RESTRICT, -- don't delete slabs that are still referenced by objects
     slab_index INTEGER NOT NULL, -- index within corresponding object to retrieve slabs in right order
     slab_offset INTEGER NOT NULL, -- offset within slab
     slab_length INTEGER NOT NULL, -- length of object data within slab

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -209,4 +209,11 @@ CREATE INDEX preauthorized_keys_expires_at_idx ON preauthorized_keys(expires_at)
 `)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		_, err := tx.Exec(ctx, `
+ALTER TABLE object_slabs DROP CONSTRAINT object_slabs_slab_digest_fkey;
+ALTER TABLE object_slabs ADD CONSTRAINT object_slabs_slab_digest_fkey FOREIGN KEY (slab_digest) REFERENCES slabs(digest) ON DELETE RESTRICT;
+`)
+		return err
+	},
 }

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -264,23 +264,21 @@ func (s *Store) DeleteObject(account proto.Account, objectKey types.Hash256) err
 			return fmt.Errorf("failed to get object id: %w", err)
 		}
 
-		// remember the object's slabs so the now unreferenced ones can be
-		// unpinned after the object is deleted
-		rows, err := tx.Query(ctx, `SELECT DISTINCT s.id FROM slabs s
-INNER JOIN object_slabs os ON (os.slab_digest = s.digest)
-WHERE os.object_id = $1`, objectID)
+		// delete the object's slab references, remembering the slabs so the
+		// now unreferenced ones can be unpinned after the object is deleted
+		rows, err := tx.Query(ctx, `WITH deleted AS (
+	DELETE FROM object_slabs WHERE object_id = $1 RETURNING slab_digest
+)
+SELECT DISTINCT s.id FROM slabs s
+INNER JOIN deleted d ON (d.slab_digest = s.digest)`, objectID)
 		if err != nil {
-			return fmt.Errorf("failed to query object slabs: %w", err)
+			return fmt.Errorf("failed to delete object slabs: %w", err)
 		}
 		objectSlabIDs, err := pgx.CollectRows(rows, pgx.RowTo[int64])
 		if err != nil {
 			return fmt.Errorf("failed to collect object slab ids: %w", err)
 		}
 
-		_, err = tx.Exec(ctx, `DELETE FROM object_slabs WHERE object_id = $1`, objectID)
-		if err != nil {
-			return fmt.Errorf("failed to delete object slabs: %w", err)
-		}
 		_, err = tx.Exec(ctx, `DELETE FROM objects WHERE id = $1`, objectID)
 		if err != nil {
 			return fmt.Errorf("failed to delete object: %w", err)

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -246,6 +246,9 @@ func (s *Store) ListObjects(account proto.Account, cursor slabs.Cursor, limit in
 }
 
 // DeleteObject deletes the object with the given key for the given account.
+// Slabs that were referenced by the object and are no longer referenced by any
+// of the account's objects are unpinned and queued for deletion by
+// PruneDeletedSlabs.
 func (s *Store) DeleteObject(account proto.Account, objectKey types.Hash256) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
 		accountID, _, err := accountID(ctx, tx, account)
@@ -254,12 +257,26 @@ func (s *Store) DeleteObject(account proto.Account, objectKey types.Hash256) err
 		}
 
 		var objectID int64
-		err = tx.QueryRow(ctx, `SELECT id FROM objects WHERE object_key = $1 AND account_id = $2`, sqlHash256(objectKey), accountID).Scan(&objectID)
+		err = tx.QueryRow(ctx, `SELECT id FROM objects WHERE object_key = $1 AND account_id = $2 FOR UPDATE`, sqlHash256(objectKey), accountID).Scan(&objectID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return slabs.ErrObjectNotFound
 		} else if err != nil {
 			return fmt.Errorf("failed to get object id: %w", err)
 		}
+
+		// remember the object's slabs so the now unreferenced ones can be
+		// unpinned after the object is deleted
+		rows, err := tx.Query(ctx, `SELECT DISTINCT s.id FROM slabs s
+INNER JOIN object_slabs os ON (os.slab_digest = s.digest)
+WHERE os.object_id = $1`, objectID)
+		if err != nil {
+			return fmt.Errorf("failed to query object slabs: %w", err)
+		}
+		objectSlabIDs, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+		if err != nil {
+			return fmt.Errorf("failed to collect object slab ids: %w", err)
+		}
+
 		_, err = tx.Exec(ctx, `DELETE FROM object_slabs WHERE object_id = $1`, objectID)
 		if err != nil {
 			return fmt.Errorf("failed to delete object slabs: %w", err)
@@ -276,6 +293,42 @@ func (s *Store) DeleteObject(account proto.Account, objectKey types.Hash256) err
 			return fmt.Errorf("failed to update object events: %w", err)
 		}
 
+		// lock the object's slabs so concurrent deletions of objects sharing
+		// a slab serialize; otherwise two deleters could each still see the
+		// other's object and neither would unpin the shared slab. This also
+		// serializes against PinObject's pin check, so an object pinned
+		// concurrently can't lose a slab it references.
+		if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = ANY($1) ORDER BY id FOR UPDATE`, objectSlabIDs); err != nil {
+			return fmt.Errorf("failed to lock slabs: %w", err)
+		}
+
+		// unpin the slabs that are no longer referenced by any of the
+		// account's objects
+		rows, err = tx.Query(ctx, `SELECT s.id
+FROM slabs s
+JOIN account_slabs a ON s.id = a.slab_id
+WHERE a.account_id = $1
+	AND s.id = ANY($2)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM objects o
+		JOIN object_slabs os ON o.id = os.object_id
+		WHERE o.account_id = a.account_id
+		AND os.slab_digest = s.digest
+	)`, accountID, objectSlabIDs)
+		if err != nil {
+			return fmt.Errorf("failed to query unreferenced slabs: %w", err)
+		}
+		toUnpin, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+		if err != nil {
+			return fmt.Errorf("failed to collect unreferenced slab ids: %w", err)
+		}
+
+		if len(toUnpin) > 0 {
+			if err := s.unpinSlabs(ctx, tx, accountID, toUnpin); err != nil {
+				return fmt.Errorf("failed to unpin unreferenced slabs: %w", err)
+			}
+		}
 		return nil
 	})
 }
@@ -361,11 +414,17 @@ func (s *Store) PinObject(account proto.Account, obj slabs.PinObjectRequest) err
 			args = append(args, sqlHash256(slabIDs[i]))
 		}
 
+		// lock the slabs so a concurrent prune of the deletion queue can't
+		// delete them between this check and the object_slabs insert below
 		var count int
-		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM slabs
-JOIN account_slabs ON account_slabs.slab_id = slabs.id
-WHERE account_slabs.account_id = $1
-AND slabs.digest = ANY($2)`, accountID, args).Scan(&count); err != nil {
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM (
+	SELECT slabs.id FROM slabs
+	JOIN account_slabs ON account_slabs.slab_id = slabs.id
+	WHERE account_slabs.account_id = $1
+	AND slabs.digest = ANY($2)
+	ORDER BY slabs.id
+	FOR KEY SHARE OF slabs
+) locked`, accountID, args).Scan(&count); err != nil {
 			return fmt.Errorf("failed to check how many slab IDs exist: %w", err)
 		} else if len(seen) != count {
 			return slabs.ErrObjectUnpinnedSlab

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -298,30 +298,15 @@ WHERE os.object_id = $1`, objectID)
 		// other's object and neither would unpin the shared slab. This also
 		// serializes against PinObject's pin check, so an object pinned
 		// concurrently can't lose a slab it references.
-		if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = ANY($1) ORDER BY id FOR UPDATE`, objectSlabIDs); err != nil {
-			return fmt.Errorf("failed to lock slabs: %w", err)
+		if err := lockSlabs(ctx, tx, objectSlabIDs); err != nil {
+			return err
 		}
 
 		// unpin the slabs that are no longer referenced by any of the
 		// account's objects
-		rows, err = tx.Query(ctx, `SELECT s.id
-FROM slabs s
-JOIN account_slabs a ON s.id = a.slab_id
-WHERE a.account_id = $1
-	AND s.id = ANY($2)
-	AND NOT EXISTS (
-		SELECT 1
-		FROM objects o
-		JOIN object_slabs os ON o.id = os.object_id
-		WHERE o.account_id = a.account_id
-		AND os.slab_digest = s.digest
-	)`, accountID, objectSlabIDs)
+		toUnpin, err := unreferencedSlabs(ctx, tx, accountID, objectSlabIDs, nil)
 		if err != nil {
-			return fmt.Errorf("failed to query unreferenced slabs: %w", err)
-		}
-		toUnpin, err := pgx.CollectRows(rows, pgx.RowTo[int64])
-		if err != nil {
-			return fmt.Errorf("failed to collect unreferenced slab ids: %w", err)
+			return err
 		}
 
 		if len(toUnpin) > 0 {
@@ -415,16 +400,23 @@ func (s *Store) PinObject(account proto.Account, obj slabs.PinObjectRequest) err
 		}
 
 		// lock the slabs so a concurrent prune of the deletion queue can't
-		// delete them between this check and the object_slabs insert below
+		// delete them between the pin check and the object_slabs insert
+		// below. KEY SHARE is what the FK insert takes anyway; it conflicts
+		// with the FOR UPDATE held by deleters but not with pinned_at
+		// refreshes. Locks are acquired in digest order like everywhere else.
+		if _, err := tx.Exec(ctx, `SELECT digest FROM slabs WHERE digest = ANY($1) ORDER BY digest FOR KEY SHARE`, args); err != nil {
+			return fmt.Errorf("failed to lock slabs: %w", err)
+		}
+
+		// check that this account has pinned these slabs. The check runs as
+		// a separate statement after the lock so its snapshot includes pins
+		// removed by a concurrent unpin we may have waited on; a single
+		// combined statement would count rows from before the wait.
 		var count int
-		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM (
-	SELECT slabs.id FROM slabs
-	JOIN account_slabs ON account_slabs.slab_id = slabs.id
-	WHERE account_slabs.account_id = $1
-	AND slabs.digest = ANY($2)
-	ORDER BY slabs.id
-	FOR KEY SHARE OF slabs
-) locked`, accountID, args).Scan(&count); err != nil {
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM slabs
+JOIN account_slabs ON account_slabs.slab_id = slabs.id
+WHERE account_slabs.account_id = $1
+AND slabs.digest = ANY($2)`, accountID, args).Scan(&count); err != nil {
 			return fmt.Errorf("failed to check how many slab IDs exist: %w", err)
 		} else if len(seen) != count {
 			return slabs.ErrObjectUnpinnedSlab

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -291,28 +291,12 @@ INNER JOIN deleted d ON (d.slab_digest = s.digest)`, objectID)
 			return fmt.Errorf("failed to update object events: %w", err)
 		}
 
-		// lock the object's slabs so concurrent deletions of objects sharing
-		// a slab serialize; otherwise two deleters could each still see the
-		// other's object and neither would unpin the shared slab. This also
-		// serializes against PinObject's pin check, so an object pinned
-		// concurrently can't lose a slab it references.
-		if err := lockSlabs(ctx, tx, objectSlabIDs); err != nil {
-			return err
-		}
-
-		// unpin the slabs that are no longer referenced by any of the
-		// account's objects
-		toUnpin, err := unreferencedSlabs(ctx, tx, accountID, objectSlabIDs, nil)
-		if err != nil {
-			return err
-		}
-
-		if len(toUnpin) > 0 {
-			if err := s.unpinSlabs(ctx, tx, accountID, toUnpin); err != nil {
-				return fmt.Errorf("failed to unpin unreferenced slabs: %w", err)
-			}
-		}
-		return nil
+		// unpin the object's slabs that are no longer referenced by any of
+		// the account's objects; the locking inside serializes concurrent
+		// deletions of objects sharing a slab, which could otherwise each
+		// still see the other's object and leave the shared slab pinned
+		// forever
+		return s.unpinUnreferencedSlabs(ctx, tx, accountID, objectSlabIDs, nil)
 	})
 }
 

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -18,6 +18,45 @@ import (
 	"lukechampine.com/frand"
 )
 
+// assertPinnedSlabs asserts the account pins exactly the expected slabs,
+// ignoring order.
+func (s *Store) assertPinnedSlabs(t testing.TB, acc proto.Account, expected ...slabs.SlabID) {
+	t.Helper()
+
+	got, err := s.SlabIDs(acc, 0, math.MaxInt64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sortIDs := func(ids []slabs.SlabID) {
+		sort.Slice(ids, func(i, j int) bool { return bytes.Compare(ids[i][:], ids[j][:]) < 0 })
+	}
+	sortIDs(expected)
+	sortIDs(got)
+	if !reflect.DeepEqual(expected, got) {
+		t.Fatalf("mismatched slab IDs: expected %v, got %v", expected, got)
+	}
+}
+
+// assertStoreCleanedUp asserts no slabs, sectors, pins or queued deletions
+// remain and all pinned totals are back to zero.
+func (s *Store) assertStoreCleanedUp(t testing.TB) {
+	t.Helper()
+
+	var slabCount, sectorCount, accountSlabs, queued, pinned int64
+	err := s.pool.QueryRow(t.Context(), `SELECT
+		(SELECT COUNT(*) FROM slabs),
+		(SELECT COUNT(*) FROM sectors),
+		(SELECT COUNT(*) FROM account_slabs),
+		(SELECT COUNT(*) FROM slab_deletion_queue),
+		(SELECT COALESCE(SUM(pinned_data + pinned_size), 0) FROM accounts)`).Scan(&slabCount, &sectorCount, &accountSlabs, &queued, &pinned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slabCount != 0 || sectorCount != 0 || accountSlabs != 0 || queued != 0 || pinned != 0 {
+		t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d pins, %d queued, %d pinned data", slabCount, sectorCount, accountSlabs, queued, pinned)
+	}
+}
+
 func (s *Store) pinRandomObject(t testing.TB, acc proto.Account, ss []slabs.SlabSlice) slabs.SealedObject {
 	obj := slabs.SealedObject{
 		EncryptedDataKey:     frand.Bytes(72),
@@ -730,23 +769,6 @@ func TestDeleteObjectUnpinsSlabs(t *testing.T) {
 	obj2 := store.pinRandomObject(t, acc1, []slabs.SlabSlice{slabShared.Slice(0, 100)})
 	obj3 := store.pinRandomObject(t, acc2, []slabs.SlabSlice{slabForeign.Slice(0, 100)})
 
-	assertSlabs := func(acc proto.Account, expected ...slabs.SlabID) {
-		t.Helper()
-
-		got, err := store.SlabIDs(acc, 0, math.MaxInt64)
-		if err != nil {
-			t.Fatal(err)
-		}
-		sortIDs := func(ids []slabs.SlabID) {
-			sort.Slice(ids, func(i, j int) bool { return bytes.Compare(ids[i][:], ids[j][:]) < 0 })
-		}
-		sortIDs(expected)
-		sortIDs(got)
-		if !reflect.DeepEqual(expected, got) {
-			t.Fatalf("mismatched slab IDs: expected %v, got %v", expected, got)
-		}
-	}
-
 	assertSlabExists := func(id slabs.SlabID, exists bool) {
 		t.Helper()
 
@@ -758,16 +780,16 @@ func TestDeleteObjectUnpinsSlabs(t *testing.T) {
 		}
 	}
 
-	assertSlabs(acc1, slabShared.Digest(), slabSole.Digest(), slabForeign.Digest())
-	assertSlabs(acc2, slabForeign.Digest())
+	store.assertPinnedSlabs(t, acc1, slabShared.Digest(), slabSole.Digest(), slabForeign.Digest())
+	store.assertPinnedSlabs(t, acc2, slabForeign.Digest())
 
 	// delete obj1; slabSole and slabForeign are no longer referenced by any of
 	// acc1's objects and are unpinned, slabShared is still referenced by obj2
 	if err := store.DeleteObject(acc1, obj1.ID()); err != nil {
 		t.Fatal(err)
 	}
-	assertSlabs(acc1, slabShared.Digest())
-	assertSlabs(acc2, slabForeign.Digest())
+	store.assertPinnedSlabs(t, acc1, slabShared.Digest())
+	store.assertPinnedSlabs(t, acc2, slabForeign.Digest())
 
 	// process the deletion queue; slabSole is deleted, slabForeign survives
 	// since acc2 still pins it
@@ -783,27 +805,13 @@ func TestDeleteObjectUnpinsSlabs(t *testing.T) {
 	if err := store.DeleteObject(acc2, obj3.ID()); err != nil {
 		t.Fatal(err)
 	}
-	assertSlabs(acc1)
-	assertSlabs(acc2)
+	store.assertPinnedSlabs(t, acc1)
+	store.assertPinnedSlabs(t, acc2)
 
 	store.pruneAllDeletedSlabs(t)
 	assertSlabExists(slabShared.Digest(), false)
 	assertSlabExists(slabForeign.Digest(), false)
-
-	// no slabs, sectors or queued deletions may remain and the accounts'
-	// pinned totals must be back to zero
-	var slabCount, sectorCount, queued, pinned int64
-	err := store.pool.QueryRow(t.Context(), `SELECT
-		(SELECT COUNT(*) FROM slabs),
-		(SELECT COUNT(*) FROM sectors),
-		(SELECT COUNT(*) FROM slab_deletion_queue),
-		(SELECT COALESCE(SUM(pinned_data + pinned_size), 0) FROM accounts)`).Scan(&slabCount, &sectorCount, &queued, &pinned)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if slabCount != 0 || sectorCount != 0 || queued != 0 || pinned != 0 {
-		t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d queued, %d pinned", slabCount, sectorCount, queued, pinned)
-	}
+	store.assertStoreCleanedUp(t)
 }
 
 // TestPinObjectAfterScheduledDeletion asserts that an object can be pinned
@@ -930,18 +938,7 @@ func TestUnpinSlabInUse(t *testing.T) {
 		t.Fatalf("expected slab to be deleted, got %v", err)
 	}
 
-	// no slabs, sectors or queued deletions may remain
-	var slabCount, sectorCount, queued int64
-	err := store.pool.QueryRow(t.Context(), `SELECT
-		(SELECT COUNT(*) FROM slabs),
-		(SELECT COUNT(*) FROM sectors),
-		(SELECT COUNT(*) FROM slab_deletion_queue)`).Scan(&slabCount, &sectorCount, &queued)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if slabCount != 0 || sectorCount != 0 || queued != 0 {
-		t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d queued", slabCount, sectorCount, queued)
-	}
+	store.assertStoreCleanedUp(t)
 }
 
 // TestDeleteObjectKeepsObjectlessPin asserts that deleting the only object
@@ -971,24 +968,13 @@ func TestDeleteObjectKeepsObjectlessPin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertSlabs := func(acc proto.Account, expected ...slabs.SlabID) {
-		t.Helper()
-
-		got, err := store.SlabIDs(acc, 0, math.MaxInt64)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(expected, got) {
-			t.Fatalf("mismatched slab IDs: expected %v, got %v", expected, got)
-		}
-	}
-	assertSlabs(accA, slab.Digest())
-	assertSlabs(accB)
+	store.assertPinnedSlabs(t, accA, slab.Digest())
+	store.assertPinnedSlabs(t, accB)
 
 	// processing the queue must not delete the slab since A still pins it
 	store.pruneAllDeletedSlabs(t)
-	assertSlabs(accA, slab.Digest())
-	assertSlabs(accB)
+	store.assertPinnedSlabs(t, accA, slab.Digest())
+	store.assertPinnedSlabs(t, accB)
 	if _, err := store.PinnedSlab(accA, slab.Digest()); err != nil {
 		t.Fatalf("expected slab to still be pinned by account A, got %v", err)
 	}
@@ -1010,26 +996,6 @@ func TestParallelObjectDeletion(t *testing.T) {
 
 	hk := store.addTestHost(t)
 	store.addTestContract(t, hk)
-
-	// assertCleanedUp asserts no slabs, sectors, pins or queued deletions
-	// remain and the account's pinned totals are back to zero
-	assertCleanedUp := func(t testing.TB) {
-		t.Helper()
-
-		var slabCount, sectorCount, accountSlabs, queued, pinned int64
-		err := store.pool.QueryRow(t.Context(), `SELECT
-			(SELECT COUNT(*) FROM slabs),
-			(SELECT COUNT(*) FROM sectors),
-			(SELECT COUNT(*) FROM account_slabs),
-			(SELECT COUNT(*) FROM slab_deletion_queue),
-			(SELECT COALESCE(SUM(pinned_data + pinned_size), 0) FROM accounts)`).Scan(&slabCount, &sectorCount, &accountSlabs, &queued, &pinned)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if slabCount != 0 || sectorCount != 0 || accountSlabs != 0 || queued != 0 || pinned != 0 {
-			t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d pins, %d queued, %d pinned data", slabCount, sectorCount, accountSlabs, queued, pinned)
-		}
-	}
 
 	// two objects sharing a slab are deleted in parallel; exactly one of the
 	// deletions must unpin the shared slab
@@ -1055,7 +1021,7 @@ func TestParallelObjectDeletion(t *testing.T) {
 		if _, err := store.Slab(shared.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
 			t.Fatalf("expected slab to be deleted, got %v", err)
 		}
-		assertCleanedUp(t)
+		store.assertStoreCleanedUp(t)
 	}
 
 	// pinning a new object referencing the slab races the deletion of the
@@ -1107,7 +1073,7 @@ func TestParallelObjectDeletion(t *testing.T) {
 		if _, err := store.Slab(slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
 			t.Fatalf("expected slab to be deleted, got %v", err)
 		}
-		assertCleanedUp(t)
+		store.assertStoreCleanedUp(t)
 	}
 
 	// an explicit unpin races the deletion of the last object referencing the
@@ -1141,7 +1107,7 @@ func TestParallelObjectDeletion(t *testing.T) {
 		if _, err := store.Slab(slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
 			t.Fatalf("expected slab to be deleted, got %v", err)
 		}
-		assertCleanedUp(t)
+		store.assertStoreCleanedUp(t)
 	}
 }
 

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -1058,6 +1058,58 @@ func TestParallelObjectDeletion(t *testing.T) {
 		assertCleanedUp(t)
 	}
 
+	// pinning a new object referencing the slab races the deletion of the
+	// last object referencing it; the pin must either succeed with the slab
+	// still pinned or fail with ErrObjectUnpinnedSlab — it must never
+	// succeed while the deletion removes the pin
+	for range rounds {
+		slab := newTestSlab(hk)
+		store.pinTestSlabs(t, acc, slab)
+		obj1 := store.pinRandomObject(t, acc, []slabs.SlabSlice{slab.Slice(0, 100)})
+		obj2 := slabs.SealedObject{
+			EncryptedDataKey:     frand.Bytes(72),
+			EncryptedMetadataKey: frand.Bytes(72),
+			Slabs:                []slabs.SlabSlice{slab.Slice(0, 100), slab.Slice(100, 200)},
+			DataSignature:        (types.Signature)(frand.Bytes(64)),
+			MetadataSignature:    (types.Signature)(frand.Bytes(64)),
+		}
+
+		delErrCh := make(chan error, 1)
+		pinErrCh := make(chan error, 1)
+		go func() {
+			delErrCh <- store.DeleteObject(acc, obj1.ID())
+		}()
+		go func() {
+			pinErrCh <- store.PinObject(acc, obj2.PinRequest())
+		}()
+		if err := <-delErrCh; err != nil {
+			t.Fatal(err)
+		}
+		pinErr := <-pinErrCh
+		if pinErr != nil && !errors.Is(pinErr, slabs.ErrObjectUnpinnedSlab) {
+			t.Fatal(pinErr)
+		}
+
+		if pinErr == nil {
+			// the object was pinned, so the account must still pin the slab
+			ids, err := store.SlabIDs(acc, 0, math.MaxInt64)
+			if err != nil {
+				t.Fatal(err)
+			} else if !slices.Contains(ids, slab.Digest()) {
+				t.Fatal("pinned object references a slab the account no longer pins")
+			}
+			if err := store.DeleteObject(acc, obj2.ID()); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		store.pruneAllDeletedSlabs(t)
+		if _, err := store.Slab(slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
+			t.Fatalf("expected slab to be deleted, got %v", err)
+		}
+		assertCleanedUp(t)
+	}
+
 	// an explicit unpin races the deletion of the last object referencing the
 	// slab; the account's totals must only be decremented once
 	for range rounds {

--- a/persist/postgres/objects_test.go
+++ b/persist/postgres/objects_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math"
 	"reflect"
 	"slices"
@@ -691,6 +692,404 @@ func TestObjectsForSlab(t *testing.T) {
 		t.Fatal(err)
 	} else if len(objects) != 0 {
 		t.Fatalf("expected 0 objects, got %d", len(objects))
+	}
+}
+
+// TestDeleteObjectUnpinsSlabs asserts that deleting an object unpins the slabs
+// that are no longer referenced by any of the account's objects and queues
+// them for deletion, while slabs referenced by other objects or pinned by
+// other accounts stay alive.
+func TestDeleteObjectUnpinsSlabs(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc1, acc2 := proto.Account{1}, proto.Account{2}
+	for _, acc := range []proto.Account{acc1, acc2} {
+		store.addTestAccount(t, types.PublicKey(acc))
+	}
+
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// slabShared is referenced by both of acc1's objects, slabSole only by
+	// acc1's first object and slabForeign by acc1's first object as well as
+	// acc2's object
+	slabShared := newTestSlab(hk)
+	slabSole := newTestSlab(hk)
+	slabForeign := newTestSlab(hk)
+	store.pinTestSlabs(t, acc1, slabShared, slabSole, slabForeign)
+	store.pinTestSlabs(t, acc2, slabForeign)
+
+	// obj1 references slabSole twice to make sure duplicate references are
+	// handled
+	obj1 := store.pinRandomObject(t, acc1, []slabs.SlabSlice{
+		slabShared.Slice(0, 100),
+		slabSole.Slice(0, 100),
+		slabSole.Slice(100, 200),
+		slabForeign.Slice(0, 100),
+	})
+	obj2 := store.pinRandomObject(t, acc1, []slabs.SlabSlice{slabShared.Slice(0, 100)})
+	obj3 := store.pinRandomObject(t, acc2, []slabs.SlabSlice{slabForeign.Slice(0, 100)})
+
+	assertSlabs := func(acc proto.Account, expected ...slabs.SlabID) {
+		t.Helper()
+
+		got, err := store.SlabIDs(acc, 0, math.MaxInt64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sortIDs := func(ids []slabs.SlabID) {
+			sort.Slice(ids, func(i, j int) bool { return bytes.Compare(ids[i][:], ids[j][:]) < 0 })
+		}
+		sortIDs(expected)
+		sortIDs(got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatched slab IDs: expected %v, got %v", expected, got)
+		}
+	}
+
+	assertSlabExists := func(id slabs.SlabID, exists bool) {
+		t.Helper()
+
+		_, err := store.Slab(id)
+		if exists && err != nil {
+			t.Fatalf("expected slab %v to exist, got %v", id, err)
+		} else if !exists && !errors.Is(err, slabs.ErrSlabNotFound) {
+			t.Fatalf("expected slab %v to be gone, got %v", id, err)
+		}
+	}
+
+	assertSlabs(acc1, slabShared.Digest(), slabSole.Digest(), slabForeign.Digest())
+	assertSlabs(acc2, slabForeign.Digest())
+
+	// delete obj1; slabSole and slabForeign are no longer referenced by any of
+	// acc1's objects and are unpinned, slabShared is still referenced by obj2
+	if err := store.DeleteObject(acc1, obj1.ID()); err != nil {
+		t.Fatal(err)
+	}
+	assertSlabs(acc1, slabShared.Digest())
+	assertSlabs(acc2, slabForeign.Digest())
+
+	// process the deletion queue; slabSole is deleted, slabForeign survives
+	// since acc2 still pins it
+	store.pruneAllDeletedSlabs(t)
+	assertSlabExists(slabShared.Digest(), true)
+	assertSlabExists(slabSole.Digest(), false)
+	assertSlabExists(slabForeign.Digest(), true)
+
+	// delete the remaining objects; all pins are removed
+	if err := store.DeleteObject(acc1, obj2.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteObject(acc2, obj3.ID()); err != nil {
+		t.Fatal(err)
+	}
+	assertSlabs(acc1)
+	assertSlabs(acc2)
+
+	store.pruneAllDeletedSlabs(t)
+	assertSlabExists(slabShared.Digest(), false)
+	assertSlabExists(slabForeign.Digest(), false)
+
+	// no slabs, sectors or queued deletions may remain and the accounts'
+	// pinned totals must be back to zero
+	var slabCount, sectorCount, queued, pinned int64
+	err := store.pool.QueryRow(t.Context(), `SELECT
+		(SELECT COUNT(*) FROM slabs),
+		(SELECT COUNT(*) FROM sectors),
+		(SELECT COUNT(*) FROM slab_deletion_queue),
+		(SELECT COALESCE(SUM(pinned_data + pinned_size), 0) FROM accounts)`).Scan(&slabCount, &sectorCount, &queued, &pinned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slabCount != 0 || sectorCount != 0 || queued != 0 || pinned != 0 {
+		t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d queued, %d pinned", slabCount, sectorCount, queued, pinned)
+	}
+}
+
+// TestPinObjectAfterScheduledDeletion asserts that an object can be pinned
+// while its slabs are queued for deletion and that processing the queue
+// afterwards keeps the referenced slabs alive.
+func TestPinObjectAfterScheduledDeletion(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc1, acc2 := proto.Account{1}, proto.Account{2}
+	for _, acc := range []proto.Account{acc1, acc2} {
+		store.addTestAccount(t, types.PublicKey(acc))
+	}
+
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// both accounts pin the slab, only acc1 references it with an object
+	slab := newTestSlab(hk)
+	store.pinTestSlabs(t, acc1, slab)
+	store.pinTestSlabs(t, acc2, slab)
+	obj1 := store.pinRandomObject(t, acc1, []slabs.SlabSlice{slab.Slice(0, 100)})
+
+	// delete the object; the slab is unpinned for acc1 and queued for deletion
+	if err := store.DeleteObject(acc1, obj1.ID()); err != nil {
+		t.Fatal(err)
+	}
+
+	// acc1 unpinned the slab, so it can't pin the object again without
+	// re-pinning the slab first
+	obj2 := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: frand.Bytes(72),
+		Slabs:                []slabs.SlabSlice{slab.Slice(0, 100)},
+		DataSignature:        (types.Signature)(frand.Bytes(64)),
+		MetadataSignature:    (types.Signature)(frand.Bytes(64)),
+	}
+	if err := store.PinObject(acc1, obj2.PinRequest()); !errors.Is(err, slabs.ErrObjectUnpinnedSlab) {
+		t.Fatalf("expected ErrObjectUnpinnedSlab, got %v", err)
+	}
+
+	// acc2 still pins the slab and pins the object while the slab is queued
+	// for deletion
+	obj2 = store.pinRandomObject(t, acc2, []slabs.SlabSlice{slab.Slice(0, 100)})
+
+	// processing the queue must not delete the slab
+	store.pruneAllDeletedSlabs(t)
+	if _, err := store.Slab(slab.Digest()); err != nil {
+		t.Fatalf("expected slab to survive the prune, got %v", err)
+	}
+
+	// simulate the transient state where an object references the slab while
+	// no account pins it; the prune must keep the slab alive as well
+	_, err := store.pool.Exec(t.Context(), `DELETE FROM account_slabs`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.pool.Exec(t.Context(), `INSERT INTO slab_deletion_queue (slab_id) SELECT id FROM slabs`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.pruneAllDeletedSlabs(t)
+	if _, err := store.Slab(slab.Digest()); err != nil {
+		t.Fatalf("expected referenced slab to survive the prune, got %v", err)
+	}
+
+	// the object must still be fully intact
+	obj, err := store.Object(acc2, obj2.ID())
+	if err != nil {
+		t.Fatal(err)
+	} else if len(obj.Slabs) != 1 {
+		t.Fatalf("expected 1 slab, got %d", len(obj.Slabs))
+	} else if len(obj.Slabs[0].Sectors) != len(slab.Sectors) {
+		t.Fatalf("expected %d sectors, got %d", len(slab.Sectors), len(obj.Slabs[0].Sectors))
+	}
+}
+
+// TestUnpinSlabInUse asserts that a slab can not be unpinned while an object
+// of the same account references it, that objects of other accounts don't
+// block the unpin, and that deleting the object cleans the slab up through the
+// regular unpin path.
+func TestUnpinSlabInUse(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	accA, accB := proto.Account{1}, proto.Account{2}
+	for _, acc := range []proto.Account{accA, accB} {
+		store.addTestAccount(t, types.PublicKey(acc))
+	}
+
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// both accounts pin the slab, only accB references it with an object
+	slab := newTestSlab(hk)
+	store.pinTestSlabs(t, accA, slab)
+	store.pinTestSlabs(t, accB, slab)
+	obj := store.pinRandomObject(t, accB, []slabs.SlabSlice{slab.Slice(0, 100)})
+
+	// explicitly unpinning the slab while the account's own object references
+	// it must fail
+	if err := store.UnpinSlab(accB, slab.Digest()); !errors.Is(err, slabs.ErrSlabInUse) {
+		t.Fatalf("expected ErrSlabInUse, got %v", err)
+	}
+
+	// accB's object doesn't prevent accA from unpinning the slab
+	if err := store.UnpinSlab(accA, slab.Digest()); err != nil {
+		t.Fatal(err)
+	}
+
+	// the queued deletion must not remove the slab since accB still pins it
+	store.pruneAllDeletedSlabs(t)
+	if _, err := store.Slab(slab.Digest()); err != nil {
+		t.Fatalf("expected slab to survive the prune, got %v", err)
+	}
+
+	// deleting the object unpins the slab and queues it for deletion
+	if err := store.DeleteObject(accB, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UnpinSlab(accB, slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
+		t.Fatalf("expected ErrSlabNotFound, got %v", err)
+	}
+	store.pruneAllDeletedSlabs(t)
+	if _, err := store.Slab(slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
+		t.Fatalf("expected slab to be deleted, got %v", err)
+	}
+
+	// no slabs, sectors or queued deletions may remain
+	var slabCount, sectorCount, queued int64
+	err := store.pool.QueryRow(t.Context(), `SELECT
+		(SELECT COUNT(*) FROM slabs),
+		(SELECT COUNT(*) FROM sectors),
+		(SELECT COUNT(*) FROM slab_deletion_queue)`).Scan(&slabCount, &sectorCount, &queued)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slabCount != 0 || sectorCount != 0 || queued != 0 {
+		t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d queued", slabCount, sectorCount, queued)
+	}
+}
+
+// TestDeleteObjectKeepsObjectlessPin asserts that deleting the only object
+// referencing a slab unpins it for the deleting account only; another account
+// pinning the slab without any object keeps its pin and the slab survives the
+// deletion queue.
+func TestDeleteObjectKeepsObjectlessPin(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	accA, accB := proto.Account{1}, proto.Account{2}
+	for _, acc := range []proto.Account{accA, accB} {
+		store.addTestAccount(t, types.PublicKey(acc))
+	}
+
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// account A pins the slab without attaching it to an object, account B
+	// pins it and references it with an object
+	slab := newTestSlab(hk)
+	store.pinTestSlabs(t, accA, slab)
+	store.pinTestSlabs(t, accB, slab)
+	obj := store.pinRandomObject(t, accB, []slabs.SlabSlice{slab.Slice(0, 100)})
+
+	// delete the object; B's pin is removed, A's pin stays
+	if err := store.DeleteObject(accB, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+
+	assertSlabs := func(acc proto.Account, expected ...slabs.SlabID) {
+		t.Helper()
+
+		got, err := store.SlabIDs(acc, 0, math.MaxInt64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatched slab IDs: expected %v, got %v", expected, got)
+		}
+	}
+	assertSlabs(accA, slab.Digest())
+	assertSlabs(accB)
+
+	// processing the queue must not delete the slab since A still pins it
+	store.pruneAllDeletedSlabs(t)
+	assertSlabs(accA, slab.Digest())
+	assertSlabs(accB)
+	if _, err := store.PinnedSlab(accA, slab.Digest()); err != nil {
+		t.Fatalf("expected slab to still be pinned by account A, got %v", err)
+	}
+	if _, err := store.PinnedSlab(accB, slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
+		t.Fatalf("expected slab to no longer be pinned by account B, got %v", err)
+	}
+}
+
+// TestParallelObjectDeletion races deletions of objects sharing a slab as well
+// as explicit unpins against object deletions. The shared slab must be cleaned
+// up exactly once and the account's pinned totals must return to zero.
+func TestParallelObjectDeletion(t *testing.T) {
+	const rounds = 30
+
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account{1}
+	store.addTestAccount(t, types.PublicKey(acc))
+
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	// assertCleanedUp asserts no slabs, sectors, pins or queued deletions
+	// remain and the account's pinned totals are back to zero
+	assertCleanedUp := func(t testing.TB) {
+		t.Helper()
+
+		var slabCount, sectorCount, accountSlabs, queued, pinned int64
+		err := store.pool.QueryRow(t.Context(), `SELECT
+			(SELECT COUNT(*) FROM slabs),
+			(SELECT COUNT(*) FROM sectors),
+			(SELECT COUNT(*) FROM account_slabs),
+			(SELECT COUNT(*) FROM slab_deletion_queue),
+			(SELECT COALESCE(SUM(pinned_data + pinned_size), 0) FROM accounts)`).Scan(&slabCount, &sectorCount, &accountSlabs, &queued, &pinned)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if slabCount != 0 || sectorCount != 0 || accountSlabs != 0 || queued != 0 || pinned != 0 {
+			t.Fatalf("expected everything cleaned up, got %d slabs, %d sectors, %d pins, %d queued, %d pinned data", slabCount, sectorCount, accountSlabs, queued, pinned)
+		}
+	}
+
+	// two objects sharing a slab are deleted in parallel; exactly one of the
+	// deletions must unpin the shared slab
+	for range rounds {
+		shared := newTestSlab(hk)
+		store.pinTestSlabs(t, acc, shared)
+		obj1 := store.pinRandomObject(t, acc, []slabs.SlabSlice{shared.Slice(0, 100)})
+		obj2 := store.pinRandomObject(t, acc, []slabs.SlabSlice{shared.Slice(0, 100), shared.Slice(100, 200)})
+
+		errs := make(chan error, 2)
+		for _, key := range []types.Hash256{obj1.ID(), obj2.ID()} {
+			go func() {
+				errs <- store.DeleteObject(acc, key)
+			}()
+		}
+		for range 2 {
+			if err := <-errs; err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		store.pruneAllDeletedSlabs(t)
+		if _, err := store.Slab(shared.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
+			t.Fatalf("expected slab to be deleted, got %v", err)
+		}
+		assertCleanedUp(t)
+	}
+
+	// an explicit unpin races the deletion of the last object referencing the
+	// slab; the account's totals must only be decremented once
+	for range rounds {
+		slab := newTestSlab(hk)
+		store.pinTestSlabs(t, acc, slab)
+		obj := store.pinRandomObject(t, acc, []slabs.SlabSlice{slab.Slice(0, 100)})
+
+		errs := make(chan error, 2)
+		go func() {
+			errs <- store.DeleteObject(acc, obj.ID())
+		}()
+		go func() {
+			// the slab is in use until the object is deleted and unpinned
+			// right after, so the explicit unpin always fails with one of the
+			// two errors depending on how the calls interleave
+			if err := store.UnpinSlab(acc, slab.Digest()); errors.Is(err, slabs.ErrSlabInUse) || errors.Is(err, slabs.ErrSlabNotFound) {
+				errs <- nil
+			} else {
+				errs <- fmt.Errorf("expected ErrSlabInUse or ErrSlabNotFound, got %w", err)
+			}
+		}()
+		for range 2 {
+			if err := <-errs; err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		store.pruneAllDeletedSlabs(t)
+		if _, err := store.Slab(slab.Digest()); !errors.Is(err, slabs.ErrSlabNotFound) {
+			t.Fatalf("expected slab to be deleted, got %v", err)
+		}
+		assertCleanedUp(t)
 	}
 }
 

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -702,9 +702,9 @@ func (s *Store) UnpinSlab(account proto.Account, slabID slabs.SlabID) error {
 			return fmt.Errorf("failed to get account ID: %w", err)
 		}
 
-		// lock the slab before any checks so they serialize against
+		// lock the slab before the checks so they serialize against
 		// concurrent unpins and against PinObject attaching the slab to a
-		// new object; the checks run as separate statements after the lock,
+		// new object; the checks run in a separate statement after the lock,
 		// so they see the state committed by whoever held the lock before us
 		var sID int64
 		err = tx.QueryRow(ctx, `SELECT id FROM slabs WHERE digest = $1 FOR UPDATE`, sqlHash256(slabID)).Scan(&sID)
@@ -714,28 +714,23 @@ func (s *Store) UnpinSlab(account proto.Account, slabID slabs.SlabID) error {
 			return fmt.Errorf("failed to lock slab: %w", err)
 		}
 
-		var pinned bool
-		err = tx.QueryRow(ctx, `SELECT EXISTS (
-			SELECT 1 FROM account_slabs WHERE account_id = $1 AND slab_id = $2
-		)`, id, sID).Scan(&pinned)
+		// the slab must still be pinned by the account and must not be
+		// referenced by one of its objects; refusing the unpin while an object
+		// references the slab stops the account from freeing quota while the
+		// object keeps the slab alive
+		var pinned, inUse bool
+		err = tx.QueryRow(ctx, `SELECT
+			EXISTS (SELECT 1 FROM account_slabs WHERE account_id = $1 AND slab_id = $2),
+			EXISTS (
+				SELECT 1
+				FROM objects o
+				JOIN object_slabs os ON o.id = os.object_id
+				WHERE o.account_id = $1 AND os.slab_digest = $3
+			)`, id, sID, sqlHash256(slabID)).Scan(&pinned, &inUse)
 		if err != nil {
-			return fmt.Errorf("failed to check if slab is pinned: %w", err)
+			return fmt.Errorf("failed to check slab pin state: %w", err)
 		} else if !pinned {
 			return slabs.ErrSlabNotFound
-		}
-
-		// refuse to unpin a slab that is still referenced by one of the
-		// account's objects; otherwise the account would free up quota while
-		// the object keeps the slab alive
-		var inUse bool
-		err = tx.QueryRow(ctx, `SELECT EXISTS (
-			SELECT 1
-			FROM objects o
-			JOIN object_slabs os ON o.id = os.object_id
-			WHERE o.account_id = $1 AND os.slab_digest = $2
-		)`, id, sqlHash256(slabID)).Scan(&inUse)
-		if err != nil {
-			return fmt.Errorf("failed to check if slab is in use: %w", err)
 		} else if inUse {
 			return slabs.ErrSlabInUse
 		}

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -570,38 +570,19 @@ func (s *Store) deleteOrphanedSlabs(ctx context.Context, tx *txn, sIDs []int64) 
 		return err
 	}
 
-	// ignore the slabs that are pinned by an account or referenced by an
-	// object; a slab can be re-pinned and attached to a new object after it
-	// was queued for deletion
-	rows, err := tx.Query(ctx, `SELECT slab_id FROM account_slabs WHERE slab_id = ANY($1)
-UNION
-SELECT s.id FROM slabs s
-JOIN object_slabs os ON os.slab_digest = s.digest
-WHERE s.id = ANY($1)`, sIDs)
+	// get the slabs that are neither pinned by an account nor referenced by
+	// an object; a slab can be re-pinned and attached to a new object after
+	// it was queued for deletion
+	rows, err := tx.Query(ctx, `SELECT s.id FROM slabs s
+WHERE s.id = ANY($1)
+	AND NOT EXISTS (SELECT 1 FROM account_slabs a WHERE a.slab_id = s.id)
+	AND NOT EXISTS (SELECT 1 FROM object_slabs os WHERE os.slab_digest = s.digest)`, sIDs)
 	if err != nil {
-		return fmt.Errorf("failed to check if slab was pinned or referenced: %w", err)
+		return fmt.Errorf("failed to query deletable slabs: %w", err)
 	}
-	defer rows.Close()
-
-	seen := make(map[int64]struct{})
-	for rows.Next() {
-		var sID int64
-		if err := rows.Scan(&sID); err != nil {
-			return fmt.Errorf("failed to scan in-use slab: %w", err)
-		}
-		seen[sID] = struct{}{}
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("failed to get in-use slabs: %w", err)
-	}
-
-	// get all of the slabs that are neither pinned nor referenced
-	var toDelete []int64
-	for _, sID := range sIDs {
-		if _, ok := seen[sID]; ok {
-			continue
-		}
-		toDelete = append(toDelete, sID)
+	toDelete, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return fmt.Errorf("failed to collect deletable slabs: %w", err)
 	}
 
 	// delete sectors

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -286,14 +286,38 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 			return fmt.Errorf("failed to get good host rows: %w", err)
 		}
 
-		var newPinnedData, newPinnedSize uint64
+		// validate the slabs and compute their digests
+		digestArgs := make([]any, 0, len(toPin))
+		rootArgs := make([]any, 0, len(toPin))
 		for _, slab := range toPin {
 			if slab.MinShards <= 0 || uint(len(slab.Sectors)) < slab.MinShards {
 				return slabs.ErrMinShards
 			}
-
 			digest := slab.Digest()
 			digests = append(digests, digest)
+			digestArgs = append(digestArgs, sqlHash256(digest))
+			for _, sector := range slab.Sectors {
+				rootArgs = append(rootArgs, sqlHash256(sector.Root))
+			}
+		}
+
+		// lock the slabs and sectors that already exist up front, in the
+		// same order the other lockers use (slabs by digest, then sectors by
+		// root), so the row locks the upserts below take can't deadlock with
+		// concurrent deletions and prunes. Rows the upserts insert are
+		// invisible to concurrent lockers, so the upserts themselves may run
+		// in the caller's order, which also determines the order sectors are
+		// pinned to contracts in.
+		if _, err := tx.Exec(ctx, `SELECT digest FROM slabs WHERE digest = ANY($1) ORDER BY digest FOR NO KEY UPDATE`, digestArgs); err != nil {
+			return fmt.Errorf("failed to lock slabs: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `SELECT sector_root FROM sectors WHERE sector_root = ANY($1) ORDER BY sector_root FOR NO KEY UPDATE`, rootArgs); err != nil {
+			return fmt.Errorf("failed to lock sectors: %w", err)
+		}
+
+		var newPinnedData, newPinnedSize uint64
+		for idx, slab := range toPin {
+			digest := digests[idx]
 
 			// insert slab
 			var slabID int64
@@ -442,6 +466,45 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 	return digests, err
 }
 
+// lockSlabs locks the given slabs FOR UPDATE. Locks are always acquired in
+// ascending digest order — the same order PinSlabs upserts slab rows in — so
+// concurrent transactions locking overlapping sets can't deadlock. Every
+// other slab locker must use the same order.
+func lockSlabs(ctx context.Context, tx *txn, sIDs []int64) error {
+	if len(sIDs) == 0 {
+		return nil
+	}
+	if _, err := tx.Exec(ctx, `SELECT digest FROM slabs WHERE id = ANY($1) ORDER BY digest FOR UPDATE`, sIDs); err != nil {
+		return fmt.Errorf("failed to lock slabs: %w", err)
+	}
+	return nil
+}
+
+// unreferencedSlabs returns the subset of the given slabs that are pinned by
+// the account but not referenced by any of the account's objects. Only slabs
+// pinned before cutoff are returned; a nil cutoff returns them regardless of
+// when they were pinned. Callers must hold locks on the slabs so the check
+// can't race a concurrent PinObject.
+func unreferencedSlabs(ctx context.Context, tx *txn, accountID int64, sIDs []int64, cutoff *time.Time) ([]int64, error) {
+	rows, err := tx.Query(ctx, `SELECT s.id
+FROM slabs s
+JOIN account_slabs a ON s.id = a.slab_id
+WHERE a.account_id = $1
+	AND s.id = ANY($2)
+	AND ($3::TIMESTAMPTZ IS NULL OR s.pinned_at < $3)
+	AND NOT EXISTS (
+		SELECT 1
+		FROM objects o
+		JOIN object_slabs os ON o.id = os.object_id
+		WHERE o.account_id = a.account_id
+		AND os.slab_digest = s.digest
+	)`, accountID, sIDs, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query unreferenced slabs: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowTo[int64])
+}
+
 // unpinSlabs removes the account's association with the given slabs and updates
 // the account's pinned totals. Slabs the account no longer pins are ignored, so
 // a concurrent unpin of the same slab can't double-decrement the totals. The
@@ -503,8 +566,8 @@ SELECT * FROM unnest($1::bigint[])`, unpinned); err != nil {
 func (s *Store) deleteOrphanedSlabs(ctx context.Context, tx *txn, sIDs []int64) error {
 	// lock the candidate slabs so a concurrent re-pin serializes against the
 	// pinned check below
-	if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = ANY($1) ORDER BY id FOR UPDATE`, sIDs); err != nil {
-		return fmt.Errorf("failed to lock slabs: %w", err)
+	if err := lockSlabs(ctx, tx, sIDs); err != nil {
+		return err
 	}
 
 	// ignore the slabs that are pinned by an account or referenced by an
@@ -545,11 +608,13 @@ WHERE s.id = ANY($1)`, sIDs)
 	var pinned, unpinned, unpinnable int64
 	var unpinnedDeltas []unpinnedDelta
 	if len(toDelete) > 0 {
-		// lock the candidate sectors too, so a concurrent re-pin reusing a shared
-		// sector serializes against the orphan check below
-		if _, err := tx.Exec(ctx, `SELECT id FROM sectors WHERE id IN (
+		// lock the candidate sectors too, so a concurrent re-pin reusing a
+		// shared sector serializes against the orphan check below. Locks are
+		// acquired in ascending root order to match the order PinSlabs
+		// upserts sectors in.
+		if _, err := tx.Exec(ctx, `SELECT sector_root FROM sectors WHERE id IN (
 	SELECT sector_id FROM slab_sectors WHERE slab_id = ANY($1)
-) ORDER BY id FOR UPDATE`, toDelete); err != nil {
+) ORDER BY sector_root FOR UPDATE`, toDelete); err != nil {
 			return fmt.Errorf("failed to lock sectors: %w", err)
 		}
 
@@ -639,18 +704,26 @@ func (s *Store) UnpinSlab(account proto.Account, slabID slabs.SlabID) error {
 			return fmt.Errorf("failed to get account ID: %w", err)
 		}
 
+		// lock the slab before any checks so they serialize against
+		// concurrent unpins and against PinObject attaching the slab to a
+		// new object; the checks run as separate statements after the lock,
+		// so they see the state committed by whoever held the lock before us
 		var sID int64
-		err = tx.QueryRow(ctx, `SELECT slab_id FROM account_slabs WHERE account_id = $1 and slab_id = (SELECT id FROM slabs WHERE digest = $2)`, id, sqlHash256(slabID)).Scan(&sID)
+		err = tx.QueryRow(ctx, `SELECT id FROM slabs WHERE digest = $1 FOR UPDATE`, sqlHash256(slabID)).Scan(&sID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return slabs.ErrSlabNotFound
 		} else if err != nil {
-			return fmt.Errorf("failed to check if slab exists: %w", err)
+			return fmt.Errorf("failed to lock slab: %w", err)
 		}
 
-		// lock the slab so the reference check below serializes against a
-		// concurrent PinObject attaching the slab to a new object
-		if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = $1 FOR UPDATE`, sID); err != nil {
-			return fmt.Errorf("failed to lock slab: %w", err)
+		var pinned bool
+		err = tx.QueryRow(ctx, `SELECT EXISTS (
+			SELECT 1 FROM account_slabs WHERE account_id = $1 AND slab_id = $2
+		)`, id, sID).Scan(&pinned)
+		if err != nil {
+			return fmt.Errorf("failed to check if slab is pinned: %w", err)
+		} else if !pinned {
+			return slabs.ErrSlabNotFound
 		}
 
 		// refuse to unpin a slab that is still referenced by one of the

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -480,12 +480,17 @@ func lockSlabs(ctx context.Context, tx *txn, sIDs []int64) error {
 	return nil
 }
 
-// unreferencedSlabs returns the subset of the given slabs that are pinned by
-// the account but not referenced by any of the account's objects. Only slabs
-// pinned before cutoff are returned; a nil cutoff returns them regardless of
-// when they were pinned. Callers must hold locks on the slabs so the check
-// can't race a concurrent PinObject.
-func unreferencedSlabs(ctx context.Context, tx *txn, accountID int64, sIDs []int64, cutoff *time.Time) ([]int64, error) {
+// unpinUnreferencedSlabs unpins the subset of the given slabs that are pinned
+// by the account but not referenced by any of the account's objects, queueing
+// them for deletion by deleteOrphanedSlabs. Only slabs pinned before cutoff
+// are unpinned; a nil cutoff unpins them regardless of when they were pinned.
+// The slabs are locked first so the reference check can't race a concurrent
+// PinObject or another unpinner.
+func (s *Store) unpinUnreferencedSlabs(ctx context.Context, tx *txn, accountID int64, sIDs []int64, cutoff *time.Time) error {
+	if err := lockSlabs(ctx, tx, sIDs); err != nil {
+		return err
+	}
+
 	rows, err := tx.Query(ctx, `SELECT s.id
 FROM slabs s
 JOIN account_slabs a ON s.id = a.slab_id
@@ -500,9 +505,17 @@ WHERE a.account_id = $1
 		AND os.slab_digest = s.digest
 	)`, accountID, sIDs, cutoff)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query unreferenced slabs: %w", err)
+		return fmt.Errorf("failed to query unreferenced slabs: %w", err)
 	}
-	return pgx.CollectRows(rows, pgx.RowTo[int64])
+	toUnpin, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return fmt.Errorf("failed to collect unreferenced slabs: %w", err)
+	}
+
+	if len(toUnpin) == 0 {
+		return nil
+	}
+	return s.unpinSlabs(ctx, tx, accountID, toUnpin)
 }
 
 // unpinSlabs removes the account's association with the given slabs and updates

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -443,14 +443,26 @@ func (s *Store) PinSlabs(account proto.Account, nextIntegrityCheck time.Time, to
 }
 
 // unpinSlabs removes the account's association with the given slabs and updates
-// the account's pinned totals. The slabs and their sectors are not deleted
-// inline; they are queued for deleteOrphanedSlabs to prune in a background loop.
+// the account's pinned totals. Slabs the account no longer pins are ignored, so
+// a concurrent unpin of the same slab can't double-decrement the totals. The
+// slabs and their sectors are not deleted inline; they are queued for
+// deleteOrphanedSlabs to prune in a background loop.
 func (s *Store) unpinSlabs(ctx context.Context, tx *txn, accountID int64, sIDs []int64) error {
-	// delete the association between the account and the slab
-	_, err := tx.Exec(ctx, `DELETE FROM account_slabs a
-WHERE a.account_id = $1 AND a.slab_id = ANY($2);`, accountID, sIDs)
+	// delete the association between the account and the slab, keeping track
+	// of the associations that actually existed
+	rows, err := tx.Query(ctx, `DELETE FROM account_slabs a
+WHERE a.account_id = $1 AND a.slab_id = ANY($2)
+RETURNING a.slab_id`, accountID, sIDs)
 	if err != nil {
 		return fmt.Errorf("failed to delete account slabs: %w", err)
+	}
+	unpinned, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return fmt.Errorf("failed to collect unpinned slab ids: %w", err)
+	}
+
+	if len(unpinned) == 0 {
+		return nil // all slabs were already unpinned
 	}
 
 	// update the account's pinned data and pinned size
@@ -458,7 +470,7 @@ WHERE a.account_id = $1 AND a.slab_id = ANY($2);`, accountID, sIDs)
 	if err := tx.QueryRow(ctx, `SELECT
 		(SELECT COALESCE(SUM(min_shards::bigint), 0) * $1 FROM slabs WHERE id = ANY($2)),
 		(SELECT COUNT(*) * $1 FROM slab_sectors WHERE slab_id = ANY($2))`,
-		proto.SectorSize, sIDs).Scan(&pinnedDataDelta, &pinnedSizeDelta); err != nil {
+		proto.SectorSize, unpinned).Scan(&pinnedDataDelta, &pinnedSizeDelta); err != nil {
 		return fmt.Errorf("failed to get storage delta: %w", err)
 	}
 
@@ -477,16 +489,17 @@ RETURNING connect_key_id`, pinnedDataDelta, pinnedSizeDelta, accountID).Scan(&co
 	// queue the slabs for background deletion; the queue is append-only so a
 	// concurrent prune can't swallow a re-queue
 	if _, err := tx.Exec(ctx, `INSERT INTO slab_deletion_queue (slab_id)
-SELECT * FROM unnest($1::bigint[])`, sIDs); err != nil {
+SELECT * FROM unnest($1::bigint[])`, unpinned); err != nil {
 		return fmt.Errorf("failed to queue slabs for deletion: %w", err)
 	}
 	return nil
 }
 
 // deleteOrphanedSlabs deletes the slabs in sIDs that are no longer pinned by
-// any account, along with any sectors that are only referenced by those slabs,
-// and updates the relevant sector and slab statistics. Callers must have
-// already removed the relevant account_slabs associations.
+// any account nor referenced by any object, along with any sectors that are
+// only referenced by those slabs, and updates the relevant sector and slab
+// statistics. Callers must have already removed the relevant account_slabs
+// associations.
 func (s *Store) deleteOrphanedSlabs(ctx context.Context, tx *txn, sIDs []int64) error {
 	// lock the candidate slabs so a concurrent re-pin serializes against the
 	// pinned check below
@@ -494,10 +507,16 @@ func (s *Store) deleteOrphanedSlabs(ctx context.Context, tx *txn, sIDs []int64) 
 		return fmt.Errorf("failed to lock slabs: %w", err)
 	}
 
-	// ignore the slabs that are pinned by another account
-	rows, err := tx.Query(ctx, `SELECT slab_id FROM account_slabs WHERE slab_id = ANY($1)`, sIDs)
+	// ignore the slabs that are pinned by an account or referenced by an
+	// object; a slab can be re-pinned and attached to a new object after it
+	// was queued for deletion
+	rows, err := tx.Query(ctx, `SELECT slab_id FROM account_slabs WHERE slab_id = ANY($1)
+UNION
+SELECT s.id FROM slabs s
+JOIN object_slabs os ON os.slab_digest = s.digest
+WHERE s.id = ANY($1)`, sIDs)
 	if err != nil {
-		return fmt.Errorf("failed to check if slab was pinned: %w", err)
+		return fmt.Errorf("failed to check if slab was pinned or referenced: %w", err)
 	}
 	defer rows.Close()
 
@@ -505,15 +524,15 @@ func (s *Store) deleteOrphanedSlabs(ctx context.Context, tx *txn, sIDs []int64) 
 	for rows.Next() {
 		var sID int64
 		if err := rows.Scan(&sID); err != nil {
-			return fmt.Errorf("failed to check pinned slab: %w", err)
+			return fmt.Errorf("failed to scan in-use slab: %w", err)
 		}
 		seen[sID] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("failed to get pinned slabs: %w", err)
+		return fmt.Errorf("failed to get in-use slabs: %w", err)
 	}
 
-	// get all of the slabs that are not pinned by another account
+	// get all of the slabs that are neither pinned nor referenced
 	var toDelete []int64
 	for _, sID := range sIDs {
 		if _, ok := seen[sID]; ok {
@@ -608,9 +627,11 @@ func (s *Store) deleteOrphanedSlabs(ctx context.Context, tx *txn, sIDs []int64) 
 	return nil
 }
 
-// UnpinSlab removes the association between the account and the given slab. If
-// this slab is no longer owned by any account, it and its sectors are queued
-// for deletion by PruneDeletedSlabs in a background loop.
+// UnpinSlab removes the association between the account and the given slab. A
+// slab that is still referenced by one of the account's objects can not be
+// unpinned and returns ErrSlabInUse. If this slab is no longer owned by any
+// account, it and its sectors are queued for deletion by PruneDeletedSlabs in
+// a background loop.
 func (s *Store) UnpinSlab(account proto.Account, slabID slabs.SlabID) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {
 		id, _, err := accountID(ctx, tx, account)
@@ -624,6 +645,28 @@ func (s *Store) UnpinSlab(account proto.Account, slabID slabs.SlabID) error {
 			return slabs.ErrSlabNotFound
 		} else if err != nil {
 			return fmt.Errorf("failed to check if slab exists: %w", err)
+		}
+
+		// lock the slab so the reference check below serializes against a
+		// concurrent PinObject attaching the slab to a new object
+		if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = $1 FOR UPDATE`, sID); err != nil {
+			return fmt.Errorf("failed to lock slab: %w", err)
+		}
+
+		// refuse to unpin a slab that is still referenced by one of the
+		// account's objects; otherwise the account would free up quota while
+		// the object keeps the slab alive
+		var inUse bool
+		err = tx.QueryRow(ctx, `SELECT EXISTS (
+			SELECT 1
+			FROM objects o
+			JOIN object_slabs os ON o.id = os.object_id
+			WHERE o.account_id = $1 AND os.slab_digest = $2
+		)`, id, sqlHash256(slabID)).Scan(&inUse)
+		if err != nil {
+			return fmt.Errorf("failed to check if slab is in use: %w", err)
+		} else if inUse {
+			return slabs.ErrSlabInUse
 		}
 
 		if err := s.unpinSlabs(ctx, tx, id, []int64{sID}); err != nil {

--- a/persist/postgres/sectors.go
+++ b/persist/postgres/sectors.go
@@ -551,15 +551,19 @@ RETURNING a.slab_id`, accountID, sIDs)
 	}
 
 	var connectKeyID int64
+	var active bool
 	err = tx.QueryRow(ctx, `UPDATE accounts
 SET pinned_data = pinned_data - $1, pinned_size = pinned_size - $2
 WHERE id = $3
-RETURNING connect_key_id`, pinnedDataDelta, pinnedSizeDelta, accountID).Scan(&connectKeyID)
+RETURNING connect_key_id, deleted_at IS NULL`, pinnedDataDelta, pinnedSizeDelta, accountID).Scan(&connectKeyID, &active)
 	if err != nil {
 		return fmt.Errorf("failed to update account's pinned data: %w", err)
 	}
-	if _, err := tx.Exec(ctx, `UPDATE app_connect_keys SET pinned_data = pinned_data - $1, pinned_size = pinned_size - $2 WHERE id = $3`, pinnedDataDelta, pinnedSizeDelta, connectKeyID); err != nil {
-		return fmt.Errorf("failed to update connect key pinned data: %w", err)
+
+	if active {
+		if _, err := tx.Exec(ctx, `UPDATE app_connect_keys SET pinned_data = pinned_data - $1, pinned_size = pinned_size - $2 WHERE id = $3`, pinnedDataDelta, pinnedSizeDelta, connectKeyID); err != nil {
+			return fmt.Errorf("failed to update connect key pinned data: %w", err)
+		}
 	}
 
 	// queue the slabs for background deletion; the queue is append-only so a

--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/slabs"
@@ -189,22 +190,7 @@ LIMIT $3
 		if err != nil {
 			return nil, fmt.Errorf("failed to get unused slabs: %w", err)
 		}
-		defer rows.Close()
-
-		var slabIDs []int64
-		for rows.Next() {
-			var slabID int64
-			if err := rows.Scan(&slabID); err != nil {
-				return nil, fmt.Errorf("failed to scan slab ID: %w", err)
-			}
-			slabIDs = append(slabIDs, slabID)
-		}
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("failed to get slab IDs: %w", err)
-		} else if len(slabIDs) == 0 {
-			return nil, nil
-		}
-		return slabIDs, nil
+		return pgx.CollectRows(rows, pgx.RowTo[int64])
 	}
 
 	var exhausted bool

--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/slabs"
@@ -225,30 +224,14 @@ LIMIT $3
 			// concurrent PinObject attaching one of them to an object;
 			// without it the check and the pin could interleave, leaving a
 			// slab unpinned while an object references it
-			if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = ANY($1) ORDER BY id FOR UPDATE`, candidates); err != nil {
-				return fmt.Errorf("failed to lock slabs: %w", err)
+			if err := lockSlabs(ctx, tx, candidates); err != nil {
+				return err
 			}
 
 			// re-check the candidates under the lock
-			rows, err := tx.Query(ctx, `SELECT s.id
-FROM slabs s
-JOIN account_slabs a ON s.id = a.slab_id
-WHERE a.account_id = $1
-	AND s.id = ANY($2)
-	AND s.pinned_at < $3
-	AND NOT EXISTS (
-		SELECT 1
-		FROM objects o
-		JOIN object_slabs os ON o.id = os.object_id
-		WHERE o.account_id = a.account_id
-		AND os.slab_digest = s.digest
-	)`, id, candidates, cutoff)
+			toUnpin, err := unreferencedSlabs(ctx, tx, id, candidates, &cutoff)
 			if err != nil {
-				return fmt.Errorf("failed to re-check slabs to unpin: %w", err)
-			}
-			toUnpin, err := pgx.CollectRows(rows, pgx.RowTo[int64])
-			if err != nil {
-				return fmt.Errorf("failed to collect slabs to unpin: %w", err)
+				return err
 			}
 
 			if err := s.unpinSlabs(ctx, tx, id, toUnpin); err != nil {

--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -206,24 +206,7 @@ LIMIT $3
 				return nil
 			}
 
-			// lock the candidates so the re-check below serializes against a
-			// concurrent PinObject attaching one of them to an object;
-			// without it the check and the pin could interleave, leaving a
-			// slab unpinned while an object references it
-			if err := lockSlabs(ctx, tx, candidates); err != nil {
-				return err
-			}
-
-			// re-check the candidates under the lock
-			toUnpin, err := unreferencedSlabs(ctx, tx, id, candidates, &cutoff)
-			if err != nil {
-				return err
-			}
-
-			if err := s.unpinSlabs(ctx, tx, id, toUnpin); err != nil {
-				return fmt.Errorf("failed to unpin slabs: %w", err)
-			}
-			return nil
+			return s.unpinUnreferencedSlabs(ctx, tx, id, candidates, &cutoff)
 		})
 		if err != nil {
 			return err

--- a/persist/postgres/slabs.go
+++ b/persist/postgres/slabs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/slabs"
@@ -211,14 +212,47 @@ LIMIT $3
 	const batchSize = 100
 	for !exhausted {
 		err := s.transaction(func(ctx context.Context, tx *txn) error {
-			slabIDs, err := getSlabs(ctx, tx, batchSize)
+			candidates, err := getSlabs(ctx, tx, batchSize)
 			if err != nil {
 				return fmt.Errorf("failed to get slabs to unpin: %w", err)
-			} else if err := s.unpinSlabs(ctx, tx, id, slabIDs); err != nil {
-				return fmt.Errorf("failed to unpin slabs: %w", err)
 			}
-			if len(slabIDs) < batchSize {
-				exhausted = true
+			exhausted = len(candidates) < batchSize
+			if len(candidates) == 0 {
+				return nil
+			}
+
+			// lock the candidates so the re-check below serializes against a
+			// concurrent PinObject attaching one of them to an object;
+			// without it the check and the pin could interleave, leaving a
+			// slab unpinned while an object references it
+			if _, err := tx.Exec(ctx, `SELECT id FROM slabs WHERE id = ANY($1) ORDER BY id FOR UPDATE`, candidates); err != nil {
+				return fmt.Errorf("failed to lock slabs: %w", err)
+			}
+
+			// re-check the candidates under the lock
+			rows, err := tx.Query(ctx, `SELECT s.id
+FROM slabs s
+JOIN account_slabs a ON s.id = a.slab_id
+WHERE a.account_id = $1
+	AND s.id = ANY($2)
+	AND s.pinned_at < $3
+	AND NOT EXISTS (
+		SELECT 1
+		FROM objects o
+		JOIN object_slabs os ON o.id = os.object_id
+		WHERE o.account_id = a.account_id
+		AND os.slab_digest = s.digest
+	)`, id, candidates, cutoff)
+			if err != nil {
+				return fmt.Errorf("failed to re-check slabs to unpin: %w", err)
+			}
+			toUnpin, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+			if err != nil {
+				return fmt.Errorf("failed to collect slabs to unpin: %w", err)
+			}
+
+			if err := s.unpinSlabs(ctx, tx, id, toUnpin); err != nil {
+				return fmt.Errorf("failed to unpin slabs: %w", err)
 			}
 			return nil
 		})

--- a/persist/postgres/slabs_test.go
+++ b/persist/postgres/slabs_test.go
@@ -447,6 +447,20 @@ func TestSlabPruning(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// pin a third slab for the first account that is never attached to an
+	// object
+	slab3 := slabs.SlabPinParams{
+		MinShards: 1,
+		Sectors: []slabs.PinnedSector{{
+			Root:    frand.Entropy256(),
+			HostKey: hk,
+		}},
+	}
+	if _, err := store.PinSlabs(acc1, time.Time{}, slab3); err != nil {
+		t.Fatal(err)
+	}
+	slab3ID := slab3.Digest()
+
 	assertSlabs := func(acc proto.Account, expected ...slabs.SlabID) {
 		t.Helper()
 
@@ -459,18 +473,20 @@ func TestSlabPruning(t *testing.T) {
 		}
 	}
 
-	assertSlabs(acc1, slab2ID, slab1ID)
+	assertSlabs(acc1, slab3ID, slab2ID, slab1ID)
 	assertSlabs(acc2, slab1ID)
 
-	// delete object for acc1
+	// delete object for acc1; slab1 is no longer referenced by any of acc1's
+	// objects and is unpinned right away
 	if err := store.DeleteObject(acc1, obj1Key); err != nil {
 		t.Fatal(err)
 	}
 
-	assertSlabs(acc1, slab2ID, slab1ID)
+	assertSlabs(acc1, slab3ID, slab2ID)
 	assertSlabs(acc2, slab1ID)
 
-	// prune slabs for acc1
+	// prune slabs for acc1; this removes slab3 which was pinned but never
+	// attached to an object
 	if err := store.PruneSlabs(acc1, time.Now()); err != nil {
 		t.Fatal(err)
 	}
@@ -478,15 +494,15 @@ func TestSlabPruning(t *testing.T) {
 	assertSlabs(acc1, slab2ID)
 	assertSlabs(acc2, slab1ID)
 
-	// delete object for acc2
+	// delete object for acc2; slab1 is unpinned right away
 	if err := store.DeleteObject(acc2, obj1Key); err != nil {
 		t.Fatal(err)
 	}
 
 	assertSlabs(acc1, slab2ID)
-	assertSlabs(acc2, slab1ID)
+	assertSlabs(acc2)
 
-	// prune slabs for acc2
+	// prune slabs for acc2 is a no-op
 	if err := store.PruneSlabs(acc2, time.Now()); err != nil {
 		t.Fatal(err)
 	}

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -283,6 +283,8 @@ func (m *SlabManager) Object(ctx context.Context, account proto.Account, key typ
 }
 
 // DeleteObject deletes the object with the given key for the given account.
+// Slabs that were referenced by the object and are no longer referenced by any
+// of the account's objects are unpinned and queued for deletion.
 func (m *SlabManager) DeleteObject(ctx context.Context, account proto.Account, objectKey types.Hash256) error {
 	return m.store.DeleteObject(account, objectKey)
 }

--- a/slabs/slabs.go
+++ b/slabs/slabs.go
@@ -28,6 +28,10 @@ var (
 	// ErrSlabNotFound is returned when a slab is not found in the database.
 	ErrSlabNotFound = errors.New("slab not found")
 
+	// ErrSlabInUse is returned when attempting to unpin a slab that is still
+	// referenced by one of the account's objects.
+	ErrSlabInUse = errors.New("slab is in use by an object")
+
 	// ErrUnrecoverable is returned when a slab is unrecoverable, meaning it cannot be repaired or migrated.
 	ErrUnrecoverable = errors.New("slab is unrecoverable")
 
@@ -199,9 +203,11 @@ func (m *SlabManager) PinSlabs(ctx context.Context, account proto.Account, nextI
 	return m.store.PinSlabs(account, nextIntegrityCheck, toPin...)
 }
 
-// UnpinSlab removes the association between the account and the given slab. If
-// this slab is no longer referenced by any account, it and its potentially
-// orphaned sectors are queued for deletion and removed by a background process.
+// UnpinSlab removes the association between the account and the given slab. A
+// slab that is still referenced by one of the account's objects can not be
+// unpinned and returns ErrSlabInUse. If this slab is no longer referenced by
+// any account, it and its potentially orphaned sectors are queued for deletion
+// and removed by a background process.
 func (m *SlabManager) UnpinSlab(ctx context.Context, account proto.Account, slabID SlabID) error {
 	return m.store.UnpinSlab(account, slabID)
 }


### PR DESCRIPTION
This PR causes slabs of an object to be scheduled for deletion after the object was deleted.

It also closes a gap we had where it was possible to unpin a slab that was currently referenced by an object.

Reviewers please pay close attention to the locking. When reference counting is involved things get a bit tricky. There is a good amount of test coverage for concurrent operations but still.