### PR TITLE
Support adding and removing sharing keys and shared objects

### DIFF
--- a/.changeset/added_support_for_sharing_keys.md
+++ b/.changeset/added_support_for_sharing_keys.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Added support for sharing keys
+
+Sharing keys let an app grant read-only access to a specific set of objects without requiring the viewer to sign up or log in. Each key is a scoped, read-only credential derived from the app's own key and limited to the objects explicitly attached to it.

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -21,6 +21,7 @@ import (
 	"go.sia.tech/indexd/accounts"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/sharing"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/jape"
 	"go.uber.org/zap"
@@ -46,6 +47,18 @@ type (
 		PinObject(ctx context.Context, account proto.Account, obj slabs.PinObjectRequest) error
 		ListObjects(ctx context.Context, account proto.Account, cursor slabs.Cursor, limit int) ([]slabs.ObjectEvent, error)
 		SharedObject(ctx context.Context, key types.Hash256) (slabs.SharedObject, error)
+	}
+
+	// Sharing defines the sharing key management interface for the application
+	// API.
+	Sharing interface {
+		AddSharingKey(account proto.Account, req sharing.KeyRequest) (sharing.Key, error)
+		SharingKey(publicKey types.PublicKey) (sharing.Key, error)
+		SharingKeys(account proto.Account, offset, limit int) ([]sharing.Key, error)
+		DeleteSharingKey(account proto.Account, publicKey types.PublicKey) error
+		AddSharedObject(account proto.Account, sharingKey types.PublicKey, req sharing.SharedObjectRequest) error
+		DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error
+		OwnedSharedObjects(account proto.Account, sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
 	}
 
 	// Hosts defines the hosts interface for the application API.
@@ -159,6 +172,7 @@ type (
 		accounts  Accounts
 		contracts Contracts
 		slabs     Slabs
+		sharing   Sharing
 		log       *zap.Logger
 		rl        RateLimiter
 
@@ -359,6 +373,142 @@ func (a *app) handleDELETEObjects(jc jape.Context, pk types.PublicKey) {
 
 	err := a.slabs.DeleteObject(jc.Request.Context(), proto.Account(pk), key)
 	if errors.Is(err, slabs.ErrObjectNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(nil)
+}
+
+func (a *app) handlePOSTSharing(jc jape.Context, pk types.PublicKey) {
+	req, ok := decodeRequest[sharing.KeyRequest](jc)
+	if !ok {
+		return
+	}
+
+	key, err := a.sharing.AddSharingKey(proto.Account(pk), req)
+	if errors.Is(err, sharing.ErrInvalidRequest) {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	} else if errors.Is(err, sharing.ErrSharingKeyExists) {
+		jc.Error(err, http.StatusConflict)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(key)
+}
+
+func (a *app) handleGETSharing(jc jape.Context, pk types.PublicKey) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	keys, err := a.sharing.SharingKeys(proto.Account(pk), offset, limit)
+	if jc.Check("failed to list sharing keys", err) != nil {
+		return
+	}
+	jc.Encode(keys)
+}
+
+func (a *app) handleGETSharingKey(jc jape.Context, pk types.PublicKey) {
+	var key types.PublicKey
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	sk, err := a.sharing.SharingKey(key)
+	// scope to the caller: a key owned by another account reads as not found
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) || (err == nil && sk.Account != pk) {
+		jc.Error(sharing.ErrSharingKeyNotFound, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(sk)
+}
+
+func (a *app) handleDELETESharing(jc jape.Context, pk types.PublicKey) {
+	var key types.PublicKey
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	err := a.sharing.DeleteSharingKey(proto.Account(pk), key)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(nil)
+}
+
+func (a *app) handlePOSTSharingObject(jc jape.Context, pk types.PublicKey) {
+	var key types.PublicKey
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	req, ok := decodeRequest[sharing.SharedObjectRequest](jc)
+	if !ok {
+		return
+	}
+
+	err := a.sharing.AddSharedObject(proto.Account(pk), key, req)
+	if errors.Is(err, sharing.ErrInvalidRequest) {
+		jc.Error(err, http.StatusBadRequest)
+		return
+	} else if errors.Is(err, sharing.ErrSharingKeyNotFound) || errors.Is(err, slabs.ErrObjectNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(nil)
+}
+
+func (a *app) handleGETSharingObjects(jc jape.Context, pk types.PublicKey) {
+	var key types.PublicKey
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	objects, err := a.sharing.OwnedSharedObjects(proto.Account(pk), key, offset, limit)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(objects)
+}
+
+func (a *app) handleDELETESharingObject(jc jape.Context, pk types.PublicKey) {
+	var key types.PublicKey
+	if jc.DecodeParam("key", &key) != nil {
+		return
+	}
+	var objectKey types.Hash256
+	if jc.DecodeParam("objectkey", &objectKey) != nil {
+		return
+	}
+
+	err := a.sharing.DeleteSharedObject(proto.Account(pk), key, objectKey)
+	if errors.Is(err, sharing.ErrSharedObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
 	} else if err != nil {
@@ -799,7 +949,7 @@ func decodeRequest[T any](jc jape.Context) (T, bool) {
 // users, or rather their applications, to pin slabs to the indexer.
 // Authentication happens through presigned URLs that are signed with a private
 // key that corresponds to a previously registered public key.
-func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, slabs Slabs, opts ...Option) (http.Handler, error) {
+func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, slabs Slabs, sharing Sharing, opts ...Option) (http.Handler, error) {
 	u, err := url.Parse(advertiseURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse advertise URL %q: %w", advertiseURL, err)
@@ -809,6 +959,7 @@ func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, sla
 		accounts:  am,
 		contracts: contracts,
 		slabs:     slabs,
+		sharing:   sharing,
 		log:       zap.NewNop(),
 
 		hostname:     u.Host,
@@ -873,6 +1024,14 @@ func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, sla
 		"GET /objects/:key/shared": wrapSignedAuth(a.handleGETObjectShared),
 		"POST /objects":            wrapSignedAuth(a.handlePOSTObjects),
 		"DELETE /objects/:key":     wrapSignedAuth(a.handleDELETEObjects),
+
+		"POST /sharing":                           wrapSignedAuth(a.handlePOSTSharing),
+		"GET /sharing":                            wrapSignedAuth(a.handleGETSharing),
+		"GET /sharing/:key":                       wrapSignedAuth(a.handleGETSharingKey),
+		"DELETE /sharing/:key":                    wrapSignedAuth(a.handleDELETESharing),
+		"POST /sharing/:key/objects":              wrapSignedAuth(a.handlePOSTSharingObject),
+		"GET /sharing/:key/objects":               wrapSignedAuth(a.handleGETSharingObjects),
+		"DELETE /sharing/:key/objects/:objectkey": wrapSignedAuth(a.handleDELETESharingObject),
 
 		"GET /slabs":            wrapSignedAuth(a.handleGETSlabs),
 		"POST /slabs":           wrapSignedAuth(a.handlePOSTSlabs),

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -53,9 +53,9 @@ type (
 	// API.
 	Sharing interface {
 		AddSharingKey(account proto.Account, req sharing.KeyRequest) (sharing.Key, error)
-		SharingKey(publicKey types.PublicKey) (sharing.Key, error)
-		SharingKeys(account proto.Account, offset, limit int) ([]sharing.Key, error)
 		DeleteSharingKey(account proto.Account, publicKey types.PublicKey) error
+		SharingKeys(account proto.Account, offset, limit int) ([]sharing.Key, error)
+		OwnedSharingKey(account proto.Account, publicKey types.PublicKey) (sharing.Key, error)
 		AddSharedObject(account proto.Account, sharingKey types.PublicKey, req sharing.SharedObjectRequest) error
 		DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error
 		OwnedSharedObjects(account proto.Account, sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
@@ -421,10 +421,9 @@ func (a *app) handleGETSharingKey(jc jape.Context, pk types.PublicKey) {
 		return
 	}
 
-	sk, err := a.sharing.SharingKey(key)
-	// scope to the caller: a key owned by another account reads as not found
-	if errors.Is(err, sharing.ErrSharingKeyNotFound) || (err == nil && sk.Account != pk) {
-		jc.Error(sharing.ErrSharingKeyNotFound, http.StatusNotFound)
+	sk, err := a.sharing.OwnedSharingKey(proto.Account(pk), key)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(err, http.StatusNotFound)
 		return
 	} else if err != nil {
 		jc.Error(err, http.StatusInternalServerError)
@@ -464,6 +463,9 @@ func (a *app) handlePOSTSharingObject(jc jape.Context, pk types.PublicKey) {
 	err := a.sharing.AddSharedObject(proto.Account(pk), key, req)
 	if errors.Is(err, sharing.ErrInvalidRequest) {
 		jc.Error(err, http.StatusBadRequest)
+		return
+	} else if errors.Is(err, sharing.ErrSharedObjectConflict) {
+		jc.Error(err, http.StatusConflict)
 		return
 	} else if errors.Is(err, sharing.ErrSharingKeyNotFound) || errors.Is(err, slabs.ErrObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)

--- a/api/app/auth_test.go
+++ b/api/app/auth_test.go
@@ -135,7 +135,7 @@ func TestPreAuthorizedAuth(t *testing.T) {
 	}
 	defer l.Close()
 	appAPIAddr := fmt.Sprintf("http://%s", l.Addr())
-	handler, err := NewAPI(appAPIAddr, nil, s, &mockContracts{}, nil)
+	handler, err := NewAPI(appAPIAddr, nil, s, &mockContracts{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestPreAuthorizationBoundToEphemeralKey(t *testing.T) {
 	}
 	defer l.Close()
 	appAPIAddr := fmt.Sprintf("http://%s", l.Addr())
-	handler, err := NewAPI(appAPIAddr, nil, s, &mockContracts{}, nil)
+	handler, err := NewAPI(appAPIAddr, nil, s, &mockContracts{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestAuthConnectFieldLimits(t *testing.T) {
 	defer l.Close()
 
 	appAPIAddr := fmt.Sprintf("http://%s", l.Addr().String())
-	handler, err := NewAPI(appAPIAddr, nil, s, nil, nil)
+	handler, err := NewAPI(appAPIAddr, nil, s, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestAuthConnectRateLimit(t *testing.T) {
 	defer l.Close()
 
 	appAPIAddr := fmt.Sprintf("http://%s", l.Addr().String())
-	handler, err := NewAPI(appAPIAddr, nil, s, nil, nil, WithRateLimiter(rl))
+	handler, err := NewAPI(appAPIAddr, nil, s, nil, nil, nil, WithRateLimiter(rl))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -267,7 +267,8 @@ func (c *Client) Account(ctx context.Context, appKey types.PrivateKey) (resp Acc
 	return
 }
 
-// AddSharingKey creates a sharing key for the account.
+// AddSharingKey creates a sharing key for the account. The request must be
+// signed by the sharing key.
 func (c *Client) AddSharingKey(ctx context.Context, appKey types.PrivateKey, req sharing.KeyRequest) (key sharing.Key, err error) {
 	err = c.signedRequestJSON(ctx, appKey, http.MethodPost, "/sharing", req, &key)
 	return

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -18,6 +18,7 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/sharing"
 	"go.sia.tech/indexd/slabs"
 )
 
@@ -263,6 +264,57 @@ func (c *Client) DeleteObject(ctx context.Context, appKey types.PrivateKey, key 
 // Account retrieves the account of the current user.
 func (c *Client) Account(ctx context.Context, appKey types.PrivateKey) (resp AccountResponse, err error) {
 	err = c.signedRequestJSON(ctx, appKey, http.MethodGet, "/account", nil, &resp)
+	return
+}
+
+// AddSharingKey creates a sharing key for the account.
+func (c *Client) AddSharingKey(ctx context.Context, appKey types.PrivateKey, req sharing.KeyRequest) (key sharing.Key, err error) {
+	err = c.signedRequestJSON(ctx, appKey, http.MethodPost, "/sharing", req, &key)
+	return
+}
+
+// SharingKey retrieves one of the account's sharing keys by its public key.
+func (c *Client) SharingKey(ctx context.Context, appKey types.PrivateKey, publicKey types.PublicKey) (key sharing.Key, err error) {
+	err = c.signedRequestJSON(ctx, appKey, http.MethodGet, fmt.Sprintf("/sharing/%s", publicKey), nil, &key)
+	return
+}
+
+// SharingKeys lists the account's sharing keys. It supports pagination through
+// the provided options.
+func (c *Client) SharingKeys(ctx context.Context, appKey types.PrivateKey, opts ...api.URLQueryParameterOption) (keys []sharing.Key, err error) {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+
+	err = c.signedRequestJSON(ctx, appKey, http.MethodGet, "/sharing?"+values.Encode(), nil, &keys)
+	return
+}
+
+// DeleteSharingKey deletes one of the account's sharing keys.
+func (c *Client) DeleteSharingKey(ctx context.Context, appKey types.PrivateKey, publicKey types.PublicKey) error {
+	return c.signedRequestJSON(ctx, appKey, http.MethodDelete, fmt.Sprintf("/sharing/%s", publicKey), nil, nil)
+}
+
+// AddSharedObject attaches an object the account owns to one of its sharing
+// keys.
+func (c *Client) AddSharedObject(ctx context.Context, appKey types.PrivateKey, sharingKey types.PublicKey, req sharing.SharedObjectRequest) error {
+	return c.signedRequestJSON(ctx, appKey, http.MethodPost, fmt.Sprintf("/sharing/%s/objects", sharingKey), req, nil)
+}
+
+// DeleteSharedObject detaches an object from one of the account's sharing keys.
+func (c *Client) DeleteSharedObject(ctx context.Context, appKey types.PrivateKey, sharingKey types.PublicKey, objectKey types.Hash256) error {
+	return c.signedRequestJSON(ctx, appKey, http.MethodDelete, fmt.Sprintf("/sharing/%s/objects/%s", sharingKey, objectKey), nil, nil)
+}
+
+// SharedObjects lists the object IDs attached to one of the account's sharing
+// keys. It supports pagination through the provided options.
+func (c *Client) SharedObjects(ctx context.Context, appKey types.PrivateKey, sharingKey types.PublicKey, opts ...api.URLQueryParameterOption) (objects []slabs.SealedObject, err error) {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	err = c.signedRequestJSON(ctx, appKey, http.MethodGet, fmt.Sprintf("/sharing/%s/objects?%s", sharingKey, values.Encode()), nil, &objects)
 	return
 }
 

--- a/api/app/sharing_test.go
+++ b/api/app/sharing_test.go
@@ -1,0 +1,215 @@
+package app_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/api/app"
+	"go.sia.tech/indexd/client/v2"
+	"go.sia.tech/indexd/hosts"
+	"go.sia.tech/indexd/sharing"
+	"go.sia.tech/indexd/slabs"
+	"go.sia.tech/indexd/testutils"
+	"go.uber.org/zap"
+	"lukechampine.com/frand"
+)
+
+func assertStatus(t *testing.T, err error, status int) {
+	t.Helper()
+	var he *app.HTTPError
+	if !errors.As(err, &he) {
+		t.Fatalf("expected *app.HTTPError, got %v", err)
+	} else if he.StatusCode != status {
+		t.Fatalf("expected status %d, got %d (%s)", status, he.StatusCode, he.Body)
+	}
+}
+
+func TestSharingKeys(t *testing.T) {
+	ctx := t.Context()
+
+	logger := zap.NewNop()
+	cluster := testutils.NewCluster(t, testutils.WithHosts(14), testutils.WithLogger(logger))
+	indexer := cluster.Indexer
+
+	hc := client.New(client.NewProvider(hosts.NewHostStore(indexer.Store())), logger)
+	defer hc.Close()
+
+	cluster.WaitForContracts(t)
+
+	hostList, err := indexer.Admin.Hosts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sk1, _ := newAccount(t, cluster)
+	sk2, _ := newAccount(t, cluster)
+	appClient := indexer.App
+
+	slabParams := uploadRandomSlab(t, hc, sk1, hostList)
+	if _, err := appClient.PinSlabs(ctx, sk1, slabParams); err != nil {
+		t.Fatal(err)
+	}
+	obj := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(sharing.EncryptionKeySize),
+		EncryptedMetadataKey: frand.Bytes(sharing.EncryptionKeySize),
+		Slabs:                []slabs.SlabSlice{slabParams.Slice(0, 256)},
+	}
+	obj.Sign(sk1)
+	if err := appClient.PinObject(ctx, sk1, obj); err != nil {
+		t.Fatal(err)
+	}
+
+	nonce := (sharing.Nonce)(frand.Bytes(32))
+	shareKeyPriv := sharing.DeriveSharingKey(sk1, nonce)
+	shareKey := shareKeyPriv.PublicKey()
+	req := sharing.KeyRequest{
+		PublicKey:   shareKey,
+		Nonce:       nonce,
+		Description: "my share",
+	}
+	key, err := appClient.AddSharingKey(ctx, sk1, req)
+	if err != nil {
+		t.Fatal(err)
+	} else if key.PublicKey != shareKey || key.Account != sk1.PublicKey() || key.Description != "my share" {
+		t.Fatalf("unexpected key: %+v", key)
+	}
+
+	if _, err := appClient.AddSharingKey(ctx, sk1, req); err == nil {
+		t.Fatal("expected error creating duplicate sharing key")
+	} else {
+		assertStatus(t, err, http.StatusConflict)
+	}
+
+	bad := req
+	bad.PublicKey = types.GeneratePrivateKey().PublicKey()
+	bad.Nonce = sharing.Nonce{}
+	if _, err := appClient.AddSharingKey(ctx, sk1, bad); err == nil {
+		t.Fatal("expected error for empty nonce")
+	} else {
+		assertStatus(t, err, http.StatusBadRequest)
+	}
+
+	if got, err := appClient.SharingKey(ctx, sk1, shareKey); err != nil {
+		t.Fatal(err)
+	} else if got.PublicKey != shareKey {
+		t.Fatalf("unexpected key: %+v", got)
+	}
+	if keys, err := appClient.SharingKeys(ctx, sk1); err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 1 || keys[0].PublicKey != shareKey {
+		t.Fatalf("unexpected keys: %+v", keys)
+	}
+
+	if _, err := appClient.SharingKey(ctx, sk2, shareKey); err == nil {
+		t.Fatal("expected error fetching another account's key")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+	if keys, err := appClient.SharingKeys(ctx, sk2); err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 0 {
+		t.Fatalf("expected 0 keys for sk2, got %d", len(keys))
+	}
+
+	sharedReq := sharing.SharedObjectRequest{
+		ObjectID:             obj.ID(),
+		EncryptedDataKey:     frand.Bytes(sharing.EncryptionKeySize),
+		EncryptedMetadataKey: frand.Bytes(sharing.EncryptionKeySize),
+		EncryptedMetadata:    frand.Bytes(32),
+	}
+	sharedReq.Sign(shareKeyPriv)
+	if err := appClient.AddSharedObject(ctx, sk1, shareKey, sharedReq); err != nil {
+		t.Fatal(err)
+	}
+
+	if key, err := appClient.SharingKey(ctx, sk1, shareKey); err != nil {
+		t.Fatal(err)
+	} else if key.ObjectCount != 1 || key.ObjectSize != 256 ||
+		key.PinnedData != 4*uint64(proto.SectorSize) ||
+		key.PinnedSize != uint64(len(hostList))*uint64(proto.SectorSize) {
+		t.Fatalf("unexpected totals: %+v", key)
+	}
+
+	if objs, err := appClient.SharedObjects(ctx, sk1, shareKey); err != nil {
+		t.Fatal(err)
+	} else if len(objs) != 1 || objs[0].ID() != obj.ID() {
+		t.Fatalf("unexpected shared objects: %v", objs)
+	}
+
+	if objs, err := appClient.SharedObjects(ctx, sk1, shareKey, api.WithOffset(1)); err != nil {
+		t.Fatal(err)
+	} else if len(objs) != 0 {
+		t.Fatalf("expected no objects at offset 1, got %d", len(objs))
+	}
+
+	if _, err := appClient.SharedObjects(ctx, sk1, types.GeneratePrivateKey().PublicKey()); err == nil {
+		t.Fatal("expected error listing objects of unknown key")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+
+	if _, err := appClient.SharedObjects(ctx, sk2, shareKey); err == nil {
+		t.Fatal("expected error listing another account's key objects")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+
+	forged := sharedReq
+	forged.DataSignature = types.Signature{}
+	if err := appClient.AddSharedObject(ctx, sk1, shareKey, forged); err == nil {
+		t.Fatal("expected error for invalid signature")
+	} else {
+		assertStatus(t, err, http.StatusBadRequest)
+	}
+
+	oversized := sharedReq
+	oversized.EncryptedMetadata = frand.Bytes(sharing.MaxMetadataSize + 1)
+	oversized.Sign(shareKeyPriv)
+	if err := appClient.AddSharedObject(ctx, sk1, shareKey, oversized); err == nil {
+		t.Fatal("expected error for oversized metadata")
+	} else {
+		assertStatus(t, err, http.StatusBadRequest)
+	}
+
+	unknown := sharedReq
+	unknown.ObjectID = types.Hash256(frand.Entropy256())
+	unknown.Sign(shareKeyPriv)
+	if err := appClient.AddSharedObject(ctx, sk1, shareKey, unknown); err == nil {
+		t.Fatal("expected error attaching unknown object")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+
+	if err := appClient.AddSharedObject(ctx, sk2, shareKey, sharedReq); err == nil {
+		t.Fatal("expected error attaching to another account's key")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+
+	if err := appClient.DeleteSharedObject(ctx, sk1, shareKey, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if err := appClient.DeleteSharedObject(ctx, sk1, shareKey, obj.ID()); err == nil {
+		t.Fatal("expected error detaching already-detached object")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+
+	if err := appClient.DeleteSharingKey(ctx, sk1, shareKey); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := appClient.SharingKey(ctx, sk1, shareKey); err == nil {
+		t.Fatal("expected error fetching deleted key")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+	if err := appClient.DeleteSharingKey(ctx, sk1, shareKey); err == nil {
+		t.Fatal("expected error deleting already-deleted key")
+	} else {
+		assertStatus(t, err, http.StatusNotFound)
+	}
+}

--- a/api/app/sharing_test.go
+++ b/api/app/sharing_test.go
@@ -71,6 +71,7 @@ func TestSharingKeys(t *testing.T) {
 		Nonce:       nonce,
 		Description: "my share",
 	}
+	req.Sign(shareKeyPriv)
 	key, err := appClient.AddSharingKey(ctx, sk1, req)
 	if err != nil {
 		t.Fatal(err)
@@ -89,6 +90,14 @@ func TestSharingKeys(t *testing.T) {
 	bad.Nonce = sharing.Nonce{}
 	if _, err := appClient.AddSharingKey(ctx, sk1, bad); err == nil {
 		t.Fatal("expected error for empty nonce")
+	} else {
+		assertStatus(t, err, http.StatusBadRequest)
+	}
+
+	badSignature := req
+	badSignature.Description = "tampered"
+	if _, err := appClient.AddSharingKey(ctx, sk1, badSignature); err == nil {
+		t.Fatal("expected error for invalid sharing key signature")
 	} else {
 		assertStatus(t, err, http.StatusBadRequest)
 	}
@@ -124,6 +133,25 @@ func TestSharingKeys(t *testing.T) {
 	sharedReq.Sign(shareKeyPriv)
 	if err := appClient.AddSharedObject(ctx, sk1, shareKey, sharedReq); err != nil {
 		t.Fatal(err)
+	}
+
+	// reusing an encrypted key envelope under another sharing key is rejected.
+	nonce2 := sharing.Nonce(frand.Entropy256())
+	shareKeyPriv2 := sharing.DeriveSharingKey(sk1, nonce2)
+	keyReq2 := sharing.KeyRequest{
+		Nonce:       nonce2,
+		Description: "second share",
+	}
+	keyReq2.Sign(shareKeyPriv2)
+	if _, err := appClient.AddSharingKey(ctx, sk1, keyReq2); err != nil {
+		t.Fatal(err)
+	}
+	reusedKeyReq := sharedReq
+	reusedKeyReq.Sign(shareKeyPriv2)
+	if err := appClient.AddSharedObject(ctx, sk1, shareKeyPriv2.PublicKey(), reusedKeyReq); err == nil {
+		t.Fatal("expected error reusing encrypted key envelope")
+	} else {
+		assertStatus(t, err, http.StatusConflict)
 	}
 
 	if key, err := appClient.SharingKey(ctx, sk1, shareKey); err != nil {

--- a/cmd/indexd/run.go
+++ b/cmd/indexd/run.go
@@ -35,6 +35,7 @@ import (
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/persist/postgres"
 	"go.sia.tech/indexd/pins"
+	"go.sia.tech/indexd/sharing"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/stats"
 	"go.sia.tech/indexd/subscriber"
@@ -262,6 +263,12 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 	}
 	defer slabs.Close()
 
+	sharing, err := sharing.NewManager(store, sharing.WithLogger(log.Named("sharing")))
+	if err != nil {
+		return fmt.Errorf("failed to create sharing manager: %w", err)
+	}
+	defer sharing.Close()
+
 	subscriber, err := subscriber.New(cm, hm, contracts, wm, store,
 		subscriber.WithLogger(log.Named("subscriber")),
 		subscriber.WithBatchSize(cfg.Consensus.IndexBatchSize),
@@ -334,7 +341,7 @@ func runRootCmd(ctx context.Context, cfg config.Config, walletKey types.PrivateK
 		}
 	}
 
-	appHandler, err := app.NewAPI(advertiseURL, hm, am, contracts, slabs, appAPIOpts...)
+	appHandler, err := app.NewAPI(advertiseURL, hm, am, contracts, slabs, sharing, appAPIOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create application API: %w", err)
 	}

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -357,6 +357,8 @@ paths:
           description: Invalid request or signature
         "404":
           description: Sharing key not found, or the account does not own the object
+        "409":
+          description: The encrypted keys or signatures are already used by another shared-object attachment
   /sharing/{key}/objects/{objectKey}:
     delete:
       tags:
@@ -930,8 +932,8 @@ components:
       $ref: "./components.yml#/components/schemas/ObjectSlab"
     SharedObject:
       $ref: "./components.yml#/components/schemas/SharedObject"
-    Nonce:
-      $ref: "./components.yml#/components/schemas/Nonce"
+    SharingKeyNonce:
+      $ref: "./components.yml#/components/schemas/SharingKeyNonce"
     SharingKey:
       $ref: "./components.yml#/components/schemas/SharingKey"
     SharingKeyRequest:

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -18,6 +18,8 @@ tags:
     description: List, pin, unpin and retrieve pinned slab details
   - name: accounts
     description: Retrieve current account
+  - name: sharing
+    description: Create, list and delete sharing keys and the objects attached to them
 
 paths:
   /account:
@@ -203,6 +205,180 @@ paths:
         "404":
           description: Object not found
 
+  /sharing:
+    get:
+      tags:
+        - sharing
+      summary: List the account's sharing keys
+      operationId: listSharingKeys
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of sharing keys to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: The number of sharing keys to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: A list of sharing keys, most recently created first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SharingKey"
+    post:
+      tags:
+        - sharing
+      summary: Create a sharing key
+      operationId: addSharingKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SharingKeyRequest"
+      responses:
+        "200":
+          description: The created sharing key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SharingKey"
+        "400":
+          description: Invalid request, e.g. a missing public key or nonce
+        "409":
+          description: A sharing key with the same public key already exists
+  /sharing/{key}:
+    get:
+      tags:
+        - sharing
+      summary: Get one of the account's sharing keys
+      operationId: getSharingKey
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+      responses:
+        "200":
+          description: The sharing key
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SharingKey"
+        "404":
+          description: Sharing key not found
+    delete:
+      tags:
+        - sharing
+      summary: Delete one of the account's sharing keys and its attached objects
+      operationId: deleteSharingKey
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+      responses:
+        "200":
+          description: Sharing key deleted successfully
+        "404":
+          description: Sharing key not found
+  /sharing/{key}/objects:
+    get:
+      tags:
+        - sharing
+      summary: List the objects attached to one of the account's sharing keys
+      operationId: listSharingKeyObjects
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+        - name: limit
+          in: query
+          description: The maximum number of objects to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: The number of objects to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: A list of objects with their re-sealed keys, most recently attached first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SealedObject"
+        "404":
+          description: Sharing key not found
+    post:
+      tags:
+        - sharing
+      summary: Attach an object to a sharing key
+      operationId: addSharedObject
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SharedObjectRequest"
+      responses:
+        "200":
+          description: Object attached successfully
+        "400":
+          description: Invalid request or signature
+        "404":
+          description: Sharing key not found, or the account does not own the object
+  /sharing/{key}/objects/{objectKey}:
+    delete:
+      tags:
+        - sharing
+      summary: Detach an object from a sharing key
+      operationId: deleteSharedObject
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+        - name: objectKey
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Hash256"
+      responses:
+        "200":
+          description: Object detached successfully
+        "404":
+          description: Object not attached to the sharing key
   /slabs:
     get:
       tags:
@@ -754,3 +930,11 @@ components:
       $ref: "./components.yml#/components/schemas/ObjectSlab"
     SharedObject:
       $ref: "./components.yml#/components/schemas/SharedObject"
+    Nonce:
+      $ref: "./components.yml#/components/schemas/Nonce"
+    SharingKey:
+      $ref: "./components.yml#/components/schemas/SharingKey"
+    SharingKeyRequest:
+      $ref: "./components.yml#/components/schemas/SharingKeyRequest"
+    SharedObjectRequest:
+      $ref: "./components.yml#/components/schemas/SharedObjectRequest"

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -241,6 +241,113 @@ components:
           items:
             $ref: "#/components/schemas/SlabSlice"
 
+    Nonce:
+      type: string
+      pattern: "^[0-9a-fA-F]{64}$"
+      description: A 32-byte value (hex-encoded) used as the HKDF salt to derive a sharing key from an app key
+
+    # A scoped, read-only key that grants access to a specific set of objects
+    # without requiring the recipient to log in.
+    SharingKey:
+      type: object
+      properties:
+        account:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: The public key of the account that owns the sharing key
+        publicKey:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: The sharing key's public key, derived from the owner's app key and nonce
+        nonce:
+          $ref: "#/components/schemas/Nonce"
+        description:
+          type: string
+        objectCount:
+          type: integer
+          format: uint64
+          description: The number of objects attached to the key
+        objectSize:
+          type: integer
+          format: uint64
+          description: The total logical size of the attached objects in bytes
+        pinnedData:
+          type: integer
+          format: uint64
+          description: The total size of the attached objects before redundancy in bytes
+        pinnedSize:
+          type: integer
+          format: uint64
+          description: The total size of the attached objects including redundancy in bytes
+        expiresAt:
+          type: string
+          format: date-time
+          description: Optional expiration; after this time the key is no longer returned and is eventually pruned
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    SharingKeyRequest:
+      type: object
+      description: The request body for creating a sharing key
+      required:
+        - publicKey
+        - nonce
+      properties:
+        publicKey:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: The sharing key's public key, derived from the owner's app key and nonce
+        nonce:
+          $ref: "#/components/schemas/Nonce"
+        description:
+          type: string
+          description: Optional description (max 1024 bytes)
+        expiresAt:
+          type: string
+          format: date-time
+          description: Optional expiration time
+
+    SharedObjectRequest:
+      type: object
+      description: >
+        The request body for attaching an object to a sharing key. The object's
+        encryption keys are re-sealed under the sharing key and signed with it so
+        the recipient can decrypt and verify them.
+      required:
+        - objectID
+        - encryptedDataKey
+        - dataSignature
+        - metadataSignature
+      properties:
+        objectID:
+          allOf:
+            - $ref: "#/components/schemas/Hash256"
+            - description: The ID of the object to attach; the account must own it
+        encryptedDataKey:
+          type: string
+          format: byte
+          description: The object's data key re-sealed with the sharing key (base64-encoded in JSON)
+        dataSignature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: A signature of blake2b(object ID, encrypted_data_key) made with the sharing key
+        encryptedMetadataKey:
+          type: string
+          format: byte
+          description: Optional metadata key re-sealed with the sharing key (base64-encoded in JSON)
+        encryptedMetadata:
+          type: string
+          format: byte
+          description: Optional metadata (base64-encoded in JSON) limitted to 1KiB.
+        metadataSignature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: A signature of blake2b(object ID, metadata key, encrypted_metadata) made with the sharing key
+
     # A sector pinned to a host.
     PinnedSector:
       type: object

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -241,7 +241,7 @@ components:
           items:
             $ref: "#/components/schemas/SlabSlice"
 
-    Nonce:
+    SharingKeyNonce:
       type: string
       pattern: "^[0-9a-fA-F]{64}$"
       description: A 32-byte value (hex-encoded) used as the HKDF salt to derive a sharing key from an app key
@@ -260,7 +260,7 @@ components:
             - $ref: "#/components/schemas/PublicKey"
             - description: The sharing key's public key, derived from the owner's app key and nonce
         nonce:
-          $ref: "#/components/schemas/Nonce"
+          $ref: "#/components/schemas/SharingKeyNonce"
         description:
           type: string
         objectCount:
@@ -292,17 +292,22 @@ components:
 
     SharingKeyRequest:
       type: object
-      description: The request body for creating a sharing key
+      description: The request body for creating a sharing key, signed by that key to prove control of its private key
       required:
         - publicKey
+        - signature
         - nonce
       properties:
         publicKey:
           allOf:
             - $ref: "#/components/schemas/PublicKey"
             - description: The sharing key's public key, derived from the owner's app key and nonce
+        signature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: A signature of the complete request made with the sharing key
         nonce:
-          $ref: "#/components/schemas/Nonce"
+          $ref: "#/components/schemas/SharingKeyNonce"
         description:
           type: string
           description: Optional description (max 1024 bytes)

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -438,35 +438,76 @@ CREATE FUNCTION shared_objects_maintain_totals() RETURNS TRIGGER AS $$
 BEGIN
     IF (TG_OP = 'INSERT') THEN
         UPDATE sharing_keys SET
-            object_count = object_count + 1,
-            size = size + NEW.size,
-            pinned_data = pinned_data + NEW.pinned_data,
-            pinned_size = pinned_size + NEW.pinned_size,
+            object_count = sharing_keys.object_count + agg.object_count,
+            size = sharing_keys.size + agg.size,
+            pinned_data = sharing_keys.pinned_data + agg.pinned_data,
+            pinned_size = sharing_keys.pinned_size + agg.pinned_size,
             updated_at = NOW()
-        WHERE id = NEW.sharing_key_id;
+        FROM (
+            SELECT sharing_key_id,
+                COUNT(*) AS object_count,
+                SUM(size) AS size,
+                SUM(pinned_data) AS pinned_data,
+                SUM(pinned_size) AS pinned_size
+            FROM new_rows
+            GROUP BY sharing_key_id
+        ) agg
+        WHERE sharing_keys.id = agg.sharing_key_id;
     ELSIF (TG_OP = 'UPDATE') THEN
         UPDATE sharing_keys SET
-            size = size + NEW.size - OLD.size,
-            pinned_data = pinned_data + NEW.pinned_data - OLD.pinned_data,
-            pinned_size = pinned_size + NEW.pinned_size - OLD.pinned_size,
+            size = sharing_keys.size + agg.size,
+            pinned_data = sharing_keys.pinned_data + agg.pinned_data,
+            pinned_size = sharing_keys.pinned_size + agg.pinned_size,
             updated_at = NOW()
-        WHERE id = NEW.sharing_key_id;
+        FROM (
+            SELECT sharing_key_id,
+                SUM(size) AS size,
+                SUM(pinned_data) AS pinned_data,
+                SUM(pinned_size) AS pinned_size
+            FROM (
+                SELECT sharing_key_id, size, pinned_data, pinned_size FROM new_rows
+                UNION ALL
+                SELECT sharing_key_id, -size, -pinned_data, -pinned_size FROM old_rows
+            ) deltas
+            GROUP BY sharing_key_id
+        ) agg
+        WHERE sharing_keys.id = agg.sharing_key_id;
     ELSIF (TG_OP = 'DELETE') THEN
         UPDATE sharing_keys SET
-            object_count = object_count - 1,
-            size = size - OLD.size,
-            pinned_data = pinned_data - OLD.pinned_data,
-            pinned_size = pinned_size - OLD.pinned_size,
+            object_count = sharing_keys.object_count - agg.object_count,
+            size = sharing_keys.size - agg.size,
+            pinned_data = sharing_keys.pinned_data - agg.pinned_data,
+            pinned_size = sharing_keys.pinned_size - agg.pinned_size,
             updated_at = NOW()
-        WHERE id = OLD.sharing_key_id;
+        FROM (
+            SELECT sharing_key_id,
+                COUNT(*) AS object_count,
+                SUM(size) AS size,
+                SUM(pinned_data) AS pinned_data,
+                SUM(pinned_size) AS pinned_size
+            FROM old_rows
+            GROUP BY sharing_key_id
+        ) agg
+        WHERE sharing_keys.id = agg.sharing_key_id;
     END IF;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER shared_objects_maintain_totals
-AFTER INSERT OR UPDATE OR DELETE ON shared_objects
-FOR EACH ROW EXECUTE FUNCTION shared_objects_maintain_totals();
+CREATE TRIGGER shared_objects_maintain_totals_insert
+AFTER INSERT ON shared_objects
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT EXECUTE FUNCTION shared_objects_maintain_totals();
+
+CREATE TRIGGER shared_objects_maintain_totals_update
+AFTER UPDATE ON shared_objects
+REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+FOR EACH STATEMENT EXECUTE FUNCTION shared_objects_maintain_totals();
+
+CREATE TRIGGER shared_objects_maintain_totals_delete
+AFTER DELETE ON shared_objects
+REFERENCING OLD TABLE AS old_rows
+FOR EACH STATEMENT EXECUTE FUNCTION shared_objects_maintain_totals();
 
 CREATE TABLE account_slabs (
     account_id INTEGER REFERENCES accounts(id) NOT NULL, -- account that owns slab

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -413,6 +413,7 @@ CREATE TABLE sharing_keys (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW() -- allow sorting by update time
 );
 CREATE INDEX sharing_keys_account_id_idx ON sharing_keys(account_id);
+CREATE INDEX sharing_keys_expires_at_idx ON sharing_keys(expires_at);
 
 CREATE TABLE shared_objects (
     object_id BIGINT NOT NULL REFERENCES objects(id) ON DELETE CASCADE,

--- a/persist/postgres/init.sql
+++ b/persist/postgres/init.sql
@@ -398,6 +398,75 @@ CREATE INDEX object_events_updated_at_object_key_idx ON object_events(updated_at
 -- probe by object_key alone since the PK leads with account_id
 CREATE INDEX object_events_object_key_idx ON object_events(object_key);
 
+CREATE TABLE sharing_keys (
+    id BIGSERIAL PRIMARY KEY,
+    account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    public_key BYTEA UNIQUE NOT NULL CHECK(LENGTH(public_key) = 32),
+    nonce BYTEA UNIQUE NOT NULL CHECK(LENGTH(nonce) = 32), -- share_key = HKDF(app_key, nonce, "share key")
+    use_description TEXT NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE, -- optional automatic expiration
+    object_count BIGINT NOT NULL CHECK(object_count >= 0), -- number of attached objects, maintained by trigger
+    size BIGINT NOT NULL CHECK(size >= 0), -- total logical size of attached objects (sum of object.Size()), maintained by trigger
+    pinned_data BIGINT NOT NULL CHECK(pinned_data >= 0), -- total data size of attached objects before redundancy, maintained by trigger
+    pinned_size BIGINT NOT NULL CHECK(pinned_size >= 0), -- total size of attached objects including redundancy, maintained by trigger
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW() -- allow sorting by update time
+);
+CREATE INDEX sharing_keys_account_id_idx ON sharing_keys(account_id);
+
+CREATE TABLE shared_objects (
+    object_id BIGINT NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    sharing_key_id BIGINT NOT NULL REFERENCES sharing_keys(id) ON DELETE CASCADE,
+    encrypted_data_key BYTEA UNIQUE NOT NULL CHECK(LENGTH(encrypted_data_key) = 72), -- user provided, data encryption key (xchacha20 nonce + key + tag)
+    encrypted_meta_key BYTEA UNIQUE CHECK(LENGTH(encrypted_meta_key) = 72), -- user provided, metadata encryption key (xchacha20 nonce + key + tag)
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), -- allow sorting by update time
+    encrypted_metadata BYTEA, -- user provided, encrypted metadata
+    data_signature BYTEA UNIQUE NOT NULL CHECK(LENGTH(data_signature) = 64), -- signature of blake2b(object_key || encrypted_data_key)
+    meta_signature BYTEA UNIQUE NOT NULL CHECK(LENGTH(meta_signature) = 64), -- signature of blake2b(object ID || metadata key || encrypted_metadata)
+    size BIGINT NOT NULL, -- logical size of the object (object.Size()), captured at attach time for trigger
+    pinned_data BIGINT NOT NULL, -- data size of the object before redundancy, captured at attach time for trigger
+    pinned_size BIGINT NOT NULL, -- size of the object including redundancy, captured at attach time for trigger
+    PRIMARY KEY (object_id, sharing_key_id)
+);
+CREATE INDEX shared_objects_sharing_key_id_idx ON shared_objects(sharing_key_id);
+
+-- maintain sharing_keys.{object_count, pinned_data, pinned_size} as objects are
+-- attached and detached.
+CREATE FUNCTION shared_objects_maintain_totals() RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        UPDATE sharing_keys SET
+            object_count = object_count + 1,
+            size = size + NEW.size,
+            pinned_data = pinned_data + NEW.pinned_data,
+            pinned_size = pinned_size + NEW.pinned_size,
+            updated_at = NOW()
+        WHERE id = NEW.sharing_key_id;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        UPDATE sharing_keys SET
+            size = size + NEW.size - OLD.size,
+            pinned_data = pinned_data + NEW.pinned_data - OLD.pinned_data,
+            pinned_size = pinned_size + NEW.pinned_size - OLD.pinned_size,
+            updated_at = NOW()
+        WHERE id = NEW.sharing_key_id;
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE sharing_keys SET
+            object_count = object_count - 1,
+            size = size - OLD.size,
+            pinned_data = pinned_data - OLD.pinned_data,
+            pinned_size = pinned_size - OLD.pinned_size,
+            updated_at = NOW()
+        WHERE id = OLD.sharing_key_id;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER shared_objects_maintain_totals
+AFTER INSERT OR UPDATE OR DELETE ON shared_objects
+FOR EACH ROW EXECUTE FUNCTION shared_objects_maintain_totals();
+
 CREATE TABLE account_slabs (
     account_id INTEGER REFERENCES accounts(id) NOT NULL, -- account that owns slab
     slab_id BIGSERIAL REFERENCES slabs(id) NOT NULL,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -226,6 +226,7 @@ CREATE TABLE sharing_keys (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW() -- allow sorting by update time
 );
 CREATE INDEX sharing_keys_account_id_idx ON sharing_keys(account_id);
+CREATE INDEX sharing_keys_expires_at_idx ON sharing_keys(expires_at);
 
 CREATE TABLE shared_objects (
     object_id BIGINT NOT NULL REFERENCES objects(id) ON DELETE CASCADE,

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -209,4 +209,75 @@ CREATE INDEX preauthorized_keys_expires_at_idx ON preauthorized_keys(expires_at)
 `)
 		return err
 	},
+	func(ctx context.Context, tx *txn, log *zap.Logger) error {
+		_, err := tx.Exec(ctx, `
+CREATE TABLE sharing_keys (
+    id BIGSERIAL PRIMARY KEY,
+    account_id INTEGER NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    public_key BYTEA UNIQUE NOT NULL CHECK(LENGTH(public_key) = 32),
+    nonce BYTEA UNIQUE NOT NULL CHECK(LENGTH(nonce) = 32), -- share_key = HKDF(app_key, nonce, "share key")
+    use_description TEXT NOT NULL,
+    expires_at TIMESTAMP WITH TIME ZONE, -- optional automatic expiration
+    object_count BIGINT NOT NULL CHECK(object_count >= 0), -- number of attached objects, maintained by trigger
+    size BIGINT NOT NULL CHECK(size >= 0), -- total logical size of attached objects (sum of object.Size())
+    pinned_data BIGINT NOT NULL CHECK(pinned_data >= 0), -- total data size of attached objects before redundancy
+    pinned_size BIGINT NOT NULL CHECK(pinned_size >= 0), -- total size of attached objects including redundancy
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW() -- allow sorting by update time
+);
+CREATE INDEX sharing_keys_account_id_idx ON sharing_keys(account_id);
+
+CREATE TABLE shared_objects (
+    object_id BIGINT NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    sharing_key_id BIGINT NOT NULL REFERENCES sharing_keys(id) ON DELETE CASCADE,
+    encrypted_data_key BYTEA UNIQUE NOT NULL CHECK(LENGTH(encrypted_data_key) = 72), -- user provided, data encryption key (xchacha20 nonce + key + tag)
+    encrypted_meta_key BYTEA UNIQUE CHECK(LENGTH(encrypted_meta_key) = 72), -- user provided, metadata encryption key (xchacha20 nonce + key + tag)
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(), -- allow sorting by update time
+    encrypted_metadata BYTEA, -- user provided, encrypted metadata
+    data_signature BYTEA UNIQUE NOT NULL CHECK(LENGTH(data_signature) = 64), -- signature of blake2b(object_key || encrypted_data_key)
+    meta_signature BYTEA UNIQUE NOT NULL CHECK(LENGTH(meta_signature) = 64), -- signature of blake2b(object ID || metadata key || encrypted_metadata)
+    size BIGINT NOT NULL, -- logical size of the object (object.Size()), captured at attach time
+    pinned_data BIGINT NOT NULL, -- data size of the object before redundancy, captured at attach time
+    pinned_size BIGINT NOT NULL, -- size of the object including redundancy, captured at attach time
+    PRIMARY KEY (object_id, sharing_key_id)
+);
+CREATE INDEX shared_objects_sharing_key_id_idx ON shared_objects(sharing_key_id);
+
+CREATE FUNCTION shared_objects_maintain_totals() RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        UPDATE sharing_keys SET
+            object_count = object_count + 1,
+            size = size + NEW.size,
+            pinned_data = pinned_data + NEW.pinned_data,
+            pinned_size = pinned_size + NEW.pinned_size,
+            updated_at = NOW()
+        WHERE id = NEW.sharing_key_id;
+    ELSIF (TG_OP = 'UPDATE') THEN
+        UPDATE sharing_keys SET
+            size = size + NEW.size - OLD.size,
+            pinned_data = pinned_data + NEW.pinned_data - OLD.pinned_data,
+            pinned_size = pinned_size + NEW.pinned_size - OLD.pinned_size,
+            updated_at = NOW()
+        WHERE id = NEW.sharing_key_id;
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE sharing_keys SET
+            object_count = object_count - 1,
+            size = size - OLD.size,
+            pinned_data = pinned_data - OLD.pinned_data,
+            pinned_size = pinned_size - OLD.pinned_size,
+            updated_at = NOW()
+        WHERE id = OLD.sharing_key_id;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER shared_objects_maintain_totals
+AFTER INSERT OR UPDATE OR DELETE ON shared_objects
+FOR EACH ROW EXECUTE FUNCTION shared_objects_maintain_totals();
+`)
+		return err
+	},
 }

--- a/persist/postgres/migrations.go
+++ b/persist/postgres/migrations.go
@@ -249,35 +249,76 @@ CREATE FUNCTION shared_objects_maintain_totals() RETURNS TRIGGER AS $$
 BEGIN
     IF (TG_OP = 'INSERT') THEN
         UPDATE sharing_keys SET
-            object_count = object_count + 1,
-            size = size + NEW.size,
-            pinned_data = pinned_data + NEW.pinned_data,
-            pinned_size = pinned_size + NEW.pinned_size,
+            object_count = sharing_keys.object_count + agg.object_count,
+            size = sharing_keys.size + agg.size,
+            pinned_data = sharing_keys.pinned_data + agg.pinned_data,
+            pinned_size = sharing_keys.pinned_size + agg.pinned_size,
             updated_at = NOW()
-        WHERE id = NEW.sharing_key_id;
+        FROM (
+            SELECT sharing_key_id,
+                COUNT(*) AS object_count,
+                SUM(size) AS size,
+                SUM(pinned_data) AS pinned_data,
+                SUM(pinned_size) AS pinned_size
+            FROM new_rows
+            GROUP BY sharing_key_id
+        ) agg
+        WHERE sharing_keys.id = agg.sharing_key_id;
     ELSIF (TG_OP = 'UPDATE') THEN
         UPDATE sharing_keys SET
-            size = size + NEW.size - OLD.size,
-            pinned_data = pinned_data + NEW.pinned_data - OLD.pinned_data,
-            pinned_size = pinned_size + NEW.pinned_size - OLD.pinned_size,
+            size = sharing_keys.size + agg.size,
+            pinned_data = sharing_keys.pinned_data + agg.pinned_data,
+            pinned_size = sharing_keys.pinned_size + agg.pinned_size,
             updated_at = NOW()
-        WHERE id = NEW.sharing_key_id;
+        FROM (
+            SELECT sharing_key_id,
+                SUM(size) AS size,
+                SUM(pinned_data) AS pinned_data,
+                SUM(pinned_size) AS pinned_size
+            FROM (
+                SELECT sharing_key_id, size, pinned_data, pinned_size FROM new_rows
+                UNION ALL
+                SELECT sharing_key_id, -size, -pinned_data, -pinned_size FROM old_rows
+            ) deltas
+            GROUP BY sharing_key_id
+        ) agg
+        WHERE sharing_keys.id = agg.sharing_key_id;
     ELSIF (TG_OP = 'DELETE') THEN
         UPDATE sharing_keys SET
-            object_count = object_count - 1,
-            size = size - OLD.size,
-            pinned_data = pinned_data - OLD.pinned_data,
-            pinned_size = pinned_size - OLD.pinned_size,
+            object_count = sharing_keys.object_count - agg.object_count,
+            size = sharing_keys.size - agg.size,
+            pinned_data = sharing_keys.pinned_data - agg.pinned_data,
+            pinned_size = sharing_keys.pinned_size - agg.pinned_size,
             updated_at = NOW()
-        WHERE id = OLD.sharing_key_id;
+        FROM (
+            SELECT sharing_key_id,
+                COUNT(*) AS object_count,
+                SUM(size) AS size,
+                SUM(pinned_data) AS pinned_data,
+                SUM(pinned_size) AS pinned_size
+            FROM old_rows
+            GROUP BY sharing_key_id
+        ) agg
+        WHERE sharing_keys.id = agg.sharing_key_id;
     END IF;
     RETURN NULL;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER shared_objects_maintain_totals
-AFTER INSERT OR UPDATE OR DELETE ON shared_objects
-FOR EACH ROW EXECUTE FUNCTION shared_objects_maintain_totals();
+CREATE TRIGGER shared_objects_maintain_totals_insert
+AFTER INSERT ON shared_objects
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT EXECUTE FUNCTION shared_objects_maintain_totals();
+
+CREATE TRIGGER shared_objects_maintain_totals_update
+AFTER UPDATE ON shared_objects
+REFERENCING OLD TABLE AS old_rows NEW TABLE AS new_rows
+FOR EACH STATEMENT EXECUTE FUNCTION shared_objects_maintain_totals();
+
+CREATE TRIGGER shared_objects_maintain_totals_delete
+AFTER DELETE ON shared_objects
+REFERENCING OLD TABLE AS old_rows
+FOR EACH STATEMENT EXECUTE FUNCTION shared_objects_maintain_totals();
 `)
 		return err
 	},

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -177,37 +177,8 @@ func (s *Store) ListObjects(account proto.Account, cursor slabs.Cursor, limit in
 			if events[i].Deleted {
 				continue
 			}
-
-			rows, err = tx.Query(ctx, `
-				SELECT slabs.id, slab_offset, slab_length, slabs.encryption_key, slabs.min_shards, slabs.version
-				FROM object_slabs
-				JOIN slabs ON slabs.digest = object_slabs.slab_digest
-				WHERE object_id = $1
-				ORDER BY slab_index ASC
-			`, objectIDs[events[i].Key])
-			if err != nil {
-				return fmt.Errorf("failed to query slabs: %w", err)
-			}
-
-			var slabIDs []int64
-			for rows.Next() {
-				var slab slabs.SlabSlice
-				var slabID int64
-				err := rows.Scan(&slabID, &slab.Offset, &slab.Length, (*sqlHash256)(&slab.EncryptionKey), &slab.MinShards, &slab.Version)
-				if err != nil {
-					rows.Close()
-					return fmt.Errorf("failed to scan slab: %w", err)
-				}
-				events[i].Object.Slabs = append(events[i].Object.Slabs, slab)
-				slabIDs = append(slabIDs, slabID)
-			}
-			if err := rows.Err(); err != nil {
+			if err := loadObjectSlabs(ctx, tx, objectIDs[events[i].Key], events[i].Object); err != nil {
 				return err
-			}
-			rows.Close()
-
-			if err := decorateSectors(ctx, tx, events[i].Object, slabIDs); err != nil {
-				return fmt.Errorf("failed to decorate sectors of slab: %w", err)
 			}
 		}
 		return nil

--- a/persist/postgres/objects.go
+++ b/persist/postgres/objects.go
@@ -105,37 +105,7 @@ func (s *Store) Object(account proto.Account, key types.Hash256) (obj slabs.Seal
 			obj.EncryptedMetadataKey = metaKey.V
 		}
 
-		rows, err := tx.Query(ctx, `
-			SELECT slabs.id, slab_offset, slab_length, slabs.encryption_key, slabs.min_shards, slabs.version
-			FROM object_slabs
-			JOIN slabs ON slabs.digest = object_slabs.slab_digest
-			WHERE object_id = $1
-			ORDER BY slab_index ASC
-		`, objID)
-		if err != nil {
-			return fmt.Errorf("failed to query slabs: %w", err)
-		}
-		defer rows.Close()
-
-		var slabIDs []int64
-		for rows.Next() {
-			var slab slabs.SlabSlice
-			var slabID int64
-			err := rows.Scan(&slabID, &slab.Offset, &slab.Length, (*sqlHash256)(&slab.EncryptionKey), &slab.MinShards, &slab.Version)
-			if err != nil {
-				return fmt.Errorf("failed to scan slab: %w", err)
-			}
-			obj.Slabs = append(obj.Slabs, slab)
-			slabIDs = append(slabIDs, slabID)
-		}
-		if err := rows.Err(); err != nil {
-			return err
-		}
-
-		if err := decorateSectors(ctx, tx, &obj, slabIDs); err != nil {
-			return fmt.Errorf("failed to decorate sectors of slab: %w", err)
-		}
-		return nil
+		return loadObjectSlabs(ctx, tx, objID, &obj)
 	})
 	return obj, err
 }
@@ -400,6 +370,42 @@ func accountID(ctx context.Context, tx *txn, account proto.Account) (int64, bool
 		return 0, false, fmt.Errorf("failed to get account id: %w", err)
 	}
 	return accountID, deleted, nil
+}
+
+// loadObjectSlabs loads the object's slab slices in order and decorates them
+// with their sectors.
+func loadObjectSlabs(ctx context.Context, tx *txn, objectID int64, obj *slabs.SealedObject) error {
+	rows, err := tx.Query(ctx, `
+		SELECT slabs.id, slab_offset, slab_length, slabs.encryption_key, slabs.min_shards, slabs.version
+		FROM object_slabs
+		JOIN slabs ON slabs.digest = object_slabs.slab_digest
+		WHERE object_id = $1
+		ORDER BY slab_index ASC
+	`, objectID)
+	if err != nil {
+		return fmt.Errorf("failed to query slabs: %w", err)
+	}
+
+	var slabIDs []int64
+	for rows.Next() {
+		var slab slabs.SlabSlice
+		var slabID int64
+		if err := rows.Scan(&slabID, &slab.Offset, &slab.Length, (*sqlHash256)(&slab.EncryptionKey), &slab.MinShards, &slab.Version); err != nil {
+			rows.Close()
+			return fmt.Errorf("failed to scan slab: %w", err)
+		}
+		obj.Slabs = append(obj.Slabs, slab)
+		slabIDs = append(slabIDs, slabID)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if err := decorateSectors(ctx, tx, obj, slabIDs); err != nil {
+		return fmt.Errorf("failed to decorate sectors of slab: %w", err)
+	}
+	return nil
 }
 
 func decorateSectors(ctx context.Context, tx *txn, so *slabs.SealedObject, slabIDs []int64) error {

--- a/persist/postgres/sharing.go
+++ b/persist/postgres/sharing.go
@@ -17,7 +17,6 @@ import (
 )
 
 func scanSharingKey(s scanner) (key sharing.Key, err error) {
-	var expiresAt sql.NullTime
 	var nonce []byte
 	err = s.Scan(
 		(*sqlPublicKey)(&key.Account),
@@ -28,14 +27,11 @@ func scanSharingKey(s scanner) (key sharing.Key, err error) {
 		&key.ObjectSize,
 		&key.PinnedData,
 		&key.PinnedSize,
-		&expiresAt,
+		&key.ExpiresAt,
 		&key.CreatedAt,
 		&key.UpdatedAt,
 	)
 	copy(key.Nonce[:], nonce)
-	if expiresAt.Valid {
-		key.ExpiresAt = &expiresAt.Time
-	}
 	return
 }
 
@@ -211,6 +207,10 @@ func (s *Store) AddSharedObject(account proto.Account, sharingKey types.PublicKe
 			ON CONFLICT (object_id, sharing_key_id) DO UPDATE SET (encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, size, pinned_data, pinned_size, updated_at) = (EXCLUDED.encrypted_data_key, EXCLUDED.encrypted_meta_key, EXCLUDED.encrypted_metadata, EXCLUDED.data_signature, EXCLUDED.meta_signature, EXCLUDED.size, EXCLUDED.pinned_data, EXCLUDED.pinned_size, NOW())`,
 			objectID, sharingKeyID, req.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(req.DataSignature), sqlSignature(req.MetadataSignature), size, pinnedData, pinnedSize)
 		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+				return sharing.ErrSharedObjectConflict
+			}
 			return fmt.Errorf("failed to insert shared object: %w", err)
 		}
 		return nil

--- a/persist/postgres/sharing.go
+++ b/persist/postgres/sharing.go
@@ -1,0 +1,315 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/accounts"
+	"go.sia.tech/indexd/sharing"
+	"go.sia.tech/indexd/slabs"
+)
+
+func scanSharingKey(s scanner) (key sharing.Key, err error) {
+	var expiresAt sql.NullTime
+	var nonce []byte
+	err = s.Scan(
+		(*sqlPublicKey)(&key.Account),
+		(*sqlPublicKey)(&key.PublicKey),
+		&nonce,
+		&key.Description,
+		&key.ObjectCount,
+		&key.ObjectSize,
+		&key.PinnedData,
+		&key.PinnedSize,
+		&expiresAt,
+		&key.CreatedAt,
+		&key.UpdatedAt,
+	)
+	copy(key.Nonce[:], nonce)
+	if expiresAt.Valid {
+		key.ExpiresAt = &expiresAt.Time
+	}
+	return
+}
+
+// AddSharingKey creates a sharing key owned by the given account.
+func (s *Store) AddSharingKey(account proto.Account, req sharing.KeyRequest) (key sharing.Key, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		accountID, deleted, err := accountID(ctx, tx, account)
+		if err != nil {
+			return err
+		} else if deleted {
+			return accounts.ErrNotFound
+		}
+
+		var expiresAt any
+		if req.ExpiresAt != nil {
+			expiresAt = *req.ExpiresAt
+		}
+		key, err = scanSharingKey(tx.QueryRow(ctx, `
+			WITH ins AS (
+				INSERT INTO sharing_keys (account_id, public_key, nonce, use_description, object_count, size, pinned_data, pinned_size, expires_at)
+				VALUES ($1, $2, $3, $4, 0, 0, 0, 0, $5)
+				ON CONFLICT (public_key) DO NOTHING
+				RETURNING account_id, public_key, nonce, use_description, object_count, size, pinned_data, pinned_size, expires_at, created_at, updated_at
+			)
+			SELECT a.public_key, ins.public_key, ins.nonce, ins.use_description, ins.object_count, ins.size, ins.pinned_data, ins.pinned_size, ins.expires_at, ins.created_at, ins.updated_at
+			FROM ins INNER JOIN accounts a ON a.id = ins.account_id
+		`, accountID, sqlPublicKey(req.PublicKey), req.Nonce[:], req.Description, expiresAt))
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharingKeyExists
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation {
+			return sharing.ErrSharingKeyExists
+		}
+		return err
+	})
+	return
+}
+
+// SharingKey returns the sharing key with the given public key.
+func (s *Store) SharingKey(publicKey types.PublicKey) (key sharing.Key, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		key, err = scanSharingKey(tx.QueryRow(ctx, `
+			SELECT a.public_key, sk.public_key, sk.nonce, sk.use_description, sk.object_count, sk.size, sk.pinned_data, sk.pinned_size, sk.expires_at, sk.created_at, sk.updated_at
+			FROM sharing_keys sk
+			INNER JOIN accounts a ON a.id = sk.account_id
+			WHERE sk.public_key = $1 AND a.deleted_at IS NULL AND (sk.expires_at IS NULL OR sk.expires_at > NOW())
+		`, sqlPublicKey(publicKey)))
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharingKeyNotFound
+		}
+		return err
+	})
+	return
+}
+
+// SharingKeys returns a paginated list of the given account's sharing keys,
+// most recently created first.
+func (s *Store) SharingKeys(account proto.Account, offset, limit int) (keys []sharing.Key, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		accountID, _, err := accountID(ctx, tx, account)
+		if err != nil {
+			return err
+		}
+
+		rows, err := tx.Query(ctx, `
+			SELECT a.public_key, sk.public_key, sk.nonce, sk.use_description, sk.object_count, sk.size, sk.pinned_data, sk.pinned_size, sk.expires_at, sk.created_at, sk.updated_at
+			FROM sharing_keys sk
+			INNER JOIN accounts a ON a.id = sk.account_id
+			WHERE sk.account_id = $1 AND (sk.expires_at IS NULL OR sk.expires_at > NOW())
+			ORDER BY sk.created_at DESC
+			LIMIT $2 OFFSET $3
+		`, accountID, limit, offset)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		keys = keys[:0]
+		for rows.Next() {
+			key, err := scanSharingKey(rows)
+			if err != nil {
+				return err
+			}
+			keys = append(keys, key)
+		}
+		return rows.Err()
+	})
+	return
+}
+
+// DeleteSharingKey deletes the given account's sharing key along with its
+// attached objects.
+func (s *Store) DeleteSharingKey(account proto.Account, publicKey types.PublicKey) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		accountID, _, err := accountID(ctx, tx, account)
+		if err != nil {
+			return err
+		}
+
+		res, err := tx.Exec(ctx, `DELETE FROM sharing_keys WHERE public_key = $1 AND account_id = $2`, sqlPublicKey(publicKey), accountID)
+		if err != nil {
+			return err
+		} else if res.RowsAffected() == 0 {
+			return sharing.ErrSharingKeyNotFound
+		}
+		return nil
+	})
+}
+
+// AddSharedObject attaches an object the account owns to one of its sharing
+// keys. If the object is already attached, its re-sealed keys and signatures
+// are overwritten.
+func (s *Store) AddSharedObject(account proto.Account, sharingKey types.PublicKey, req sharing.SharedObjectRequest) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		accountID, deleted, err := accountID(ctx, tx, account)
+		if err != nil {
+			return err
+		} else if deleted {
+			return accounts.ErrNotFound
+		}
+
+		var sharingKeyID int64
+		err = tx.QueryRow(ctx, `SELECT id FROM sharing_keys WHERE public_key = $1 AND account_id = $2 AND (expires_at IS NULL OR expires_at > NOW())`, sqlPublicKey(sharingKey), accountID).Scan(&sharingKeyID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharingKeyNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get sharing key: %w", err)
+		}
+
+		var objectID int64
+		err = tx.QueryRow(ctx, `SELECT id FROM objects WHERE object_key = $1 AND account_id = $2`, sqlHash256(req.ObjectID), accountID).Scan(&objectID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return slabs.ErrObjectNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get object: %w", err)
+		}
+
+		// capture the object's sizes at attach time so the trigger can
+		// maintain the sharing key's totals: size is the object's logical size
+		// (sum of slab slice lengths), pinned_data/pinned_size are its storage
+		// footprint before and after redundancy.
+		var objectSize, minShards, sectorCount int64
+		err = tx.QueryRow(ctx, `
+			SELECT
+				COALESCE(SUM(os.slab_length), 0)::bigint,
+				COALESCE(SUM(s.min_shards), 0)::bigint,
+				COALESCE(SUM((SELECT COUNT(*) FROM slab_sectors ss WHERE ss.slab_id = s.id)), 0)::bigint
+			FROM object_slabs os
+			INNER JOIN slabs s ON s.digest = os.slab_digest
+			WHERE os.object_id = $1
+		`, objectID).Scan(&objectSize, &minShards, &sectorCount)
+		if err != nil {
+			return fmt.Errorf("failed to compute object size: %w", err)
+		}
+		size := uint64(objectSize)
+		pinnedData := uint64(minShards) * proto.SectorSize
+		pinnedSize := uint64(sectorCount) * proto.SectorSize
+
+		// ensure empty slices are passed as nil
+		var encryptedMetaKey []byte
+		if len(req.EncryptedMetadataKey) > 0 {
+			encryptedMetaKey = req.EncryptedMetadataKey
+		}
+		var encryptedMeta []byte
+		if len(req.EncryptedMetadata) > 0 {
+			encryptedMeta = req.EncryptedMetadata
+		}
+
+		_, err = tx.Exec(ctx, `
+			INSERT INTO shared_objects (object_id, sharing_key_id, encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, size, pinned_data, pinned_size)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			ON CONFLICT (object_id, sharing_key_id) DO UPDATE SET (encrypted_data_key, encrypted_meta_key, encrypted_metadata, data_signature, meta_signature, size, pinned_data, pinned_size, updated_at) = (EXCLUDED.encrypted_data_key, EXCLUDED.encrypted_meta_key, EXCLUDED.encrypted_metadata, EXCLUDED.data_signature, EXCLUDED.meta_signature, EXCLUDED.size, EXCLUDED.pinned_data, EXCLUDED.pinned_size, NOW())`,
+			objectID, sharingKeyID, req.EncryptedDataKey, encryptedMetaKey, encryptedMeta, sqlSignature(req.DataSignature), sqlSignature(req.MetadataSignature), size, pinnedData, pinnedSize)
+		if err != nil {
+			return fmt.Errorf("failed to insert shared object: %w", err)
+		}
+		return nil
+	})
+}
+
+// PruneExpiredSharingKeys deletes all sharing keys that expired on or before
+// the cutoff.
+func (s *Store) PruneExpiredSharingKeys(cutoff time.Time) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		_, err := tx.Exec(ctx, `DELETE FROM sharing_keys WHERE expires_at IS NOT NULL AND expires_at <= $1`, cutoff)
+		return err
+	})
+}
+
+// SharedObjects returns a paginated list of the objects attached to the sharing
+// key, most recently attached first. Each object's encryption keys and
+// signatures are the ones re-sealed under the sharing key.
+func (s *Store) SharedObjects(sharingKey types.PublicKey, offset, limit int) (objects []slabs.SealedObject, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		var sharingKeyID int64
+		err = tx.QueryRow(ctx, `
+			SELECT sk.id FROM sharing_keys sk
+			INNER JOIN accounts a ON a.id = sk.account_id
+			WHERE sk.public_key = $1 AND a.deleted_at IS NULL AND (sk.expires_at IS NULL OR sk.expires_at > NOW())
+		`, sqlPublicKey(sharingKey)).Scan(&sharingKeyID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharingKeyNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get sharing key: %w", err)
+		}
+
+		// fetch the page of shared objects along with their re-sealed keys
+		rows, err := tx.Query(ctx, `
+			SELECT so.object_id, so.encrypted_data_key, so.encrypted_meta_key, so.encrypted_metadata, so.data_signature, so.meta_signature, so.created_at, so.updated_at
+			FROM shared_objects so
+			WHERE so.sharing_key_id = $1
+			ORDER BY so.created_at DESC
+			LIMIT $2 OFFSET $3
+		`, sharingKeyID, limit, offset)
+		if err != nil {
+			return err
+		}
+
+		var objectIDs []int64
+		objects = objects[:0]
+		for rows.Next() {
+			var objectID int64
+			var obj slabs.SealedObject
+			var metaKey sql.Null[[]byte]
+			if err := rows.Scan(&objectID, &obj.EncryptedDataKey, &metaKey, &obj.EncryptedMetadata, (*sqlSignature)(&obj.DataSignature), (*sqlSignature)(&obj.MetadataSignature), &obj.CreatedAt, &obj.UpdatedAt); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to scan shared object: %w", err)
+			}
+			if metaKey.Valid {
+				obj.EncryptedMetadataKey = metaKey.V
+			}
+			objects = append(objects, obj)
+			objectIDs = append(objectIDs, objectID)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
+		// load each object's slabs (with decorated sectors)
+		for i := range objects {
+			if err := loadObjectSlabs(ctx, tx, objectIDs[i], &objects[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return
+}
+
+// DeleteSharedObject detaches an object from one of the account's sharing keys.
+func (s *Store) DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error {
+	return s.transaction(func(ctx context.Context, tx *txn) error {
+		accountID, _, err := accountID(ctx, tx, account)
+		if err != nil {
+			return err
+		}
+
+		res, err := tx.Exec(ctx, `
+			DELETE FROM shared_objects so
+			USING sharing_keys sk, objects o
+			WHERE so.sharing_key_id = sk.id
+				AND so.object_id = o.id
+				AND sk.public_key = $1
+				AND sk.account_id = $2
+				AND o.object_key = $3
+				AND o.account_id = $2`,
+			sqlPublicKey(sharingKey), accountID, sqlHash256(objectKey))
+		if err != nil {
+			return err
+		} else if res.RowsAffected() == 0 {
+			return sharing.ErrSharedObjectNotFound
+		}
+		return nil
+	})
+}

--- a/persist/postgres/sharing_test.go
+++ b/persist/postgres/sharing_test.go
@@ -1,0 +1,439 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/sharing"
+	"go.sia.tech/indexd/slabs"
+	"go.uber.org/zap"
+	"lukechampine.com/frand"
+)
+
+func (s *Store) pinTestObject(t testing.TB, acc proto.Account, hk types.PublicKey) slabs.SealedObject {
+	t.Helper()
+	params := slabs.SlabPinParams{
+		EncryptionKey: frand.Entropy256(),
+		MinShards:     1,
+		Sectors:       []slabs.PinnedSector{{Root: frand.Entropy256(), HostKey: hk}},
+	}
+	if _, err := s.PinSlabs(acc, time.Time{}, params); err != nil {
+		t.Fatalf("failed to pin slabs: %v", err)
+	}
+	obj := slabs.SealedObject{
+		EncryptedDataKey:     frand.Bytes(72),
+		EncryptedMetadataKey: frand.Bytes(72),
+		EncryptedMetadata:    frand.Bytes(50),
+		DataSignature:        types.Signature(frand.Bytes(64)),
+		MetadataSignature:    types.Signature(frand.Bytes(64)),
+		Slabs:                []slabs.SlabSlice{params.Slice(0, 100)},
+	}
+	if err := s.PinObject(acc, obj.PinRequest()); err != nil {
+		t.Fatalf("failed to pin object: %v", err)
+	}
+	return obj
+}
+
+func TestSharingKeys(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+
+	pk := types.GeneratePrivateKey().PublicKey()
+	if _, err := store.SharingKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+
+	nonce := (sharing.Nonce)(frand.Bytes(32))
+	expires := time.Now().Add(time.Hour).Truncate(time.Microsecond)
+	req := sharing.KeyRequest{
+		PublicKey:   pk,
+		Nonce:       nonce,
+		Description: "my share",
+		ExpiresAt:   &expires,
+	}
+
+	key, err := store.AddSharingKey(acc, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch {
+	case key.PublicKey != pk:
+		t.Fatalf("expected public key %v, got %v", pk, key.PublicKey)
+	case key.Account != types.PublicKey(acc):
+		t.Fatalf("expected account %v, got %v", types.PublicKey(acc), key.Account)
+	case key.Nonce != nonce:
+		t.Fatalf("expected nonce %x, got %x", nonce, key.Nonce)
+	case key.Description != "my share":
+		t.Fatalf("expected description %q, got %q", "my share", key.Description)
+	case key.ExpiresAt == nil || !key.ExpiresAt.Equal(expires):
+		t.Fatalf("expected expiry %v, got %v", expires, key.ExpiresAt)
+	case key.CreatedAt.IsZero() || key.UpdatedAt.IsZero():
+		t.Fatalf("expected non-zero timestamps, got %v and %v", key.CreatedAt, key.UpdatedAt)
+	}
+
+	// adding the same public key again fails
+	if _, err := store.AddSharingKey(acc, req); !errors.Is(err, sharing.ErrSharingKeyExists) {
+		t.Fatalf("expected ErrSharingKeyExists, got %v", err)
+	}
+
+	// reusing the nonce with a different public key is a domain conflict, not a raw db error
+	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   types.GeneratePrivateKey().PublicKey(),
+		Nonce:       nonce,
+		Description: "duplicate nonce",
+	}); !errors.Is(err, sharing.ErrSharingKeyExists) {
+		t.Fatalf("expected ErrSharingKeyExists for duplicate nonce, got %v", err)
+	}
+
+	// fetch by public key
+	got, err := store.SharingKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	switch {
+	case got.PublicKey != key.PublicKey || got.Account != key.Account:
+		t.Fatalf("fetched key mismatch: %+v vs %+v", got, key)
+	case got.Nonce != key.Nonce || got.Description != key.Description:
+		t.Fatalf("fetched key mismatch: %+v vs %+v", got, key)
+	case !got.ExpiresAt.Equal(*key.ExpiresAt) || !got.CreatedAt.Equal(key.CreatedAt):
+		t.Fatalf("fetched key mismatch: %+v vs %+v", got, key)
+	}
+
+	// add a second key without an expiration
+	pk2 := types.GeneratePrivateKey().PublicKey()
+	key2, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   pk2,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: "second",
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if key2.ExpiresAt != nil {
+		t.Fatalf("expected nil expiry, got %v", key2.ExpiresAt)
+	}
+
+	// list, newest first
+	keys, err := store.SharingKeys(acc, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	} else if keys[0].PublicKey != pk2 || keys[1].PublicKey != pk {
+		t.Fatalf("unexpected key order: %v, %v", keys[0].PublicKey, keys[1].PublicKey)
+	}
+
+	// pagination
+	if page, err := store.SharingKeys(acc, 0, 1); err != nil {
+		t.Fatal(err)
+	} else if len(page) != 1 || page[0].PublicKey != pk2 {
+		t.Fatalf("unexpected first page: %+v", page)
+	}
+	if page, err := store.SharingKeys(acc, 1, 1); err != nil {
+		t.Fatal(err)
+	} else if len(page) != 1 || page[0].PublicKey != pk {
+		t.Fatalf("unexpected second page: %+v", page)
+	}
+
+	// another account only sees its own keys
+	acc2 := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc2))
+	if keys, err := store.SharingKeys(acc2, 0, 10); err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 0 {
+		t.Fatalf("expected 0 keys for other account, got %d", len(keys))
+	}
+
+	// another account cannot delete this account's key
+	if err := store.DeleteSharingKey(acc2, pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+
+	if err := store.DeleteSharingKey(acc, pk); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SharingKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound after delete, got %v", err)
+	}
+	// deleting again fails
+	if err := store.DeleteSharingKey(acc, pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+}
+
+func TestPruneExpiredSharingKeys(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+
+	add := func(desc string, expiresAt *time.Time) types.PublicKey {
+		pk := types.GeneratePrivateKey().PublicKey()
+		if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+			PublicKey:   pk,
+			Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+			Description: desc,
+			ExpiresAt:   expiresAt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return pk
+	}
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	expiredPK := add("expired", &past)
+	futurePK := add("future", &future)
+	neverPK := add("never", nil)
+
+	// an expired key is not returned even before it is pruned
+	if _, err := store.SharingKey(expiredPK); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected expired key to be filtered, got %v", err)
+	}
+
+	if err := store.PruneExpiredSharingKeys(time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	// prune physically deletes the expired row; the others remain
+	count := func(pk types.PublicKey) (n int) {
+		if err := store.pool.QueryRow(t.Context(), `SELECT COUNT(*) FROM sharing_keys WHERE public_key = $1`, sqlPublicKey(pk)).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if count(expiredPK) != 0 {
+		t.Fatal("expected expired key to be pruned")
+	} else if count(futurePK) != 1 {
+		t.Fatal("expected future key to survive")
+	} else if count(neverPK) != 1 {
+		t.Fatal("expected non-expiring key to survive")
+	}
+}
+
+func TestSharingKeyDeletedAccount(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+
+	pk := types.GeneratePrivateKey().PublicKey()
+	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   pk,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: "share",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// the key is reachable while the account is active
+	if _, err := store.SharingKey(pk); err != nil {
+		t.Fatal(err)
+	}
+
+	// soft-deleting the account hides the key from recipient reads before pruning
+	if err := store.DeleteAccount(acc); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SharingKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound for soft-deleted account, got %v", err)
+	}
+	if _, err := store.SharedObjects(pk, 0, 10); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound for soft-deleted account, got %v", err)
+	}
+}
+
+func TestSharedObjectRequest(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	obj := store.pinTestObject(t, acc, hk)
+
+	skPK := types.GeneratePrivateKey().PublicKey()
+	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   skPK,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: "share",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := sharing.SharedObjectRequest{
+		ObjectID:             obj.ID(),
+		EncryptedDataKey:     frand.Bytes(72),
+		DataSignature:        types.Signature(frand.Bytes(64)),
+		EncryptedMetadataKey: frand.Bytes(72),
+		EncryptedMetadata:    frand.Bytes(40),
+		MetadataSignature:    types.Signature(frand.Bytes(64)),
+	}
+
+	if err := store.AddSharedObject(acc, types.GeneratePrivateKey().PublicKey(), req); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+
+	// attaching to an expired key is rejected
+	expiredPK := types.GeneratePrivateKey().PublicKey()
+	past := time.Now().Add(-time.Hour)
+	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   expiredPK,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: "expired",
+		ExpiresAt:   &past,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddSharedObject(acc, expiredPK, req); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound attaching to expired key, got %v", err)
+	}
+
+	badReq := req
+	badReq.ObjectID = types.Hash256(frand.Entropy256())
+	if err := store.AddSharedObject(acc, skPK, badReq); !errors.Is(err, slabs.ErrObjectNotFound) {
+		t.Fatalf("expected ErrObjectNotFound, got %v", err)
+	}
+
+	if err := store.AddSharedObject(acc, skPK, req); err != nil {
+		t.Fatal(err)
+	}
+	if n := countSharedObjects(t, store); n != 1 {
+		t.Fatalf("expected 1 shared object, got %d", n)
+	}
+
+	// re-attaching overwrites (upsert) rather than duplicating
+	req2 := req
+	req2.EncryptedDataKey = frand.Bytes(72)
+	req2.DataSignature = types.Signature(frand.Bytes(64))
+	if err := store.AddSharedObject(acc, skPK, req2); err != nil {
+		t.Fatal(err)
+	}
+	if n := countSharedObjects(t, store); n != 1 {
+		t.Fatalf("expected 1 shared object after re-attach, got %d", n)
+	}
+
+	// another account can neither reach the sharing key nor detach
+	acc2 := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc2))
+	if err := store.AddSharedObject(acc2, skPK, req); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+	if err := store.DeleteSharedObject(acc2, skPK, obj.ID()); !errors.Is(err, sharing.ErrSharedObjectNotFound) {
+		t.Fatalf("expected ErrSharedObjectNotFound, got %v", err)
+	}
+
+	if err := store.DeleteSharedObject(acc, skPK, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteSharedObject(acc, skPK, obj.ID()); !errors.Is(err, sharing.ErrSharedObjectNotFound) {
+		t.Fatalf("expected ErrSharedObjectNotFound after detach, got %v", err)
+	}
+
+	// deleting the object removes it from the sharing key via cascade
+	if err := store.AddSharedObject(acc, skPK, req); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DeleteObject(acc, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if n := countSharedObjects(t, store); n != 0 {
+		t.Fatalf("expected shared objects to be cascade-deleted, got %d", n)
+	}
+}
+
+func countSharedObjects(t testing.TB, store *Store) (n int) {
+	t.Helper()
+	if err := store.pool.QueryRow(t.Context(), `SELECT COUNT(*) FROM shared_objects`).Scan(&n); err != nil {
+		t.Fatalf("failed to count shared objects: %v", err)
+	}
+	return
+}
+
+func TestSharingKeyTotals(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	obj := store.pinTestObject(t, acc, hk)
+
+	skPK := types.GeneratePrivateKey().PublicKey()
+	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   skPK,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: "totals",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	assertTotals := func(count, size, pinnedData, pinnedSize uint64) {
+		t.Helper()
+		key, err := store.SharingKey(skPK)
+		if err != nil {
+			t.Fatal(err)
+		} else if key.ObjectCount != count || key.ObjectSize != size || key.PinnedData != pinnedData || key.PinnedSize != pinnedSize {
+			t.Fatalf("unexpected totals: count=%d objectSize=%d pinnedData=%d pinnedSize=%d, want %d/%d/%d/%d",
+				key.ObjectCount, key.ObjectSize, key.PinnedData, key.PinnedSize, count, size, pinnedData, pinnedSize)
+		}
+	}
+	resetUpdatedAt := func() time.Time {
+		t.Helper()
+		updatedAt := time.Unix(1, 0).UTC()
+		if _, err := store.pool.Exec(t.Context(), `UPDATE sharing_keys SET updated_at = $1 WHERE public_key = $2`, updatedAt, sqlPublicKey(skPK)); err != nil {
+			t.Fatal(err)
+		}
+		return updatedAt
+	}
+	assertUpdatedAtBumped := func(previous time.Time) {
+		t.Helper()
+		key, err := store.SharingKey(skPK)
+		if err != nil {
+			t.Fatal(err)
+		} else if !key.UpdatedAt.After(previous) {
+			t.Fatalf("expected updated_at after %v, got %v", previous, key.UpdatedAt)
+		}
+	}
+
+	assertTotals(0, 0, 0, 0)
+
+	updatedAt := resetUpdatedAt()
+	if err := store.AddSharedObject(acc, skPK, sharing.SharedObjectRequest{
+		ObjectID:          obj.ID(),
+		EncryptedDataKey:  frand.Bytes(sharing.EncryptionKeySize),
+		DataSignature:     types.Signature(frand.Bytes(64)),
+		MetadataSignature: types.Signature(frand.Bytes(64)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(1, 100, uint64(proto.SectorSize), uint64(proto.SectorSize))
+	assertUpdatedAtBumped(updatedAt)
+
+	// re-attaching the same object is an upsert; the totals are unchanged
+	updatedAt = resetUpdatedAt()
+	if err := store.AddSharedObject(acc, skPK, sharing.SharedObjectRequest{
+		ObjectID:          obj.ID(),
+		EncryptedDataKey:  frand.Bytes(sharing.EncryptionKeySize),
+		DataSignature:     types.Signature(frand.Bytes(64)),
+		MetadataSignature: types.Signature(frand.Bytes(64)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(1, 100, uint64(proto.SectorSize), uint64(proto.SectorSize))
+	assertUpdatedAtBumped(updatedAt)
+
+	// deleting the object cascades into shared_objects
+	updatedAt = resetUpdatedAt()
+	if err := store.DeleteObject(acc, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+	assertTotals(0, 0, 0, 0)
+	assertUpdatedAtBumped(updatedAt)
+}

--- a/persist/postgres/sharing_test.go
+++ b/persist/postgres/sharing_test.go
@@ -318,6 +318,20 @@ func TestSharedObjectRequest(t *testing.T) {
 		t.Fatalf("expected 1 shared object after re-attach, got %d", n)
 	}
 
+	skPK2 := types.GeneratePrivateKey().PublicKey()
+	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   skPK2,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: "second share",
+	}); err != nil {
+		t.Fatal(err)
+	} else if err := store.AddSharedObject(acc, skPK2, req2); !errors.Is(err, sharing.ErrSharedObjectConflict) {
+		t.Fatalf("expected ErrSharedObjectConflict for reused sealed keys, got %v", err)
+	}
+	if n := countSharedObjects(t, store); n != 1 {
+		t.Fatalf("expected 1 shared object after conflict, got %d", n)
+	}
+
 	// another account can neither reach the sharing key nor detach
 	acc2 := proto.Account(types.GeneratePrivateKey().PublicKey())
 	store.addTestAccount(t, types.PublicKey(acc2))

--- a/persist/postgres/sharing_test.go
+++ b/persist/postgres/sharing_test.go
@@ -361,6 +361,42 @@ func TestSharedObjectRequest(t *testing.T) {
 	}
 }
 
+func (s *Store) addTestSharingKey(t testing.TB, acc proto.Account, description string) types.PublicKey {
+	t.Helper()
+	pk := types.GeneratePrivateKey().PublicKey()
+	if _, err := s.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   pk,
+		Nonce:       (sharing.Nonce)(frand.Bytes(32)),
+		Description: description,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return pk
+}
+
+func attachTestObject(t testing.TB, store *Store, acc proto.Account, sharingKey types.PublicKey, objectID types.Hash256) {
+	t.Helper()
+	if err := store.AddSharedObject(acc, sharingKey, sharing.SharedObjectRequest{
+		ObjectID:          objectID,
+		EncryptedDataKey:  frand.Bytes(sharing.EncryptionKeySize),
+		DataSignature:     types.Signature(frand.Bytes(64)),
+		MetadataSignature: types.Signature(frand.Bytes(64)),
+	}); err != nil {
+		t.Fatalf("failed to attach object: %v", err)
+	}
+}
+
+func assertKeyTotals(t testing.TB, store *Store, pk types.PublicKey, count, size, pinnedData, pinnedSize uint64) {
+	t.Helper()
+	key, err := store.SharingKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	} else if key.ObjectCount != count || key.ObjectSize != size || key.PinnedData != pinnedData || key.PinnedSize != pinnedSize {
+		t.Fatalf("unexpected totals: count=%d objectSize=%d pinnedData=%d pinnedSize=%d, want %d/%d/%d/%d",
+			key.ObjectCount, key.ObjectSize, key.PinnedData, key.PinnedSize, count, size, pinnedData, pinnedSize)
+	}
+}
+
 func countSharedObjects(t testing.TB, store *Store) (n int) {
 	t.Helper()
 	if err := store.pool.QueryRow(t.Context(), `SELECT COUNT(*) FROM shared_objects`).Scan(&n); err != nil {
@@ -450,4 +486,70 @@ func TestSharingKeyTotals(t *testing.T) {
 	}
 	assertTotals(0, 0, 0, 0)
 	assertUpdatedAtBumped(updatedAt)
+}
+
+func TestSharedObjectCascadeAcrossKeys(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	objA := store.pinTestObject(t, acc, hk)
+	objB := store.pinTestObject(t, acc, hk)
+
+	k1 := store.addTestSharingKey(t, acc, "k1")
+	k2 := store.addTestSharingKey(t, acc, "k2")
+	for _, sk := range []types.PublicKey{k1, k2} {
+		attachTestObject(t, store, acc, sk, objA.ID())
+		attachTestObject(t, store, acc, sk, objB.ID())
+	}
+
+	sectorSize := uint64(proto.SectorSize)
+	assertKeyTotals(t, store, k1, 2, 200, 2*sectorSize, 2*sectorSize)
+	assertKeyTotals(t, store, k2, 2, 200, 2*sectorSize, 2*sectorSize)
+	if n := countSharedObjects(t, store); n != 4 {
+		t.Fatalf("expected 4 shared objects, got %d", n)
+	}
+
+	// deleting objA cascades a single DELETE spanning both keys
+	if err := store.DeleteObject(acc, objA.ID()); err != nil {
+		t.Fatal(err)
+	}
+	assertKeyTotals(t, store, k1, 1, 100, sectorSize, sectorSize)
+	assertKeyTotals(t, store, k2, 1, 100, sectorSize, sectorSize)
+	if n := countSharedObjects(t, store); n != 2 {
+		t.Fatalf("expected 2 shared objects after cascade, got %d", n)
+	}
+}
+
+func TestSharingKeyDeleteCascadesObjects(t *testing.T) {
+	store := initPostgres(t, zap.NewNop())
+
+	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
+	store.addTestAccount(t, types.PublicKey(acc))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	objA := store.pinTestObject(t, acc, hk)
+	objB := store.pinTestObject(t, acc, hk)
+
+	sk := store.addTestSharingKey(t, acc, "share")
+	attachTestObject(t, store, acc, sk, objA.ID())
+	attachTestObject(t, store, acc, sk, objB.ID())
+	if n := countSharedObjects(t, store); n != 2 {
+		t.Fatalf("expected 2 shared objects, got %d", n)
+	}
+
+	// the DELETE trigger fires against the key row being deleted
+	if err := store.DeleteSharingKey(acc, sk); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SharingKey(sk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound after delete, got %v", err)
+	}
+	if n := countSharedObjects(t, store); n != 0 {
+		t.Fatalf("expected shared objects to be cascade-deleted, got %d", n)
+	}
 }

--- a/sharing/manager.go
+++ b/sharing/manager.go
@@ -28,14 +28,14 @@ type (
 
 	// A Manager manages sharing keys and the objects attached to them.
 	Manager struct {
-		pruneInterval time.Duration
-
 		store Store
 
 		tg  *threadgroup.ThreadGroup
 		log *zap.Logger
 	}
 )
+
+const pruneInterval = 10 * time.Minute
 
 // An Option is a functional option for the Manager.
 type Option func(*Manager)
@@ -47,16 +47,9 @@ func WithLogger(l *zap.Logger) Option {
 	}
 }
 
-// WithPruneInterval sets the interval at which expired sharing keys are pruned.
-func WithPruneInterval(interval time.Duration) Option {
-	return func(m *Manager) {
-		m.pruneInterval = interval
-	}
-}
-
 // maintenanceLoop prunes expired sharing keys on a fixed interval.
 func (m *Manager) maintenanceLoop(ctx context.Context) {
-	ticker := time.NewTicker(m.pruneInterval)
+	ticker := time.NewTicker(pruneInterval)
 	defer ticker.Stop()
 
 	for {
@@ -81,6 +74,8 @@ func (m *Manager) Close() error {
 func (m *Manager) AddSharingKey(account proto.Account, req KeyRequest) (Key, error) {
 	if err := req.validate(); err != nil {
 		return Key{}, err
+	} else if err := req.VerifySignature(); err != nil {
+		return Key{}, err
 	}
 	return m.store.AddSharingKey(account, req)
 }
@@ -88,6 +83,18 @@ func (m *Manager) AddSharingKey(account proto.Account, req KeyRequest) (Key, err
 // SharingKey returns the sharing key with the given public key.
 func (m *Manager) SharingKey(publicKey types.PublicKey) (Key, error) {
 	return m.store.SharingKey(publicKey)
+}
+
+// OwnedSharingKey returns the sharing key with the given public key if it is
+// owned by the account.
+func (m *Manager) OwnedSharingKey(account proto.Account, publicKey types.PublicKey) (Key, error) {
+	key, err := m.SharingKey(publicKey)
+	if err != nil {
+		return Key{}, err
+	} else if key.Account != types.PublicKey(account) {
+		return Key{}, ErrSharingKeyNotFound
+	}
+	return key, nil
 }
 
 // SharingKeys returns a paginated list of the given account's sharing keys.
@@ -117,13 +124,11 @@ func (m *Manager) DeleteSharedObject(account proto.Account, sharingKey types.Pub
 	return m.store.DeleteSharedObject(account, sharingKey, objectKey)
 }
 
-// OwnedSharedObjects returns a paginated list of the object IDs attached to a
+// OwnedSharedObjects returns a paginated list of sealed objects attached to a
 // sharing key owned by the account.
 func (m *Manager) OwnedSharedObjects(account proto.Account, sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error) {
-	if key, err := m.store.SharingKey(sharingKey); err != nil {
+	if _, err := m.OwnedSharingKey(account, sharingKey); err != nil {
 		return nil, err
-	} else if key.Account != types.PublicKey(account) {
-		return nil, ErrSharingKeyNotFound
 	}
 	return m.store.SharedObjects(sharingKey, offset, limit)
 }
@@ -131,10 +136,9 @@ func (m *Manager) OwnedSharedObjects(account proto.Account, sharingKey types.Pub
 // NewManager creates a new sharing Manager.
 func NewManager(store Store, opts ...Option) (*Manager, error) {
 	m := &Manager{
-		pruneInterval: 10 * time.Minute,
-		store:         store,
-		tg:            threadgroup.New(),
-		log:           zap.NewNop(),
+		store: store,
+		tg:    threadgroup.New(),
+		log:   zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(m)

--- a/sharing/manager.go
+++ b/sharing/manager.go
@@ -1,0 +1,154 @@
+package sharing
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/threadgroup"
+	"go.sia.tech/indexd/slabs"
+	"go.uber.org/zap"
+)
+
+type (
+	// Store defines the persistence layer the Manager depends on.
+	Store interface {
+		AddSharingKey(account proto.Account, req KeyRequest) (Key, error)
+		SharingKey(publicKey types.PublicKey) (Key, error)
+		SharingKeys(account proto.Account, offset, limit int) ([]Key, error)
+		DeleteSharingKey(account proto.Account, publicKey types.PublicKey) error
+		AddSharedObject(account proto.Account, sharingKey types.PublicKey, req SharedObjectRequest) error
+		DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error
+		PruneExpiredSharingKeys(cutoff time.Time) error
+
+		SharedObjects(sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
+	}
+
+	// A Manager manages sharing keys and the objects attached to them.
+	Manager struct {
+		pruneInterval time.Duration
+
+		store Store
+
+		tg  *threadgroup.ThreadGroup
+		log *zap.Logger
+	}
+)
+
+// An Option is a functional option for the Manager.
+type Option func(*Manager)
+
+// WithLogger sets the logger for the Manager.
+func WithLogger(l *zap.Logger) Option {
+	return func(m *Manager) {
+		m.log = l
+	}
+}
+
+// WithPruneInterval sets the interval at which expired sharing keys are pruned.
+func WithPruneInterval(interval time.Duration) Option {
+	return func(m *Manager) {
+		m.pruneInterval = interval
+	}
+}
+
+// maintenanceLoop prunes expired sharing keys on a fixed interval.
+func (m *Manager) maintenanceLoop(ctx context.Context) {
+	ticker := time.NewTicker(m.pruneInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
+		if err := m.store.PruneExpiredSharingKeys(time.Now()); err != nil && !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			m.log.Error("maintenance failed", zap.String("task", "prune expired sharing keys"), zap.Error(err))
+		}
+	}
+}
+
+// Close closes the Manager.
+func (m *Manager) Close() error {
+	m.tg.Stop()
+	return nil
+}
+
+// AddSharingKey creates a sharing key owned by the given account.
+func (m *Manager) AddSharingKey(account proto.Account, req KeyRequest) (Key, error) {
+	if err := req.validate(); err != nil {
+		return Key{}, err
+	}
+	return m.store.AddSharingKey(account, req)
+}
+
+// SharingKey returns the sharing key with the given public key.
+func (m *Manager) SharingKey(publicKey types.PublicKey) (Key, error) {
+	return m.store.SharingKey(publicKey)
+}
+
+// SharingKeys returns a paginated list of the given account's sharing keys.
+func (m *Manager) SharingKeys(account proto.Account, offset, limit int) ([]Key, error) {
+	return m.store.SharingKeys(account, offset, limit)
+}
+
+// DeleteSharingKey deletes the given account's sharing key along with its
+// attached objects.
+func (m *Manager) DeleteSharingKey(account proto.Account, publicKey types.PublicKey) error {
+	return m.store.DeleteSharingKey(account, publicKey)
+}
+
+// AddSharedObject attaches an object the account owns to one of its sharing
+// keys.
+func (m *Manager) AddSharedObject(account proto.Account, sharingKey types.PublicKey, req SharedObjectRequest) error {
+	if err := req.validate(); err != nil {
+		return err
+	} else if err := req.VerifySignatures(sharingKey); err != nil {
+		return err
+	}
+	return m.store.AddSharedObject(account, sharingKey, req)
+}
+
+// DeleteSharedObject detaches an object from one of the account's sharing keys.
+func (m *Manager) DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error {
+	return m.store.DeleteSharedObject(account, sharingKey, objectKey)
+}
+
+// OwnedSharedObjects returns a paginated list of the object IDs attached to a
+// sharing key owned by the account.
+func (m *Manager) OwnedSharedObjects(account proto.Account, sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error) {
+	if key, err := m.store.SharingKey(sharingKey); err != nil {
+		return nil, err
+	} else if key.Account != types.PublicKey(account) {
+		return nil, ErrSharingKeyNotFound
+	}
+	return m.store.SharedObjects(sharingKey, offset, limit)
+}
+
+// NewManager creates a new sharing Manager.
+func NewManager(store Store, opts ...Option) (*Manager, error) {
+	m := &Manager{
+		pruneInterval: 10 * time.Minute,
+		store:         store,
+		tg:            threadgroup.New(),
+		log:           zap.NewNop(),
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	ctx, cancel, err := m.tg.AddContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer cancel()
+		m.maintenanceLoop(ctx)
+	}()
+
+	return m, nil
+}

--- a/sharing/manager_test.go
+++ b/sharing/manager_test.go
@@ -42,11 +42,17 @@ func TestManager(t *testing.T) {
 		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
 	}
 
-	key, err := m.AddSharingKey(acc, sharing.KeyRequest{
+	req := sharing.KeyRequest{
 		PublicKey:   pk,
 		Nonce:       nonce,
 		Description: "share",
-	})
+	}
+	if _, err := m.AddSharingKey(acc, req); !errors.Is(err, sharing.ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest for unsigned sharing key, got %v", err)
+	}
+	req.Sign(shareKey)
+
+	key, err := m.AddSharingKey(acc, req)
 	if err != nil {
 		t.Fatal(err)
 	} else if key.PublicKey != pk || key.Description != "share" || key.Account != appKey.PublicKey() {
@@ -60,6 +66,16 @@ func TestManager(t *testing.T) {
 		t.Fatalf("expected public key %v, got %v", pk, got.PublicKey)
 	} else if got.Nonce != nonce {
 		t.Fatalf("expected stored nonce %x, got %x", nonce, got.Nonce)
+	}
+
+	if got, err := m.OwnedSharingKey(acc, pk); err != nil {
+		t.Fatal(err)
+	} else if got.PublicKey != pk {
+		t.Fatalf("expected public key %v, got %v", pk, got.PublicKey)
+	}
+	otherAccount := proto.Account(types.GeneratePrivateKey().PublicKey())
+	if _, err := m.OwnedSharingKey(otherAccount, pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound for another account, got %v", err)
 	}
 
 	// the owner can re-derive the same sharing key from the app key and the

--- a/sharing/manager_test.go
+++ b/sharing/manager_test.go
@@ -1,0 +1,102 @@
+package sharing_test
+
+import (
+	"errors"
+	"testing"
+
+	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/contracts"
+	"go.sia.tech/indexd/sharing"
+	"go.sia.tech/indexd/testutils"
+	"go.uber.org/zap/zaptest"
+	"lukechampine.com/frand"
+)
+
+func newTestStore(t testing.TB) testutils.TestStore {
+	s := testutils.NewDB(t, contracts.DefaultMaintenanceSettings, zaptest.NewLogger(t))
+	t.Cleanup(func() {
+		s.Close()
+	})
+	return s
+}
+
+func TestManager(t *testing.T) {
+	store := newTestStore(t)
+	m, err := sharing.NewManager(store, sharing.WithLogger(zaptest.NewLogger(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+
+	appKey := types.GeneratePrivateKey()
+	acc := proto.Account(appKey.PublicKey())
+	store.AddTestAccount(t, appKey.PublicKey())
+
+	// the sharing key is derived from the app key and a random nonce
+	nonce := (sharing.Nonce)(frand.Bytes(32))
+	shareKey := sharing.DeriveSharingKey(appKey, nonce)
+	pk := shareKey.PublicKey()
+
+	if _, err := m.SharingKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+
+	key, err := m.AddSharingKey(acc, sharing.KeyRequest{
+		PublicKey:   pk,
+		Nonce:       nonce,
+		Description: "share",
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else if key.PublicKey != pk || key.Description != "share" || key.Account != appKey.PublicKey() {
+		t.Fatalf("unexpected key: %+v", key)
+	}
+
+	got, err := m.SharingKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	} else if got.PublicKey != pk {
+		t.Fatalf("expected public key %v, got %v", pk, got.PublicKey)
+	} else if got.Nonce != nonce {
+		t.Fatalf("expected stored nonce %x, got %x", nonce, got.Nonce)
+	}
+
+	// the owner can re-derive the same sharing key from the app key and the
+	// stored nonce
+	if rederived := sharing.DeriveSharingKey(appKey, got.Nonce); rederived.PublicKey() != pk {
+		t.Fatalf("re-derived sharing key mismatch: got %v, want %v", rederived.PublicKey(), pk)
+	}
+
+	if keys, err := m.SharingKeys(acc, 0, 10); err != nil {
+		t.Fatal(err)
+	} else if len(keys) != 1 || keys[0].PublicKey != pk {
+		t.Fatalf("unexpected keys: %+v", keys)
+	}
+
+	// a shared object with an invalid signature is rejected before the store
+	shareKeyPriv := types.GeneratePrivateKey()
+	sharedReq := sharing.SharedObjectRequest{
+		ObjectID:         types.Hash256(frand.Entropy256()),
+		EncryptedDataKey: frand.Bytes(sharing.EncryptionKeySize),
+	}
+	if err := m.AddSharedObject(acc, shareKeyPriv.PublicKey(), sharedReq); !errors.Is(err, sharing.ErrInvalidRequest) {
+		t.Fatalf("expected ErrInvalidRequest, got %v", err)
+	}
+
+	// once signed, attaching to a sharing key the account does not own fails
+	sharedReq.Sign(shareKeyPriv)
+	if err := m.AddSharedObject(acc, shareKeyPriv.PublicKey(), sharedReq); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound, got %v", err)
+	}
+	if err := m.DeleteSharedObject(acc, pk, types.Hash256(frand.Entropy256())); !errors.Is(err, sharing.ErrSharedObjectNotFound) {
+		t.Fatalf("expected ErrSharedObjectNotFound, got %v", err)
+	}
+
+	if err := m.DeleteSharingKey(acc, pk); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.SharingKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound after delete, got %v", err)
+	}
+}

--- a/sharing/sharing.go
+++ b/sharing/sharing.go
@@ -1,0 +1,163 @@
+package sharing
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/keys"
+)
+
+const (
+	// NonceSize is the required length of a sharing key's nonce, used as the
+	// HKDF salt when deriving the sharing key from the app key.
+	NonceSize = 32
+	// EncryptionKeySize is the length of a sealed encryption key (xchacha20
+	// nonce + key + tag).
+	EncryptionKeySize = 72
+	// MaxDescriptionSize is the maximum length of a sharing key description.
+	MaxDescriptionSize = 1024
+	// MaxMetadataSize is the maximum length of a shared object's encrypted
+	// metadata, mirroring the limit on a normal object's metadata.
+	MaxMetadataSize = 1024
+)
+
+var (
+	// ErrSharingKeyNotFound is returned when a sharing key does not exist.
+	ErrSharingKeyNotFound = errors.New("sharing key not found")
+	// ErrSharingKeyExists is returned when creating a sharing key that already
+	// exists.
+	ErrSharingKeyExists = errors.New("sharing key already exists")
+	// ErrSharedObjectNotFound is returned when an object is not attached to a
+	// sharing key.
+	ErrSharedObjectNotFound = errors.New("shared object not found")
+	// ErrInvalidRequest is returned when a request fails validation.
+	ErrInvalidRequest = errors.New("invalid request")
+)
+
+type (
+	// A Nonce is the per-key HKDF salt used to derive a sharing key from the
+	// creator's app key. It marshals to text as a hex string.
+	Nonce [NonceSize]byte
+
+	// A Key is a scoped, read-only sharing key that grants access to a specific
+	// set of objects without requiring the recipient to log in.
+	Key struct {
+		Account     types.PublicKey `json:"account"`
+		PublicKey   types.PublicKey `json:"publicKey"`
+		Nonce       Nonce           `json:"nonce"`
+		Description string          `json:"description"`
+		// ObjectCount is the total number of objects attached to this key
+		ObjectCount uint64 `json:"objectCount"`
+		// ObjectSize is the logical size of all objects attached to this key
+		ObjectSize uint64 `json:"objectSize"`
+		// PinnedData is the size of all objects attached to this key on the network, excluding redundancy
+		PinnedData uint64 `json:"pinnedData"`
+		// PinnedSize is the size of all objects attached to this key on the network, including redundancy
+		PinnedSize uint64     `json:"pinnedSize"`
+		ExpiresAt  *time.Time `json:"expiresAt,omitempty"`
+		CreatedAt  time.Time  `json:"createdAt"`
+		UpdatedAt  time.Time  `json:"updatedAt"`
+	}
+
+	// A KeyRequest contains the fields required to create a sharing key.
+	KeyRequest struct {
+		PublicKey   types.PublicKey `json:"publicKey"`
+		Nonce       Nonce           `json:"nonce"`
+		Description string          `json:"description"`
+		ExpiresAt   *time.Time      `json:"expiresAt,omitempty"`
+	}
+
+	// A SharedObjectRequest attaches an object to a sharing key. The object's
+	// encryption keys are re-sealed under the sharing key and re-signed so the
+	// recipient can decrypt and verify them.
+	SharedObjectRequest struct {
+		ObjectID             types.Hash256   `json:"objectID"`
+		EncryptedDataKey     []byte          `json:"encryptedDataKey"`
+		DataSignature        types.Signature `json:"dataSignature"`
+		EncryptedMetadataKey []byte          `json:"encryptedMetadataKey,omitempty"`
+		EncryptedMetadata    []byte          `json:"encryptedMetadata,omitempty"`
+		MetadataSignature    types.Signature `json:"metadataSignature"`
+	}
+)
+
+func (r KeyRequest) validate() error {
+	switch {
+	case r.PublicKey == (types.PublicKey{}):
+		return fmt.Errorf("%w: public key is required", ErrInvalidRequest)
+	case r.Nonce == (Nonce{}):
+		return fmt.Errorf("%w: nonce is required", ErrInvalidRequest)
+	case len(r.Description) > MaxDescriptionSize:
+		return fmt.Errorf("%w: description exceeds %d bytes", ErrInvalidRequest, MaxDescriptionSize)
+	}
+	return nil
+}
+
+func (r SharedObjectRequest) validate() error {
+	switch {
+	case r.ObjectID == (types.Hash256{}):
+		return fmt.Errorf("%w: object ID is required", ErrInvalidRequest)
+	case len(r.EncryptedDataKey) != EncryptionKeySize:
+		return fmt.Errorf("%w: encrypted data key must be %d bytes", ErrInvalidRequest, EncryptionKeySize)
+	case len(r.EncryptedMetadataKey) != 0 && len(r.EncryptedMetadataKey) != EncryptionKeySize:
+		return fmt.Errorf("%w: encrypted metadata key must be %d bytes", ErrInvalidRequest, EncryptionKeySize)
+	case len(r.EncryptedMetadata) > MaxMetadataSize:
+		return fmt.Errorf("%w: encrypted metadata exceeds %d bytes", ErrInvalidRequest, MaxMetadataSize)
+	}
+	return nil
+}
+
+func (r SharedObjectRequest) dataSigHash() types.Hash256 {
+	h := types.NewHasher()
+	r.ObjectID.EncodeTo(h.E)
+	h.E.Write(r.EncryptedDataKey)
+	return h.Sum()
+}
+
+func (r SharedObjectRequest) metaSigHash() types.Hash256 {
+	h := types.NewHasher()
+	r.ObjectID.EncodeTo(h.E)
+	h.E.Write(r.EncryptedMetadataKey)
+	h.E.Write(r.EncryptedMetadata)
+	return h.Sum()
+}
+
+// Sign signs the re-sealed keys with the sharing key's private key so the
+// recipient can verify them.
+func (r *SharedObjectRequest) Sign(sharingKey types.PrivateKey) {
+	r.DataSignature = sharingKey.SignHash(r.dataSigHash())
+	r.MetadataSignature = sharingKey.SignHash(r.metaSigHash())
+}
+
+// VerifySignatures verifies the re-sealed keys against the sharing key.
+func (r SharedObjectRequest) VerifySignatures(sharingKey types.PublicKey) error {
+	if !sharingKey.VerifyHash(r.dataSigHash(), r.DataSignature) {
+		return fmt.Errorf("%w: invalid data signature", ErrInvalidRequest)
+	} else if !sharingKey.VerifyHash(r.metaSigHash(), r.MetadataSignature) {
+		return fmt.Errorf("%w: invalid metadata signature", ErrInvalidRequest)
+	}
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (n Nonce) MarshalText() ([]byte, error) {
+	return []byte(hex.EncodeToString(n[:])), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (n *Nonce) UnmarshalText(b []byte) error {
+	if len(b) != hex.EncodedLen(NonceSize) {
+		return fmt.Errorf("invalid nonce: expected %d hex characters, got %d", hex.EncodedLen(NonceSize), len(b))
+	}
+	_, err := hex.Decode(n[:], b)
+	return err
+}
+
+// DeriveSharingKey derives a new ed25519 private key from the given private key and random nonce
+func DeriveSharingKey(key types.PrivateKey, nonce Nonce) types.PrivateKey {
+	buf := keys.Derive(key[:], nonce[:], []byte("share key"), 32)
+	defer clear(buf)
+	return types.NewPrivateKeyFromSeed(buf)
+}

--- a/sharing/sharing.go
+++ b/sharing/sharing.go
@@ -8,6 +8,7 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/keys"
+	"go.sia.tech/indexd/slabs"
 )
 
 const (
@@ -20,8 +21,8 @@ const (
 	// MaxDescriptionSize is the maximum length of a sharing key description.
 	MaxDescriptionSize = 1024
 	// MaxMetadataSize is the maximum length of a shared object's encrypted
-	// metadata, mirroring the limit on a normal object's metadata.
-	MaxMetadataSize = 1024
+	// metadata.
+	MaxMetadataSize = slabs.MaxMetadataSize
 )
 
 var (
@@ -33,6 +34,9 @@ var (
 	// ErrSharedObjectNotFound is returned when an object is not attached to a
 	// sharing key.
 	ErrSharedObjectNotFound = errors.New("shared object not found")
+	// ErrSharedObjectConflict is returned when an attachment reuses encrypted
+	// keys or signatures from another attachment.
+	ErrSharedObjectConflict = errors.New("shared object conflicts with existing attachment")
 	// ErrInvalidRequest is returned when a request fails validation.
 	ErrInvalidRequest = errors.New("invalid request")
 )
@@ -62,9 +66,11 @@ type (
 		UpdatedAt  time.Time  `json:"updatedAt"`
 	}
 
-	// A KeyRequest contains the fields required to create a sharing key.
+	// A KeyRequest contains the fields required to create a sharing key. It must
+	// be signed by the sharing key to prove control of its private key.
 	KeyRequest struct {
 		PublicKey   types.PublicKey `json:"publicKey"`
+		Signature   types.Signature `json:"signature"`
 		Nonce       Nonce           `json:"nonce"`
 		Description string          `json:"description"`
 		ExpiresAt   *time.Time      `json:"expiresAt,omitempty"`
@@ -82,6 +88,36 @@ type (
 		MetadataSignature    types.Signature `json:"metadataSignature"`
 	}
 )
+
+// SigHash returns the domain-separated hash signed when creating a sharing
+// key.
+func (r KeyRequest) SigHash() types.Hash256 {
+	h := types.NewHasher()
+	h.E.WriteString("indexd/sharing-key/create/v1")
+	r.PublicKey.EncodeTo(h.E)
+	h.E.Write(r.Nonce[:])
+	h.E.WriteString(r.Description)
+	h.E.WriteBool(r.ExpiresAt != nil)
+	if r.ExpiresAt != nil {
+		h.E.WriteTime(*r.ExpiresAt)
+	}
+	return h.Sum()
+}
+
+// Sign proves control of privateKey and binds the complete sharing key request
+// to its corresponding public key.
+func (r *KeyRequest) Sign(privateKey types.PrivateKey) {
+	r.PublicKey = privateKey.PublicKey()
+	r.Signature = privateKey.SignHash(r.SigHash())
+}
+
+// VerifySignature verifies that the sharing key owner signed the request.
+func (r KeyRequest) VerifySignature() error {
+	if !r.PublicKey.VerifyHash(r.SigHash(), r.Signature) {
+		return fmt.Errorf("%w: invalid signature", ErrInvalidRequest)
+	}
+	return nil
+}
 
 func (r KeyRequest) validate() error {
 	switch {

--- a/sharing/sharing.go
+++ b/sharing/sharing.go
@@ -125,6 +125,8 @@ func (r KeyRequest) validate() error {
 		return fmt.Errorf("%w: public key is required", ErrInvalidRequest)
 	case r.Nonce == (Nonce{}):
 		return fmt.Errorf("%w: nonce is required", ErrInvalidRequest)
+	case r.ExpiresAt != nil && r.ExpiresAt.Before(time.Now()):
+		return fmt.Errorf("%w: expires at must be in the future", ErrInvalidRequest)
 	case len(r.Description) > MaxDescriptionSize:
 		return fmt.Errorf("%w: description exceeds %d bytes", ErrInvalidRequest, MaxDescriptionSize)
 	}

--- a/sharing/sharing_test.go
+++ b/sharing/sharing_test.go
@@ -1,0 +1,86 @@
+package sharing_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/sharing"
+	"lukechampine.com/frand"
+)
+
+func TestKeyRequestSignature(t *testing.T) {
+	privateKey := types.GeneratePrivateKey()
+	expiresAt := time.Now().Add(time.Hour).Truncate(time.Second)
+	req := sharing.KeyRequest{
+		Nonce:       sharing.Nonce(frand.Entropy256()),
+		Description: "share",
+		ExpiresAt:   &expiresAt,
+	}
+	req.Sign(privateKey)
+
+	if req.PublicKey != privateKey.PublicKey() {
+		t.Fatalf("expected public key %v, got %v", privateKey.PublicKey(), req.PublicKey)
+	} else if err := req.VerifySignature(); err != nil {
+		t.Fatal(err)
+	}
+
+	buf, err := json.Marshal(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded sharing.KeyRequest
+	if err := json.Unmarshal(buf, &decoded); err != nil {
+		t.Fatal(err)
+	} else if err := decoded.VerifySignature(); err != nil {
+		t.Fatalf("signature did not survive JSON round trip: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*sharing.KeyRequest)
+	}{
+		{
+			name: "public key",
+			mutate: func(req *sharing.KeyRequest) {
+				req.PublicKey = types.GeneratePrivateKey().PublicKey()
+			},
+		},
+		{
+			name: "nonce",
+			mutate: func(req *sharing.KeyRequest) {
+				req.Nonce[0]++
+			},
+		},
+		{
+			name: "description",
+			mutate: func(req *sharing.KeyRequest) {
+				req.Description = "tampered"
+			},
+		},
+		{
+			name: "expiration",
+			mutate: func(req *sharing.KeyRequest) {
+				t := req.ExpiresAt.Add(time.Second)
+				req.ExpiresAt = &t
+			},
+		},
+		{
+			name: "signature",
+			mutate: func(req *sharing.KeyRequest) {
+				req.Signature = types.Signature{}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mutated := req
+			test.mutate(&mutated)
+			if err := mutated.VerifySignature(); !errors.Is(err, sharing.ErrInvalidRequest) {
+				t.Fatalf("expected ErrInvalidRequest, got %v", err)
+			}
+		})
+	}
+}

--- a/slabs/objects.go
+++ b/slabs/objects.go
@@ -160,9 +160,8 @@ func (o *SharedObject) Size() uint64 {
 	return size
 }
 
-// metadataLimit represents the maximum size of an objects metadata we will
-// store.
-const metadataLimit = 1024
+// MaxMetadataSize is the maximum size of object metadata that may be stored.
+const MaxMetadataSize = 1024
 
 var (
 	// ErrInvalidObjectSignature is returned when an object's signature is invalid.
@@ -172,7 +171,7 @@ var (
 	// ErrObjectMinimumSlabs is returned when the object has no slabs.
 	ErrObjectMinimumSlabs = errors.New("object must have at least one slab")
 	// ErrObjectMetadataLimitExceeded is returned when the provided metadata is too large.
-	ErrObjectMetadataLimitExceeded = fmt.Errorf("object metadata size limit (%d) exceeded", metadataLimit)
+	ErrObjectMetadataLimitExceeded = fmt.Errorf("object metadata size limit (%d) exceeded", MaxMetadataSize)
 	// ErrObjectUnpinnedSlab is returned when an user attempts to save an
 	// object containing a slab that is not pinned to their account.
 	ErrObjectUnpinnedSlab = errors.New("object contains unpinned slab")
@@ -292,7 +291,7 @@ func (m *SlabManager) DeleteObject(ctx context.Context, account proto.Account, o
 func (m *SlabManager) PinObject(ctx context.Context, account proto.Account, obj PinObjectRequest) error {
 	if len(obj.Slabs) == 0 {
 		return ErrObjectMinimumSlabs
-	} else if len(obj.EncryptedMetadata) > metadataLimit {
+	} else if len(obj.EncryptedMetadata) > MaxMetadataSize {
 		return fmt.Errorf("%w: got %d bytes", ErrObjectMetadataLimitExceeded, len(obj.EncryptedMetadata))
 	} else if pinnedObjectID(obj.Slabs) != obj.ID {
 		return fmt.Errorf("%w: object ID does not match slabs", ErrInvalidObjectSignature)

--- a/testutils/indexer.go
+++ b/testutils/indexer.go
@@ -25,6 +25,7 @@ import (
 	"go.sia.tech/indexd/geoip"
 	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/pins"
+	"go.sia.tech/indexd/sharing"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/indexd/stats"
 	"go.sia.tech/indexd/subscriber"
@@ -200,6 +201,11 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		t.Fatalf("failed to create slab manager: %v", err)
 	}
 
+	sharing, err := sharing.NewManager(store, sharing.WithLogger(log.Named("sharing")))
+	if err != nil {
+		t.Fatalf("failed to create sharing manager: %v", err)
+	}
+
 	subscriber, err := subscriber.New(c.cm, hm, contracts, wm, store, subscriber.WithLogger(log.Named("subscriber")))
 	if err != nil {
 		t.Fatalf("failed to create subscriber: %v", err)
@@ -260,7 +266,7 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 	if cfg.advertiseURL == "" {
 		cfg.advertiseURL = appAPIAddr
 	}
-	appHandler, err := app.NewAPI(cfg.advertiseURL, hm, am, contracts, slabs, appAPIOpts...)
+	appHandler, err := app.NewAPI(cfg.advertiseURL, hm, am, contracts, slabs, sharing, appAPIOpts...)
 	if err != nil {
 		t.Fatalf("failed to create application API: %v", err)
 	}
@@ -302,6 +308,9 @@ func NewIndexer(t testing.TB, c *ConsensusNode, log *zap.Logger, opts ...Indexer
 		}
 		if err := closeWithTimeout(slabs.Close); err != nil {
 			t.Errorf("failed to close slab manager: %v", err)
+		}
+		if err := closeWithTimeout(sharing.Close); err != nil {
+			t.Errorf("failed to close sharing manager: %v", err)
 		}
 		if err := closeWithTimeout(subscriber.Close); err != nil {
 			t.Errorf("failed to close subscriber: %v", err)


### PR DESCRIPTION
This adds the app methods required to manage sharing keys and shared objects. It does not include shared auth logic or the methods needed for sharing keys to download data.