### PR TITLE
Add connect timeout

### DIFF
--- a/.changeset/bound_host_connects_in_the_rhp4_client.md
+++ b/.changeset/bound_host_connects_in_the_rhp4_client.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Bound host connects in the RHP4 client with a 10 second connect timeout

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -21,7 +21,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// defaultConnectTimeout bounds connection establishment separately from the
+// RPC context, so an unresponsive host costs seconds instead of the full RPC
+// budget.
+const defaultConnectTimeout = 10 * time.Second
+
 type transport struct {
+	connectTimeout time.Duration
+
 	mu     sync.Mutex
 	dialCh chan struct{} // signals dial completion
 	tc     rhp.TransportClient
@@ -89,7 +96,7 @@ func (t *transport) dial(ctx context.Context, hostKey types.PublicKey, addresses
 
 	var wg sync.WaitGroup
 	sema := make(chan struct{}, 2)
-	var dialCtx, dialCancel = context.WithCancel(ctx)
+	var dialCtx, dialCancel = context.WithTimeout(ctx, t.connectTimeout)
 	defer dialCancel()
 
 	connectErrs := make([]error, len(addresses))
@@ -179,7 +186,7 @@ func (c *Client) hostTransport(ctx context.Context, hostKey types.PublicKey) (rh
 	c.mu.Lock()
 	t := c.transports[hostKey]
 	if t == nil {
-		t = &transport{}
+		t = &transport{connectTimeout: defaultConnectTimeout}
 		c.transports[hostKey] = t
 	}
 	c.mu.Unlock()

--- a/client/v2/rpc_test.go
+++ b/client/v2/rpc_test.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
 	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
 	"go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/mux/v3"
 )
 
@@ -44,6 +49,51 @@ func TestIsFailedRPC(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tt.want, got)
 			}
 		})
+	}
+}
+
+func TestTransportDialConnectTimeout(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	// accept and hold connections open without completing the mux handshake
+	var mu sync.Mutex
+	var conns []net.Conn
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, conn := range conns {
+			conn.Close()
+		}
+	})
+
+	// dial with a deadline well beyond the connect timeout
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	tr := &transport{connectTimeout: 100 * time.Millisecond}
+	addresses := []chain.NetAddress{{Protocol: siamux.Protocol, Address: l.Addr().String()}}
+
+	start := time.Now()
+	_, err = tr.dial(ctx, types.GeneratePrivateKey().PublicKey(), addresses)
+	if err == nil {
+		t.Fatal("expected dial to fail")
+	} else if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatal("dial ignored connect timeout", elapsed)
 	}
 }
 


### PR DESCRIPTION
While benchmarking the Go SDK I saw several stuck goroutines, each of them consuming an inflight-slot. This PR adds a connection timeout, matching the behaviour in the Rust SDK. A connect timeout now also fails while the RPC context is still alive, so the failure is counted and the host gets demoted, which was not the case before.

```
    goroutine 10715 [IO wait, 2 minutes]:
    net.(*netFD).connect(...)

    goroutine 12708 [sync.WaitGroup.Wait, 2 minutes]:
    go.sia.tech/indexd/client/v2.(*transport).dial(...)
      client/v2/client.go:140

    goroutine 10284 [select, 2 minutes]:
    go.sia.tech/indexd/client/v2.(*transport).dial(...)
      client/v2/client.go:63
    go.sia.tech/indexd/client/v2.(*Client).WriteSector(...)
```


