### PR TITLE
Add support for sharing keys

### DIFF
--- a/.changeset/added_support_for_sharing_keys.md
+++ b/.changeset/added_support_for_sharing_keys.md
@@ -5,3 +5,5 @@ default: minor
 # Added support for sharing keys
 
 Sharing keys let an app grant read-only access to a specific set of objects without requiring the viewer to sign up or log in. Each key is a scoped, read-only credential derived from the app's own key and limited to the objects explicitly attached to it.
+
+SDKs can access objects using the `/shared` endpoints and a valid sharing key

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -1054,11 +1054,11 @@ func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, sla
 		"DELETE /sharing/:key/objects/:objectkey": wrapSignedAuth(a.handleDELETESharingObject),
 
 		// shared-key endpoints, authenticated with a sharing key
-		"GET /shared":                     wrapSharedAuth(a.handleGETShared),
-		"GET /shared/objects":             wrapSharedAuth(a.handleGETSharedObjects),
-		"GET /shared/objects/:id":         wrapSharedAuth(a.handleGETSharedObject),
-		"GET /shared/hosts":               wrapSharedAuth(a.handleGETSharedHosts),
-		"GET /shared/hosts/:pubkey/token": wrapSharedAuth(a.handleGETSharedHostToken),
+		"GET /shared":                      wrapSharedAuth(a.handleGETShared),
+		"GET /shared/objects":              wrapSharedAuth(a.handleGETSharedObjects),
+		"GET /shared/objects/:id":          wrapSharedAuth(a.handleGETSharedObject),
+		"GET /shared/hosts":                wrapSharedAuth(a.handleGETSharedHosts),
+		"GET /shared/hosts/:hostkey/token": wrapSharedAuth(a.handleGETSharedHostToken),
 
 		"GET /slabs":            wrapSignedAuth(a.handleGETSlabs),
 		"POST /slabs":           wrapSignedAuth(a.handlePOSTSlabs),

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -55,10 +55,14 @@ type (
 		AddSharingKey(account proto.Account, req sharing.KeyRequest) (sharing.Key, error)
 		DeleteSharingKey(account proto.Account, publicKey types.PublicKey) error
 		SharingKeys(account proto.Account, offset, limit int) ([]sharing.Key, error)
+		SharingKey(publicKey types.PublicKey) (sharing.Key, error)
 		OwnedSharingKey(account proto.Account, publicKey types.PublicKey) (sharing.Key, error)
 		AddSharedObject(account proto.Account, sharingKey types.PublicKey, req sharing.SharedObjectRequest) error
 		DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error
 		OwnedSharedObjects(account proto.Account, sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
+		SharedObjects(sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
+		SharedObject(sharingKey types.PublicKey, objectKey types.Hash256) (slabs.SealedObject, error)
+		AccountToken(sharingKey types.PublicKey, hostKey types.PublicKey) (proto.AccountToken, error)
 	}
 
 	// Hosts defines the hosts interface for the application API.
@@ -241,6 +245,10 @@ func WrapRateLimit(rl RateLimiter, next jape.Handler) jape.Handler {
 }
 
 func (a *app) handleGETHosts(jc jape.Context, _ types.PublicKey) {
+	a.listUsableHosts(jc)
+}
+
+func (a *app) listUsableHosts(jc jape.Context) {
 	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
 		return
@@ -982,6 +990,16 @@ func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, sla
 		}
 	}
 
+	wrapSharedAuth := func(h sharedHandler) jape.Handler {
+		return func(jc jape.Context) {
+			key, ok := validateSharedURLAuth(jc, a.hostname, sharing)
+			if !ok {
+				return
+			}
+			h(jc, key)
+		}
+	}
+
 	wrapBasicAuth := func(h jape.Handler) jape.Handler {
 		return func(jc jape.Context) {
 			_, password, ok := jc.Request.BasicAuth()
@@ -1034,6 +1052,13 @@ func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, sla
 		"POST /sharing/:key/objects":              wrapSignedAuth(a.handlePOSTSharingObject),
 		"GET /sharing/:key/objects":               wrapSignedAuth(a.handleGETSharingObjects),
 		"DELETE /sharing/:key/objects/:objectkey": wrapSignedAuth(a.handleDELETESharingObject),
+
+		// shared-key endpoints, authenticated with a sharing key
+		"GET /shared":                     wrapSharedAuth(a.handleGETShared),
+		"GET /shared/objects":             wrapSharedAuth(a.handleGETSharedObjects),
+		"GET /shared/objects/:id":         wrapSharedAuth(a.handleGETSharedObject),
+		"GET /shared/hosts":               wrapSharedAuth(a.handleGETSharedHosts),
+		"GET /shared/hosts/:pubkey/token": wrapSharedAuth(a.handleGETSharedHostToken),
 
 		"GET /slabs":            wrapSignedAuth(a.handleGETSlabs),
 		"POST /slabs":           wrapSignedAuth(a.handlePOSTSlabs),

--- a/api/app/app.go
+++ b/api/app/app.go
@@ -62,7 +62,7 @@ type (
 		OwnedSharedObjects(account proto.Account, sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
 		SharedObjects(sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
 		SharedObject(sharingKey types.PublicKey, objectKey types.Hash256) (slabs.SealedObject, error)
-		AccountToken(sharingKey types.PublicKey, hostKey types.PublicKey) (proto.AccountToken, error)
+		AccountTokens(sharingKey types.PublicKey, hostKeys []types.PublicKey) ([]proto.AccountToken, error)
 	}
 
 	// Hosts defines the hosts interface for the application API.
@@ -245,51 +245,53 @@ func WrapRateLimit(rl RateLimiter, next jape.Handler) jape.Handler {
 }
 
 func (a *app) handleGETHosts(jc jape.Context, _ types.PublicKey) {
-	a.listUsableHosts(jc)
+	if h, ok := a.usableHosts(jc); ok {
+		jc.Encode(h)
+	}
 }
 
-func (a *app) listUsableHosts(jc jape.Context) {
+func (a *app) usableHosts(jc jape.Context) ([]hosts.HostInfo, bool) {
 	offset, limit, ok := api.ParseOffsetLimit(jc)
 	if !ok {
-		return
+		return nil, false
 	}
 
 	var opts []hosts.UsableHostQueryOpt
 
 	var protocol string
 	if jc.DecodeForm("protocol", &protocol) != nil {
-		return
+		return nil, false
 	} else if protocol != "" && protocol != string(siamux.Protocol) && protocol != string(quic.Protocol) {
 		jc.Error(fmt.Errorf("invalid protocol %q", protocol), http.StatusBadRequest)
-		return
+		return nil, false
 	} else if protocol != "" {
 		opts = append(opts, hosts.WithProtocol(chain.Protocol(protocol)))
 	}
 
 	var countryCode string
 	if jc.DecodeForm("country", &countryCode) != nil {
-		return
+		return nil, false
 	} else if countryCode != "" {
 		opts = append(opts, hosts.WithCountry(countryCode))
 	}
 
 	var locationStr string
 	if jc.DecodeForm("location", &locationStr) != nil {
-		return
+		return nil, false
 	} else if locationStr != "" {
 		var lat, lng float64
 		if _, err := fmt.Sscanf(locationStr, "(%f,%f)", &lat, &lng); err != nil {
 			jc.Error(fmt.Errorf("invalid location %q, must be of the form (lat,lng)", locationStr), http.StatusBadRequest)
-			return
+			return nil, false
 		}
 		opts = append(opts, hosts.SortByDistance(lat, lng))
 	}
 
-	hosts, err := a.hosts.UsableHosts(jc.Request.Context(), offset, limit, opts...)
+	h, err := a.hosts.UsableHosts(jc.Request.Context(), offset, limit, opts...)
 	if jc.Check("failed to get hosts", err) != nil {
-		return
+		return nil, false
 	}
-	jc.Encode(hosts)
+	return h, true
 }
 
 func (a *app) handleGETObject(jc jape.Context, pk types.PublicKey) {
@@ -1054,11 +1056,10 @@ func NewAPI(advertiseURL string, hm Hosts, am Accounts, contracts Contracts, sla
 		"DELETE /sharing/:key/objects/:objectkey": wrapSignedAuth(a.handleDELETESharingObject),
 
 		// shared-key endpoints, authenticated with a sharing key
-		"GET /shared":                      wrapSharedAuth(a.handleGETShared),
-		"GET /shared/objects":              wrapSharedAuth(a.handleGETSharedObjects),
-		"GET /shared/objects/:id":          wrapSharedAuth(a.handleGETSharedObject),
-		"GET /shared/hosts":                wrapSharedAuth(a.handleGETSharedHosts),
-		"GET /shared/hosts/:hostkey/token": wrapSharedAuth(a.handleGETSharedHostToken),
+		"GET /shared":             wrapSharedAuth(a.handleGETShared),
+		"GET /shared/objects":     wrapSharedAuth(a.handleGETSharedObjects),
+		"GET /shared/objects/:id": wrapSharedAuth(a.handleGETSharedObject),
+		"GET /shared/hosts":       wrapSharedAuth(a.handleGETSharedHosts),
 
 		"GET /slabs":            wrapSignedAuth(a.handleGETSlabs),
 		"POST /slabs":           wrapSignedAuth(a.handlePOSTSlabs),

--- a/api/app/auth.go
+++ b/api/app/auth.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/sharing"
 	"go.sia.tech/jape"
 )
 
@@ -20,6 +21,8 @@ import (
 const maxRequestSize = 10 << 20 // 10 MB
 
 type authedHandler func(jape.Context, types.PublicKey)
+
+type sharedHandler func(jape.Context, sharing.Key)
 
 var (
 	// ErrInternalError is returned when a signed URL can not be authenticated
@@ -118,6 +121,27 @@ func validateSignedURLAuth(jc jape.Context, hostname string, store Accounts) (ty
 		return types.PublicKey{}, false
 	}
 	return pk, true
+}
+
+// validateSharedURLAuth validates a signed URL for the shared-key API. The
+// request must be signed with a sharing key's private key; the signer's public
+// key must resolve to an existing, unexpired sharing key. On success it returns
+// that sharing key.
+func validateSharedURLAuth(jc jape.Context, hostname string, store Sharing) (sharing.Key, bool) {
+	pk, ok := ValidateURLSignature(jc.Request, jc.ResponseWriter, hostname)
+	if !ok {
+		return sharing.Key{}, false
+	}
+
+	key, err := store.SharingKey(pk)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(sharing.ErrSharingKeyNotFound, http.StatusUnauthorized)
+		return sharing.Key{}, false
+	} else if err != nil {
+		jc.Error(ErrInternalError, http.StatusInternalServerError)
+		return sharing.Key{}, false
+	}
+	return key, true
 }
 
 func parseCredential(req *http.Request) (pk types.PublicKey, _ error) {

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
@@ -308,14 +309,57 @@ func (c *Client) DeleteSharedObject(ctx context.Context, appKey types.PrivateKey
 	return c.signedRequestJSON(ctx, appKey, http.MethodDelete, fmt.Sprintf("/sharing/%s/objects/%s", sharingKey, objectKey), nil, nil)
 }
 
-// SharedObjects lists the object IDs attached to one of the account's sharing
+// SharingKeyObjects lists the objects attached to one of the account's sharing
 // keys. It supports pagination through the provided options.
-func (c *Client) SharedObjects(ctx context.Context, appKey types.PrivateKey, sharingKey types.PublicKey, opts ...api.URLQueryParameterOption) (objects []slabs.SealedObject, err error) {
+func (c *Client) SharingKeyObjects(ctx context.Context, appKey types.PrivateKey, sharingKey types.PublicKey, opts ...api.URLQueryParameterOption) (objects []slabs.SealedObject, err error) {
 	values := url.Values{}
 	for _, opt := range opts {
 		opt(values)
 	}
 	err = c.signedRequestJSON(ctx, appKey, http.MethodGet, fmt.Sprintf("/sharing/%s/objects?%s", sharingKey, values.Encode()), nil, &objects)
+	return
+}
+
+// SharedStats returns the sharing key's aggregate totals. The request is signed
+// with the sharing key's private key.
+func (c *Client) SharedStats(ctx context.Context, sharingKey types.PrivateKey) (stats sharing.KeyStats, err error) {
+	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, "/shared", nil, &stats)
+	return
+}
+
+// SharedObjects lists the objects the sharing key grants access to. The request
+// is signed with the sharing key's private key.
+func (c *Client) SharedObjects(ctx context.Context, sharingKey types.PrivateKey, opts ...api.URLQueryParameterOption) (objects []slabs.SealedObject, err error) {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, "/shared/objects?"+values.Encode(), nil, &objects)
+	return
+}
+
+// SharedObjectByID retrieves a single object the sharing key grants access to.
+// The request is signed with the sharing key's private key.
+func (c *Client) SharedObjectByID(ctx context.Context, sharingKey types.PrivateKey, objectKey types.Hash256) (obj slabs.SealedObject, err error) {
+	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, fmt.Sprintf("/shared/objects/%s", objectKey), nil, &obj)
+	return
+}
+
+// SharedHosts lists usable hosts using the sharing key for authentication.
+func (c *Client) SharedHosts(ctx context.Context, sharingKey types.PrivateKey, opts ...api.URLQueryParameterOption) (hosts []hosts.HostInfo, err error) {
+	values := url.Values{}
+	for _, opt := range opts {
+		opt(values)
+	}
+	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, "/shared/hosts?"+values.Encode(), nil, &hosts)
+	return
+}
+
+// SharedHostToken returns an account token for the given host, signed with the
+// sharing account of the sharing key's owner. The recipient uses it to pay for
+// downloads from the host.
+func (c *Client) SharedHostToken(ctx context.Context, sharingKey types.PrivateKey, hostKey types.PublicKey) (token proto.AccountToken, err error) {
+	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, fmt.Sprintf("/shared/hosts/%s/token", hostKey), nil, &token)
 	return
 }
 

--- a/api/app/client.go
+++ b/api/app/client.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api"
 	"go.sia.tech/indexd/hosts"
@@ -345,21 +344,15 @@ func (c *Client) SharedObjectByID(ctx context.Context, sharingKey types.PrivateK
 	return
 }
 
-// SharedHosts lists usable hosts using the sharing key for authentication.
-func (c *Client) SharedHosts(ctx context.Context, sharingKey types.PrivateKey, opts ...api.URLQueryParameterOption) (hosts []hosts.HostInfo, err error) {
+// SharedHosts lists usable hosts using the sharing key for authentication. Each
+// host includes an account token the recipient can use to pay for downloads
+// from that host.
+func (c *Client) SharedHosts(ctx context.Context, sharingKey types.PrivateKey, opts ...api.URLQueryParameterOption) (sharedHosts []SharedHost, err error) {
 	values := url.Values{}
 	for _, opt := range opts {
 		opt(values)
 	}
-	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, "/shared/hosts?"+values.Encode(), nil, &hosts)
-	return
-}
-
-// SharedHostToken returns an account token for the given host, signed with the
-// sharing account of the sharing key's owner. The recipient uses it to pay for
-// downloads from the host.
-func (c *Client) SharedHostToken(ctx context.Context, sharingKey types.PrivateKey, hostKey types.PublicKey) (token proto.AccountToken, err error) {
-	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, fmt.Sprintf("/shared/hosts/%s/token", hostKey), nil, &token)
+	err = c.signedRequestJSON(ctx, sharingKey, http.MethodGet, "/shared/hosts?"+values.Encode(), nil, &sharedHosts)
 	return
 }
 

--- a/api/app/shared.go
+++ b/api/app/shared.go
@@ -43,8 +43,7 @@ func (a *app) handleGETSharedObject(jc jape.Context, key sharing.Key) {
 	} else if errors.Is(err, sharing.ErrSharedObjectNotFound) {
 		jc.Error(err, http.StatusNotFound)
 		return
-	} else if err != nil {
-		jc.Error(err, http.StatusInternalServerError)
+	} else if jc.Check("failed to get shared object", err) != nil {
 		return
 	}
 	jc.Encode(obj)
@@ -56,7 +55,7 @@ func (a *app) handleGETSharedHosts(jc jape.Context, _ sharing.Key) {
 
 func (a *app) handleGETSharedHostToken(jc jape.Context, key sharing.Key) {
 	var hostKey types.PublicKey
-	if jc.DecodeParam("pubkey", &hostKey) != nil {
+	if jc.DecodeParam("hostkey", &hostKey) != nil {
 		return
 	}
 

--- a/api/app/shared.go
+++ b/api/app/shared.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"errors"
+	"net/http"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/sharing"
+	"go.sia.tech/jape"
+)
+
+func (a *app) handleGETShared(jc jape.Context, key sharing.Key) {
+	jc.Encode(key.Stats())
+}
+
+func (a *app) handleGETSharedObjects(jc jape.Context, key sharing.Key) {
+	offset, limit, ok := api.ParseOffsetLimit(jc)
+	if !ok {
+		return
+	}
+
+	objects, err := a.sharing.SharedObjects(key.PublicKey, offset, limit)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(err, http.StatusUnauthorized)
+		return
+	} else if jc.Check("failed to list shared objects", err) != nil {
+		return
+	}
+	jc.Encode(objects)
+}
+
+func (a *app) handleGETSharedObject(jc jape.Context, key sharing.Key) {
+	var objectKey types.Hash256
+	if jc.DecodeParam("id", &objectKey) != nil {
+		return
+	}
+
+	obj, err := a.sharing.SharedObject(key.PublicKey, objectKey)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(err, http.StatusUnauthorized)
+		return
+	} else if errors.Is(err, sharing.ErrSharedObjectNotFound) {
+		jc.Error(err, http.StatusNotFound)
+		return
+	} else if err != nil {
+		jc.Error(err, http.StatusInternalServerError)
+		return
+	}
+	jc.Encode(obj)
+}
+
+func (a *app) handleGETSharedHosts(jc jape.Context, _ sharing.Key) {
+	a.listUsableHosts(jc)
+}
+
+func (a *app) handleGETSharedHostToken(jc jape.Context, key sharing.Key) {
+	var hostKey types.PublicKey
+	if jc.DecodeParam("pubkey", &hostKey) != nil {
+		return
+	}
+
+	token, err := a.sharing.AccountToken(key.PublicKey, hostKey)
+	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		jc.Error(err, http.StatusUnauthorized)
+		return
+	} else if jc.Check("failed to create account token", err) != nil {
+		return
+	}
+	jc.Encode(token)
+}

--- a/api/app/shared.go
+++ b/api/app/shared.go
@@ -4,11 +4,20 @@ import (
 	"errors"
 	"net/http"
 
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/api"
+	"go.sia.tech/indexd/hosts"
 	"go.sia.tech/indexd/sharing"
 	"go.sia.tech/jape"
 )
+
+// A SharedHost is a usable host paired with an account token the recipient can
+// use to pay for downloads from that host.
+type SharedHost struct {
+	hosts.HostInfo
+	Token proto.AccountToken `json:"token"`
+}
 
 func (a *app) handleGETShared(jc jape.Context, key sharing.Key) {
 	jc.Encode(key.Stats())
@@ -49,22 +58,28 @@ func (a *app) handleGETSharedObject(jc jape.Context, key sharing.Key) {
 	jc.Encode(obj)
 }
 
-func (a *app) handleGETSharedHosts(jc jape.Context, _ sharing.Key) {
-	a.listUsableHosts(jc)
-}
-
-func (a *app) handleGETSharedHostToken(jc jape.Context, key sharing.Key) {
-	var hostKey types.PublicKey
-	if jc.DecodeParam("hostkey", &hostKey) != nil {
+func (a *app) handleGETSharedHosts(jc jape.Context, key sharing.Key) {
+	usable, ok := a.usableHosts(jc)
+	if !ok {
 		return
 	}
 
-	token, err := a.sharing.AccountToken(key.PublicKey, hostKey)
+	hostKeys := make([]types.PublicKey, len(usable))
+	for i, h := range usable {
+		hostKeys[i] = h.PublicKey
+	}
+
+	tokens, err := a.sharing.AccountTokens(key.PublicKey, hostKeys)
 	if errors.Is(err, sharing.ErrSharingKeyNotFound) {
 		jc.Error(err, http.StatusUnauthorized)
 		return
-	} else if jc.Check("failed to create account token", err) != nil {
+	} else if jc.Check("failed to create account tokens", err) != nil {
 		return
 	}
-	jc.Encode(token)
+
+	sharedHosts := make([]SharedHost, len(usable))
+	for i, h := range usable {
+		sharedHosts[i] = SharedHost{HostInfo: h, Token: tokens[i]}
+	}
+	jc.Encode(sharedHosts)
 }

--- a/api/app/sharing_test.go
+++ b/api/app/sharing_test.go
@@ -1,6 +1,7 @@
 package app_test
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"testing"
@@ -162,28 +163,73 @@ func TestSharingKeys(t *testing.T) {
 		t.Fatalf("unexpected totals: %+v", key)
 	}
 
-	if objs, err := appClient.SharedObjects(ctx, sk1, shareKey); err != nil {
+	if objs, err := appClient.SharingKeyObjects(ctx, sk1, shareKey); err != nil {
 		t.Fatal(err)
 	} else if len(objs) != 1 || objs[0].ID() != obj.ID() {
 		t.Fatalf("unexpected shared objects: %v", objs)
 	}
 
-	if objs, err := appClient.SharedObjects(ctx, sk1, shareKey, api.WithOffset(1)); err != nil {
+	if objs, err := appClient.SharingKeyObjects(ctx, sk1, shareKey, api.WithOffset(1)); err != nil {
 		t.Fatal(err)
 	} else if len(objs) != 0 {
 		t.Fatalf("expected no objects at offset 1, got %d", len(objs))
 	}
 
-	if _, err := appClient.SharedObjects(ctx, sk1, types.GeneratePrivateKey().PublicKey()); err == nil {
+	if _, err := appClient.SharingKeyObjects(ctx, sk1, types.GeneratePrivateKey().PublicKey()); err == nil {
 		t.Fatal("expected error listing objects of unknown key")
 	} else {
 		assertStatus(t, err, http.StatusNotFound)
 	}
 
-	if _, err := appClient.SharedObjects(ctx, sk2, shareKey); err == nil {
+	if _, err := appClient.SharingKeyObjects(ctx, sk2, shareKey); err == nil {
 		t.Fatal("expected error listing another account's key objects")
 	} else {
 		assertStatus(t, err, http.StatusNotFound)
+	}
+
+	// the following requests are authenticated with the sharing key itself
+	if stats, err := appClient.SharedStats(ctx, shareKeyPriv); err != nil {
+		t.Fatal(err)
+	} else if stats.ObjectCount != 1 || stats.ObjectSize != 256 ||
+		stats.PinnedData != 4*uint64(proto.SectorSize) ||
+		stats.PinnedSize != uint64(len(hostList))*uint64(proto.SectorSize) {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+
+	if objs, err := appClient.SharedObjects(ctx, shareKeyPriv); err != nil {
+		t.Fatal(err)
+	} else if len(objs) != 1 || objs[0].ID() != obj.ID() || !bytes.Equal(objs[0].EncryptedDataKey, sharedReq.EncryptedDataKey) {
+		t.Fatalf("unexpected shared objects: %+v", objs)
+	}
+
+	if got, err := appClient.SharedObjectByID(ctx, shareKeyPriv, obj.ID()); err != nil {
+		t.Fatal(err)
+	} else if got.ID() != obj.ID() || !bytes.Equal(got.EncryptedDataKey, sharedReq.EncryptedDataKey) {
+		t.Fatalf("unexpected shared object: %+v", got)
+	}
+
+	if _, err := appClient.SharedObjects(ctx, types.GeneratePrivateKey()); err == nil {
+		t.Fatal("expected unauthorized for a non-sharing key")
+	} else {
+		assertStatus(t, err, http.StatusUnauthorized)
+	}
+
+	appHosts, err := appClient.Hosts(ctx, sk1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sharedHosts, err := appClient.SharedHosts(ctx, shareKeyPriv); err != nil {
+		t.Fatal(err)
+	} else if len(sharedHosts) != len(appHosts) {
+		t.Fatalf("expected %d shared hosts, got %d", len(appHosts), len(sharedHosts))
+	}
+
+	if token, err := appClient.SharedHostToken(ctx, shareKeyPriv, hostList[0].PublicKey); err != nil {
+		t.Fatal(err)
+	} else if token.HostKey != hostList[0].PublicKey {
+		t.Fatalf("unexpected token host: %v", token.HostKey)
+	} else if !types.PublicKey(token.Account).VerifyHash(token.SigHash(), token.Signature) {
+		t.Fatal("invalid account token signature")
 	}
 
 	forged := sharedReq

--- a/api/app/sharing_test.go
+++ b/api/app/sharing_test.go
@@ -218,18 +218,18 @@ func TestSharingKeys(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sharedHosts, err := appClient.SharedHosts(ctx, shareKeyPriv); err != nil {
+	sharedHosts, err := appClient.SharedHosts(ctx, shareKeyPriv)
+	if err != nil {
 		t.Fatal(err)
 	} else if len(sharedHosts) != len(appHosts) {
 		t.Fatalf("expected %d shared hosts, got %d", len(appHosts), len(sharedHosts))
 	}
-
-	if token, err := appClient.SharedHostToken(ctx, shareKeyPriv, hostList[0].PublicKey); err != nil {
-		t.Fatal(err)
-	} else if token.HostKey != hostList[0].PublicKey {
-		t.Fatalf("unexpected token host: %v", token.HostKey)
-	} else if !types.PublicKey(token.Account).VerifyHash(token.SigHash(), token.Signature) {
-		t.Fatal("invalid account token signature")
+	for _, h := range sharedHosts {
+		if h.Token.HostKey != h.PublicKey {
+			t.Fatalf("expected token host %v, got %v", h.PublicKey, h.Token.HostKey)
+		} else if !types.PublicKey(h.Token.Account).VerifyHash(h.Token.SigHash(), h.Token.Signature) {
+			t.Fatal("invalid account token signature")
+		}
 	}
 
 	forged := sharedReq

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -513,14 +513,14 @@ paths:
                   $ref: "#/components/schemas/HostInfo"
         "401":
           description: The request is not signed by a valid sharing key
-  /shared/hosts/{pubkey}/token:
+  /shared/hosts/{hostkey}/token:
     get:
       tags:
         - shared
       summary: Get an account token for a host, signed by the owner's sharing account
       operationId: getSharedHostToken
       parameters:
-        - name: pubkey
+        - name: hostkey
           in: path
           required: true
           schema:

--- a/openapi/app.yml
+++ b/openapi/app.yml
@@ -20,6 +20,8 @@ tags:
     description: Retrieve current account
   - name: sharing
     description: Create, list and delete sharing keys and the objects attached to them
+  - name: shared
+    description: Recipient endpoints authenticated with a sharing key
 
 paths:
   /account:
@@ -64,6 +66,16 @@ paths:
           schema:
             type: string
             enum: [siamux, quic]
+        - name: country
+          in: query
+          description: Filter hosts by country code
+          schema:
+            type: string
+        - name: location
+          in: query
+          description: Filter hosts by proximity to a location of the form (lat,lng)
+          schema:
+            type: string
       operationId: listHosts
       responses:
         "200":
@@ -381,6 +393,147 @@ paths:
           description: Object detached successfully
         "404":
           description: Object not attached to the sharing key
+  /shared:
+    get:
+      tags:
+        - shared
+      summary: Get the aggregate stats of the authenticated sharing key
+      operationId: getSharedStats
+      responses:
+        "200":
+          description: The sharing key's stats
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KeyStats"
+        "401":
+          description: The request is not signed by a valid sharing key
+  /shared/objects:
+    get:
+      tags:
+        - shared
+      summary: List the objects the sharing key grants access to
+      operationId: getSharedObjects
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of objects to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: The number of objects to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        "200":
+          description: A list of objects with their re-sealed keys, most recently attached first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SealedObject"
+        "401":
+          description: The request is not signed by a valid sharing key
+  /shared/objects/{id}:
+    get:
+      tags:
+        - shared
+      summary: Get a single object the sharing key grants access to
+      operationId: getSharedObject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/Hash256"
+      responses:
+        "200":
+          description: The object with its re-sealed keys and slabs
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SealedObject"
+        "401":
+          description: The request is not signed by a valid sharing key
+        "404":
+          description: Object not attached to the sharing key
+  /shared/hosts:
+    get:
+      tags:
+        - shared
+      summary: List usable hosts, authenticated with the sharing key
+      operationId: getSharedHosts
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of hosts to return
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 100
+        - name: offset
+          in: query
+          description: The number of hosts to skip
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: protocol
+          in: query
+          description: Filter hosts by protocol
+          schema:
+            type: string
+            enum: [siamux, quic]
+        - name: country
+          in: query
+          description: Filter hosts by country code
+          schema:
+            type: string
+        - name: location
+          in: query
+          description: Filter hosts by proximity to a location of the form (lat,lng)
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A list of usable hosts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HostInfo"
+        "401":
+          description: The request is not signed by a valid sharing key
+  /shared/hosts/{pubkey}/token:
+    get:
+      tags:
+        - shared
+      summary: Get an account token for a host, signed by the owner's sharing account
+      operationId: getSharedHostToken
+      parameters:
+        - name: pubkey
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/PublicKey"
+      responses:
+        "200":
+          description: A signed account token for the host
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountToken"
+        "401":
+          description: The request is not signed by a valid sharing key
   /slabs:
     get:
       tags:
@@ -940,3 +1093,7 @@ components:
       $ref: "./components.yml#/components/schemas/SharingKeyRequest"
     SharedObjectRequest:
       $ref: "./components.yml#/components/schemas/SharedObjectRequest"
+    KeyStats:
+      $ref: "./components.yml#/components/schemas/KeyStats"
+    AccountToken:
+      $ref: "./components.yml#/components/schemas/AccountToken"

--- a/openapi/components.yml
+++ b/openapi/components.yml
@@ -290,6 +290,56 @@ components:
           type: string
           format: date-time
 
+    KeyStats:
+      type: object
+      description: A sharing key's aggregate totals, returned to recipients (omits fields identifying the key or its owner).
+      properties:
+        objectCount:
+          type: integer
+          format: uint64
+          description: The number of objects attached to the key
+        objectSize:
+          type: integer
+          format: uint64
+          description: The total logical size of the attached objects in bytes
+        pinnedData:
+          type: integer
+          format: uint64
+          description: The total size of the attached objects before redundancy in bytes
+        pinnedSize:
+          type: integer
+          format: uint64
+          description: The total size of the attached objects including redundancy in bytes
+        expiresAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    AccountToken:
+      type: object
+      description: An RHP4 account token authorizing debits from a sharing account on a host, used to pay for downloads.
+      properties:
+        hostKey:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: The host the token is valid for
+        account:
+          allOf:
+            - $ref: "#/components/schemas/PublicKey"
+            - description: The sharing account the token debits
+        validUntil:
+          type: string
+          format: date-time
+        signature:
+          allOf:
+            - $ref: "#/components/schemas/Signature"
+            - description: A signature over the token made with the sharing account key
+
     SharingKeyRequest:
       type: object
       description: The request body for creating a sharing key, signed by that key to prove control of its private key

--- a/persist/postgres/sharing.go
+++ b/persist/postgres/sharing.go
@@ -287,6 +287,71 @@ func (s *Store) SharedObjects(sharingKey types.PublicKey, offset, limit int) (ob
 	return
 }
 
+// SharingKeyObject returns a single object attached to the sharing key with its
+// encryption keys re-sealed under the sharing key and its slabs decorated with
+// sectors.
+func (s *Store) SharingKeyObject(sharingKey types.PublicKey, objectKey types.Hash256) (obj slabs.SealedObject, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		obj = slabs.SealedObject{} // reset if the transaction retries
+
+		var sharingKeyID int64
+		err := tx.QueryRow(ctx, `
+			SELECT sk.id FROM sharing_keys sk
+			INNER JOIN accounts a ON a.id = sk.account_id
+			WHERE sk.public_key = $1 AND a.deleted_at IS NULL AND (sk.expires_at IS NULL OR sk.expires_at > NOW())
+		`, sqlPublicKey(sharingKey)).Scan(&sharingKeyID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharingKeyNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get sharing key: %w", err)
+		}
+
+		var objectID int64
+		var metaKey sql.Null[[]byte]
+		err = tx.QueryRow(ctx, `
+			SELECT so.object_id, so.encrypted_data_key, so.encrypted_meta_key, so.encrypted_metadata, so.data_signature, so.meta_signature, so.created_at, so.updated_at
+			FROM shared_objects so
+			INNER JOIN objects o ON o.id = so.object_id
+			WHERE so.sharing_key_id = $1 AND o.object_key = $2
+		`, sharingKeyID, sqlHash256(objectKey)).Scan(&objectID, &obj.EncryptedDataKey, &metaKey, &obj.EncryptedMetadata, (*sqlSignature)(&obj.DataSignature), (*sqlSignature)(&obj.MetadataSignature), &obj.CreatedAt, &obj.UpdatedAt)
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharedObjectNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get shared object: %w", err)
+		}
+		if metaKey.Valid {
+			obj.EncryptedMetadataKey = metaKey.V
+		}
+
+		return loadObjectSlabs(ctx, tx, objectID, &obj)
+	})
+	return
+}
+
+// SharingAccountKey returns the sharing account key derived from the owner of
+// the sharing key. It is used to sign account tokens for downloading the
+// shared objects.
+func (s *Store) SharingAccountKey(sharingKey types.PublicKey) (key types.PrivateKey, err error) {
+	err = s.transaction(func(ctx context.Context, tx *txn) error {
+		var userSecret types.Hash256
+		err := tx.QueryRow(ctx, `
+			SELECT ack.user_secret
+			FROM sharing_keys sk
+			INNER JOIN accounts a ON a.id = sk.account_id
+			INNER JOIN app_connect_keys ack ON ack.id = a.connect_key_id
+			WHERE sk.public_key = $1 AND a.deleted_at IS NULL AND (sk.expires_at IS NULL OR sk.expires_at > NOW())
+		`, sqlPublicKey(sharingKey)).Scan((*sqlHash256)(&userSecret))
+		if errors.Is(err, sql.ErrNoRows) {
+			return sharing.ErrSharingKeyNotFound
+		} else if err != nil {
+			return fmt.Errorf("failed to get user secret: %w", err)
+		}
+		key = accounts.DeriveSharingAccountKey(userSecret)
+		return nil
+	})
+	return
+}
+
 // DeleteSharedObject detaches an object from one of the account's sharing keys.
 func (s *Store) DeleteSharedObject(account proto.Account, sharingKey types.PublicKey, objectKey types.Hash256) error {
 	return s.transaction(func(ctx context.Context, tx *txn) error {

--- a/persist/postgres/sharing_test.go
+++ b/persist/postgres/sharing_test.go
@@ -220,6 +220,10 @@ func TestSharingKeyDeletedAccount(t *testing.T) {
 
 	acc := proto.Account(types.GeneratePrivateKey().PublicKey())
 	store.addTestAccount(t, types.PublicKey(acc))
+	hk := store.addTestHost(t)
+	store.addTestContract(t, hk)
+
+	obj := store.pinTestObject(t, acc, hk)
 
 	pk := types.GeneratePrivateKey().PublicKey()
 	if _, err := store.AddSharingKey(acc, sharing.KeyRequest{
@@ -229,21 +233,41 @@ func TestSharingKeyDeletedAccount(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
-	// the key is reachable while the account is active
-	if _, err := store.SharingKey(pk); err != nil {
+	if err := store.AddSharedObject(acc, pk, sharing.SharedObjectRequest{
+		ObjectID:          obj.ID(),
+		EncryptedDataKey:  frand.Bytes(sharing.EncryptionKeySize),
+		DataSignature:     types.Signature(frand.Bytes(64)),
+		MetadataSignature: types.Signature(frand.Bytes(64)),
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// soft-deleting the account hides the key from recipient reads before pruning
+	// every recipient read is reachable while the account is active
+	if _, err := store.SharingKey(pk); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SharingKeyObject(pk, obj.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SharingAccountKey(pk); err != nil {
+		t.Fatal(err)
+	}
+
+	// soft-deleting the account hides the key from every recipient read before pruning
 	if err := store.DeleteAccount(acc); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := store.SharingKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
-		t.Fatalf("expected ErrSharingKeyNotFound for soft-deleted account, got %v", err)
+		t.Fatalf("expected ErrSharingKeyNotFound from SharingKey, got %v", err)
 	}
 	if _, err := store.SharedObjects(pk, 0, 10); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
-		t.Fatalf("expected ErrSharingKeyNotFound for soft-deleted account, got %v", err)
+		t.Fatalf("expected ErrSharingKeyNotFound from SharedObjects, got %v", err)
+	}
+	if _, err := store.SharingKeyObject(pk, obj.ID()); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound from SharingKeyObject, got %v", err)
+	}
+	if _, err := store.SharingAccountKey(pk); !errors.Is(err, sharing.ErrSharingKeyNotFound) {
+		t.Fatalf("expected ErrSharingKeyNotFound from SharingAccountKey, got %v", err)
 	}
 }
 

--- a/sharing/manager.go
+++ b/sharing/manager.go
@@ -24,6 +24,8 @@ type (
 		PruneExpiredSharingKeys(cutoff time.Time) error
 
 		SharedObjects(sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error)
+		SharingKeyObject(sharingKey types.PublicKey, objectKey types.Hash256) (slabs.SealedObject, error)
+		SharingAccountKey(sharingKey types.PublicKey) (types.PrivateKey, error)
 	}
 
 	// A Manager manages sharing keys and the objects attached to them.
@@ -131,6 +133,29 @@ func (m *Manager) OwnedSharedObjects(account proto.Account, sharingKey types.Pub
 		return nil, err
 	}
 	return m.store.SharedObjects(sharingKey, offset, limit)
+}
+
+// SharedObjects returns a paginated list of the objects attached to the sharing
+// key. It is the recipient-facing view: the caller is authenticated by the
+// sharing key itself, so no ownership check is required.
+func (m *Manager) SharedObjects(sharingKey types.PublicKey, offset, limit int) ([]slabs.SealedObject, error) {
+	return m.store.SharedObjects(sharingKey, offset, limit)
+}
+
+// SharedObject returns a single object attached to the sharing key.
+func (m *Manager) SharedObject(sharingKey types.PublicKey, objectKey types.Hash256) (slabs.SealedObject, error) {
+	return m.store.SharingKeyObject(sharingKey, objectKey)
+}
+
+// AccountToken returns an RHP4 account token for the given host, signed with the
+// sharing account derived from the sharing key's owner. The recipient uses it to
+// pay for downloading the shared objects.
+func (m *Manager) AccountToken(sharingKey types.PublicKey, hostKey types.PublicKey) (proto.AccountToken, error) {
+	key, err := m.store.SharingAccountKey(sharingKey)
+	if err != nil {
+		return proto.AccountToken{}, err
+	}
+	return proto.NewAccountToken(key, hostKey), nil
 }
 
 // NewManager creates a new sharing Manager.

--- a/sharing/manager.go
+++ b/sharing/manager.go
@@ -147,15 +147,19 @@ func (m *Manager) SharedObject(sharingKey types.PublicKey, objectKey types.Hash2
 	return m.store.SharingKeyObject(sharingKey, objectKey)
 }
 
-// AccountToken returns an RHP4 account token for the given host, signed with the
-// sharing account derived from the sharing key's owner. The recipient uses it to
-// pay for downloading the shared objects.
-func (m *Manager) AccountToken(sharingKey types.PublicKey, hostKey types.PublicKey) (proto.AccountToken, error) {
+// AccountTokens returns an RHP4 account token for each of the given hosts, all
+// signed with the sharing account derived from the sharing key's owner. The
+// recipient uses them to pay for downloading the shared objects.
+func (m *Manager) AccountTokens(sharingKey types.PublicKey, hostKeys []types.PublicKey) ([]proto.AccountToken, error) {
 	key, err := m.store.SharingAccountKey(sharingKey)
 	if err != nil {
-		return proto.AccountToken{}, err
+		return nil, err
 	}
-	return proto.NewAccountToken(key, hostKey), nil
+	tokens := make([]proto.AccountToken, len(hostKeys))
+	for i, hostKey := range hostKeys {
+		tokens[i] = proto.NewAccountToken(key, hostKey)
+	}
+	return tokens, nil
 }
 
 // NewManager creates a new sharing Manager.

--- a/sharing/sharing.go
+++ b/sharing/sharing.go
@@ -66,6 +66,18 @@ type (
 		UpdatedAt  time.Time  `json:"updatedAt"`
 	}
 
+	// KeyStats reports a sharing key's aggregate totals. It omits the fields
+	// that identify the key or its owner so it is safe to return to recipients.
+	KeyStats struct {
+		ObjectCount uint64     `json:"objectCount"`
+		ObjectSize  uint64     `json:"objectSize"`
+		PinnedData  uint64     `json:"pinnedData"`
+		PinnedSize  uint64     `json:"pinnedSize"`
+		ExpiresAt   *time.Time `json:"expiresAt,omitempty"`
+		CreatedAt   time.Time  `json:"createdAt"`
+		UpdatedAt   time.Time  `json:"updatedAt"`
+	}
+
 	// A KeyRequest contains the fields required to create a sharing key. It must
 	// be signed by the sharing key to prove control of its private key.
 	KeyRequest struct {
@@ -117,6 +129,19 @@ func (r KeyRequest) VerifySignature() error {
 		return fmt.Errorf("%w: invalid signature", ErrInvalidRequest)
 	}
 	return nil
+}
+
+// Stats returns the key's aggregate totals.
+func (k Key) Stats() KeyStats {
+	return KeyStats{
+		ObjectCount: k.ObjectCount,
+		ObjectSize:  k.ObjectSize,
+		PinnedData:  k.PinnedData,
+		PinnedSize:  k.PinnedSize,
+		ExpiresAt:   k.ExpiresAt,
+		CreatedAt:   k.CreatedAt,
+		UpdatedAt:   k.UpdatedAt,
+	}
 }
 
 func (r KeyRequest) validate() error {


### PR DESCRIPTION
SDKs will be able to access objects using the `/shared` endpoints and a valid sharing key
