### PR TITLE
Skip redundant settings validation

### DIFF
--- a/.changeset/skip_redundant_host_settings_verification_on_cache_hits.md
+++ b/.changeset/skip_redundant_host_settings_verification_on_cache_hits.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Skip redundant host settings signature verification on cache hits

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -455,7 +455,7 @@ func (c *Client) settings(ctx context.Context, hostKey types.PublicKey, transpor
 	c.mu.Lock()
 	settings, ok := c.cachedSettings[hostKey]
 	c.mu.Unlock()
-	// only fresh, validated settings are cached, so the signature never needs
+	// settings are cached only after signature validation, so the signature never needs
 	// rechecking here. this keeps the ed25519 verify off the per-rpc hot path
 	if ok && time.Until(settings.Prices.ValidUntil) > 30*time.Second {
 		return settings, true, nil

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -453,12 +453,13 @@ func (c *Client) Close() error {
 // boolean flag set to 'true'.
 func (c *Client) settings(ctx context.Context, hostKey types.PublicKey, transport rhp.TransportClient) (proto.HostSettings, bool, error) {
 	c.mu.Lock()
-	settings := c.cachedSettings[hostKey]
-	if settings.Prices.Validate(hostKey) == nil && time.Until(settings.Prices.ValidUntil) > 30*time.Second {
-		c.mu.Unlock()
+	settings, ok := c.cachedSettings[hostKey]
+	c.mu.Unlock()
+	// only fresh, validated settings are cached, so the signature never needs
+	// rechecking here. this keeps the ed25519 verify off the per-rpc hot path
+	if ok && time.Until(settings.Prices.ValidUntil) > 30*time.Second {
 		return settings, true, nil
 	}
-	c.mu.Unlock()
 
 	settings, err := rhp.RPCSettings(ctx, transport)
 	if err != nil {

--- a/client/v2/settings_test.go
+++ b/client/v2/settings_test.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+)
+
+func signedSettings() (types.PublicKey, proto.HostSettings) {
+	priv := types.GeneratePrivateKey()
+	prices := proto.HostPrices{ValidUntil: time.Now().Add(time.Hour)}
+	prices.Signature = priv.SignHash(prices.SigHash())
+	return priv.PublicKey(), proto.HostSettings{Prices: prices}
+}
+
+// TestSettingsCacheHit verifies that fresh cached settings are served without a
+// transport, confirming the cache-hit path never touches the network.
+func TestSettingsCacheHit(t *testing.T) {
+	hostKey, settings := signedSettings()
+	c := &Client{cachedSettings: map[types.PublicKey]proto.HostSettings{hostKey: settings}}
+
+	got, cached, err := c.settings(t.Context(), hostKey, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if !cached {
+		t.Fatal("expected cache hit")
+	} else if got.Prices.ValidUntil != settings.Prices.ValidUntil {
+		t.Fatal("mismatch")
+	}
+}
+
+// BenchmarkSettingsCacheHit guards the per-rpc cache-hit path against a
+// regression that reintroduces the ed25519 verify under the client mutex.
+func BenchmarkSettingsCacheHit(b *testing.B) {
+	hostKey, settings := signedSettings()
+	c := &Client{cachedSettings: map[types.PublicKey]proto.HostSettings{hostKey: settings}}
+	ctx := b.Context()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, cached, err := c.settings(ctx, hostKey, nil); err != nil || !cached {
+				b.Fatal("expected cache hit")
+			}
+		}
+	})
+}


### PR DESCRIPTION
We re-validate the settings under lock for every RPC. Under heavy concurrency that serializes every RPC across every host behind ~28µs of crypto and 1600 B of allocations per call. It's a very tiny change but it came up during benchmarking and I figured it's probably worth fixing.